### PR TITLE
Bridge all routines in gw_common and gw_front

### DIFF
--- a/components/cmake/modules/FindNETCDF.cmake
+++ b/components/cmake/modules/FindNETCDF.cmake
@@ -44,11 +44,13 @@ endfunction()
 
 function(create_netcdf_target)
 
+  message("JGF ${NetCDF_C_PATH}")
+
   # Grab things from env
-  set(PNETCDF_PATH        $ENV{PNETCDF_PATH})
+  set(PNETCDF_PATH        ${PnetCDF_C_PATH})
   set(NETCDF_PATH         $ENV{NETCDF_PATH})
-  set(NETCDF_C_PATH       $ENV{NETCDF_C_PATH})
-  set(NETCDF_FORTRAN_PATH $ENV{NETCDF_FORTRAN_PATH})
+  set(NETCDF_C_PATH       ${NetCDF_C_PATH})
+  set(NETCDF_FORTRAN_PATH ${NetCDF_Fortran_PATH})
 
   # Pnetcdf is optional, and only if not running serial
   if (NOT MPILIB STREQUAL mpi-serial)

--- a/components/cmake/modules/FindNETCDF.cmake
+++ b/components/cmake/modules/FindNETCDF.cmake
@@ -44,13 +44,11 @@ endfunction()
 
 function(create_netcdf_target)
 
-  message("JGF ${NetCDF_C_PATH}")
-
   # Grab things from env
-  set(PNETCDF_PATH        ${PnetCDF_C_PATH})
+  set(PNETCDF_PATH        $ENV{PNETCDF_PATH})
   set(NETCDF_PATH         $ENV{NETCDF_PATH})
-  set(NETCDF_C_PATH       ${NetCDF_C_PATH})
-  set(NETCDF_FORTRAN_PATH ${NetCDF_Fortran_PATH})
+  set(NETCDF_C_PATH       $ENV{NETCDF_C_PATH})
+  set(NETCDF_FORTRAN_PATH $ENV{NETCDF_FORTRAN_PATH})
 
   # Pnetcdf is optional, and only if not running serial
   if (NOT MPILIB STREQUAL mpi-serial)

--- a/components/eam/src/physics/cam/gw/gw_common.F90
+++ b/components/eam/src/physics/cam/gw/gw_common.F90
@@ -865,7 +865,6 @@ subroutine gw_drag_prof(ncol, ngwv, src_level, tend_level, do_taper, dt, &
   !------------------------------------------------------------------------
 
   ! Initialize gravity wave drag tendencies to zero.
-
   utgw = 0._r8
   vtgw = 0._r8
   taucd = 0._r8

--- a/components/eam/src/physics/cam/gw/gw_common.F90
+++ b/components/eam/src/physics/cam/gw/gw_common.F90
@@ -26,11 +26,12 @@ public :: fcrit2
 public :: kwv
 public :: gravit
 public :: rair
-public :: gwd_compute_tendencies_from_stress_divergence
 
 ! These only need to be public for unit testing
 public :: gwd_compute_stress_profiles_and_diffusivities
 public :: gwd_project_tau
+public :: gwd_compute_tendencies_from_stress_divergence
+public :: gwd_precalc_rhoi
 
 ! This flag preserves answers for vanilla CAM by making a few changes (e.g.
 ! order of operations) when only orographic waves are on.

--- a/components/eam/src/physics/cam/gw/gw_common.F90
+++ b/components/eam/src/physics/cam/gw/gw_common.F90
@@ -28,6 +28,9 @@ public :: gravit
 public :: rair
 public :: gwd_compute_tendencies_from_stress_divergence
 
+! These only need to be public for unit testing
+public :: gwd_compute_stress_profiles_and_diffusivities
+
 ! This flag preserves answers for vanilla CAM by making a few changes (e.g.
 ! order of operations) when only orographic waves are on.
 logical(btype), public :: orographic_only = .false.

--- a/components/eam/src/physics/cam/gw/gw_common.F90
+++ b/components/eam/src/physics/cam/gw/gw_common.F90
@@ -30,6 +30,7 @@ public :: gwd_compute_tendencies_from_stress_divergence
 
 ! These only need to be public for unit testing
 public :: gwd_compute_stress_profiles_and_diffusivities
+public :: gwd_project_tau
 
 ! This flag preserves answers for vanilla CAM by making a few changes (e.g.
 ! order of operations) when only orographic waves are on.

--- a/components/eam/src/physics/cam/gw/gw_front.F90
+++ b/components/eam/src/physics/cam/gw/gw_front.F90
@@ -15,6 +15,9 @@ save
 public :: gw_front_init
 public :: gw_cm_src
 
+! Only public for testing
+public :: gw_front_project_winds
+
 ! Tuneable settings.
 
 ! Frontogenesis function critical threshold.

--- a/components/eam/src/physics/cam/gw/gw_front.F90
+++ b/components/eam/src/physics/cam/gw/gw_front.F90
@@ -17,6 +17,7 @@ public :: gw_cm_src
 
 ! Only public for testing
 public :: gw_front_project_winds
+public :: gw_front_gw_sources
 
 ! Tuneable settings.
 

--- a/components/eamxx/scripts/machines_specs.py
+++ b/components/eamxx/scripts/machines_specs.py
@@ -47,7 +47,7 @@ def get_available_cpu_count(logical=True):
     if 'SLURM_CPU_BIND_LIST' in os.environ:
         cpu_count = len(get_cpu_ids_from_slurm_env_var())
     else:
-        cpu_count = psutil.cpu_count()
+        cpu_count = len(psutil.Process().cpu_affinity())
 
     if not logical:
         hyperthread_ratio = logical_cores_per_physical_core()
@@ -125,25 +125,6 @@ class Aurora(Machine):
 
         cls.batch = "qsub -q debug_scaling -l walltime=01:00:00 -A E3SM_Dec"
         cls.num_run_res = 12 # twelve gpus
-
-###############################################################################
-class Maclap(Machine):
-###############################################################################
-    concrete = True
-    @classmethod
-    def setup(cls):
-        super().setup_base("maclap")
-
-        cls.cxx_compiler = "mpicxx"
-        cls.c_compiler   = "mpicc"
-        cls.ftn_compiler = "mpifort"
-
-        compiler = "gnu"
-
-        cls.baselines_dir = "/Users/jgfouca/1400/ACME/eamxx_files/baselines"
-
-        cls.num_bld_res = 10
-        cls.num_run_res = 10
 
 ###############################################################################
 class PM(CrayMachine):

--- a/components/eamxx/scripts/machines_specs.py
+++ b/components/eamxx/scripts/machines_specs.py
@@ -47,7 +47,7 @@ def get_available_cpu_count(logical=True):
     if 'SLURM_CPU_BIND_LIST' in os.environ:
         cpu_count = len(get_cpu_ids_from_slurm_env_var())
     else:
-        cpu_count = len(psutil.Process().cpu_affinity())
+        cpu_count = psutil.cpu_count()
 
     if not logical:
         hyperthread_ratio = logical_cores_per_physical_core()
@@ -125,6 +125,25 @@ class Aurora(Machine):
 
         cls.batch = "qsub -q debug_scaling -l walltime=01:00:00 -A E3SM_Dec"
         cls.num_run_res = 12 # twelve gpus
+
+###############################################################################
+class Maclap(Machine):
+###############################################################################
+    concrete = True
+    @classmethod
+    def setup(cls):
+        super().setup_base("maclap")
+
+        cls.cxx_compiler = "mpicxx"
+        cls.c_compiler   = "mpicc"
+        cls.ftn_compiler = "mpifort"
+
+        compiler = "gnu"
+
+        cls.baselines_dir = "/Users/jgfouca/1400/ACME/eamxx_files/baselines"
+
+        cls.num_bld_res = 10
+        cls.num_run_res = 10
 
 ###############################################################################
 class PM(CrayMachine):

--- a/components/eamxx/scripts/test_all_eamxx.py
+++ b/components/eamxx/scripts/test_all_eamxx.py
@@ -496,6 +496,8 @@ class TestAllScream(object):
         expect(test.uses_baselines,
                f"Something is off. generate_baseline should have not be called for test {test}")
 
+        self._machine.setup()
+
         baseline_dir = self.get_test_dir(self._baseline_dir, test)
         test_dir = self.get_test_dir(self._work_dir, test)
         if test_dir.exists():
@@ -593,6 +595,8 @@ class TestAllScream(object):
     ###############################################################################
     def run_test(self, test):
     ###############################################################################
+        self._machine.setup()
+
         git_head = get_current_head()
 
         print("===============================================================================")

--- a/components/eamxx/scripts/test_all_eamxx.py
+++ b/components/eamxx/scripts/test_all_eamxx.py
@@ -77,7 +77,6 @@ class TestAllScream(object):
         if machine is not None:
             self._machine = get_machine(machine)
             expect (not local, "Specifying a machine while passing '-l,--local' is ambiguous.")
-            print(f"JGF __init__ {self._machine} {self._machine.name} {self._machine.mach_file}")
         else:
             # We could potentially integrate more with CIME here to do actual
             # nodename probing.
@@ -228,8 +227,6 @@ class TestAllScream(object):
         if self._c_compiler is None:
             self._c_compiler = self._machine.c_compiler
 
-        print(f"JGF __init__END {self._machine} {self._machine.name} {self._machine.mach_file}")
-
     ###############################################################################
     def create_tests_dirs(self, root, clean):
     ###############################################################################
@@ -313,7 +310,6 @@ class TestAllScream(object):
     ###############################################################################
 
         # Ctest only needs config options, and doesn't need the leading 'cmake '
-        print(f"JGF generate_cmake_config {self._machine} {self._machine.name} {self._machine.mach_file}")
         result  = f"{'' if for_ctest else 'cmake '}-C {self._machine.mach_file}"
 
         # Netcdf should be available. But if the user is doing a testing session
@@ -396,7 +392,8 @@ class TestAllScream(object):
         elif "SLURM_CPU_BIND_LIST" in os.environ:
             affinity_cp = get_cpu_ids_from_slurm_env_var()
         else:
-            affinity_cp = list(range(psutil.cpu_count()))
+            this_process = psutil.Process()
+            affinity_cp = list(this_process.cpu_affinity())
 
         affinity_cp.sort()
 
@@ -496,8 +493,6 @@ class TestAllScream(object):
     ###############################################################################
     def generate_baselines(self, test):
     ###############################################################################
-        self._machine.setup()
-        print(f"JGF generate_baselines {self._machine} {self._machine.name} {self._machine.mach_file}")
         expect(test.uses_baselines,
                f"Something is off. generate_baseline should have not be called for test {test}")
 
@@ -571,8 +566,6 @@ class TestAllScream(object):
     ###############################################################################
     def generate_all_baselines(self):
     ###############################################################################
-        print(f"JGF generate_all_baselines {self._machine} {self._machine.name} {self._machine.mach_file}")
-
         git_head = get_current_head()
 
         tests_needing_baselines = self.baselines_to_be_generated()
@@ -600,8 +593,6 @@ class TestAllScream(object):
     ###############################################################################
     def run_test(self, test):
     ###############################################################################
-        self._machine.setup()
-        print(f"JGF run_test {id(self._machine)} {self._machine.name} {self._machine.mach_file}")
         git_head = get_current_head()
 
         print("===============================================================================")
@@ -638,8 +629,6 @@ class TestAllScream(object):
         print("Running tests!")
         print("###############################################################################")
 
-        print(f"JGF run_all_tests {id(self._machine)} {self._machine.name} {self._machine.mach_file}")
-
         success = True
         tests_success = {
             test : False
@@ -647,7 +636,6 @@ class TestAllScream(object):
 
         num_workers = len(self._tests) if self._parallel else 1
         with threading3.ProcessPoolExecutor(max_workers=num_workers) as executor:
-            print(f"JGF run_all_tests::loop {id(self._machine)} {self._machine.name} {self._machine.mach_file}")
             future_to_test = {
                 executor.submit(self.run_test,test) : test
                 for test in self._tests}
@@ -727,8 +715,6 @@ class TestAllScream(object):
     ###############################################################################
     def test_all_eamxx(self):
     ###############################################################################
-
-        print(f"JGF test_all_eamxx {self._machine} {self._machine.name} {self._machine.mach_file}")
 
         # Add any override the user may have requested
         for env_var in self._custom_env_vars:

--- a/components/eamxx/scripts/test_all_eamxx.py
+++ b/components/eamxx/scripts/test_all_eamxx.py
@@ -77,6 +77,7 @@ class TestAllScream(object):
         if machine is not None:
             self._machine = get_machine(machine)
             expect (not local, "Specifying a machine while passing '-l,--local' is ambiguous.")
+            print(f"JGF __init__ {self._machine} {self._machine.name} {self._machine.mach_file}")
         else:
             # We could potentially integrate more with CIME here to do actual
             # nodename probing.
@@ -227,6 +228,8 @@ class TestAllScream(object):
         if self._c_compiler is None:
             self._c_compiler = self._machine.c_compiler
 
+        print(f"JGF __init__END {self._machine} {self._machine.name} {self._machine.mach_file}")
+
     ###############################################################################
     def create_tests_dirs(self, root, clean):
     ###############################################################################
@@ -310,6 +313,7 @@ class TestAllScream(object):
     ###############################################################################
 
         # Ctest only needs config options, and doesn't need the leading 'cmake '
+        print(f"JGF generate_cmake_config {self._machine} {self._machine.name} {self._machine.mach_file}")
         result  = f"{'' if for_ctest else 'cmake '}-C {self._machine.mach_file}"
 
         # Netcdf should be available. But if the user is doing a testing session
@@ -392,8 +396,7 @@ class TestAllScream(object):
         elif "SLURM_CPU_BIND_LIST" in os.environ:
             affinity_cp = get_cpu_ids_from_slurm_env_var()
         else:
-            this_process = psutil.Process()
-            affinity_cp = list(this_process.cpu_affinity())
+            affinity_cp = list(range(psutil.cpu_count()))
 
         affinity_cp.sort()
 
@@ -493,6 +496,8 @@ class TestAllScream(object):
     ###############################################################################
     def generate_baselines(self, test):
     ###############################################################################
+        self._machine.setup()
+        print(f"JGF generate_baselines {self._machine} {self._machine.name} {self._machine.mach_file}")
         expect(test.uses_baselines,
                f"Something is off. generate_baseline should have not be called for test {test}")
 
@@ -566,6 +571,8 @@ class TestAllScream(object):
     ###############################################################################
     def generate_all_baselines(self):
     ###############################################################################
+        print(f"JGF generate_all_baselines {self._machine} {self._machine.name} {self._machine.mach_file}")
+
         git_head = get_current_head()
 
         tests_needing_baselines = self.baselines_to_be_generated()
@@ -593,6 +600,8 @@ class TestAllScream(object):
     ###############################################################################
     def run_test(self, test):
     ###############################################################################
+        self._machine.setup()
+        print(f"JGF run_test {id(self._machine)} {self._machine.name} {self._machine.mach_file}")
         git_head = get_current_head()
 
         print("===============================================================================")
@@ -629,6 +638,8 @@ class TestAllScream(object):
         print("Running tests!")
         print("###############################################################################")
 
+        print(f"JGF run_all_tests {id(self._machine)} {self._machine.name} {self._machine.mach_file}")
+
         success = True
         tests_success = {
             test : False
@@ -636,6 +647,7 @@ class TestAllScream(object):
 
         num_workers = len(self._tests) if self._parallel else 1
         with threading3.ProcessPoolExecutor(max_workers=num_workers) as executor:
+            print(f"JGF run_all_tests::loop {id(self._machine)} {self._machine.name} {self._machine.mach_file}")
             future_to_test = {
                 executor.submit(self.run_test,test) : test
                 for test in self._tests}
@@ -715,6 +727,8 @@ class TestAllScream(object):
     ###############################################################################
     def test_all_eamxx(self):
     ###############################################################################
+
+        print(f"JGF test_all_eamxx {self._machine} {self._machine.name} {self._machine.mach_file}")
 
         # Add any override the user may have requested
         for env_var in self._custom_env_vars:

--- a/components/eamxx/src/physics/gw/CMakeLists.txt
+++ b/components/eamxx/src/physics/gw/CMakeLists.txt
@@ -22,6 +22,7 @@ if (NOT EAMXX_ENABLE_GPU OR Kokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE OR Kokkos
     eti/gw_gw_drag_prof.cpp
     eti/gw_gw_front_project_winds.cpp
     eti/gw_gw_front_gw_sources.cpp
+    eti/gw_gw_cm_src.cpp
   ) # GW ETI SRCS
 endif()
 

--- a/components/eamxx/src/physics/gw/CMakeLists.txt
+++ b/components/eamxx/src/physics/gw/CMakeLists.txt
@@ -17,6 +17,7 @@ if (NOT EAMXX_ENABLE_GPU OR Kokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE OR Kokkos
     eti/gw_gw_prof.cpp
     eti/gw_momentum_energy_conservation.cpp
     eti/gw_gwd_compute_stress_profiles_and_diffusivities.cpp
+    eti/gw_gwd_project_tau.cpp
   ) # GW ETI SRCS
 endif()
 

--- a/components/eamxx/src/physics/gw/CMakeLists.txt
+++ b/components/eamxx/src/physics/gw/CMakeLists.txt
@@ -14,6 +14,7 @@ set(GW_SRCS
 if (NOT EAMXX_ENABLE_GPU OR Kokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE OR Kokkos_ENABLE_HIP_RELOCATABLE_DEVICE_CODE)
   list(APPEND GW_SRCS
     eti/gw_gwd_compute_tendencies_from_stress_divergence.cpp
+    eti/gw_gw_prof.cpp
   ) # GW ETI SRCS
 endif()
 

--- a/components/eamxx/src/physics/gw/CMakeLists.txt
+++ b/components/eamxx/src/physics/gw/CMakeLists.txt
@@ -15,6 +15,7 @@ if (NOT EAMXX_ENABLE_GPU OR Kokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE OR Kokkos
   list(APPEND GW_SRCS
     eti/gw_gwd_compute_tendencies_from_stress_divergence.cpp
     eti/gw_gw_prof.cpp
+    eti/gw_momentum_energy_conservation.cpp
   ) # GW ETI SRCS
 endif()
 

--- a/components/eamxx/src/physics/gw/CMakeLists.txt
+++ b/components/eamxx/src/physics/gw/CMakeLists.txt
@@ -19,6 +19,7 @@ if (NOT EAMXX_ENABLE_GPU OR Kokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE OR Kokkos
     eti/gw_gwd_compute_stress_profiles_and_diffusivities.cpp
     eti/gw_gwd_project_tau.cpp
     eti/gw_gwd_precalc_rhoi.cpp
+    eti/gw_gw_drag_prof.cpp
   ) # GW ETI SRCS
 endif()
 

--- a/components/eamxx/src/physics/gw/CMakeLists.txt
+++ b/components/eamxx/src/physics/gw/CMakeLists.txt
@@ -18,6 +18,7 @@ if (NOT EAMXX_ENABLE_GPU OR Kokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE OR Kokkos
     eti/gw_momentum_energy_conservation.cpp
     eti/gw_gwd_compute_stress_profiles_and_diffusivities.cpp
     eti/gw_gwd_project_tau.cpp
+    eti/gw_gwd_precalc_rhoi.cpp
   ) # GW ETI SRCS
 endif()
 

--- a/components/eamxx/src/physics/gw/CMakeLists.txt
+++ b/components/eamxx/src/physics/gw/CMakeLists.txt
@@ -20,6 +20,7 @@ if (NOT EAMXX_ENABLE_GPU OR Kokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE OR Kokkos
     eti/gw_gwd_project_tau.cpp
     eti/gw_gwd_precalc_rhoi.cpp
     eti/gw_gw_drag_prof.cpp
+    eti/gw_gw_front_project_winds.cpp
   ) # GW ETI SRCS
 endif()
 

--- a/components/eamxx/src/physics/gw/CMakeLists.txt
+++ b/components/eamxx/src/physics/gw/CMakeLists.txt
@@ -21,6 +21,7 @@ if (NOT EAMXX_ENABLE_GPU OR Kokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE OR Kokkos
     eti/gw_gwd_precalc_rhoi.cpp
     eti/gw_gw_drag_prof.cpp
     eti/gw_gw_front_project_winds.cpp
+    eti/gw_gw_front_gw_sources.cpp
   ) # GW ETI SRCS
 endif()
 

--- a/components/eamxx/src/physics/gw/CMakeLists.txt
+++ b/components/eamxx/src/physics/gw/CMakeLists.txt
@@ -16,6 +16,7 @@ if (NOT EAMXX_ENABLE_GPU OR Kokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE OR Kokkos
     eti/gw_gwd_compute_tendencies_from_stress_divergence.cpp
     eti/gw_gw_prof.cpp
     eti/gw_momentum_energy_conservation.cpp
+    eti/gw_gwd_compute_stress_profiles_and_diffusivities.cpp
   ) # GW ETI SRCS
 endif()
 

--- a/components/eamxx/src/physics/gw/eti/gw_gw_cm_src.cpp
+++ b/components/eamxx/src/physics/gw/eti/gw_gw_cm_src.cpp
@@ -1,0 +1,14 @@
+#include "impl/gw_gw_cm_src_impl.hpp"
+
+namespace scream {
+namespace gw {
+
+/*
+ * Explicit instantiation for doing gw_cm_src on Reals using the
+ * default device.
+ */
+
+template struct Functions<Real,DefaultDevice>;
+
+} // namespace gw
+} // namespace scream

--- a/components/eamxx/src/physics/gw/eti/gw_gw_drag_prof.cpp
+++ b/components/eamxx/src/physics/gw/eti/gw_gw_drag_prof.cpp
@@ -1,0 +1,14 @@
+#include "impl/gw_gw_drag_prof_impl.hpp"
+
+namespace scream {
+namespace gw {
+
+/*
+ * Explicit instantiation for doing gw_drag_prof on Reals using the
+ * default device.
+ */
+
+template struct Functions<Real,DefaultDevice>;
+
+} // namespace gw
+} // namespace scream

--- a/components/eamxx/src/physics/gw/eti/gw_gw_front_gw_sources.cpp
+++ b/components/eamxx/src/physics/gw/eti/gw_gw_front_gw_sources.cpp
@@ -1,0 +1,14 @@
+#include "impl/gw_gw_front_gw_sources_impl.hpp"
+
+namespace scream {
+namespace gw {
+
+/*
+ * Explicit instantiation for doing gw_front_gw_sources on Reals using the
+ * default device.
+ */
+
+template struct Functions<Real,DefaultDevice>;
+
+} // namespace gw
+} // namespace scream

--- a/components/eamxx/src/physics/gw/eti/gw_gw_front_project_winds.cpp
+++ b/components/eamxx/src/physics/gw/eti/gw_gw_front_project_winds.cpp
@@ -1,0 +1,14 @@
+#include "impl/gw_gw_front_project_winds_impl.hpp"
+
+namespace scream {
+namespace gw {
+
+/*
+ * Explicit instantiation for doing gw_front_project_winds on Reals using the
+ * default device.
+ */
+
+template struct Functions<Real,DefaultDevice>;
+
+} // namespace gw
+} // namespace scream

--- a/components/eamxx/src/physics/gw/eti/gw_gw_prof.cpp
+++ b/components/eamxx/src/physics/gw/eti/gw_gw_prof.cpp
@@ -1,0 +1,14 @@
+#include "impl/gw_gw_prof_impl.hpp"
+
+namespace scream {
+namespace gw {
+
+/*
+ * Explicit instantiation for doing gw_prof on Reals using the
+ * default device.
+ */
+
+template struct Functions<Real,DefaultDevice>;
+
+} // namespace gw
+} // namespace scream

--- a/components/eamxx/src/physics/gw/eti/gw_gwd_compute_stress_profiles_and_diffusivities.cpp
+++ b/components/eamxx/src/physics/gw/eti/gw_gwd_compute_stress_profiles_and_diffusivities.cpp
@@ -1,0 +1,14 @@
+#include "impl/gw_gwd_compute_stress_profiles_and_diffusivities_impl.hpp"
+
+namespace scream {
+namespace gw {
+
+/*
+ * Explicit instantiation for doing gwd_compute_stress_profiles_and_diffusivities on Reals using the
+ * default device.
+ */
+
+template struct Functions<Real,DefaultDevice>;
+
+} // namespace gw
+} // namespace scream

--- a/components/eamxx/src/physics/gw/eti/gw_gwd_precalc_rhoi.cpp
+++ b/components/eamxx/src/physics/gw/eti/gw_gwd_precalc_rhoi.cpp
@@ -1,0 +1,14 @@
+#include "impl/gw_gwd_precalc_rhoi_impl.hpp"
+
+namespace scream {
+namespace gw {
+
+/*
+ * Explicit instantiation for doing gwd_precalc_rhoi on Reals using the
+ * default device.
+ */
+
+template struct Functions<Real,DefaultDevice>;
+
+} // namespace gw
+} // namespace scream

--- a/components/eamxx/src/physics/gw/eti/gw_gwd_project_tau.cpp
+++ b/components/eamxx/src/physics/gw/eti/gw_gwd_project_tau.cpp
@@ -1,0 +1,14 @@
+#include "impl/gw_gwd_project_tau_impl.hpp"
+
+namespace scream {
+namespace gw {
+
+/*
+ * Explicit instantiation for doing gwd_project_tau on Reals using the
+ * default device.
+ */
+
+template struct Functions<Real,DefaultDevice>;
+
+} // namespace gw
+} // namespace scream

--- a/components/eamxx/src/physics/gw/eti/gw_momentum_energy_conservation.cpp
+++ b/components/eamxx/src/physics/gw/eti/gw_momentum_energy_conservation.cpp
@@ -1,0 +1,14 @@
+#include "impl/gw_momentum_energy_conservation_impl.hpp"
+
+namespace scream {
+namespace gw {
+
+/*
+ * Explicit instantiation for doing momentum_energy_conservation on Reals using the
+ * default device.
+ */
+
+template struct Functions<Real,DefaultDevice>;
+
+} // namespace gw
+} // namespace scream

--- a/components/eamxx/src/physics/gw/gw_functions.hpp
+++ b/components/eamxx/src/physics/gw/gw_functions.hpp
@@ -130,6 +130,25 @@ struct Functions
     const uview_1d<Spack>& utgw,
     const uview_1d<Spack>& vtgw,
     const uview_1d<Spack>& ttgw);
+
+  KOKKOS_FUNCTION
+  static void gwd_compute_stress_profiles_and_diffusivities(
+    // Inputs
+    const Int& pver,
+    const Int& pgwv,
+    const Int& ncol,
+    const Int& ngwv,
+    const uview_1d<const Int>& src_level,
+    const uview_1d<const Spack>& ubi,
+    const uview_1d<const Spack>& c,
+    const uview_1d<const Spack>& rhoi,
+    const uview_1d<const Spack>& ni,
+    const uview_1d<const Spack>& kvtt,
+    const uview_1d<const Spack>& t,
+    const uview_1d<const Spack>& ti,
+    const uview_1d<const Spack>& piln,
+    // Inputs/Outputs
+    const uview_1d<Spack>& tau);
 }; // struct Functions
 
 } // namespace gw
@@ -142,5 +161,6 @@ struct Functions
 # include "impl/gw_gwd_compute_tendencies_from_stress_divergence_impl.hpp"
 # include "impl/gw_gw_prof_impl.hpp"
 # include "impl/gw_momentum_energy_conservation_impl.hpp"
+# include "impl/gw_gwd_compute_stress_profiles_and_diffusivities_impl.hpp"
 #endif // GPU && !KOKKOS_ENABLE_*_RELOCATABLE_DEVICE_CODE
 #endif // P3_FUNCTIONS_HPP

--- a/components/eamxx/src/physics/gw/gw_functions.hpp
+++ b/components/eamxx/src/physics/gw/gw_functions.hpp
@@ -149,6 +149,22 @@ struct Functions
     const uview_1d<const Spack>& piln,
     // Inputs/Outputs
     const uview_1d<Spack>& tau);
+
+  KOKKOS_FUNCTION
+  static void gwd_project_tau(
+    // Inputs
+    const Int& pver,
+    const Int& pgwv,
+    const Int& ncol,
+    const Int& ngwv,
+    const uview_1d<const Int>& tend_level,
+    const uview_1d<const Spack>& tau,
+    const uview_1d<const Spack>& ubi,
+    const uview_1d<const Spack>& c,
+    const uview_1d<const Spack>& xv,
+    const uview_1d<const Spack>& yv,
+    // Outputs
+    const uview_1d<Spack>& taucd);
 }; // struct Functions
 
 } // namespace gw
@@ -162,5 +178,6 @@ struct Functions
 # include "impl/gw_gw_prof_impl.hpp"
 # include "impl/gw_momentum_energy_conservation_impl.hpp"
 # include "impl/gw_gwd_compute_stress_profiles_and_diffusivities_impl.hpp"
+# include "impl/gw_gwd_project_tau_impl.hpp"
 #endif // GPU && !KOKKOS_ENABLE_*_RELOCATABLE_DEVICE_CODE
 #endif // P3_FUNCTIONS_HPP

--- a/components/eamxx/src/physics/gw/gw_functions.hpp
+++ b/components/eamxx/src/physics/gw/gw_functions.hpp
@@ -249,6 +249,18 @@ struct Functions
     const uview_1d<Spack>& yv,
     const uview_1d<Spack>& ubm,
     const uview_1d<Spack>& ubi);
+
+  KOKKOS_FUNCTION
+  static void gw_front_gw_sources(
+    // Inputs
+    const Int& pver,
+    const Int& pgwv,
+    const Int& ncol,
+    const Int& ngwv,
+    const Int& kbot,
+    const uview_1d<const Spack>& frontgf,
+    // Outputs
+    const uview_1d<Spack>& tau);
 }; // struct Functions
 
 } // namespace gw
@@ -266,5 +278,6 @@ struct Functions
 # include "impl/gw_gwd_precalc_rhoi_impl.hpp"
 # include "impl/gw_gw_drag_prof_impl.hpp"
 # include "impl/gw_gw_front_project_winds_impl.hpp"
+# include "impl/gw_gw_front_gw_sources_impl.hpp"
 #endif // GPU && !KOKKOS_ENABLE_*_RELOCATABLE_DEVICE_CODE
 #endif // P3_FUNCTIONS_HPP

--- a/components/eamxx/src/physics/gw/gw_functions.hpp
+++ b/components/eamxx/src/physics/gw/gw_functions.hpp
@@ -261,6 +261,27 @@ struct Functions
     const uview_1d<const Spack>& frontgf,
     // Outputs
     const uview_1d<Spack>& tau);
+
+  KOKKOS_FUNCTION
+  static void gw_cm_src(
+    // Inputs
+    const Int& pver,
+    const Int& pgwv,
+    const Int& ncol,
+    const Int& ngwv,
+    const Int& kbot,
+    const uview_1d<const Spack>& u,
+    const uview_1d<const Spack>& v,
+    const uview_1d<const Spack>& frontgf,
+    // Outputs
+    const uview_1d<Int>& src_level,
+    const uview_1d<Int>& tend_level,
+    const uview_1d<Spack>& tau,
+    const uview_1d<Spack>& ubm,
+    const uview_1d<Spack>& ubi,
+    const uview_1d<Spack>& xv,
+    const uview_1d<Spack>& yv,
+    const uview_1d<Spack>& c);
 }; // struct Functions
 
 } // namespace gw
@@ -279,5 +300,6 @@ struct Functions
 # include "impl/gw_gw_drag_prof_impl.hpp"
 # include "impl/gw_gw_front_project_winds_impl.hpp"
 # include "impl/gw_gw_front_gw_sources_impl.hpp"
+# include "impl/gw_gw_cm_src_impl.hpp"
 #endif // GPU && !KOKKOS_ENABLE_*_RELOCATABLE_DEVICE_CODE
 #endif // P3_FUNCTIONS_HPP

--- a/components/eamxx/src/physics/gw/gw_functions.hpp
+++ b/components/eamxx/src/physics/gw/gw_functions.hpp
@@ -95,6 +95,21 @@ struct Functions
     const uview_1d<Spack>& gwut,
     const uview_1d<Spack>& utgw,
     const uview_1d<Spack>& vtgw);
+
+  KOKKOS_FUNCTION
+  static void gw_prof(
+    // Inputs
+    const Int& pver,
+    const Int& ncol,
+    const Spack& cpair,
+    const uview_1d<const Spack>& t,
+    const uview_1d<const Spack>& pmid,
+    const uview_1d<const Spack>& pint,
+    // Outputs
+    const uview_1d<Spack>& rhoi,
+    const uview_1d<Spack>& ti,
+    const uview_1d<Spack>& nm,
+    const uview_1d<Spack>& ni);
 }; // struct Functions
 
 } // namespace gw
@@ -105,5 +120,6 @@ struct Functions
 #if defined(EAMXX_ENABLE_GPU) && !defined(KOKKOS_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE) \
                                 && !defined(KOKKOS_ENABLE_HIP_RELOCATABLE_DEVICE_CODE)
 # include "impl/gw_gwd_compute_tendencies_from_stress_divergence_impl.hpp"
+# include "impl/gw_gw_prof_impl.hpp"
 #endif // GPU && !KOKKOS_ENABLE_*_RELOCATABLE_DEVICE_CODE
 #endif // P3_FUNCTIONS_HPP

--- a/components/eamxx/src/physics/gw/gw_functions.hpp
+++ b/components/eamxx/src/physics/gw/gw_functions.hpp
@@ -165,6 +165,32 @@ struct Functions
     const uview_1d<const Spack>& yv,
     // Outputs
     const uview_1d<Spack>& taucd);
+
+  KOKKOS_FUNCTION
+  static void gwd_precalc_rhoi(
+    // Inputs
+    const Int& pver,
+    const Int& pgwv,
+    const Int& ncol,
+    const Int& ngwv,
+    const Spack& dt,
+    const uview_1d<const Int>& tend_level,
+    const uview_1d<const Spack>& pmid,
+    const uview_1d<const Spack>& pint,
+    const uview_1d<const Spack>& t,
+    const uview_1d<const Spack>& gwut,
+    const uview_1d<const Spack>& ubm,
+    const uview_1d<const Spack>& nm,
+    const uview_1d<const Spack>& rdpm,
+    const uview_1d<const Spack>& c,
+    const uview_1d<const Spack>& q,
+    const uview_1d<const Spack>& dse,
+    // Outputs
+    const uview_1d<Spack>& egwdffi,
+    const uview_1d<Spack>& qtgw,
+    const uview_1d<Spack>& dttdf,
+    const uview_1d<Spack>& dttke,
+    const uview_1d<Spack>& ttgw);
 }; // struct Functions
 
 } // namespace gw
@@ -179,5 +205,6 @@ struct Functions
 # include "impl/gw_momentum_energy_conservation_impl.hpp"
 # include "impl/gw_gwd_compute_stress_profiles_and_diffusivities_impl.hpp"
 # include "impl/gw_gwd_project_tau_impl.hpp"
+# include "impl/gw_gwd_precalc_rhoi_impl.hpp"
 #endif // GPU && !KOKKOS_ENABLE_*_RELOCATABLE_DEVICE_CODE
 #endif // P3_FUNCTIONS_HPP

--- a/components/eamxx/src/physics/gw/gw_functions.hpp
+++ b/components/eamxx/src/physics/gw/gw_functions.hpp
@@ -235,6 +235,20 @@ struct Functions
     const uview_1d<Spack>& gwut,
     const uview_1d<Spack>& dttdf,
     const uview_1d<Spack>& dttke);
+
+  KOKKOS_FUNCTION
+  static void gw_front_project_winds(
+    // Inputs
+    const Int& pver,
+    const Int& ncol,
+    const Int& kbot,
+    const uview_1d<const Spack>& u,
+    const uview_1d<const Spack>& v,
+    // Outputs
+    const uview_1d<Spack>& xv,
+    const uview_1d<Spack>& yv,
+    const uview_1d<Spack>& ubm,
+    const uview_1d<Spack>& ubi);
 }; // struct Functions
 
 } // namespace gw
@@ -251,5 +265,6 @@ struct Functions
 # include "impl/gw_gwd_project_tau_impl.hpp"
 # include "impl/gw_gwd_precalc_rhoi_impl.hpp"
 # include "impl/gw_gw_drag_prof_impl.hpp"
+# include "impl/gw_gw_front_project_winds_impl.hpp"
 #endif // GPU && !KOKKOS_ENABLE_*_RELOCATABLE_DEVICE_CODE
 #endif // P3_FUNCTIONS_HPP

--- a/components/eamxx/src/physics/gw/gw_functions.hpp
+++ b/components/eamxx/src/physics/gw/gw_functions.hpp
@@ -191,6 +191,50 @@ struct Functions
     const uview_1d<Spack>& dttdf,
     const uview_1d<Spack>& dttke,
     const uview_1d<Spack>& ttgw);
+
+  KOKKOS_FUNCTION
+  static void gw_drag_prof(
+    // Inputs
+    const Int& pver,
+    const Int& pgwv,
+    const Int& ncol,
+    const Int& ngwv,
+    const uview_1d<const Int>& src_level,
+    const uview_1d<const Int>& tend_level,
+    const bool& do_taper,
+    const Spack& dt,
+    const uview_1d<const Spack>& lat,
+    const uview_1d<const Spack>& t,
+    const uview_1d<const Spack>& ti,
+    const uview_1d<const Spack>& pmid,
+    const uview_1d<const Spack>& pint,
+    const uview_1d<const Spack>& dpm,
+    const uview_1d<const Spack>& rdpm,
+    const uview_1d<const Spack>& piln,
+    const uview_1d<const Spack>& rhoi,
+    const uview_1d<const Spack>& nm,
+    const uview_1d<const Spack>& ni,
+    const uview_1d<const Spack>& ubm,
+    const uview_1d<const Spack>& ubi,
+    const uview_1d<const Spack>& xv,
+    const uview_1d<const Spack>& yv,
+    const Spack& effgw,
+    const uview_1d<const Spack>& c,
+    const uview_1d<const Spack>& kvtt,
+    const uview_1d<const Spack>& q,
+    const uview_1d<const Spack>& dse,
+    // Inputs/Outputs
+    const uview_1d<Spack>& tau,
+    // Outputs
+    const uview_1d<Spack>& utgw,
+    const uview_1d<Spack>& vtgw,
+    const uview_1d<Spack>& ttgw,
+    const uview_1d<Spack>& qtgw,
+    const uview_1d<Spack>& taucd,
+    const uview_1d<Spack>& egwdffi,
+    const uview_1d<Spack>& gwut,
+    const uview_1d<Spack>& dttdf,
+    const uview_1d<Spack>& dttke);
 }; // struct Functions
 
 } // namespace gw
@@ -206,5 +250,6 @@ struct Functions
 # include "impl/gw_gwd_compute_stress_profiles_and_diffusivities_impl.hpp"
 # include "impl/gw_gwd_project_tau_impl.hpp"
 # include "impl/gw_gwd_precalc_rhoi_impl.hpp"
+# include "impl/gw_gw_drag_prof_impl.hpp"
 #endif // GPU && !KOKKOS_ENABLE_*_RELOCATABLE_DEVICE_CODE
 #endif // P3_FUNCTIONS_HPP

--- a/components/eamxx/src/physics/gw/gw_functions.hpp
+++ b/components/eamxx/src/physics/gw/gw_functions.hpp
@@ -110,6 +110,26 @@ struct Functions
     const uview_1d<Spack>& ti,
     const uview_1d<Spack>& nm,
     const uview_1d<Spack>& ni);
+
+  KOKKOS_FUNCTION
+  static void momentum_energy_conservation(
+    // Inputs
+    const Int& pver,
+    const Int& ncol,
+    const uview_1d<const Int>& tend_level,
+    const Spack& dt,
+    const uview_1d<const Spack>& taucd,
+    const uview_1d<const Spack>& pint,
+    const uview_1d<const Spack>& pdel,
+    const uview_1d<const Spack>& u,
+    const uview_1d<const Spack>& v,
+    // Inputs/Outputs
+    const uview_1d<Spack>& dudt,
+    const uview_1d<Spack>& dvdt,
+    const uview_1d<Spack>& dsdt,
+    const uview_1d<Spack>& utgw,
+    const uview_1d<Spack>& vtgw,
+    const uview_1d<Spack>& ttgw);
 }; // struct Functions
 
 } // namespace gw
@@ -121,5 +141,6 @@ struct Functions
                                 && !defined(KOKKOS_ENABLE_HIP_RELOCATABLE_DEVICE_CODE)
 # include "impl/gw_gwd_compute_tendencies_from_stress_divergence_impl.hpp"
 # include "impl/gw_gw_prof_impl.hpp"
+# include "impl/gw_momentum_energy_conservation_impl.hpp"
 #endif // GPU && !KOKKOS_ENABLE_*_RELOCATABLE_DEVICE_CODE
 #endif // P3_FUNCTIONS_HPP

--- a/components/eamxx/src/physics/gw/impl/gw_gw_cm_src_impl.hpp
+++ b/components/eamxx/src/physics/gw/impl/gw_gw_cm_src_impl.hpp
@@ -1,0 +1,43 @@
+#ifndef GW_GW_CM_SRC_IMPL_HPP
+#define GW_GW_CM_SRC_IMPL_HPP
+
+#include "gw_functions.hpp" // for ETI only but harmless for GPU
+
+namespace scream {
+namespace gw {
+
+/*
+ * Implementation of gw gw_cm_src. Clients should NOT
+ * #include this file, but include gw_functions.hpp instead.
+ */
+
+template<typename S, typename D>
+KOKKOS_FUNCTION
+void Functions<S,D>::gw_cm_src(
+// Inputs
+const Int& pver,
+const Int& pgwv,
+const Int& ncol,
+const Int& ngwv,
+const Int& kbot,
+const uview_1d<const Spack>& u,
+const uview_1d<const Spack>& v,
+const uview_1d<const Spack>& frontgf,
+// Outputs
+const uview_1d<Int>& src_level,
+const uview_1d<Int>& tend_level,
+const uview_1d<Spack>& tau,
+const uview_1d<Spack>& ubm,
+const uview_1d<Spack>& ubi,
+const uview_1d<Spack>& xv,
+const uview_1d<Spack>& yv,
+const uview_1d<Spack>& c)
+{
+  // TODO
+  // Note, argument types may need tweaking. Generator is not always able to tell what needs to be packed
+}
+
+} // namespace gw
+} // namespace scream
+
+#endif

--- a/components/eamxx/src/physics/gw/impl/gw_gw_drag_prof_impl.hpp
+++ b/components/eamxx/src/physics/gw/impl/gw_gw_drag_prof_impl.hpp
@@ -1,0 +1,66 @@
+#ifndef GW_GW_DRAG_PROF_IMPL_HPP
+#define GW_GW_DRAG_PROF_IMPL_HPP
+
+#include "gw_functions.hpp" // for ETI only but harmless for GPU
+
+namespace scream {
+namespace gw {
+
+/*
+ * Implementation of gw gw_drag_prof. Clients should NOT
+ * #include this file, but include gw_functions.hpp instead.
+ */
+
+template<typename S, typename D>
+KOKKOS_FUNCTION
+void Functions<S,D>::gw_drag_prof(
+// Inputs
+const Int& pver,
+const Int& pgwv,
+const Int& ncol,
+const Int& ngwv,
+const uview_1d<const Int>& src_level,
+const uview_1d<const Int>& tend_level,
+const bool& do_taper,
+const Spack& dt,
+const uview_1d<const Spack>& lat,
+const uview_1d<const Spack>& t,
+const uview_1d<const Spack>& ti,
+const uview_1d<const Spack>& pmid,
+const uview_1d<const Spack>& pint,
+const uview_1d<const Spack>& dpm,
+const uview_1d<const Spack>& rdpm,
+const uview_1d<const Spack>& piln,
+const uview_1d<const Spack>& rhoi,
+const uview_1d<const Spack>& nm,
+const uview_1d<const Spack>& ni,
+const uview_1d<const Spack>& ubm,
+const uview_1d<const Spack>& ubi,
+const uview_1d<const Spack>& xv,
+const uview_1d<const Spack>& yv,
+const Spack& effgw,
+const uview_1d<const Spack>& c,
+const uview_1d<const Spack>& kvtt,
+const uview_1d<const Spack>& q,
+const uview_1d<const Spack>& dse,
+// Inputs/Outputs
+const uview_1d<Spack>& tau,
+// Outputs
+const uview_1d<Spack>& utgw,
+const uview_1d<Spack>& vtgw,
+const uview_1d<Spack>& ttgw,
+const uview_1d<Spack>& qtgw,
+const uview_1d<Spack>& taucd,
+const uview_1d<Spack>& egwdffi,
+const uview_1d<Spack>& gwut,
+const uview_1d<Spack>& dttdf,
+const uview_1d<Spack>& dttke)
+{
+  // TODO
+  // Note, argument types may need tweaking. Generator is not always able to tell what needs to be packed
+}
+
+} // namespace gw
+} // namespace scream
+
+#endif

--- a/components/eamxx/src/physics/gw/impl/gw_gw_front_gw_sources_impl.hpp
+++ b/components/eamxx/src/physics/gw/impl/gw_gw_front_gw_sources_impl.hpp
@@ -1,0 +1,34 @@
+#ifndef GW_GW_FRONT_GW_SOURCES_IMPL_HPP
+#define GW_GW_FRONT_GW_SOURCES_IMPL_HPP
+
+#include "gw_functions.hpp" // for ETI only but harmless for GPU
+
+namespace scream {
+namespace gw {
+
+/*
+ * Implementation of gw gw_front_gw_sources. Clients should NOT
+ * #include this file, but include gw_functions.hpp instead.
+ */
+
+template<typename S, typename D>
+KOKKOS_FUNCTION
+void Functions<S,D>::gw_front_gw_sources(
+// Inputs
+const Int& pver,
+const Int& pgwv,
+const Int& ncol,
+const Int& ngwv,
+const Int& kbot,
+const uview_1d<const Spack>& frontgf,
+// Outputs
+const uview_1d<Spack>& tau)
+{
+  // TODO
+  // Note, argument types may need tweaking. Generator is not always able to tell what needs to be packed
+}
+
+} // namespace gw
+} // namespace scream
+
+#endif

--- a/components/eamxx/src/physics/gw/impl/gw_gw_front_project_winds_impl.hpp
+++ b/components/eamxx/src/physics/gw/impl/gw_gw_front_project_winds_impl.hpp
@@ -1,0 +1,36 @@
+#ifndef GW_GW_FRONT_PROJECT_WINDS_IMPL_HPP
+#define GW_GW_FRONT_PROJECT_WINDS_IMPL_HPP
+
+#include "gw_functions.hpp" // for ETI only but harmless for GPU
+
+namespace scream {
+namespace gw {
+
+/*
+ * Implementation of gw gw_front_project_winds. Clients should NOT
+ * #include this file, but include gw_functions.hpp instead.
+ */
+
+template<typename S, typename D>
+KOKKOS_FUNCTION
+void Functions<S,D>::gw_front_project_winds(
+// Inputs
+const Int& pver,
+const Int& ncol,
+const Int& kbot,
+const uview_1d<const Spack>& u,
+const uview_1d<const Spack>& v,
+// Outputs
+const uview_1d<Spack>& xv,
+const uview_1d<Spack>& yv,
+const uview_1d<Spack>& ubm,
+const uview_1d<Spack>& ubi)
+{
+  // TODO
+  // Note, argument types may need tweaking. Generator is not always able to tell what needs to be packed
+}
+
+} // namespace gw
+} // namespace scream
+
+#endif

--- a/components/eamxx/src/physics/gw/impl/gw_gw_prof_impl.hpp
+++ b/components/eamxx/src/physics/gw/impl/gw_gw_prof_impl.hpp
@@ -1,0 +1,37 @@
+#ifndef GW_GW_PROF_IMPL_HPP
+#define GW_GW_PROF_IMPL_HPP
+
+#include "gw_functions.hpp" // for ETI only but harmless for GPU
+
+namespace scream {
+namespace gw {
+
+/*
+ * Implementation of gw gw_prof. Clients should NOT
+ * #include this file, but include gw_functions.hpp instead.
+ */
+
+template<typename S, typename D>
+KOKKOS_FUNCTION
+void Functions<S,D>::gw_prof(
+// Inputs
+const Int& pver,
+const Int& ncol,
+const Spack& cpair,
+const uview_1d<const Spack>& t,
+const uview_1d<const Spack>& pmid,
+const uview_1d<const Spack>& pint,
+// Outputs
+const uview_1d<Spack>& rhoi,
+const uview_1d<Spack>& ti,
+const uview_1d<Spack>& nm,
+const uview_1d<Spack>& ni)
+{
+  // TODO
+  // Note, argument types may need tweaking. Generator is not always able to tell what needs to be packed
+}
+
+} // namespace gw
+} // namespace scream
+
+#endif

--- a/components/eamxx/src/physics/gw/impl/gw_gwd_compute_stress_profiles_and_diffusivities_impl.hpp
+++ b/components/eamxx/src/physics/gw/impl/gw_gwd_compute_stress_profiles_and_diffusivities_impl.hpp
@@ -1,0 +1,41 @@
+#ifndef GW_GWD_COMPUTE_STRESS_PROFILES_AND_DIFFUSIVITIES_IMPL_HPP
+#define GW_GWD_COMPUTE_STRESS_PROFILES_AND_DIFFUSIVITIES_IMPL_HPP
+
+#include "gw_functions.hpp" // for ETI only but harmless for GPU
+
+namespace scream {
+namespace gw {
+
+/*
+ * Implementation of gw gwd_compute_stress_profiles_and_diffusivities. Clients should NOT
+ * #include this file, but include gw_functions.hpp instead.
+ */
+
+template<typename S, typename D>
+KOKKOS_FUNCTION
+void Functions<S,D>::gwd_compute_stress_profiles_and_diffusivities(
+// Inputs
+const Int& pver,
+const Int& pgwv,
+const Int& ncol,
+const Int& ngwv,
+const uview_1d<const Int>& src_level,
+const uview_1d<const Spack>& ubi,
+const uview_1d<const Spack>& c,
+const uview_1d<const Spack>& rhoi,
+const uview_1d<const Spack>& ni,
+const uview_1d<const Spack>& kvtt,
+const uview_1d<const Spack>& t,
+const uview_1d<const Spack>& ti,
+const uview_1d<const Spack>& piln,
+// Inputs/Outputs
+const uview_1d<Spack>& tau)
+{
+  // TODO
+  // Note, argument types may need tweaking. Generator is not always able to tell what needs to be packed
+}
+
+} // namespace gw
+} // namespace scream
+
+#endif

--- a/components/eamxx/src/physics/gw/impl/gw_gwd_precalc_rhoi_impl.hpp
+++ b/components/eamxx/src/physics/gw/impl/gw_gwd_precalc_rhoi_impl.hpp
@@ -1,0 +1,48 @@
+#ifndef GW_GWD_PRECALC_RHOI_IMPL_HPP
+#define GW_GWD_PRECALC_RHOI_IMPL_HPP
+
+#include "gw_functions.hpp" // for ETI only but harmless for GPU
+
+namespace scream {
+namespace gw {
+
+/*
+ * Implementation of gw gwd_precalc_rhoi. Clients should NOT
+ * #include this file, but include gw_functions.hpp instead.
+ */
+
+template<typename S, typename D>
+KOKKOS_FUNCTION
+void Functions<S,D>::gwd_precalc_rhoi(
+// Inputs
+const Int& pver,
+const Int& pgwv,
+const Int& ncol,
+const Int& ngwv,
+const Spack& dt,
+const uview_1d<const Int>& tend_level,
+const uview_1d<const Spack>& pmid,
+const uview_1d<const Spack>& pint,
+const uview_1d<const Spack>& t,
+const uview_1d<const Spack>& gwut,
+const uview_1d<const Spack>& ubm,
+const uview_1d<const Spack>& nm,
+const uview_1d<const Spack>& rdpm,
+const uview_1d<const Spack>& c,
+const uview_1d<const Spack>& q,
+const uview_1d<const Spack>& dse,
+// Outputs
+const uview_1d<Spack>& egwdffi,
+const uview_1d<Spack>& qtgw,
+const uview_1d<Spack>& dttdf,
+const uview_1d<Spack>& dttke,
+const uview_1d<Spack>& ttgw)
+{
+  // TODO
+  // Note, argument types may need tweaking. Generator is not always able to tell what needs to be packed
+}
+
+} // namespace gw
+} // namespace scream
+
+#endif

--- a/components/eamxx/src/physics/gw/impl/gw_gwd_project_tau_impl.hpp
+++ b/components/eamxx/src/physics/gw/impl/gw_gwd_project_tau_impl.hpp
@@ -1,0 +1,38 @@
+#ifndef GW_GWD_PROJECT_TAU_IMPL_HPP
+#define GW_GWD_PROJECT_TAU_IMPL_HPP
+
+#include "gw_functions.hpp" // for ETI only but harmless for GPU
+
+namespace scream {
+namespace gw {
+
+/*
+ * Implementation of gw gwd_project_tau. Clients should NOT
+ * #include this file, but include gw_functions.hpp instead.
+ */
+
+template<typename S, typename D>
+KOKKOS_FUNCTION
+void Functions<S,D>::gwd_project_tau(
+// Inputs
+const Int& pver,
+const Int& pgwv,
+const Int& ncol,
+const Int& ngwv,
+const uview_1d<const Int>& tend_level,
+const uview_1d<const Spack>& tau,
+const uview_1d<const Spack>& ubi,
+const uview_1d<const Spack>& c,
+const uview_1d<const Spack>& xv,
+const uview_1d<const Spack>& yv,
+// Outputs
+const uview_1d<Spack>& taucd)
+{
+  // TODO
+  // Note, argument types may need tweaking. Generator is not always able to tell what needs to be packed
+}
+
+} // namespace gw
+} // namespace scream
+
+#endif

--- a/components/eamxx/src/physics/gw/impl/gw_momentum_energy_conservation_impl.hpp
+++ b/components/eamxx/src/physics/gw/impl/gw_momentum_energy_conservation_impl.hpp
@@ -1,0 +1,42 @@
+#ifndef GW_MOMENTUM_ENERGY_CONSERVATION_IMPL_HPP
+#define GW_MOMENTUM_ENERGY_CONSERVATION_IMPL_HPP
+
+#include "gw_functions.hpp" // for ETI only but harmless for GPU
+
+namespace scream {
+namespace gw {
+
+/*
+ * Implementation of gw momentum_energy_conservation. Clients should NOT
+ * #include this file, but include gw_functions.hpp instead.
+ */
+
+template<typename S, typename D>
+KOKKOS_FUNCTION
+void Functions<S,D>::momentum_energy_conservation(
+// Inputs
+const Int& pver,
+const Int& ncol,
+const uview_1d<const Int>& tend_level,
+const Spack& dt,
+const uview_1d<const Spack>& taucd,
+const uview_1d<const Spack>& pint,
+const uview_1d<const Spack>& pdel,
+const uview_1d<const Spack>& u,
+const uview_1d<const Spack>& v,
+// Inputs/Outputs
+const uview_1d<Spack>& dudt,
+const uview_1d<Spack>& dvdt,
+const uview_1d<Spack>& dsdt,
+const uview_1d<Spack>& utgw,
+const uview_1d<Spack>& vtgw,
+const uview_1d<Spack>& ttgw)
+{
+  // TODO
+  // Note, argument types may need tweaking. Generator is not always able to tell what needs to be packed
+}
+
+} // namespace gw
+} // namespace scream
+
+#endif

--- a/components/eamxx/src/physics/gw/tests/CMakeLists.txt
+++ b/components/eamxx/src/physics/gw/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ set(GW_TESTS_SRCS
     gw_gwd_compute_stress_profiles_and_diffusivities_tests.cpp
     gw_gwd_project_tau_tests.cpp
     gw_gwd_precalc_rhoi_tests.cpp
+    gw_gw_drag_prof_tests.cpp
 ) # GW_TESTS_SRCS
 
 # All tests should understand the same baseline args

--- a/components/eamxx/src/physics/gw/tests/CMakeLists.txt
+++ b/components/eamxx/src/physics/gw/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ set(GW_TESTS_SRCS
     gw_momentum_energy_conservation_tests.cpp
     gw_gwd_compute_stress_profiles_and_diffusivities_tests.cpp
     gw_gwd_project_tau_tests.cpp
+    gw_gwd_precalc_rhoi_tests.cpp
 ) # GW_TESTS_SRCS
 
 # All tests should understand the same baseline args

--- a/components/eamxx/src/physics/gw/tests/CMakeLists.txt
+++ b/components/eamxx/src/physics/gw/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ set(GW_TESTS_SRCS
     gw_gwd_project_tau_tests.cpp
     gw_gwd_precalc_rhoi_tests.cpp
     gw_gw_drag_prof_tests.cpp
+    gw_gw_front_project_winds_tests.cpp
 ) # GW_TESTS_SRCS
 
 # All tests should understand the same baseline args

--- a/components/eamxx/src/physics/gw/tests/CMakeLists.txt
+++ b/components/eamxx/src/physics/gw/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ set(GW_TESTS_SRCS
     gw_gw_drag_prof_tests.cpp
     gw_gw_front_project_winds_tests.cpp
     gw_gw_front_gw_sources_tests.cpp
+    gw_gw_cm_src_tests.cpp
 ) # GW_TESTS_SRCS
 
 # All tests should understand the same baseline args

--- a/components/eamxx/src/physics/gw/tests/CMakeLists.txt
+++ b/components/eamxx/src/physics/gw/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ set(GW_TESTS_SRCS
     gw_gw_prof_tests.cpp
     gw_momentum_energy_conservation_tests.cpp
     gw_gwd_compute_stress_profiles_and_diffusivities_tests.cpp
+    gw_gwd_project_tau_tests.cpp
 ) # GW_TESTS_SRCS
 
 # All tests should understand the same baseline args

--- a/components/eamxx/src/physics/gw/tests/CMakeLists.txt
+++ b/components/eamxx/src/physics/gw/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ set(GW_TESTS_SRCS
     gw_gwd_precalc_rhoi_tests.cpp
     gw_gw_drag_prof_tests.cpp
     gw_gw_front_project_winds_tests.cpp
+    gw_gw_front_gw_sources_tests.cpp
 ) # GW_TESTS_SRCS
 
 # All tests should understand the same baseline args

--- a/components/eamxx/src/physics/gw/tests/CMakeLists.txt
+++ b/components/eamxx/src/physics/gw/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ add_subdirectory(infra)
 
 set(GW_TESTS_SRCS
     gw_gwd_compute_tendencies_from_stress_divergence_tests.cpp
+    gw_gw_prof_tests.cpp
 ) # GW_TESTS_SRCS
 
 # All tests should understand the same baseline args

--- a/components/eamxx/src/physics/gw/tests/CMakeLists.txt
+++ b/components/eamxx/src/physics/gw/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ set(GW_TESTS_SRCS
     gw_gwd_compute_tendencies_from_stress_divergence_tests.cpp
     gw_gw_prof_tests.cpp
     gw_momentum_energy_conservation_tests.cpp
+    gw_gwd_compute_stress_profiles_and_diffusivities_tests.cpp
 ) # GW_TESTS_SRCS
 
 # All tests should understand the same baseline args

--- a/components/eamxx/src/physics/gw/tests/CMakeLists.txt
+++ b/components/eamxx/src/physics/gw/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ add_subdirectory(infra)
 set(GW_TESTS_SRCS
     gw_gwd_compute_tendencies_from_stress_divergence_tests.cpp
     gw_gw_prof_tests.cpp
+    gw_momentum_energy_conservation_tests.cpp
 ) # GW_TESTS_SRCS
 
 # All tests should understand the same baseline args

--- a/components/eamxx/src/physics/gw/tests/gw_gw_cm_src_tests.cpp
+++ b/components/eamxx/src/physics/gw/tests/gw_gw_cm_src_tests.cpp
@@ -1,0 +1,142 @@
+#include "catch2/catch.hpp"
+
+#include "share/eamxx_types.hpp"
+#include "ekat/ekat_pack.hpp"
+#include "ekat/kokkos/ekat_kokkos_utils.hpp"
+#include "physics/gw/gw_functions.hpp"
+#include "physics/gw/tests/infra/gw_test_data.hpp"
+
+#include "gw_unit_tests_common.hpp"
+
+namespace scream {
+namespace gw {
+namespace unit_test {
+
+template <typename D>
+struct UnitWrap::UnitTest<D>::TestGwCmSrc : public UnitWrap::UnitTest<D>::Base {
+
+  void run_bfb()
+  {
+    auto engine = Base::get_engine();
+
+    // Set up init data
+    GwInit init_data[] = {
+          // pver, pgwv,   dc, orog_only, molec_diff, tau_0_ubc, nbot_molec, ktop, kbotbg, fcrit2, kwv
+      GwInit(  72,   20, 0.75,     false,      false,     false,         16,   60,     16,    .67, 6.28e-5),
+      GwInit(  72,   20, 0.75,     true ,      false,     true ,         16,   60,     16,    .67, 6.28e-5),
+      GwInit(  72,   20, 0.75,     false,      true ,     true ,         16,   60,     16,    .67, 6.28e-5),
+      GwInit(  72,   20, 0.75,     true ,      true ,     false,         16,   60,     16,    .67, 6.28e-5),
+    };
+
+    for (auto& d : init_data) {
+      d.randomize(engine);
+    }
+
+    // Set up init data
+    GwFrontInitData front_init_data[] = {
+                // taubgnd,  frontgfc_in, kfront_in, init
+      GwFrontInitData(  .1,           .4,        10, init_data[0]),
+      GwFrontInitData(  .2,           .5,        11, init_data[1]),
+      GwFrontInitData(  .3,           .6,        12, init_data[2]),
+      GwFrontInitData(  .4,           .7,        13, init_data[3]),
+    };
+
+    for (auto& d : front_init_data) {
+      d.randomize(engine);
+    }
+
+    // Set up inputs
+    GwCmSrcData baseline_data[] = {
+      GwCmSrcData(2, 10, 3, front_init_data[0]),
+      GwCmSrcData(3, 11, 4, front_init_data[1]),
+      GwCmSrcData(4, 12, 5, front_init_data[2]),
+      GwCmSrcData(5, 13, 6, front_init_data[3]),
+    };
+
+    static constexpr Int num_runs = sizeof(baseline_data) / sizeof(GwCmSrcData);
+
+    // Generate random input data
+    // Alternatively, you can use the baseline_data construtors/initializer lists to hardcode data
+    for (auto& d : baseline_data) {
+      d.randomize(engine);
+    }
+
+    // Create copies of data for use by test. Needs to happen before read calls so that
+    // inout data is in original state
+    GwCmSrcData test_data[] = {
+      GwCmSrcData(baseline_data[0]),
+      GwCmSrcData(baseline_data[1]),
+      GwCmSrcData(baseline_data[2]),
+      GwCmSrcData(baseline_data[3]),
+    };
+
+    // Read baseline data
+    if (this->m_baseline_action == COMPARE) {
+      for (auto& d : baseline_data) {
+        d.read(Base::m_fid);
+      }
+    }
+
+    // Get data from test
+    for (auto& d : test_data) {
+      gw_cm_src(d);
+    }
+
+    // Verify BFB results, all data should be in C layout
+    if (SCREAM_BFB_TESTING && this->m_baseline_action == COMPARE) {
+      for (Int i = 0; i < num_runs; ++i) {
+        GwCmSrcData& d_baseline = baseline_data[i];
+        GwCmSrcData& d_test = test_data[i];
+        for (Int k = 0; k < d_baseline.total(d_baseline.tau); ++k) {
+          REQUIRE(d_baseline.total(d_baseline.tau) == d_test.total(d_test.tau));
+          REQUIRE(d_baseline.tau[k] == d_test.tau[k]);
+        }
+        for (Int k = 0; k < d_baseline.total(d_baseline.ubm); ++k) {
+          REQUIRE(d_baseline.total(d_baseline.ubm) == d_test.total(d_test.ubm));
+          REQUIRE(d_baseline.ubm[k] == d_test.ubm[k]);
+        }
+        for (Int k = 0; k < d_baseline.total(d_baseline.ubi); ++k) {
+          REQUIRE(d_baseline.total(d_baseline.ubi) == d_test.total(d_test.ubi));
+          REQUIRE(d_baseline.ubi[k] == d_test.ubi[k]);
+        }
+        for (Int k = 0; k < d_baseline.total(d_baseline.xv); ++k) {
+          REQUIRE(d_baseline.total(d_baseline.xv) == d_test.total(d_test.xv));
+          REQUIRE(d_baseline.xv[k] == d_test.xv[k]);
+          REQUIRE(d_baseline.total(d_baseline.xv) == d_test.total(d_test.yv));
+          REQUIRE(d_baseline.yv[k] == d_test.yv[k]);
+          REQUIRE(d_baseline.total(d_baseline.xv) == d_test.total(d_test.src_level));
+          REQUIRE(d_baseline.src_level[k] == d_test.src_level[k]);
+          REQUIRE(d_baseline.total(d_baseline.xv) == d_test.total(d_test.tend_level));
+          REQUIRE(d_baseline.tend_level[k] == d_test.tend_level[k]);
+        }
+        for (Int k = 0; k < d_baseline.total(d_baseline.c); ++k) {
+          REQUIRE(d_baseline.total(d_baseline.c) == d_test.total(d_test.c));
+          REQUIRE(d_baseline.c[k] == d_test.c[k]);
+        }
+
+      }
+    }
+    else if (this->m_baseline_action == GENERATE) {
+      for (Int i = 0; i < num_runs; ++i) {
+        test_data[i].write(Base::m_fid);
+      }
+    }
+  } // run_bfb
+
+};
+
+} // namespace unit_test
+} // namespace gw
+} // namespace scream
+
+namespace {
+
+TEST_CASE("gw_cm_src_bfb", "[gw]")
+{
+  using TestStruct = scream::gw::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestGwCmSrc;
+
+  TestStruct t;
+  t.run_bfb();
+}
+
+} // empty namespace

--- a/components/eamxx/src/physics/gw/tests/gw_gw_drag_prof_tests.cpp
+++ b/components/eamxx/src/physics/gw/tests/gw_gw_drag_prof_tests.cpp
@@ -1,0 +1,135 @@
+#include "catch2/catch.hpp"
+
+#include "share/eamxx_types.hpp"
+#include "ekat/ekat_pack.hpp"
+#include "ekat/kokkos/ekat_kokkos_utils.hpp"
+#include "physics/gw/gw_functions.hpp"
+#include "physics/gw/tests/infra/gw_test_data.hpp"
+
+#include "gw_unit_tests_common.hpp"
+
+namespace scream {
+namespace gw {
+namespace unit_test {
+
+template <typename D>
+struct UnitWrap::UnitTest<D>::TestGwDragProf : public UnitWrap::UnitTest<D>::Base {
+
+  void run_bfb()
+  {
+    auto engine = Base::get_engine();
+
+    // Set up init data
+    GwInit init_data[] = {
+          // pver, pgwv,   dc, orog_only, molec_diff, tau_0_ubc, nbot_molec, ktop, kbotbg, fcrit2, kwv
+      GwInit(  72,   20, 0.75,     false,      false,     false,         16,   60,     16,    .67, 6.28e-5),
+      GwInit(  72,   20, 0.75,     true ,      false,     true ,         16,   60,     16,    .67, 6.28e-5),
+      GwInit(  72,   20, 0.75,     false,      true ,     true ,         16,   60,     16,    .67, 6.28e-5),
+      GwInit(  72,   20, 0.75,     true ,      true ,     false,         16,   60,     16,    .67, 6.28e-5),
+    };
+
+    for (auto& d : init_data) {
+      d.randomize(engine);
+    }
+
+    // Set up inputs
+    GwDragProfData baseline_data[] = {
+      GwDragProfData(5, 2, 10, true, .4, 1.8, init_data[0]),
+      GwDragProfData(6, 3, 11, false, .8, 2.4, init_data[1]),
+      GwDragProfData(7, 4, 12, true, 1.4, 3.4, init_data[2]),
+      GwDragProfData(8, 5, 13, false, 2.4, 4.4, init_data[3]),
+    };
+
+    static constexpr Int num_runs = sizeof(baseline_data) / sizeof(GwDragProfData);
+
+    // Generate random input data
+    // Alternatively, you can use the baseline_data construtors/initializer lists to hardcode data
+    for (auto& d : baseline_data) {
+      d.randomize(engine);
+    }
+
+    // Create copies of data for use by test. Needs to happen before read calls so that
+    // inout data is in original state
+    GwDragProfData test_data[] = {
+      GwDragProfData(baseline_data[0]),
+      GwDragProfData(baseline_data[1]),
+      GwDragProfData(baseline_data[2]),
+      GwDragProfData(baseline_data[3]),
+    };
+
+    // Read baseline data
+    if (this->m_baseline_action == COMPARE) {
+      for (auto& d : baseline_data) {
+        d.read(Base::m_fid);
+      }
+    }
+
+    // Get data from test
+    for (auto& d : test_data) {
+      gw_drag_prof(d);
+    }
+
+    // Verify BFB results, all data should be in C layout
+    if (SCREAM_BFB_TESTING && this->m_baseline_action == COMPARE) {
+      for (Int i = 0; i < num_runs; ++i) {
+        GwDragProfData& d_baseline = baseline_data[i];
+        GwDragProfData& d_test = test_data[i];
+        for (Int k = 0; k < d_baseline.total(d_baseline.tau); ++k) {
+          REQUIRE(d_baseline.total(d_baseline.tau) == d_test.total(d_test.tau));
+          REQUIRE(d_baseline.tau[k] == d_test.tau[k]);
+        }
+        for (Int k = 0; k < d_baseline.total(d_baseline.utgw); ++k) {
+          REQUIRE(d_baseline.total(d_baseline.utgw) == d_test.total(d_test.utgw));
+          REQUIRE(d_baseline.utgw[k] == d_test.utgw[k]);
+          REQUIRE(d_baseline.total(d_baseline.utgw) == d_test.total(d_test.vtgw));
+          REQUIRE(d_baseline.vtgw[k] == d_test.vtgw[k]);
+          REQUIRE(d_baseline.total(d_baseline.utgw) == d_test.total(d_test.ttgw));
+          REQUIRE(d_baseline.ttgw[k] == d_test.ttgw[k]);
+          REQUIRE(d_baseline.total(d_baseline.utgw) == d_test.total(d_test.dttdf));
+          REQUIRE(d_baseline.dttdf[k] == d_test.dttdf[k]);
+          REQUIRE(d_baseline.total(d_baseline.utgw) == d_test.total(d_test.dttke));
+          REQUIRE(d_baseline.dttke[k] == d_test.dttke[k]);
+        }
+        for (Int k = 0; k < d_baseline.total(d_baseline.qtgw); ++k) {
+          REQUIRE(d_baseline.total(d_baseline.qtgw) == d_test.total(d_test.qtgw));
+          REQUIRE(d_baseline.qtgw[k] == d_test.qtgw[k]);
+        }
+        for (Int k = 0; k < d_baseline.total(d_baseline.taucd); ++k) {
+          REQUIRE(d_baseline.total(d_baseline.taucd) == d_test.total(d_test.taucd));
+          REQUIRE(d_baseline.taucd[k] == d_test.taucd[k]);
+        }
+        for (Int k = 0; k < d_baseline.total(d_baseline.egwdffi); ++k) {
+          REQUIRE(d_baseline.total(d_baseline.egwdffi) == d_test.total(d_test.egwdffi));
+          REQUIRE(d_baseline.egwdffi[k] == d_test.egwdffi[k]);
+        }
+        for (Int k = 0; k < d_baseline.total(d_baseline.gwut); ++k) {
+          REQUIRE(d_baseline.total(d_baseline.gwut) == d_test.total(d_test.gwut));
+          REQUIRE(d_baseline.gwut[k] == d_test.gwut[k]);
+        }
+
+      }
+    }
+    else if (this->m_baseline_action == GENERATE) {
+      for (Int i = 0; i < num_runs; ++i) {
+        test_data[i].write(Base::m_fid);
+      }
+    }
+  } // run_bfb
+
+};
+
+} // namespace unit_test
+} // namespace gw
+} // namespace scream
+
+namespace {
+
+TEST_CASE("gw_drag_prof_bfb", "[gw]")
+{
+  using TestStruct = scream::gw::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestGwDragProf;
+
+  TestStruct t;
+  t.run_bfb();
+}
+
+} // empty namespace

--- a/components/eamxx/src/physics/gw/tests/gw_gw_front_gw_sources_tests.cpp
+++ b/components/eamxx/src/physics/gw/tests/gw_gw_front_gw_sources_tests.cpp
@@ -1,0 +1,120 @@
+#include "catch2/catch.hpp"
+
+#include "share/eamxx_types.hpp"
+#include "ekat/ekat_pack.hpp"
+#include "ekat/kokkos/ekat_kokkos_utils.hpp"
+#include "physics/gw/gw_functions.hpp"
+#include "physics/gw/tests/infra/gw_test_data.hpp"
+
+#include "gw_unit_tests_common.hpp"
+
+namespace scream {
+namespace gw {
+namespace unit_test {
+
+template <typename D>
+struct UnitWrap::UnitTest<D>::TestGwFrontGwSources : public UnitWrap::UnitTest<D>::Base {
+
+  void run_bfb()
+  {
+    auto engine = Base::get_engine();
+
+    // Set up init data
+    GwInit init_data[] = {
+          // pver, pgwv,   dc, orog_only, molec_diff, tau_0_ubc, nbot_molec, ktop, kbotbg, fcrit2, kwv
+      GwInit(  72,   20, 0.75,     false,      false,     false,         16,   60,     16,    .67, 6.28e-5),
+      GwInit(  72,   20, 0.75,     true ,      false,     true ,         16,   60,     16,    .67, 6.28e-5),
+      GwInit(  72,   20, 0.75,     false,      true ,     true ,         16,   60,     16,    .67, 6.28e-5),
+      GwInit(  72,   20, 0.75,     true ,      true ,     false,         16,   60,     16,    .67, 6.28e-5),
+    };
+
+    for (auto& d : init_data) {
+      d.randomize(engine);
+    }
+
+    // Set up init data
+    GwFrontInitData front_init_data[] = {
+                // taubgnd,  frontgfc_in, kfront_in, init
+      GwFrontInitData(  .1,           .4,        10, init_data[0]),
+      GwFrontInitData(  .2,           .5,        11, init_data[1]),
+      GwFrontInitData(  .3,           .6,        12, init_data[2]),
+      GwFrontInitData(  .4,           .7,        13, init_data[3]),
+    };
+
+    for (auto& d : front_init_data) {
+      d.randomize(engine);
+    }
+
+    // Set up inputs
+    GwFrontGwSourcesData baseline_data[] = {
+      GwFrontGwSourcesData(2, 10, 3, front_init_data[0]),
+      GwFrontGwSourcesData(3, 11, 4, front_init_data[1]),
+      GwFrontGwSourcesData(4, 12, 5, front_init_data[2]),
+      GwFrontGwSourcesData(5, 13, 6, front_init_data[3]),
+    };
+
+    static constexpr Int num_runs = sizeof(baseline_data) / sizeof(GwFrontGwSourcesData);
+
+    // Generate random input data
+    // Alternatively, you can use the baseline_data construtors/initializer lists to hardcode data
+    for (auto& d : baseline_data) {
+      d.randomize(engine);
+    }
+
+    // Create copies of data for use by test. Needs to happen before read calls so that
+    // inout data is in original state
+    GwFrontGwSourcesData test_data[] = {
+      GwFrontGwSourcesData(baseline_data[0]),
+      GwFrontGwSourcesData(baseline_data[1]),
+      GwFrontGwSourcesData(baseline_data[2]),
+      GwFrontGwSourcesData(baseline_data[3]),
+    };
+
+    // Read baseline data
+    if (this->m_baseline_action == COMPARE) {
+      for (auto& d : baseline_data) {
+        d.read(Base::m_fid);
+      }
+    }
+
+    // Get data from test
+    for (auto& d : test_data) {
+      gw_front_gw_sources(d);
+    }
+
+    // Verify BFB results, all data should be in C layout
+    if (SCREAM_BFB_TESTING && this->m_baseline_action == COMPARE) {
+      for (Int i = 0; i < num_runs; ++i) {
+        GwFrontGwSourcesData& d_baseline = baseline_data[i];
+        GwFrontGwSourcesData& d_test = test_data[i];
+        for (Int k = 0; k < d_baseline.total(d_baseline.tau); ++k) {
+          REQUIRE(d_baseline.total(d_baseline.tau) == d_test.total(d_test.tau));
+          REQUIRE(d_baseline.tau[k] == d_test.tau[k]);
+        }
+
+      }
+    }
+    else if (this->m_baseline_action == GENERATE) {
+      for (Int i = 0; i < num_runs; ++i) {
+        test_data[i].write(Base::m_fid);
+      }
+    }
+  } // run_bfb
+
+};
+
+} // namespace unit_test
+} // namespace gw
+} // namespace scream
+
+namespace {
+
+TEST_CASE("gw_front_gw_sources_bfb", "[gw]")
+{
+  using TestStruct = scream::gw::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestGwFrontGwSources;
+
+  TestStruct t;
+  t.run_bfb();
+}
+
+} // empty namespace

--- a/components/eamxx/src/physics/gw/tests/gw_gw_front_project_winds_tests.cpp
+++ b/components/eamxx/src/physics/gw/tests/gw_gw_front_project_winds_tests.cpp
@@ -1,0 +1,130 @@
+#include "catch2/catch.hpp"
+
+#include "share/eamxx_types.hpp"
+#include "ekat/ekat_pack.hpp"
+#include "ekat/kokkos/ekat_kokkos_utils.hpp"
+#include "physics/gw/gw_functions.hpp"
+#include "physics/gw/tests/infra/gw_test_data.hpp"
+
+#include "gw_unit_tests_common.hpp"
+
+namespace scream {
+namespace gw {
+namespace unit_test {
+
+template <typename D>
+struct UnitWrap::UnitTest<D>::TestGwFrontProjectWinds : public UnitWrap::UnitTest<D>::Base {
+
+  void run_bfb()
+  {
+    auto engine = Base::get_engine();
+
+    // Set up init data
+    GwInit init_data[] = {
+          // pver, pgwv,   dc, orog_only, molec_diff, tau_0_ubc, nbot_molec, ktop, kbotbg, fcrit2, kwv
+      GwInit(  72,   20, 0.75,     false,      false,     false,         16,   60,     16,    .67, 6.28e-5),
+      GwInit(  72,   20, 0.75,     true ,      false,     true ,         16,   60,     16,    .67, 6.28e-5),
+      GwInit(  72,   20, 0.75,     false,      true ,     true ,         16,   60,     16,    .67, 6.28e-5),
+      GwInit(  72,   20, 0.75,     true ,      true ,     false,         16,   60,     16,    .67, 6.28e-5),
+    };
+
+    for (auto& d : init_data) {
+      d.randomize(engine);
+    }
+
+    // Set up init data
+    GwFrontInitData front_init_data[] = {
+                // taubgnd,  frontgfc_in, kfront_in, init
+      GwFrontInitData(  .1,           .4,        10, init_data[0]),
+      GwFrontInitData(  .2,           .5,        11, init_data[1]),
+      GwFrontInitData(  .3,           .6,        12, init_data[2]),
+      GwFrontInitData(  .4,           .7,        13, init_data[3]),
+    };
+
+    for (auto& d : front_init_data) {
+      d.randomize(engine);
+    }
+
+    // Set up inputs
+    GwFrontProjectWindsData baseline_data[] = {
+      GwFrontProjectWindsData(10, 60, front_init_data[0]),
+      GwFrontProjectWindsData(11, 61, front_init_data[1]),
+      GwFrontProjectWindsData(12, 62, front_init_data[2]),
+      GwFrontProjectWindsData(13, 63, front_init_data[3]),
+    };
+
+    static constexpr Int num_runs = sizeof(baseline_data) / sizeof(GwFrontProjectWindsData);
+
+    // Generate random input data
+    // Alternatively, you can use the baseline_data construtors/initializer lists to hardcode data
+    for (auto& d : baseline_data) {
+      d.randomize(engine);
+    }
+
+    // Create copies of data for use by test. Needs to happen before read calls so that
+    // inout data is in original state
+    GwFrontProjectWindsData test_data[] = {
+      GwFrontProjectWindsData(baseline_data[0]),
+      GwFrontProjectWindsData(baseline_data[1]),
+      GwFrontProjectWindsData(baseline_data[2]),
+      GwFrontProjectWindsData(baseline_data[3]),
+    };
+
+    // Read baseline data
+    if (this->m_baseline_action == COMPARE) {
+      for (auto& d : baseline_data) {
+        d.read(Base::m_fid);
+      }
+    }
+
+    // Get data from test
+    for (auto& d : test_data) {
+      gw_front_project_winds(d);
+    }
+
+    // Verify BFB results, all data should be in C layout
+    if (SCREAM_BFB_TESTING && this->m_baseline_action == COMPARE) {
+      for (Int i = 0; i < num_runs; ++i) {
+        GwFrontProjectWindsData& d_baseline = baseline_data[i];
+        GwFrontProjectWindsData& d_test = test_data[i];
+        for (Int k = 0; k < d_baseline.total(d_baseline.xv); ++k) {
+          REQUIRE(d_baseline.total(d_baseline.xv) == d_test.total(d_test.xv));
+          REQUIRE(d_baseline.xv[k] == d_test.xv[k]);
+          REQUIRE(d_baseline.total(d_baseline.xv) == d_test.total(d_test.yv));
+          REQUIRE(d_baseline.yv[k] == d_test.yv[k]);
+        }
+        for (Int k = 0; k < d_baseline.total(d_baseline.ubm); ++k) {
+          REQUIRE(d_baseline.total(d_baseline.ubm) == d_test.total(d_test.ubm));
+          REQUIRE(d_baseline.ubm[k] == d_test.ubm[k]);
+        }
+        for (Int k = 0; k < d_baseline.total(d_baseline.ubi); ++k) {
+          REQUIRE(d_baseline.total(d_baseline.ubi) == d_test.total(d_test.ubi));
+          REQUIRE(d_baseline.ubi[k] == d_test.ubi[k]);
+        }
+
+      }
+    }
+    else if (this->m_baseline_action == GENERATE) {
+      for (Int i = 0; i < num_runs; ++i) {
+        test_data[i].write(Base::m_fid);
+      }
+    }
+  } // run_bfb
+
+};
+
+} // namespace unit_test
+} // namespace gw
+} // namespace scream
+
+namespace {
+
+TEST_CASE("gw_front_project_winds_bfb", "[gw]")
+{
+  using TestStruct = scream::gw::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestGwFrontProjectWinds;
+
+  TestStruct t;
+  t.run_bfb();
+}
+
+} // empty namespace

--- a/components/eamxx/src/physics/gw/tests/gw_gw_prof_tests.cpp
+++ b/components/eamxx/src/physics/gw/tests/gw_gw_prof_tests.cpp
@@ -1,0 +1,111 @@
+#include "catch2/catch.hpp"
+
+#include "share/eamxx_types.hpp"
+#include "ekat/ekat_pack.hpp"
+#include "ekat/kokkos/ekat_kokkos_utils.hpp"
+#include "physics/gw/gw_functions.hpp"
+#include "physics/gw/tests/infra/gw_test_data.hpp"
+
+#include "gw_unit_tests_common.hpp"
+
+namespace scream {
+namespace gw {
+namespace unit_test {
+
+template <typename D>
+struct UnitWrap::UnitTest<D>::TestGwProf : public UnitWrap::UnitTest<D>::Base {
+
+  void run_bfb()
+  {
+    auto engine = Base::get_engine();
+
+    // Set up init data
+    GwInit init_data[] = {
+          // pver, pgwv,   dc, orog_only, molec_diff, tau_0_ubc, nbot_molec, ktop, kbotbg, fcrit2, kwv
+      GwInit(  72,   20, 0.75,     false,      false,     false,         16,   60,     16,    .67, 6.28e-5),
+      GwInit(  72,   20, 0.75,     true ,      false,     true ,         16,   60,     16,    .67, 6.28e-5),
+      GwInit(  72,   20, 0.75,     false,      true ,     true ,         16,   60,     16,    .67, 6.28e-5),
+      GwInit(  72,   20, 0.75,     true ,      true ,     false,         16,   60,     16,    .67, 6.28e-5),
+    };
+
+    // Set up inputs
+    GwProfData baseline_data[] = {
+      GwProfData(2, .4,  init_data[0]),
+      GwProfData(3, .8,  init_data[1]),
+      GwProfData(4, 1.4, init_data[2]),
+      GwProfData(5, 2.4, init_data[3]),
+    };
+
+    static constexpr Int num_runs = sizeof(baseline_data) / sizeof(GwProfData);
+
+    // Generate random input data
+    // Alternatively, you can use the baseline_data construtors/initializer lists to hardcode data
+    for (auto& d : baseline_data) {
+      d.randomize(engine);
+    }
+
+    // Create copies of data for use by test. Needs to happen before read calls so that
+    // inout data is in original state
+    GwProfData test_data[] = {
+      GwProfData(baseline_data[0]),
+      GwProfData(baseline_data[1]),
+      GwProfData(baseline_data[2]),
+      GwProfData(baseline_data[3]),
+    };
+
+    // Read baseline data
+    if (this->m_baseline_action == COMPARE) {
+      for (auto& d : baseline_data) {
+        d.read(Base::m_fid);
+      }
+    }
+
+    // Get data from test
+    for (auto& d : test_data) {
+      gw_prof(d);
+    }
+
+    // Verify BFB results, all data should be in C layout
+    if (SCREAM_BFB_TESTING && this->m_baseline_action == COMPARE) {
+      for (Int i = 0; i < num_runs; ++i) {
+        GwProfData& d_baseline = baseline_data[i];
+        GwProfData& d_test = test_data[i];
+        for (Int k = 0; k < d_baseline.total(d_baseline.rhoi); ++k) {
+          REQUIRE(d_baseline.total(d_baseline.rhoi) == d_test.total(d_test.rhoi));
+          REQUIRE(d_baseline.rhoi[k] == d_test.rhoi[k]);
+          REQUIRE(d_baseline.total(d_baseline.rhoi) == d_test.total(d_test.ti));
+          REQUIRE(d_baseline.ti[k] == d_test.ti[k]);
+          REQUIRE(d_baseline.total(d_baseline.rhoi) == d_test.total(d_test.ni));
+          REQUIRE(d_baseline.ni[k] == d_test.ni[k]);
+        }
+        for (Int k = 0; k < d_baseline.total(d_baseline.nm); ++k) {
+          REQUIRE(d_baseline.total(d_baseline.nm) == d_test.total(d_test.nm));
+          REQUIRE(d_baseline.nm[k] == d_test.nm[k]);
+        }
+
+      }
+    }
+    else if (this->m_baseline_action == GENERATE) {
+      for (Int i = 0; i < num_runs; ++i) {
+        test_data[i].write(Base::m_fid);
+      }
+    }
+  } // run_bfb
+
+};
+
+} // namespace unit_test
+} // namespace gw
+} // namespace scream
+
+namespace {
+
+TEST_CASE("gw_prof_bfb", "[gw]")
+{
+  using TestStruct = scream::gw::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestGwProf;
+
+  TestStruct t;
+  t.run_bfb();
+}
+
+} // empty namespace

--- a/components/eamxx/src/physics/gw/tests/gw_gwd_compute_stress_profiles_and_diffusivities_tests.cpp
+++ b/components/eamxx/src/physics/gw/tests/gw_gwd_compute_stress_profiles_and_diffusivities_tests.cpp
@@ -1,0 +1,107 @@
+#include "catch2/catch.hpp"
+
+#include "share/eamxx_types.hpp"
+#include "ekat/ekat_pack.hpp"
+#include "ekat/kokkos/ekat_kokkos_utils.hpp"
+#include "physics/gw/gw_functions.hpp"
+#include "physics/gw/tests/infra/gw_test_data.hpp"
+
+#include "gw_unit_tests_common.hpp"
+
+namespace scream {
+namespace gw {
+namespace unit_test {
+
+template <typename D>
+struct UnitWrap::UnitTest<D>::TestGwdComputeStressProfilesAndDiffusivities : public UnitWrap::UnitTest<D>::Base {
+
+  void run_bfb()
+  {
+    auto engine = Base::get_engine();
+
+    // Set up init data
+    GwInit init_data[] = {
+          // pver, pgwv,   dc, orog_only, molec_diff, tau_0_ubc, nbot_molec, ktop, kbotbg, fcrit2, kwv
+      GwInit(  72,   20, 0.75,     false,      false,     false,         16,   60,     16,    .67, 6.28e-5),
+      GwInit(  72,   20, 0.75,     true ,      false,     true ,         16,   60,     16,    .67, 6.28e-5),
+      GwInit(  72,   20, 0.75,     false,      true ,     true ,         16,   60,     16,    .67, 6.28e-5),
+      GwInit(  72,   20, 0.75,     true ,      true ,     false,         16,   60,     16,    .67, 6.28e-5),
+    };
+
+    for (auto& d : init_data) {
+      d.randomize(engine);
+    }
+
+    // Set up inputs
+    GwdComputeStressProfilesAndDiffusivitiesData baseline_data[] = {
+      GwdComputeStressProfilesAndDiffusivitiesData(2, 10, init_data[0]),
+      GwdComputeStressProfilesAndDiffusivitiesData(3, 11, init_data[1]),
+      GwdComputeStressProfilesAndDiffusivitiesData(4, 12, init_data[2]),
+      GwdComputeStressProfilesAndDiffusivitiesData(5, 13, init_data[3]),
+    };
+
+    static constexpr Int num_runs = sizeof(baseline_data) / sizeof(GwdComputeStressProfilesAndDiffusivitiesData);
+
+    // Generate random input data
+    // Alternatively, you can use the baseline_data construtors/initializer lists to hardcode data
+    for (auto& d : baseline_data) {
+      d.randomize(engine);
+    }
+
+    // Create copies of data for use by test. Needs to happen before read calls so that
+    // inout data is in original state
+    GwdComputeStressProfilesAndDiffusivitiesData test_data[] = {
+      GwdComputeStressProfilesAndDiffusivitiesData(baseline_data[0]),
+      GwdComputeStressProfilesAndDiffusivitiesData(baseline_data[1]),
+      GwdComputeStressProfilesAndDiffusivitiesData(baseline_data[2]),
+      GwdComputeStressProfilesAndDiffusivitiesData(baseline_data[3]),
+    };
+
+    // Read baseline data
+    if (this->m_baseline_action == COMPARE) {
+      for (auto& d : baseline_data) {
+        d.read(Base::m_fid);
+      }
+    }
+
+    // Get data from test
+    for (auto& d : test_data) {
+      gwd_compute_stress_profiles_and_diffusivities(d);
+    }
+
+    // Verify BFB results, all data should be in C layout
+    if (SCREAM_BFB_TESTING && this->m_baseline_action == COMPARE) {
+      for (Int i = 0; i < num_runs; ++i) {
+        GwdComputeStressProfilesAndDiffusivitiesData& d_baseline = baseline_data[i];
+        GwdComputeStressProfilesAndDiffusivitiesData& d_test = test_data[i];
+        for (Int k = 0; k < d_baseline.total(d_baseline.tau); ++k) {
+          REQUIRE(d_baseline.total(d_baseline.tau) == d_test.total(d_test.tau));
+          REQUIRE(d_baseline.tau[k] == d_test.tau[k]);
+        }
+
+      }
+    }
+    else if (this->m_baseline_action == GENERATE) {
+      for (Int i = 0; i < num_runs; ++i) {
+        test_data[i].write(Base::m_fid);
+      }
+    }
+  } // run_bfb
+
+};
+
+} // namespace unit_test
+} // namespace gw
+} // namespace scream
+
+namespace {
+
+TEST_CASE("gwd_compute_stress_profiles_and_diffusivities_bfb", "[gw]")
+{
+  using TestStruct = scream::gw::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestGwdComputeStressProfilesAndDiffusivities;
+
+  TestStruct t;
+  t.run_bfb();
+}
+
+} // empty namespace

--- a/components/eamxx/src/physics/gw/tests/gw_gwd_compute_tendencies_from_stress_divergence_tests.cpp
+++ b/components/eamxx/src/physics/gw/tests/gw_gwd_compute_tendencies_from_stress_divergence_tests.cpp
@@ -36,9 +36,9 @@ struct UnitWrap::UnitTest<D>::TestGwdComputeTendenciesFromStressDivergence : pub
     GwdComputeTendenciesFromStressDivergenceData baseline_data[] = {
       //                                        ncol, ngwv, do_taper,   dt, effgw, init
       GwdComputeTendenciesFromStressDivergenceData(2,   10,    false,  0.4,   0.3, init_data[0]),
-      GwdComputeTendenciesFromStressDivergenceData(3,   10,    false,  0.4,   0.3, init_data[0]),
-      GwdComputeTendenciesFromStressDivergenceData(4,   10,    true ,  0.4,   0.3, init_data[0]),
-      GwdComputeTendenciesFromStressDivergenceData(5,   10,    true ,  0.4,   0.3, init_data[0]),
+      GwdComputeTendenciesFromStressDivergenceData(3,   10,    false,  0.4,   0.3, init_data[1]),
+      GwdComputeTendenciesFromStressDivergenceData(4,   10,    true ,  0.4,   0.3, init_data[2]),
+      GwdComputeTendenciesFromStressDivergenceData(5,   10,    true ,  0.4,   0.3, init_data[3]),
     };
 
     static constexpr Int num_runs = sizeof(baseline_data) / sizeof(GwdComputeTendenciesFromStressDivergenceData);

--- a/components/eamxx/src/physics/gw/tests/gw_gwd_precalc_rhoi_tests.cpp
+++ b/components/eamxx/src/physics/gw/tests/gw_gwd_precalc_rhoi_tests.cpp
@@ -1,0 +1,119 @@
+#include "catch2/catch.hpp"
+
+#include "share/eamxx_types.hpp"
+#include "ekat/ekat_pack.hpp"
+#include "ekat/kokkos/ekat_kokkos_utils.hpp"
+#include "physics/gw/gw_functions.hpp"
+#include "physics/gw/tests/infra/gw_test_data.hpp"
+
+#include "gw_unit_tests_common.hpp"
+
+namespace scream {
+namespace gw {
+namespace unit_test {
+
+template <typename D>
+struct UnitWrap::UnitTest<D>::TestGwdPrecalcRhoi : public UnitWrap::UnitTest<D>::Base {
+
+  void run_bfb()
+  {
+    auto engine = Base::get_engine();
+
+    // Set up init data
+    GwInit init_data[] = {
+          // pver, pgwv,   dc, orog_only, molec_diff, tau_0_ubc, nbot_molec, ktop, kbotbg, fcrit2, kwv
+      GwInit(  72,   20, 0.75,     false,      false,     false,         16,   60,     16,    .67, 6.28e-5),
+      GwInit(  72,   20, 0.75,     true ,      false,     true ,         16,   60,     16,    .67, 6.28e-5),
+      GwInit(  72,   20, 0.75,     false,      true ,     true ,         16,   60,     16,    .67, 6.28e-5),
+      GwInit(  72,   20, 0.75,     true ,      true ,     false,         16,   60,     16,    .67, 6.28e-5),
+    };
+
+    for (auto& d : init_data) {
+      d.randomize(engine);
+    }
+
+    // Set up inputs
+    GwdPrecalcRhoiData baseline_data[] = {
+      GwdPrecalcRhoiData(5, 2, 10, .4, init_data[0]),
+      GwdPrecalcRhoiData(6, 3, 11, .8, init_data[1]),
+      GwdPrecalcRhoiData(7, 4, 12, 1.4, init_data[2]),
+      GwdPrecalcRhoiData(8, 5, 13, 2.4, init_data[3]),
+    };
+
+    static constexpr Int num_runs = sizeof(baseline_data) / sizeof(GwdPrecalcRhoiData);
+
+    // Generate random input data
+    // Alternatively, you can use the baseline_data construtors/initializer lists to hardcode data
+    for (auto& d : baseline_data) {
+      d.randomize(engine);
+    }
+
+    // Create copies of data for use by test. Needs to happen before read calls so that
+    // inout data is in original state
+    GwdPrecalcRhoiData test_data[] = {
+      GwdPrecalcRhoiData(baseline_data[0]),
+      GwdPrecalcRhoiData(baseline_data[1]),
+      GwdPrecalcRhoiData(baseline_data[2]),
+      GwdPrecalcRhoiData(baseline_data[3]),
+    };
+
+    // Read baseline data
+    if (this->m_baseline_action == COMPARE) {
+      for (auto& d : baseline_data) {
+        d.read(Base::m_fid);
+      }
+    }
+
+    // Get data from test
+    for (auto& d : test_data) {
+      gwd_precalc_rhoi(d);
+    }
+
+    // Verify BFB results, all data should be in C layout
+    if (SCREAM_BFB_TESTING && this->m_baseline_action == COMPARE) {
+      for (Int i = 0; i < num_runs; ++i) {
+        GwdPrecalcRhoiData& d_baseline = baseline_data[i];
+        GwdPrecalcRhoiData& d_test = test_data[i];
+        for (Int k = 0; k < d_baseline.total(d_baseline.egwdffi); ++k) {
+          REQUIRE(d_baseline.total(d_baseline.egwdffi) == d_test.total(d_test.egwdffi));
+          REQUIRE(d_baseline.egwdffi[k] == d_test.egwdffi[k]);
+        }
+        for (Int k = 0; k < d_baseline.total(d_baseline.qtgw); ++k) {
+          REQUIRE(d_baseline.total(d_baseline.qtgw) == d_test.total(d_test.qtgw));
+          REQUIRE(d_baseline.qtgw[k] == d_test.qtgw[k]);
+        }
+        for (Int k = 0; k < d_baseline.total(d_baseline.dttdf); ++k) {
+          REQUIRE(d_baseline.total(d_baseline.dttdf) == d_test.total(d_test.dttdf));
+          REQUIRE(d_baseline.dttdf[k] == d_test.dttdf[k]);
+          REQUIRE(d_baseline.total(d_baseline.dttdf) == d_test.total(d_test.dttke));
+          REQUIRE(d_baseline.dttke[k] == d_test.dttke[k]);
+          REQUIRE(d_baseline.total(d_baseline.dttdf) == d_test.total(d_test.ttgw));
+          REQUIRE(d_baseline.ttgw[k] == d_test.ttgw[k]);
+        }
+
+      }
+    }
+    else if (this->m_baseline_action == GENERATE) {
+      for (Int i = 0; i < num_runs; ++i) {
+        test_data[i].write(Base::m_fid);
+      }
+    }
+  } // run_bfb
+
+};
+
+} // namespace unit_test
+} // namespace gw
+} // namespace scream
+
+namespace {
+
+TEST_CASE("gwd_precalc_rhoi_bfb", "[gw]")
+{
+  using TestStruct = scream::gw::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestGwdPrecalcRhoi;
+
+  TestStruct t;
+  t.run_bfb();
+}
+
+} // empty namespace

--- a/components/eamxx/src/physics/gw/tests/gw_gwd_project_tau_tests.cpp
+++ b/components/eamxx/src/physics/gw/tests/gw_gwd_project_tau_tests.cpp
@@ -1,0 +1,107 @@
+#include "catch2/catch.hpp"
+
+#include "share/eamxx_types.hpp"
+#include "ekat/ekat_pack.hpp"
+#include "ekat/kokkos/ekat_kokkos_utils.hpp"
+#include "physics/gw/gw_functions.hpp"
+#include "physics/gw/tests/infra/gw_test_data.hpp"
+
+#include "gw_unit_tests_common.hpp"
+
+namespace scream {
+namespace gw {
+namespace unit_test {
+
+template <typename D>
+struct UnitWrap::UnitTest<D>::TestGwdProjectTau : public UnitWrap::UnitTest<D>::Base {
+
+  void run_bfb()
+  {
+    auto engine = Base::get_engine();
+
+    // Set up init data
+    GwInit init_data[] = {
+          // pver, pgwv,   dc, orog_only, molec_diff, tau_0_ubc, nbot_molec, ktop, kbotbg, fcrit2, kwv
+      GwInit(  72,   20, 0.75,     false,      false,     false,         16,   60,     16,    .67, 6.28e-5),
+      GwInit(  72,   20, 0.75,     true ,      false,     true ,         16,   60,     16,    .67, 6.28e-5),
+      GwInit(  72,   20, 0.75,     false,      true ,     true ,         16,   60,     16,    .67, 6.28e-5),
+      GwInit(  72,   20, 0.75,     true ,      true ,     false,         16,   60,     16,    .67, 6.28e-5),
+    };
+
+    for (auto& d : init_data) {
+      d.randomize(engine);
+    }
+
+    // Set up inputs
+    GwdProjectTauData baseline_data[] = {
+      GwdProjectTauData(2, 10, init_data[0]),
+      GwdProjectTauData(3, 11, init_data[1]),
+      GwdProjectTauData(4, 12, init_data[2]),
+      GwdProjectTauData(5, 13, init_data[3]),
+    };
+
+    static constexpr Int num_runs = sizeof(baseline_data) / sizeof(GwdProjectTauData);
+
+    // Generate random input data
+    // Alternatively, you can use the baseline_data construtors/initializer lists to hardcode data
+    for (auto& d : baseline_data) {
+      d.randomize(engine);
+    }
+
+    // Create copies of data for use by test. Needs to happen before read calls so that
+    // inout data is in original state
+    GwdProjectTauData test_data[] = {
+      GwdProjectTauData(baseline_data[0]),
+      GwdProjectTauData(baseline_data[1]),
+      GwdProjectTauData(baseline_data[2]),
+      GwdProjectTauData(baseline_data[3]),
+    };
+
+    // Read baseline data
+    if (this->m_baseline_action == COMPARE) {
+      for (auto& d : baseline_data) {
+        d.read(Base::m_fid);
+      }
+    }
+
+    // Get data from test
+    for (auto& d : test_data) {
+      gwd_project_tau(d);
+    }
+
+    // Verify BFB results, all data should be in C layout
+    if (SCREAM_BFB_TESTING && this->m_baseline_action == COMPARE) {
+      for (Int i = 0; i < num_runs; ++i) {
+        GwdProjectTauData& d_baseline = baseline_data[i];
+        GwdProjectTauData& d_test = test_data[i];
+        for (Int k = 0; k < d_baseline.total(d_baseline.taucd); ++k) {
+          REQUIRE(d_baseline.total(d_baseline.taucd) == d_test.total(d_test.taucd));
+          REQUIRE(d_baseline.taucd[k] == d_test.taucd[k]);
+        }
+
+      }
+    }
+    else if (this->m_baseline_action == GENERATE) {
+      for (Int i = 0; i < num_runs; ++i) {
+        test_data[i].write(Base::m_fid);
+      }
+    }
+  } // run_bfb
+
+};
+
+} // namespace unit_test
+} // namespace gw
+} // namespace scream
+
+namespace {
+
+TEST_CASE("gwd_project_tau_bfb", "[gw]")
+{
+  using TestStruct = scream::gw::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestGwdProjectTau;
+
+  TestStruct t;
+  t.run_bfb();
+}
+
+} // empty namespace

--- a/components/eamxx/src/physics/gw/tests/gw_momentum_energy_conservation_tests.cpp
+++ b/components/eamxx/src/physics/gw/tests/gw_momentum_energy_conservation_tests.cpp
@@ -13,7 +13,7 @@ namespace gw {
 namespace unit_test {
 
 template <typename D>
-struct UnitWrap::UnitTest<D>::TestGwProf : public UnitWrap::UnitTest<D>::Base {
+struct UnitWrap::UnitTest<D>::TestMomentumEnergyConservation : public UnitWrap::UnitTest<D>::Base {
 
   void run_bfb()
   {
@@ -33,14 +33,14 @@ struct UnitWrap::UnitTest<D>::TestGwProf : public UnitWrap::UnitTest<D>::Base {
     }
 
     // Set up inputs
-    GwProfData baseline_data[] = {
-      GwProfData(2, .4,  init_data[0]),
-      GwProfData(3, .8,  init_data[1]),
-      GwProfData(4, 1.4, init_data[2]),
-      GwProfData(5, 2.4, init_data[3]),
+    MomentumEnergyConservationData baseline_data[] = {
+      MomentumEnergyConservationData(2, .4, init_data[0]),
+      MomentumEnergyConservationData(3, .8, init_data[1]),
+      MomentumEnergyConservationData(4, 1.4, init_data[2]),
+      MomentumEnergyConservationData(5, 2.4, init_data[3]),
     };
 
-    static constexpr Int num_runs = sizeof(baseline_data) / sizeof(GwProfData);
+    static constexpr Int num_runs = sizeof(baseline_data) / sizeof(MomentumEnergyConservationData);
 
     // Generate random input data
     // Alternatively, you can use the baseline_data construtors/initializer lists to hardcode data
@@ -50,11 +50,11 @@ struct UnitWrap::UnitTest<D>::TestGwProf : public UnitWrap::UnitTest<D>::Base {
 
     // Create copies of data for use by test. Needs to happen before read calls so that
     // inout data is in original state
-    GwProfData test_data[] = {
-      GwProfData(baseline_data[0]),
-      GwProfData(baseline_data[1]),
-      GwProfData(baseline_data[2]),
-      GwProfData(baseline_data[3]),
+    MomentumEnergyConservationData test_data[] = {
+      MomentumEnergyConservationData(baseline_data[0]),
+      MomentumEnergyConservationData(baseline_data[1]),
+      MomentumEnergyConservationData(baseline_data[2]),
+      MomentumEnergyConservationData(baseline_data[3]),
     };
 
     // Read baseline data
@@ -66,25 +66,29 @@ struct UnitWrap::UnitTest<D>::TestGwProf : public UnitWrap::UnitTest<D>::Base {
 
     // Get data from test
     for (auto& d : test_data) {
-      gw_prof(d);
+      momentum_energy_conservation(d);
     }
 
     // Verify BFB results, all data should be in C layout
     if (SCREAM_BFB_TESTING && this->m_baseline_action == COMPARE) {
       for (Int i = 0; i < num_runs; ++i) {
-        GwProfData& d_baseline = baseline_data[i];
-        GwProfData& d_test = test_data[i];
-        for (Int k = 0; k < d_baseline.total(d_baseline.rhoi); ++k) {
-          REQUIRE(d_baseline.total(d_baseline.rhoi) == d_test.total(d_test.rhoi));
-          REQUIRE(d_baseline.rhoi[k] == d_test.rhoi[k]);
-          REQUIRE(d_baseline.total(d_baseline.rhoi) == d_test.total(d_test.ti));
-          REQUIRE(d_baseline.ti[k] == d_test.ti[k]);
-          REQUIRE(d_baseline.total(d_baseline.rhoi) == d_test.total(d_test.ni));
-          REQUIRE(d_baseline.ni[k] == d_test.ni[k]);
+        MomentumEnergyConservationData& d_baseline = baseline_data[i];
+        MomentumEnergyConservationData& d_test = test_data[i];
+        for (Int k = 0; k < d_baseline.total(d_baseline.dudt); ++k) {
+          REQUIRE(d_baseline.total(d_baseline.dudt) == d_test.total(d_test.dudt));
+          REQUIRE(d_baseline.dudt[k] == d_test.dudt[k]);
+          REQUIRE(d_baseline.total(d_baseline.dudt) == d_test.total(d_test.dvdt));
+          REQUIRE(d_baseline.dvdt[k] == d_test.dvdt[k]);
+          REQUIRE(d_baseline.total(d_baseline.dudt) == d_test.total(d_test.dsdt));
+          REQUIRE(d_baseline.dsdt[k] == d_test.dsdt[k]);
         }
-        for (Int k = 0; k < d_baseline.total(d_baseline.nm); ++k) {
-          REQUIRE(d_baseline.total(d_baseline.nm) == d_test.total(d_test.nm));
-          REQUIRE(d_baseline.nm[k] == d_test.nm[k]);
+        for (Int k = 0; k < d_baseline.total(d_baseline.utgw); ++k) {
+          REQUIRE(d_baseline.total(d_baseline.utgw) == d_test.total(d_test.utgw));
+          REQUIRE(d_baseline.utgw[k] == d_test.utgw[k]);
+          REQUIRE(d_baseline.total(d_baseline.utgw) == d_test.total(d_test.vtgw));
+          REQUIRE(d_baseline.vtgw[k] == d_test.vtgw[k]);
+          REQUIRE(d_baseline.total(d_baseline.utgw) == d_test.total(d_test.ttgw));
+          REQUIRE(d_baseline.ttgw[k] == d_test.ttgw[k]);
         }
 
       }
@@ -104,9 +108,9 @@ struct UnitWrap::UnitTest<D>::TestGwProf : public UnitWrap::UnitTest<D>::Base {
 
 namespace {
 
-TEST_CASE("gw_prof_bfb", "[gw]")
+TEST_CASE("momentum_energy_conservation_bfb", "[gw]")
 {
-  using TestStruct = scream::gw::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestGwProf;
+  using TestStruct = scream::gw::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestMomentumEnergyConservation;
 
   TestStruct t;
   t.run_bfb();

--- a/components/eamxx/src/physics/gw/tests/infra/gw_iso_c.f90
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_iso_c.f90
@@ -73,4 +73,17 @@ contains
 
     call momentum_energy_conservation(ncol, tend_level, dt, taucd, pint, pdel, u, v, dudt, dvdt, dsdt, utgw, vtgw, ttgw)
   end subroutine momentum_energy_conservation_c
+
+  subroutine gwd_compute_stress_profiles_and_diffusivities_c(ncol, ngwv, src_level, ubi, c, rhoi, ni, kvtt, t, ti, piln, tau) bind(C)
+    use gw_common, only : gwd_compute_stress_profiles_and_diffusivities, pver, pgwv
+
+    integer(kind=c_int) , value, intent(in) :: ncol, ngwv
+    integer(kind=c_int) , intent(in), dimension(ncol) :: src_level
+    real(kind=c_real) , intent(in), dimension(ncol, 0:pver) :: ubi, rhoi, ni, kvtt, ti, piln
+    real(kind=c_real) , intent(in), dimension(ncol, -pgwv:pgwv) :: c
+    real(kind=c_real) , intent(in), dimension(ncol, pver) :: t
+    real(kind=c_real) , intent(inout), dimension(ncol, -pgwv:pgwv, 0:pver) :: tau
+
+    call gwd_compute_stress_profiles_and_diffusivities(ncol, ngwv, src_level, ubi, c, rhoi, ni, kvtt, t, ti, piln, tau)
+  end subroutine gwd_compute_stress_profiles_and_diffusivities_c
 end module gw_iso_c

--- a/components/eamxx/src/physics/gw/tests/infra/gw_iso_c.f90
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_iso_c.f90
@@ -151,4 +151,17 @@ contains
 
     call gw_front_init(taubgnd, frontgfc_in, kfront_in, errstring)
   end subroutine gw_front_init_c
+
+  subroutine gw_front_project_winds_c(ncol, kbot, u, v, xv, yv, ubm, ubi) bind(C)
+    use gw_front, only : gw_front_project_winds
+    use gw_common, only : pver
+
+    integer(kind=c_int) , value, intent(in) :: ncol, kbot
+    real(kind=c_real) , intent(in), dimension(ncol, pver) :: u, v
+    real(kind=c_real) , intent(out), dimension(ncol) :: xv, yv
+    real(kind=c_real) , intent(out), dimension(ncol, pver) :: ubm
+    real(kind=c_real) , intent(out), dimension(ncol, 0:pver) :: ubi
+
+    call gw_front_project_winds(ncol, kbot, u, v, xv, yv, ubm, ubi)
+  end subroutine gw_front_project_winds_c
 end module gw_iso_c

--- a/components/eamxx/src/physics/gw/tests/infra/gw_iso_c.f90
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_iso_c.f90
@@ -175,4 +175,21 @@ contains
 
     call gw_front_gw_sources(ncol, ngwv, kbot, frontgf, tau)
   end subroutine gw_front_gw_sources_c
+
+  subroutine gw_cm_src_c(ncol, ngwv, kbot, u, v, frontgf, src_level, tend_level, tau, ubm, ubi, xv, yv, c) bind(C)
+    use gw_common, only : pver, pgwv
+    use gw_front, only : gw_cm_src
+
+    integer(kind=c_int) , value, intent(in) :: ncol, ngwv, kbot
+    real(kind=c_real) , intent(in), dimension(ncol, pver) :: u, v
+    real(kind=c_real) , intent(in), dimension(ncol, pver) :: frontgf
+    integer(kind=c_int) , intent(out), dimension(ncol) :: src_level, tend_level
+    real(kind=c_real) , intent(out), dimension(ncol, -pgwv:pgwv, 0:pver) :: tau
+    real(kind=c_real) , intent(out), dimension(ncol, pver) :: ubm
+    real(kind=c_real) , intent(out), dimension(ncol, 0:pver) :: ubi
+    real(kind=c_real) , intent(out), dimension(ncol) :: xv, yv
+    real(kind=c_real) , intent(out), dimension(ncol, -pgwv:pgwv) :: c
+
+    call gw_cm_src(ncol, ngwv, kbot, u, v, frontgf, src_level, tend_level, tau, ubm, ubi, xv, yv, c)
+  end subroutine gw_cm_src_c
 end module gw_iso_c

--- a/components/eamxx/src/physics/gw/tests/infra/gw_iso_c.f90
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_iso_c.f90
@@ -86,4 +86,18 @@ contains
 
     call gwd_compute_stress_profiles_and_diffusivities(ncol, ngwv, src_level, ubi, c, rhoi, ni, kvtt, t, ti, piln, tau)
   end subroutine gwd_compute_stress_profiles_and_diffusivities_c
+
+  subroutine gwd_project_tau_c(ncol, ngwv, tend_level, tau, ubi, c, xv, yv, taucd) bind(C)
+    use gw_common, only : gwd_project_tau, pver, pgwv
+
+    integer(kind=c_int) , value, intent(in) :: ncol, ngwv
+    integer(kind=c_int) , intent(in), dimension(ncol) :: tend_level
+    real(kind=c_real) , intent(in), dimension(ncol, -pgwv:pgwv, 0:pver) :: tau
+    real(kind=c_real) , intent(in), dimension(ncol, 0:pver) :: ubi
+    real(kind=c_real) , intent(in), dimension(ncol, -pgwv:pgwv) :: c
+    real(kind=c_real) , intent(in), dimension(ncol) :: xv, yv
+    real(kind=c_real) , intent(out), dimension(ncol, 0:pver, 4) :: taucd
+
+    call gwd_project_tau(ncol, ngwv, tend_level, tau, ubi, c, xv, yv, taucd)
+  end subroutine gwd_project_tau_c
 end module gw_iso_c

--- a/components/eamxx/src/physics/gw/tests/infra/gw_iso_c.f90
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_iso_c.f90
@@ -118,4 +118,26 @@ contains
 
     call gwd_precalc_rhoi(ncol, ngwv, dt, tend_level, pmid, pint, t, gwut, ubm, nm, rdpm, c, q, dse, egwdffi, qtgw, dttdf, dttke, ttgw)
   end subroutine gwd_precalc_rhoi_c
+
+  subroutine gw_drag_prof_c(pcnst, ncol, ngwv, src_level, tend_level, do_taper, dt, lat, t, ti, pmid, pint, dpm, rdpm, piln, rhoi, nm, ni, ubm, ubi, xv, yv, effgw, c, kvtt, q, dse, tau, utgw, vtgw, ttgw, qtgw, taucd, egwdffi, gwut, dttdf, dttke) bind(C)
+    use gw_common, only : gw_drag_prof, pver, pgwv
+
+    integer(kind=c_int) , value, intent(in) :: pcnst, ncol, ngwv
+    integer(kind=c_int) , intent(in), dimension(ncol) :: src_level, tend_level
+    logical(kind=c_bool) , value, intent(in) :: do_taper
+    real(kind=c_real) , value, intent(in) :: dt, effgw
+    real(kind=c_real) , intent(in), dimension(ncol) :: lat, xv, yv
+    real(kind=c_real) , intent(in), dimension(ncol, pver) :: t, pmid, dpm, rdpm, nm, ubm, dse
+    real(kind=c_real) , intent(in), dimension(ncol, 0:pver) :: ti, pint, piln, rhoi, ni, ubi, kvtt
+    real(kind=c_real) , intent(in), dimension(ncol, -pgwv:pgwv) :: c
+    real(kind=c_real) , intent(in), dimension(ncol, pver, pcnst) :: q
+    real(kind=c_real) , intent(inout), dimension(ncol, -pgwv:pgwv, 0:pver) :: tau
+    real(kind=c_real) , intent(out), dimension(ncol, pver) :: utgw, vtgw, ttgw, dttdf, dttke
+    real(kind=c_real) , intent(out), dimension(ncol, pver, pcnst) :: qtgw
+    real(kind=c_real) , intent(out), dimension(ncol, 0:pver, 4) :: taucd
+    real(kind=c_real) , intent(out), dimension(ncol, 0:pver) :: egwdffi
+    real(kind=c_real) , intent(out), dimension(ncol, pver, -ngwv:ngwv) :: gwut
+
+    call gw_drag_prof(ncol, ngwv, src_level, tend_level, do_taper, dt, lat, t, ti, pmid, pint, dpm, rdpm, piln, rhoi, nm, ni, ubm, ubi, xv, yv, effgw, c, kvtt, q, dse, tau, utgw, vtgw, ttgw, qtgw, taucd, egwdffi, gwut, dttdf, dttke)
+  end subroutine gw_drag_prof_c
 end module gw_iso_c

--- a/components/eamxx/src/physics/gw/tests/infra/gw_iso_c.f90
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_iso_c.f90
@@ -100,4 +100,22 @@ contains
 
     call gwd_project_tau(ncol, ngwv, tend_level, tau, ubi, c, xv, yv, taucd)
   end subroutine gwd_project_tau_c
+
+  subroutine gwd_precalc_rhoi_c(pcnst, ncol, ngwv, dt, tend_level, pmid, pint, t, gwut, ubm, nm, rdpm, c, q, dse, egwdffi, qtgw, dttdf, dttke, ttgw) bind(C)
+    use gw_common, only : gwd_precalc_rhoi, pver, pgwv
+
+    integer(kind=c_int) , value, intent(in) :: pcnst, ncol, ngwv
+    real(kind=c_real) , value, intent(in) :: dt
+    integer(kind=c_int) , intent(in), dimension(ncol) :: tend_level
+    real(kind=c_real) , intent(in), dimension(ncol, pver) :: pmid, t, ubm, nm, rdpm, dse
+    real(kind=c_real) , intent(in), dimension(ncol, 0:pver) :: pint
+    real(kind=c_real) , intent(in), dimension(ncol, pver, -ngwv:ngwv) :: gwut
+    real(kind=c_real) , intent(in), dimension(ncol, -pgwv:pgwv) :: c
+    real(kind=c_real) , intent(in), dimension(ncol, pver, pcnst) :: q
+    real(kind=c_real) , intent(out), dimension(ncol, 0:pver) :: egwdffi
+    real(kind=c_real) , intent(out), dimension(ncol, pver, pcnst) :: qtgw
+    real(kind=c_real) , intent(out), dimension(ncol, pver) :: dttdf, dttke, ttgw
+
+    call gwd_precalc_rhoi(ncol, ngwv, dt, tend_level, pmid, pint, t, gwut, ubm, nm, rdpm, c, q, dse, egwdffi, qtgw, dttdf, dttke, ttgw)
+  end subroutine gwd_precalc_rhoi_c
 end module gw_iso_c

--- a/components/eamxx/src/physics/gw/tests/infra/gw_iso_c.f90
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_iso_c.f90
@@ -153,8 +153,8 @@ contains
   end subroutine gw_front_init_c
 
   subroutine gw_front_project_winds_c(ncol, kbot, u, v, xv, yv, ubm, ubi) bind(C)
-    use gw_front, only : gw_front_project_winds
     use gw_common, only : pver
+    use gw_front, only : gw_front_project_winds
 
     integer(kind=c_int) , value, intent(in) :: ncol, kbot
     real(kind=c_real) , intent(in), dimension(ncol, pver) :: u, v
@@ -164,4 +164,15 @@ contains
 
     call gw_front_project_winds(ncol, kbot, u, v, xv, yv, ubm, ubi)
   end subroutine gw_front_project_winds_c
+
+  subroutine gw_front_gw_sources_c(ncol, ngwv, kbot, frontgf, tau) bind(C)
+    use gw_common, only : pver, pgwv
+    use gw_front, only : gw_front_gw_sources
+
+    integer(kind=c_int) , value, intent(in) :: ncol, ngwv, kbot
+    real(kind=c_real) , intent(in), dimension(ncol, pver) :: frontgf
+    real(kind=c_real) , intent(out), dimension(ncol, -pgwv:pgwv, 0:pver) :: tau
+
+    call gw_front_gw_sources(ncol, ngwv, kbot, frontgf, tau)
+  end subroutine gw_front_gw_sources_c
 end module gw_iso_c

--- a/components/eamxx/src/physics/gw/tests/infra/gw_iso_c.f90
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_iso_c.f90
@@ -58,4 +58,19 @@ contains
 
     call gw_prof(ncol, cpair, t, pmid, pint, rhoi, ti, nm, ni)
   end subroutine gw_prof_c
+
+  subroutine momentum_energy_conservation_c(ncol, tend_level, dt, taucd, pint, pdel, u, v, dudt, dvdt, dsdt, utgw, vtgw, ttgw) bind(C)
+    use gw_common, only : momentum_energy_conservation, pver
+
+    integer(kind=c_int) , value, intent(in) :: ncol
+    integer(kind=c_int) , intent(in), dimension(ncol) :: tend_level
+    real(kind=c_real) , value, intent(in) :: dt
+    real(kind=c_real) , intent(in), dimension(ncol, 0:pver, 4) :: taucd
+    real(kind=c_real) , intent(in), dimension(ncol, pver+1) :: pint
+    real(kind=c_real) , intent(in), dimension(ncol, pver) :: pdel, u, v
+    real(kind=c_real) , intent(inout), dimension(ncol, pver) :: dudt, dvdt, dsdt
+    real(kind=c_real) , intent(inout), dimension(ncol, pver) :: utgw, vtgw, ttgw
+
+    call momentum_energy_conservation(ncol, tend_level, dt, taucd, pint, pdel, u, v, dudt, dvdt, dsdt, utgw, vtgw, ttgw)
+  end subroutine momentum_energy_conservation_c
 end module gw_iso_c

--- a/components/eamxx/src/physics/gw/tests/infra/gw_iso_c.f90
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_iso_c.f90
@@ -140,4 +140,15 @@ contains
 
     call gw_drag_prof(ncol, ngwv, src_level, tend_level, do_taper, dt, lat, t, ti, pmid, pint, dpm, rdpm, piln, rhoi, nm, ni, ubm, ubi, xv, yv, effgw, c, kvtt, q, dse, tau, utgw, vtgw, ttgw, qtgw, taucd, egwdffi, gwut, dttdf, dttke)
   end subroutine gw_drag_prof_c
+
+  subroutine gw_front_init_c(taubgnd, frontgfc_in, kfront_in) bind(C)
+    use gw_front, only : gw_front_init
+
+    real(kind=c_real) , value, intent(in) :: taubgnd, frontgfc_in
+    integer(kind=c_int) , value, intent(in) :: kfront_in
+
+    character(len=128) :: errstring
+
+    call gw_front_init(taubgnd, frontgfc_in, kfront_in, errstring)
+  end subroutine gw_front_init_c
 end module gw_iso_c

--- a/components/eamxx/src/physics/gw/tests/infra/gw_iso_c.f90
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_iso_c.f90
@@ -45,4 +45,17 @@ contains
 
     call gwd_compute_tendencies_from_stress_divergence(ncol, ngwv, do_taper, dt, effgw, tend_level, lat, dpm, rdpm, c, ubm, t, nm, xv, yv, tau, gwut, utgw, vtgw)
   end subroutine gwd_compute_tendencies_from_stress_divergence_c
+
+  subroutine gw_prof_c(ncol, cpair, t, pmid, pint, rhoi, ti, nm, ni) bind(C)
+    use gw_common, only : gw_prof, pver
+
+    integer(kind=c_int) , value, intent(in) :: ncol
+    real(kind=c_real) , value, intent(in) :: cpair
+    real(kind=c_real) , intent(in), dimension(ncol, pver) :: t, pmid
+    real(kind=c_real) , intent(in), dimension(ncol, 0:pver) :: pint
+    real(kind=c_real) , intent(out), dimension(ncol, 0:pver) :: rhoi, ti, ni
+    real(kind=c_real) , intent(out), dimension(ncol, pver) :: nm
+
+    call gw_prof(ncol, cpair, t, pmid, pint, rhoi, ti, nm, ni)
+  end subroutine gw_prof_c
 end module gw_iso_c

--- a/components/eamxx/src/physics/gw/tests/infra/gw_test_data.cpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_test_data.cpp
@@ -31,6 +31,8 @@ void gw_prof_c(Int ncol, Real cpair, Real* t, Real* pmid, Real* pint, Real* rhoi
 void momentum_energy_conservation_c(Int ncol, Int* tend_level, Real dt, Real* taucd, Real* pint, Real* pdel, Real* u, Real* v, Real* dudt, Real* dvdt, Real* dsdt, Real* utgw, Real* vtgw, Real* ttgw);
 
 void gwd_compute_stress_profiles_and_diffusivities_c(Int ncol, Int ngwv, Int* src_level, Real* ubi, Real* c, Real* rhoi, Real* ni, Real* kvtt, Real* t, Real* ti, Real* piln, Real* tau);
+
+void gwd_project_tau_c(Int ncol, Int ngwv, Int* tend_level, Real* tau, Real* ubi, Real* c, Real* xv, Real* yv, Real* taucd);
 } // extern "C" : end _c decls
 
 // Wrapper around gw_init
@@ -68,6 +70,14 @@ void gwd_compute_stress_profiles_and_diffusivities(GwdComputeStressProfilesAndDi
   gw_init(d.init);
   d.transpose<ekat::TransposeDirection::c2f>();
   gwd_compute_stress_profiles_and_diffusivities_c(d.ncol, d.ngwv, d.src_level, d.ubi, d.c, d.rhoi, d.ni, d.kvtt, d.t, d.ti, d.piln, d.tau);
+  d.transpose<ekat::TransposeDirection::f2c>();
+}
+
+void gwd_project_tau(GwdProjectTauData& d)
+{
+  gw_init(d.init);
+  d.transpose<ekat::TransposeDirection::c2f>();
+  gwd_project_tau_c(d.ncol, d.ngwv, d.tend_level, d.tau, d.ubi, d.c, d.xv, d.yv, d.taucd);
   d.transpose<ekat::TransposeDirection::f2c>();
 }
 

--- a/components/eamxx/src/physics/gw/tests/infra/gw_test_data.cpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_test_data.cpp
@@ -27,6 +27,8 @@ void gwd_compute_tendencies_from_stress_divergence_c(Int ncol, Int ngwv, bool do
 void gw_init_c(Int pver_in, Int pgwv_in, Real dc_in, Real* cref_in, bool orographic_only, bool do_molec_diff_in, bool tau_0_ubc_in, Int nbot_molec_in, Int ktop_in, Int kbotbg_in, Real fcrit2_in, Real kwv_in, Real gravit_in, Real rair_in, Real* alpha_in);
 
 void gw_prof_c(Int ncol, Real cpair, Real* t, Real* pmid, Real* pint, Real* rhoi, Real* ti, Real* nm, Real* ni);
+
+void momentum_energy_conservation_c(Int ncol, Int* tend_level, Real dt, Real* taucd, Real* pint, Real* pdel, Real* u, Real* v, Real* dudt, Real* dvdt, Real* dsdt, Real* utgw, Real* vtgw, Real* ttgw);
 } // extern "C" : end _c decls
 
 // Wrapper around gw_init
@@ -48,6 +50,14 @@ void gw_prof(GwProfData& d)
   gw_init(d.init);
   d.transpose<ekat::TransposeDirection::c2f>();
   gw_prof_c(d.ncol, d.cpair, d.t, d.pmid, d.pint, d.rhoi, d.ti, d.nm, d.ni);
+  d.transpose<ekat::TransposeDirection::f2c>();
+}
+
+void momentum_energy_conservation(MomentumEnergyConservationData& d)
+{
+  gw_init(d.init);
+  d.transpose<ekat::TransposeDirection::c2f>();
+  momentum_energy_conservation_c(d.ncol, d.tend_level, d.dt, d.taucd, d.pint, d.pdel, d.u, d.v, d.dudt, d.dvdt, d.dsdt, d.utgw, d.vtgw, d.ttgw);
   d.transpose<ekat::TransposeDirection::f2c>();
 }
 

--- a/components/eamxx/src/physics/gw/tests/infra/gw_test_data.cpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_test_data.cpp
@@ -33,6 +33,8 @@ void momentum_energy_conservation_c(Int ncol, Int* tend_level, Real dt, Real* ta
 void gwd_compute_stress_profiles_and_diffusivities_c(Int ncol, Int ngwv, Int* src_level, Real* ubi, Real* c, Real* rhoi, Real* ni, Real* kvtt, Real* t, Real* ti, Real* piln, Real* tau);
 
 void gwd_project_tau_c(Int ncol, Int ngwv, Int* tend_level, Real* tau, Real* ubi, Real* c, Real* xv, Real* yv, Real* taucd);
+
+void gwd_precalc_rhoi_c(Int pcnst, Int ncol, Int ngwv, Real dt, Int* tend_level, Real* pmid, Real* pint, Real* t, Real* gwut, Real* ubm, Real* nm, Real* rdpm, Real* c, Real* q, Real* dse, Real* egwdffi, Real* qtgw, Real* dttdf, Real* dttke, Real* ttgw);
 } // extern "C" : end _c decls
 
 // Wrapper around gw_init
@@ -78,6 +80,14 @@ void gwd_project_tau(GwdProjectTauData& d)
   gw_init(d.init);
   d.transpose<ekat::TransposeDirection::c2f>();
   gwd_project_tau_c(d.ncol, d.ngwv, d.tend_level, d.tau, d.ubi, d.c, d.xv, d.yv, d.taucd);
+  d.transpose<ekat::TransposeDirection::f2c>();
+}
+
+void gwd_precalc_rhoi(GwdPrecalcRhoiData& d)
+{
+  gw_init(d.init);
+  d.transpose<ekat::TransposeDirection::c2f>();
+  gwd_precalc_rhoi_c(d.pcnst, d.ncol, d.ngwv, d.dt, d.tend_level, d.pmid, d.pint, d.t, d.gwut, d.ubm, d.nm, d.rdpm, d.c, d.q, d.dse, d.egwdffi, d.qtgw, d.dttdf, d.dttke, d.ttgw);
   d.transpose<ekat::TransposeDirection::f2c>();
 }
 

--- a/components/eamxx/src/physics/gw/tests/infra/gw_test_data.cpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_test_data.cpp
@@ -39,6 +39,8 @@ void gwd_precalc_rhoi_c(Int pcnst, Int ncol, Int ngwv, Real dt, Int* tend_level,
 void gw_drag_prof_c(Int pcnst, Int ncol, Int ngwv, Int* src_level, Int* tend_level, bool do_taper, Real dt, Real* lat, Real* t, Real* ti, Real* pmid, Real* pint, Real* dpm, Real* rdpm, Real* piln, Real* rhoi, Real* nm, Real* ni, Real* ubm, Real* ubi, Real* xv, Real* yv, Real effgw, Real* c, Real* kvtt, Real* q, Real* dse, Real* tau, Real* utgw, Real* vtgw, Real* ttgw, Real* qtgw, Real* taucd, Real* egwdffi, Real* gwut, Real* dttdf, Real* dttke);
 
 void gw_front_init_c(Real taubgnd, Real frontgfc_in, Int kfront_in);
+
+void gw_front_project_winds_c(Int ncol, Int kbot, Real* u, Real* v, Real* xv, Real* yv, Real* ubm, Real* ubi);
 } // extern "C" : end _c decls
 
 // Wrapper around gw_init
@@ -107,6 +109,14 @@ void gw_front_init(GwFrontInitData& d)
 {
   gw_init(d.init);
   gw_front_init_c(d.taubgnd, d.frontgfc_in, d.kfront_in);
+}
+
+void gw_front_project_winds(GwFrontProjectWindsData& d)
+{
+  gw_front_init(d.init);
+  d.transpose<ekat::TransposeDirection::c2f>();
+  gw_front_project_winds_c(d.ncol, d.kbot, d.u, d.v, d.xv, d.yv, d.ubm, d.ubi);
+  d.transpose<ekat::TransposeDirection::f2c>();
 }
 
 // end _c impls

--- a/components/eamxx/src/physics/gw/tests/infra/gw_test_data.cpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_test_data.cpp
@@ -29,6 +29,8 @@ void gw_init_c(Int pver_in, Int pgwv_in, Real dc_in, Real* cref_in, bool orograp
 void gw_prof_c(Int ncol, Real cpair, Real* t, Real* pmid, Real* pint, Real* rhoi, Real* ti, Real* nm, Real* ni);
 
 void momentum_energy_conservation_c(Int ncol, Int* tend_level, Real dt, Real* taucd, Real* pint, Real* pdel, Real* u, Real* v, Real* dudt, Real* dvdt, Real* dsdt, Real* utgw, Real* vtgw, Real* ttgw);
+
+void gwd_compute_stress_profiles_and_diffusivities_c(Int ncol, Int ngwv, Int* src_level, Real* ubi, Real* c, Real* rhoi, Real* ni, Real* kvtt, Real* t, Real* ti, Real* piln, Real* tau);
 } // extern "C" : end _c decls
 
 // Wrapper around gw_init
@@ -58,6 +60,14 @@ void momentum_energy_conservation(MomentumEnergyConservationData& d)
   gw_init(d.init);
   d.transpose<ekat::TransposeDirection::c2f>();
   momentum_energy_conservation_c(d.ncol, d.tend_level, d.dt, d.taucd, d.pint, d.pdel, d.u, d.v, d.dudt, d.dvdt, d.dsdt, d.utgw, d.vtgw, d.ttgw);
+  d.transpose<ekat::TransposeDirection::f2c>();
+}
+
+void gwd_compute_stress_profiles_and_diffusivities(GwdComputeStressProfilesAndDiffusivitiesData& d)
+{
+  gw_init(d.init);
+  d.transpose<ekat::TransposeDirection::c2f>();
+  gwd_compute_stress_profiles_and_diffusivities_c(d.ncol, d.ngwv, d.src_level, d.ubi, d.c, d.rhoi, d.ni, d.kvtt, d.t, d.ti, d.piln, d.tau);
   d.transpose<ekat::TransposeDirection::f2c>();
 }
 

--- a/components/eamxx/src/physics/gw/tests/infra/gw_test_data.cpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_test_data.cpp
@@ -41,6 +41,8 @@ void gw_drag_prof_c(Int pcnst, Int ncol, Int ngwv, Int* src_level, Int* tend_lev
 void gw_front_init_c(Real taubgnd, Real frontgfc_in, Int kfront_in);
 
 void gw_front_project_winds_c(Int ncol, Int kbot, Real* u, Real* v, Real* xv, Real* yv, Real* ubm, Real* ubi);
+
+void gw_front_gw_sources_c(Int ncol, Int ngwv, Int kbot, Real* frontgf, Real* tau);
 } // extern "C" : end _c decls
 
 // Wrapper around gw_init
@@ -116,6 +118,14 @@ void gw_front_project_winds(GwFrontProjectWindsData& d)
   gw_front_init(d.init);
   d.transpose<ekat::TransposeDirection::c2f>();
   gw_front_project_winds_c(d.ncol, d.kbot, d.u, d.v, d.xv, d.yv, d.ubm, d.ubi);
+  d.transpose<ekat::TransposeDirection::f2c>();
+}
+
+void gw_front_gw_sources(GwFrontGwSourcesData& d)
+{
+  gw_front_init(d.init);
+  d.transpose<ekat::TransposeDirection::c2f>();
+  gw_front_gw_sources_c(d.ncol, d.ngwv, d.kbot, d.frontgf, d.tau);
   d.transpose<ekat::TransposeDirection::f2c>();
 }
 

--- a/components/eamxx/src/physics/gw/tests/infra/gw_test_data.cpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_test_data.cpp
@@ -43,6 +43,9 @@ void gw_front_init_c(Real taubgnd, Real frontgfc_in, Int kfront_in);
 void gw_front_project_winds_c(Int ncol, Int kbot, Real* u, Real* v, Real* xv, Real* yv, Real* ubm, Real* ubi);
 
 void gw_front_gw_sources_c(Int ncol, Int ngwv, Int kbot, Real* frontgf, Real* tau);
+
+void gw_cm_src_c(Int ncol, Int ngwv, Int kbot, Real* u, Real* v, Real* frontgf, Int* src_level, Int* tend_level, Real* tau, Real* ubm, Real* ubi, Real* xv, Real* yv, Real* c);
+
 } // extern "C" : end _c decls
 
 // Wrapper around gw_init
@@ -126,6 +129,14 @@ void gw_front_gw_sources(GwFrontGwSourcesData& d)
   gw_front_init(d.init);
   d.transpose<ekat::TransposeDirection::c2f>();
   gw_front_gw_sources_c(d.ncol, d.ngwv, d.kbot, d.frontgf, d.tau);
+  d.transpose<ekat::TransposeDirection::f2c>();
+}
+
+void gw_cm_src(GwCmSrcData& d)
+{
+  gw_front_init(d.init);
+  d.transpose<ekat::TransposeDirection::c2f>();
+  gw_cm_src_c(d.ncol, d.ngwv, d.kbot, d.u, d.v, d.frontgf, d.src_level, d.tend_level, d.tau, d.ubm, d.ubi, d.xv, d.yv, d.c);
   d.transpose<ekat::TransposeDirection::f2c>();
 }
 

--- a/components/eamxx/src/physics/gw/tests/infra/gw_test_data.cpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_test_data.cpp
@@ -37,6 +37,8 @@ void gwd_project_tau_c(Int ncol, Int ngwv, Int* tend_level, Real* tau, Real* ubi
 void gwd_precalc_rhoi_c(Int pcnst, Int ncol, Int ngwv, Real dt, Int* tend_level, Real* pmid, Real* pint, Real* t, Real* gwut, Real* ubm, Real* nm, Real* rdpm, Real* c, Real* q, Real* dse, Real* egwdffi, Real* qtgw, Real* dttdf, Real* dttke, Real* ttgw);
 
 void gw_drag_prof_c(Int pcnst, Int ncol, Int ngwv, Int* src_level, Int* tend_level, bool do_taper, Real dt, Real* lat, Real* t, Real* ti, Real* pmid, Real* pint, Real* dpm, Real* rdpm, Real* piln, Real* rhoi, Real* nm, Real* ni, Real* ubm, Real* ubi, Real* xv, Real* yv, Real effgw, Real* c, Real* kvtt, Real* q, Real* dse, Real* tau, Real* utgw, Real* vtgw, Real* ttgw, Real* qtgw, Real* taucd, Real* egwdffi, Real* gwut, Real* dttdf, Real* dttke);
+
+void gw_front_init_c(Real taubgnd, Real frontgfc_in, Int kfront_in);
 } // extern "C" : end _c decls
 
 // Wrapper around gw_init
@@ -99,6 +101,12 @@ void gw_drag_prof(GwDragProfData& d)
   d.transpose<ekat::TransposeDirection::c2f>();
   gw_drag_prof_c(d.pcnst, d.ncol, d.ngwv, d.src_level, d.tend_level, d.do_taper, d.dt, d.lat, d.t, d.ti, d.pmid, d.pint, d.dpm, d.rdpm, d.piln, d.rhoi, d.nm, d.ni, d.ubm, d.ubi, d.xv, d.yv, d.effgw, d.c, d.kvtt, d.q, d.dse, d.tau, d.utgw, d.vtgw, d.ttgw, d.qtgw, d.taucd, d.egwdffi, d.gwut, d.dttdf, d.dttke);
   d.transpose<ekat::TransposeDirection::f2c>();
+}
+
+void gw_front_init(GwFrontInitData& d)
+{
+  gw_init(d.init);
+  gw_front_init_c(d.taubgnd, d.frontgfc_in, d.kfront_in);
 }
 
 // end _c impls

--- a/components/eamxx/src/physics/gw/tests/infra/gw_test_data.cpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_test_data.cpp
@@ -26,6 +26,7 @@ void gwd_compute_tendencies_from_stress_divergence_c(Int ncol, Int ngwv, bool do
 
 void gw_init_c(Int pver_in, Int pgwv_in, Real dc_in, Real* cref_in, bool orographic_only, bool do_molec_diff_in, bool tau_0_ubc_in, Int nbot_molec_in, Int ktop_in, Int kbotbg_in, Real fcrit2_in, Real kwv_in, Real gravit_in, Real rair_in, Real* alpha_in);
 
+void gw_prof_c(Int ncol, Real cpair, Real* t, Real* pmid, Real* pint, Real* rhoi, Real* ti, Real* nm, Real* ni);
 } // extern "C" : end _c decls
 
 // Wrapper around gw_init
@@ -39,6 +40,14 @@ void gwd_compute_tendencies_from_stress_divergence(GwdComputeTendenciesFromStres
   gw_init(d.init);
   d.transpose<ekat::TransposeDirection::c2f>();
   gwd_compute_tendencies_from_stress_divergence_c(d.ncol, d.ngwv, d.do_taper, d.dt, d.effgw, d.tend_level, d.lat, d.dpm, d.rdpm, d.c, d.ubm, d.t, d.nm, d.xv, d.yv, d.tau, d.gwut, d.utgw, d.vtgw);
+  d.transpose<ekat::TransposeDirection::f2c>();
+}
+
+void gw_prof(GwProfData& d)
+{
+  gw_init(d.init);
+  d.transpose<ekat::TransposeDirection::c2f>();
+  gw_prof_c(d.ncol, d.cpair, d.t, d.pmid, d.pint, d.rhoi, d.ti, d.nm, d.ni);
   d.transpose<ekat::TransposeDirection::f2c>();
 }
 

--- a/components/eamxx/src/physics/gw/tests/infra/gw_test_data.cpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_test_data.cpp
@@ -35,6 +35,8 @@ void gwd_compute_stress_profiles_and_diffusivities_c(Int ncol, Int ngwv, Int* sr
 void gwd_project_tau_c(Int ncol, Int ngwv, Int* tend_level, Real* tau, Real* ubi, Real* c, Real* xv, Real* yv, Real* taucd);
 
 void gwd_precalc_rhoi_c(Int pcnst, Int ncol, Int ngwv, Real dt, Int* tend_level, Real* pmid, Real* pint, Real* t, Real* gwut, Real* ubm, Real* nm, Real* rdpm, Real* c, Real* q, Real* dse, Real* egwdffi, Real* qtgw, Real* dttdf, Real* dttke, Real* ttgw);
+
+void gw_drag_prof_c(Int pcnst, Int ncol, Int ngwv, Int* src_level, Int* tend_level, bool do_taper, Real dt, Real* lat, Real* t, Real* ti, Real* pmid, Real* pint, Real* dpm, Real* rdpm, Real* piln, Real* rhoi, Real* nm, Real* ni, Real* ubm, Real* ubi, Real* xv, Real* yv, Real effgw, Real* c, Real* kvtt, Real* q, Real* dse, Real* tau, Real* utgw, Real* vtgw, Real* ttgw, Real* qtgw, Real* taucd, Real* egwdffi, Real* gwut, Real* dttdf, Real* dttke);
 } // extern "C" : end _c decls
 
 // Wrapper around gw_init
@@ -88,6 +90,14 @@ void gwd_precalc_rhoi(GwdPrecalcRhoiData& d)
   gw_init(d.init);
   d.transpose<ekat::TransposeDirection::c2f>();
   gwd_precalc_rhoi_c(d.pcnst, d.ncol, d.ngwv, d.dt, d.tend_level, d.pmid, d.pint, d.t, d.gwut, d.ubm, d.nm, d.rdpm, d.c, d.q, d.dse, d.egwdffi, d.qtgw, d.dttdf, d.dttke, d.ttgw);
+  d.transpose<ekat::TransposeDirection::f2c>();
+}
+
+void gw_drag_prof(GwDragProfData& d)
+{
+  gw_init(d.init);
+  d.transpose<ekat::TransposeDirection::c2f>();
+  gw_drag_prof_c(d.pcnst, d.ncol, d.ngwv, d.src_level, d.tend_level, d.do_taper, d.dt, d.lat, d.t, d.ti, d.pmid, d.pint, d.dpm, d.rdpm, d.piln, d.rhoi, d.nm, d.ni, d.ubm, d.ubi, d.xv, d.yv, d.effgw, d.c, d.kvtt, d.q, d.dse, d.tau, d.utgw, d.vtgw, d.ttgw, d.qtgw, d.taucd, d.egwdffi, d.gwut, d.dttdf, d.dttke);
   d.transpose<ekat::TransposeDirection::f2c>();
 }
 

--- a/components/eamxx/src/physics/gw/tests/infra/gw_test_data.hpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_test_data.hpp
@@ -29,7 +29,7 @@ struct GwInit : public PhysicsTestData {
 
   GwInit(Int pver_, Int pgwv_, Real dc_, bool orographic_only_, bool do_molec_diff_, bool tau_0_ubc_, Int nbot_molec_, Int ktop_, Int kbotbg_, Real fcrit2_, Real kwv_) :
     PhysicsTestData({
-      {pgwv_ * 2},
+      {pgwv_*2 + 1},
       {pver_ + 1}
     },
     {
@@ -69,9 +69,9 @@ struct GwdComputeTendenciesFromStressDivergenceData : public PhysicsTestData {
     PhysicsTestData({
       {ncol_},
       {ncol_, init_.pver},
-      {ncol_, 2*init_.pgwv},
-      {ncol_, 2*init_.pgwv, init_.pver + 1},
-      {ncol_, init_.pver, 2*ngwv_},
+      {ncol_, 2*init_.pgwv + 1},
+      {ncol_, 2*init_.pgwv + 1, init_.pver + 1},
+      {ncol_, init_.pver, 2*ngwv_ + 1},
       {ncol_}
     },
     {
@@ -160,9 +160,9 @@ struct GwdComputeStressProfilesAndDiffusivitiesData : public PhysicsTestData {
   GwdComputeStressProfilesAndDiffusivitiesData(Int ncol_, Int ngwv_, GwInit init_) :
     PhysicsTestData({
       {ncol_, init_.pver + 1},
-      {ncol_, init_.pgwv*2},
+      {ncol_, init_.pgwv*2 + 1},
       {ncol_, init_.pver},
-      {ncol_, init_.pgwv*2, init_.pver + 1},
+      {ncol_, init_.pgwv*2 + 1, init_.pver + 1},
       {ncol_}
     },
     {
@@ -192,9 +192,9 @@ struct GwdProjectTauData : public PhysicsTestData {
 
   GwdProjectTauData(Int ncol_, Int ngwv_, GwInit init_) :
     PhysicsTestData({
-      {ncol_, init_.pgwv*2, init_.pver + 1},
+      {ncol_, init_.pgwv*2 + 1, init_.pver + 1},
       {ncol_, init_.pver + 1},
-      {ncol_, init_.pgwv*2},
+      {ncol_, init_.pgwv*2 + 1},
       {ncol_},
       {ncol_, init_.pver + 1, 4},
       {ncol_}
@@ -230,8 +230,8 @@ struct GwdPrecalcRhoiData : public PhysicsTestData {
     PhysicsTestData({
       {ncol_, init_.pver},
       {ncol_, init_.pver + 1},
-      {ncol_, init_.pver, ngwv_*2},
-      {ncol_, init_.pgwv*2},
+      {ncol_, init_.pver, ngwv_*2 + 1},
+      {ncol_, init_.pgwv*2 + 1},
       {ncol_, init_.pver, pcnst_},
       {ncol_}
     },
@@ -271,11 +271,11 @@ struct GwDragProfData : public PhysicsTestData {
       {ncol_},
       {ncol_, init_.pver},
       {ncol_, init_.pver + 1},
-      {ncol_, init_.pgwv*2},
+      {ncol_, init_.pgwv*2 + 1},
       {ncol_, init_.pver, pcnst_},
-      {ncol_, init_.pgwv*2, init_.pver + 1},
+      {ncol_, init_.pgwv*2 + 1, init_.pver + 1},
       {ncol_, init_.pver + 1, 4},
-      {ncol_, init_.pver, ngwv_*2},
+      {ncol_, init_.pver, ngwv_*2 + 1},
       {ncol_}
     },
     {
@@ -352,7 +352,7 @@ struct GwFrontGwSourcesData : public PhysicsTestData {
   GwFrontGwSourcesData(Int ncol_, Int ngwv_, Int kbot_, GwFrontInitData init_) :
     PhysicsTestData({
       {ncol_, init_.init.pver},
-      {ncol_, init_.init.pgwv*2, init_.init.pver}
+      {ncol_, init_.init.pgwv*2 + 1, init_.init.pver + 1}
     },
     {
       {&frontgf},
@@ -377,10 +377,10 @@ struct GwCmSrcData : public PhysicsTestData {
   GwCmSrcData(Int ncol_, Int ngwv_, Int kbot_, GwFrontInitData init_) :
     PhysicsTestData({
       {ncol_, init_.init.pver},
-      {ncol_, init_.init.pgwv*2, init_.init.pver + 1},
+      {ncol_, init_.init.pgwv*2 + 1, init_.init.pver + 1},
       {ncol_, init_.init.pver + 1},
       {ncol_},
-      {ncol_, init_.init.pgwv*2},
+      {ncol_, init_.init.pgwv*2 + 1},
       {ncol_}
     },
     {

--- a/components/eamxx/src/physics/gw/tests/infra/gw_test_data.hpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_test_data.hpp
@@ -251,6 +251,52 @@ struct GwdPrecalcRhoiData : public PhysicsTestData {
   PTD_STD_DEF_INIT(GwdPrecalcRhoiData, 4, pcnst, ncol, ngwv, dt);
 };
 
+struct GwDragProfData : public PhysicsTestData {
+  // Inputs
+  Int pcnst, ncol, ngwv;
+  Int *src_level, *tend_level;
+  bool do_taper;
+  Real dt, effgw;
+  Real *lat, *t, *ti, *pmid, *pint, *dpm, *rdpm, *piln, *rhoi, *nm, *ni, *ubm, *ubi, *xv, *yv, *c, *kvtt, *q, *dse;
+  GwInit init;
+
+  // Inputs/Outputs
+  Real *tau;
+
+  // Outputs
+  Real *utgw, *vtgw, *ttgw, *qtgw, *taucd, *egwdffi, *gwut, *dttdf, *dttke;
+
+  GwDragProfData(Int pcnst_, Int ncol_, Int ngwv_, bool do_taper_, Real dt_, Real effgw_, GwInit init_) :
+    PhysicsTestData({
+      {ncol_},
+      {ncol_, init_.pver},
+      {ncol_, init_.pver + 1},
+      {ncol_, init_.pgwv*2},
+      {ncol_, init_.pver, pcnst_},
+      {ncol_, init_.pgwv*2, init_.pver + 1},
+      {ncol_, init_.pver + 1, 4},
+      {ncol_, init_.pver, ngwv_*2},
+      {ncol_}
+    },
+    {
+      {&lat, &xv, &yv},
+      {&t, &pmid, &dpm, &rdpm, &nm, &ubm, &dse, &utgw, &vtgw, &ttgw, &dttdf, &dttke},
+      {&ti, &pint, &piln, &rhoi, &ni, &ubi, &kvtt, &egwdffi},
+      {&c},
+      {&q, &qtgw},
+      {&tau},
+      {&taucd},
+      {&gwut}
+    },
+    {
+      {&src_level, &tend_level}
+    }),
+    pcnst(pcnst_), ncol(ncol_), ngwv(ngwv_), do_taper(do_taper_), dt(dt_), effgw(effgw_), init(init_)
+  {}
+
+  PTD_STD_DEF_INIT(GwDragProfData, 6, pcnst, ncol, ngwv, do_taper, dt, effgw);
+};
+
 // Glue functions to call fortran from from C++ with the Data struct
 
 void gwd_compute_tendencies_from_stress_divergence(GwdComputeTendenciesFromStressDivergenceData& d);
@@ -259,6 +305,7 @@ void momentum_energy_conservation(MomentumEnergyConservationData& d);
 void gwd_compute_stress_profiles_and_diffusivities(GwdComputeStressProfilesAndDiffusivitiesData& d);
 void gwd_project_tau(GwdProjectTauData& d);
 void gwd_precalc_rhoi(GwdPrecalcRhoiData& d);
+void gw_drag_prof(GwDragProfData& d);
 
 extern "C" { // _f function decls
 }

--- a/components/eamxx/src/physics/gw/tests/infra/gw_test_data.hpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_test_data.hpp
@@ -180,13 +180,49 @@ struct GwdComputeStressProfilesAndDiffusivitiesData : public PhysicsTestData {
   PTD_STD_DEF_INIT(GwdComputeStressProfilesAndDiffusivitiesData, 2, ncol, ngwv);
 };
 
+struct GwdProjectTauData : public PhysicsTestData {
+  // Inputs
+  Int ncol, ngwv;
+  Int *tend_level;
+  Real *tau, *ubi, *c, *xv, *yv;
+  GwInit init;
+
+  // Outputs
+  Real *taucd;
+
+  GwdProjectTauData(Int ncol_, Int ngwv_, GwInit init_) :
+    PhysicsTestData({
+      {ncol_, init_.pgwv*2, init_.pver + 1},
+      {ncol_, init_.pver + 1},
+      {ncol_, init_.pgwv*2},
+      {ncol_},
+      {ncol_, init_.pver + 1, 4},
+      {ncol_}
+    },
+    {
+      {&tau},
+      {&ubi},
+      {&c},
+      {&xv, &yv},
+      {&taucd}
+    },
+    {
+      {&tend_level}
+    }),
+    ncol(ncol_), ngwv(ngwv_), init(init_)
+  {}
+
+  PTD_STD_DEF_INIT(GwdProjectTauData, 2, ncol, ngwv);
+};
+
 // Glue functions to call fortran from from C++ with the Data struct
 
 void gwd_compute_tendencies_from_stress_divergence(GwdComputeTendenciesFromStressDivergenceData& d);
 void gw_prof(GwProfData& d);
-
 void momentum_energy_conservation(MomentumEnergyConservationData& d);
 void gwd_compute_stress_profiles_and_diffusivities(GwdComputeStressProfilesAndDiffusivitiesData& d);
+void gwd_project_tau(GwdProjectTauData& d);
+
 extern "C" { // _f function decls
 }
 

--- a/components/eamxx/src/physics/gw/tests/infra/gw_test_data.hpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_test_data.hpp
@@ -115,11 +115,44 @@ struct GwProfData : public PhysicsTestData {
   PTD_STD_DEF_INIT(GwProfData, 2, ncol, cpair);
 };
 
+struct MomentumEnergyConservationData : public PhysicsTestData {
+  // Inputs
+  Int ncol;
+  Int *tend_level;
+  Real dt;
+  Real *taucd, *pint, *pdel, *u, *v;
+  GwInit init;
+
+  // Inputs/Outputs
+  Real *dudt, *dvdt, *dsdt, *utgw, *vtgw, *ttgw;
+
+  MomentumEnergyConservationData(Int ncol_, Real dt_, GwInit init_) :
+    PhysicsTestData({
+      {ncol_, init_.pver + 1, 4},
+      {ncol_, init_.pver + 1},
+      {ncol_, init_.pver},
+      {ncol_}
+    },
+    {
+      {&taucd},
+      {&pint},
+      {&pdel, &u, &v, &utgw, &vtgw, &ttgw, &dudt, &dvdt, &dsdt}
+    },
+    {
+      {&tend_level}
+    }),
+    ncol(ncol_), dt(dt_), init(init_)
+  {}
+
+  PTD_STD_DEF_INIT(MomentumEnergyConservationData, 2, ncol, dt);
+};
+
 // Glue functions to call fortran from from C++ with the Data struct
 
 void gwd_compute_tendencies_from_stress_divergence(GwdComputeTendenciesFromStressDivergenceData& d);
 void gw_prof(GwProfData& d);
 
+void momentum_energy_conservation(MomentumEnergyConservationData& d);
 extern "C" { // _f function decls
 }
 

--- a/components/eamxx/src/physics/gw/tests/infra/gw_test_data.hpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_test_data.hpp
@@ -297,6 +297,23 @@ struct GwDragProfData : public PhysicsTestData {
   PTD_STD_DEF_INIT(GwDragProfData, 6, pcnst, ncol, ngwv, do_taper, dt, effgw);
 };
 
+struct GwFrontInitData : public PhysicsTestData{
+  // Inputs
+  Real taubgnd, frontgfc_in;
+  Int kfront_in;
+  GwInit init;
+
+  GwFrontInitData(Real taubgnd_, Real frontgfc_in_, Int kfront_in_, GwInit init_) :
+    PhysicsTestData({}, {}, {}),
+    taubgnd(taubgnd_),
+    frontgfc_in(frontgfc_in_),
+    kfront_in(kfront_in_),
+    init(init_)
+  {}
+
+  PTD_STD_DEF_INIT(GwFrontInitData, 3, taubgnd, frontgfc_in, kfront_in);
+
+};
 // Glue functions to call fortran from from C++ with the Data struct
 
 void gwd_compute_tendencies_from_stress_divergence(GwdComputeTendenciesFromStressDivergenceData& d);

--- a/components/eamxx/src/physics/gw/tests/infra/gw_test_data.hpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_test_data.hpp
@@ -312,7 +312,32 @@ struct GwFrontInitData : public PhysicsTestData{
   {}
 
   PTD_STD_DEF_INIT(GwFrontInitData, 3, taubgnd, frontgfc_in, kfront_in);
+};
 
+struct GwFrontProjectWindsData : public PhysicsTestData {
+  // Inputs
+  Int ncol, kbot;
+  Real *u, *v;
+  GwFrontInitData init;
+
+  // Outputs
+  Real *xv, *yv, *ubm, *ubi;
+
+  GwFrontProjectWindsData(Int ncol_, Int kbot_, GwFrontInitData init_) :
+    PhysicsTestData({
+      {ncol_, init_.init.pver},
+      {ncol_},
+      {ncol_, init_.init.pver + 1}
+    },
+    {
+      {&u, &v, &ubm},
+      {&xv, &yv},
+      {&ubi}
+    }),
+    ncol(ncol_), kbot(kbot_), init(init_)
+  {}
+
+  PTD_STD_DEF_INIT(GwFrontProjectWindsData, 2, ncol, kbot);
 };
 // Glue functions to call fortran from from C++ with the Data struct
 
@@ -323,6 +348,7 @@ void gwd_compute_stress_profiles_and_diffusivities(GwdComputeStressProfilesAndDi
 void gwd_project_tau(GwdProjectTauData& d);
 void gwd_precalc_rhoi(GwdPrecalcRhoiData& d);
 void gw_drag_prof(GwDragProfData& d);
+void gw_front_project_winds(GwFrontProjectWindsData& d);
 
 extern "C" { // _f function decls
 }

--- a/components/eamxx/src/physics/gw/tests/infra/gw_test_data.hpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_test_data.hpp
@@ -215,6 +215,42 @@ struct GwdProjectTauData : public PhysicsTestData {
   PTD_STD_DEF_INIT(GwdProjectTauData, 2, ncol, ngwv);
 };
 
+struct GwdPrecalcRhoiData : public PhysicsTestData {
+  // Inputs
+  Int pcnst, ncol, ngwv;
+  Real dt;
+  Int *tend_level;
+  Real *pmid, *pint, *t, *gwut, *ubm, *nm, *rdpm, *c, *q, *dse;
+  GwInit init;
+
+  // Outputs
+  Real *egwdffi, *qtgw, *dttdf, *dttke, *ttgw;
+
+  GwdPrecalcRhoiData(Int pcnst_, Int ncol_, Int ngwv_, Real dt_, GwInit init_) :
+    PhysicsTestData({
+      {ncol_, init_.pver},
+      {ncol_, init_.pver + 1},
+      {ncol_, init_.pver, ngwv_*2},
+      {ncol_, init_.pgwv*2},
+      {ncol_, init_.pver, pcnst_},
+      {ncol_}
+    },
+    {
+      {&pmid, &t, &ubm, &nm, &rdpm, &dse, &dttdf, &dttke, &ttgw},
+      {&pint, &egwdffi},
+      {&gwut},
+      {&c},
+      {&q, &qtgw}
+    },
+    {
+      {&tend_level}
+    }),
+    pcnst(pcnst_), ncol(ncol_), ngwv(ngwv_), dt(dt_), init(init_)
+  {}
+
+  PTD_STD_DEF_INIT(GwdPrecalcRhoiData, 4, pcnst, ncol, ngwv, dt);
+};
+
 // Glue functions to call fortran from from C++ with the Data struct
 
 void gwd_compute_tendencies_from_stress_divergence(GwdComputeTendenciesFromStressDivergenceData& d);
@@ -222,6 +258,7 @@ void gw_prof(GwProfData& d);
 void momentum_energy_conservation(MomentumEnergyConservationData& d);
 void gwd_compute_stress_profiles_and_diffusivities(GwdComputeStressProfilesAndDiffusivitiesData& d);
 void gwd_project_tau(GwdProjectTauData& d);
+void gwd_precalc_rhoi(GwdPrecalcRhoiData& d);
 
 extern "C" { // _f function decls
 }

--- a/components/eamxx/src/physics/gw/tests/infra/gw_test_data.hpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_test_data.hpp
@@ -50,7 +50,6 @@ struct GwInit : public PhysicsTestData {
   PTD_STD_DEF(GwInit, 11, pver, pgwv, dc, orographic_only, do_molec_diff, tau_0_ubc, nbot_molec, ktop, kbotbg, fcrit2, kwv);
 };
 
-
 struct GwdComputeTendenciesFromStressDivergenceData : public PhysicsTestData {
   // Inputs
   Int ncol, ngwv;
@@ -91,9 +90,36 @@ struct GwdComputeTendenciesFromStressDivergenceData : public PhysicsTestData {
   PTD_STD_DEF_INIT(GwdComputeTendenciesFromStressDivergenceData, 5, ncol, ngwv, do_taper, dt, effgw);
 };
 
+struct GwProfData : public PhysicsTestData {
+  // Inputs
+  Int ncol;
+  Real cpair;
+  Real *t, *pmid, *pint;
+  GwInit init;
+
+  // Outputs
+  Real *rhoi, *ti, *nm, *ni;
+
+  GwProfData(Int ncol_, Real cpair_, GwInit init_) :
+    PhysicsTestData({
+      {ncol_, init_.pver},
+      {ncol_, init_.pver + 1}
+    },
+    {
+      {&t, &pmid, &nm},
+      {&pint, &rhoi, &ti, &ni}
+    }),
+    ncol(ncol_), cpair(cpair_), init(init_)
+  {}
+
+  PTD_STD_DEF_INIT(GwProfData, 2, ncol, cpair);
+};
+
 // Glue functions to call fortran from from C++ with the Data struct
 
 void gwd_compute_tendencies_from_stress_divergence(GwdComputeTendenciesFromStressDivergenceData& d);
+void gw_prof(GwProfData& d);
+
 extern "C" { // _f function decls
 }
 

--- a/components/eamxx/src/physics/gw/tests/infra/gw_test_data.hpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_test_data.hpp
@@ -147,12 +147,46 @@ struct MomentumEnergyConservationData : public PhysicsTestData {
   PTD_STD_DEF_INIT(MomentumEnergyConservationData, 2, ncol, dt);
 };
 
+struct GwdComputeStressProfilesAndDiffusivitiesData : public PhysicsTestData {
+  // Inputs
+  Int ncol, ngwv;
+  Int *src_level;
+  Real *ubi, *c, *rhoi, *ni, *kvtt, *t, *ti, *piln;
+  GwInit init;
+
+  // Inputs/Outputs
+  Real *tau;
+
+  GwdComputeStressProfilesAndDiffusivitiesData(Int ncol_, Int ngwv_, GwInit init_) :
+    PhysicsTestData({
+      {ncol_, init_.pver + 1},
+      {ncol_, init_.pgwv*2},
+      {ncol_, init_.pver},
+      {ncol_, init_.pgwv*2, init_.pver + 1},
+      {ncol_}
+    },
+    {
+      {&ubi, &rhoi, &ni, &kvtt, &ti, &piln},
+      {&c},
+      {&t},
+      {&tau}
+    },
+    {
+      {&src_level}
+    }),
+    ncol(ncol_), ngwv(ngwv_), init(init_)
+  {}
+
+  PTD_STD_DEF_INIT(GwdComputeStressProfilesAndDiffusivitiesData, 2, ncol, ngwv);
+};
+
 // Glue functions to call fortran from from C++ with the Data struct
 
 void gwd_compute_tendencies_from_stress_divergence(GwdComputeTendenciesFromStressDivergenceData& d);
 void gw_prof(GwProfData& d);
 
 void momentum_energy_conservation(MomentumEnergyConservationData& d);
+void gwd_compute_stress_profiles_and_diffusivities(GwdComputeStressProfilesAndDiffusivitiesData& d);
 extern "C" { // _f function decls
 }
 

--- a/components/eamxx/src/physics/gw/tests/infra/gw_test_data.hpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_test_data.hpp
@@ -364,8 +364,42 @@ struct GwFrontGwSourcesData : public PhysicsTestData {
   PTD_STD_DEF_INIT(GwFrontGwSourcesData, 3, ncol, ngwv, kbot);
 };
 
-// Glue functions to call fortran from from C++ with the Data struct
+struct GwCmSrcData : public PhysicsTestData {
+  // Inputs
+  Int ncol, ngwv, kbot;
+  Real *u, *v, *frontgf;
+  GwFrontInitData init;
 
+  // Outputs
+  Int *src_level, *tend_level;
+  Real *tau, *ubm, *ubi, *xv, *yv, *c;
+
+  GwCmSrcData(Int ncol_, Int ngwv_, Int kbot_, GwFrontInitData init_) :
+    PhysicsTestData({
+      {ncol_, init_.init.pver},
+      {ncol_, init_.init.pgwv*2, init_.init.pver + 1},
+      {ncol_, init_.init.pver + 1},
+      {ncol_},
+      {ncol_, init_.init.pgwv*2},
+      {ncol_}
+    },
+    {
+      {&u, &v, &ubm, &frontgf},
+      {&tau},
+      {&ubi},
+      {&xv, &yv},
+      {&c}
+    },
+    {
+      {&src_level, &tend_level}
+    }),
+    ncol(ncol_), ngwv(ngwv_), kbot(kbot_), init(init_)
+  {}
+
+  PTD_STD_DEF_INIT(GwCmSrcData, 3, ncol, ngwv, kbot);
+};
+
+// Glue functions to call fortran from from C++ with the Data struct
 void gwd_compute_tendencies_from_stress_divergence(GwdComputeTendenciesFromStressDivergenceData& d);
 void gw_prof(GwProfData& d);
 void momentum_energy_conservation(MomentumEnergyConservationData& d);
@@ -375,6 +409,7 @@ void gwd_precalc_rhoi(GwdPrecalcRhoiData& d);
 void gw_drag_prof(GwDragProfData& d);
 void gw_front_project_winds(GwFrontProjectWindsData& d);
 void gw_front_gw_sources(GwFrontGwSourcesData& d);
+void gw_cm_src(GwCmSrcData& d);
 
 extern "C" { // _f function decls
 }

--- a/components/eamxx/src/physics/gw/tests/infra/gw_test_data.hpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_test_data.hpp
@@ -339,6 +339,31 @@ struct GwFrontProjectWindsData : public PhysicsTestData {
 
   PTD_STD_DEF_INIT(GwFrontProjectWindsData, 2, ncol, kbot);
 };
+
+struct GwFrontGwSourcesData : public PhysicsTestData {
+  // Inputs
+  Int ncol, ngwv, kbot;
+  Real *frontgf;
+  GwFrontInitData init;
+
+  // Outputs
+  Real *tau;
+
+  GwFrontGwSourcesData(Int ncol_, Int ngwv_, Int kbot_, GwFrontInitData init_) :
+    PhysicsTestData({
+      {ncol_, init_.init.pver},
+      {ncol_, init_.init.pgwv*2, init_.init.pver}
+    },
+    {
+      {&frontgf},
+      {&tau}
+    }),
+    ncol(ncol_), ngwv(ngwv_), kbot(kbot_), init(init_)
+  {}
+
+  PTD_STD_DEF_INIT(GwFrontGwSourcesData, 3, ncol, ngwv, kbot);
+};
+
 // Glue functions to call fortran from from C++ with the Data struct
 
 void gwd_compute_tendencies_from_stress_divergence(GwdComputeTendenciesFromStressDivergenceData& d);
@@ -349,6 +374,7 @@ void gwd_project_tau(GwdProjectTauData& d);
 void gwd_precalc_rhoi(GwdPrecalcRhoiData& d);
 void gw_drag_prof(GwDragProfData& d);
 void gw_front_project_winds(GwFrontProjectWindsData& d);
+void gw_front_gw_sources(GwFrontGwSourcesData& d);
 
 extern "C" { // _f function decls
 }

--- a/components/eamxx/src/physics/gw/tests/infra/gw_unit_tests_common.hpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_unit_tests_common.hpp
@@ -77,6 +77,7 @@ struct UnitWrap {
 
     // Put struct decls here
     struct TestGwdComputeTendenciesFromStressDivergence;
+    struct TestGwProf;
   }; // UnitWrap
 };
 

--- a/components/eamxx/src/physics/gw/tests/infra/gw_unit_tests_common.hpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_unit_tests_common.hpp
@@ -84,6 +84,7 @@ struct UnitWrap {
     struct TestGwdPrecalcRhoi;
     struct TestGwDragProf;
     struct TestGwFrontProjectWinds;
+    struct TestGwFrontGwSources;
   }; // UnitWrap
 };
 

--- a/components/eamxx/src/physics/gw/tests/infra/gw_unit_tests_common.hpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_unit_tests_common.hpp
@@ -83,6 +83,7 @@ struct UnitWrap {
     struct TestGwdProjectTau;
     struct TestGwdPrecalcRhoi;
     struct TestGwDragProf;
+    struct TestGwFrontProjectWinds;
   }; // UnitWrap
 };
 

--- a/components/eamxx/src/physics/gw/tests/infra/gw_unit_tests_common.hpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_unit_tests_common.hpp
@@ -81,6 +81,7 @@ struct UnitWrap {
     struct TestMomentumEnergyConservation;
     struct TestGwdComputeStressProfilesAndDiffusivities;
     struct TestGwdProjectTau;
+    struct TestGwdPrecalcRhoi;
   }; // UnitWrap
 };
 

--- a/components/eamxx/src/physics/gw/tests/infra/gw_unit_tests_common.hpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_unit_tests_common.hpp
@@ -78,6 +78,7 @@ struct UnitWrap {
     // Put struct decls here
     struct TestGwdComputeTendenciesFromStressDivergence;
     struct TestGwProf;
+    struct TestMomentumEnergyConservation;
   }; // UnitWrap
 };
 

--- a/components/eamxx/src/physics/gw/tests/infra/gw_unit_tests_common.hpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_unit_tests_common.hpp
@@ -80,6 +80,7 @@ struct UnitWrap {
     struct TestGwProf;
     struct TestMomentumEnergyConservation;
     struct TestGwdComputeStressProfilesAndDiffusivities;
+    struct TestGwdProjectTau;
   }; // UnitWrap
 };
 

--- a/components/eamxx/src/physics/gw/tests/infra/gw_unit_tests_common.hpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_unit_tests_common.hpp
@@ -79,6 +79,7 @@ struct UnitWrap {
     struct TestGwdComputeTendenciesFromStressDivergence;
     struct TestGwProf;
     struct TestMomentumEnergyConservation;
+    struct TestGwdComputeStressProfilesAndDiffusivities;
   }; // UnitWrap
 };
 

--- a/components/eamxx/src/physics/gw/tests/infra/gw_unit_tests_common.hpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_unit_tests_common.hpp
@@ -82,6 +82,7 @@ struct UnitWrap {
     struct TestGwdComputeStressProfilesAndDiffusivities;
     struct TestGwdProjectTau;
     struct TestGwdPrecalcRhoi;
+    struct TestGwDragProf;
   }; // UnitWrap
 };
 

--- a/components/eamxx/src/physics/gw/tests/infra/gw_unit_tests_common.hpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_unit_tests_common.hpp
@@ -85,6 +85,7 @@ struct UnitWrap {
     struct TestGwDragProf;
     struct TestGwFrontProjectWinds;
     struct TestGwFrontGwSources;
+    struct TestGwCmSrc;
   }; // UnitWrap
 };
 

--- a/share/util/shr_infnan_mod.F90.in
+++ b/share/util/shr_infnan_mod.F90.in
@@ -1,9 +1,9 @@
 ! Flag representing compiler support of Fortran 2003's
 ! ieee_arithmetic intrinsic module.
-! #if defined CPRIBM || defined CPRPGI || defined CPRNVIDIA || defined CPRINTEL ||  defined CPRCRAY || defined CPRNAG \
-!   || defined CPRAMD || defined CPRFJ
+#if defined CPRIBM || defined CPRPGI || defined CPRNVIDIA || defined CPRINTEL ||  defined CPRCRAY || defined CPRNAG \
+  || defined CPRAMD || defined CPRFJ
 #define HAVE_IEEE_ARITHMETIC
-!#endif
+#endif
 
 module shr_infnan_mod
 !---------------------------------------------------------------------

--- a/share/util/shr_infnan_mod.F90.in
+++ b/share/util/shr_infnan_mod.F90.in
@@ -1,9 +1,9 @@
 ! Flag representing compiler support of Fortran 2003's
 ! ieee_arithmetic intrinsic module.
-#if defined CPRIBM || defined CPRPGI || defined CPRNVIDIA || defined CPRINTEL ||  defined CPRCRAY || defined CPRNAG \
-  || defined CPRAMD || defined CPRFJ
+! #if defined CPRIBM || defined CPRPGI || defined CPRNVIDIA || defined CPRINTEL ||  defined CPRCRAY || defined CPRNAG \
+!   || defined CPRAMD || defined CPRFJ
 #define HAVE_IEEE_ARITHMETIC
-#endif
+!#endif
 
 module shr_infnan_mod
 !---------------------------------------------------------------------


### PR DESCRIPTION
Change list:
* Add bridge and unit test for...
  - gw_prof
  - momentum_energy_conservation
  - gwd_compute_stress_profiles_and_diffusivities
  - gwd_project_tau
  - gwd_precalc_rhoi
  - gw_drag_prof
  - gw_front_project_winds
  - gw_front_gw_sources
  - gw_cm_src
* Some minor fixes for gen_boiler to be able to handle multiple arrays of different dims on same row
* Make gen_boiler.py executable so you can run indv doctests
* test-all-eamxx: Add machine.setup calls in thread functions. This was a weird issue I only see on my laptop. The copies of the object that the threads use does not get the initialized class-level data.
* Fix an issue where not enough data was being allocated in C++ for fortran arrays with dims (-foo:foo). These arrays need `2*foo + 1` amount of data, not just `2*foo`.

[BFB]