### PR TITLE
EAMxx: when rad does not run, set rad outputs/diags to FillValue

### DIFF
--- a/components/eamxx/src/diagnostics/longwave_cloud_forcing.cpp
+++ b/components/eamxx/src/diagnostics/longwave_cloud_forcing.cpp
@@ -52,6 +52,15 @@ void LongwaveCloudForcingDiagnostic::compute_diagnostic_impl()
   const auto& LW_flux_up        = get_field_in("LW_flux_up").get_view<const Real**>();
   const auto& LW_clrsky_flux_up = get_field_in("LW_clrsky_flux_up").get_view<const Real**>();
 
+  // NOTE: as part of fixing https://github.com/E3SM-Project/E3SM/issues/6803, this hack
+  //       may have to be revised. Namely, the "radiation_ran" extra data should be removed,
+  //       in favor of a more structured and uniform approach
+  const auto radiation_ran = get_field_in("LW_flux_up").get_header().get_extra_data<bool>("radiation_ran");
+  if (not radiation_ran) {
+    m_diagnostic_output.deep_copy(constants::DefaultFillValue<Real>().value);
+    return;
+  }
+
   Kokkos::parallel_for("LongwaveCloudForcingDiagnostic",
                        default_policy,
                        KOKKOS_LAMBDA(const MemberType& team) {

--- a/components/eamxx/src/diagnostics/tests/longwave_cloud_forcing_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/longwave_cloud_forcing_tests.cpp
@@ -96,6 +96,7 @@ void run(std::mt19937_64& engine)
     f.allocate_view();
     const auto name = f.name();
     f.get_header().get_tracking().update_time_stamp(t0);
+    f.get_header().set_extra_data("radiation_ran", true);
     diag->set_required_field(f.get_const());
     input_fields.emplace(name,f);
   }

--- a/components/eamxx/src/diagnostics/tests/shortwave_cloud_forcing_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/shortwave_cloud_forcing_tests.cpp
@@ -98,6 +98,7 @@ void run(std::mt19937_64& engine)
     f.allocate_view();
     const auto name = f.name();
     f.get_header().get_tracking().update_time_stamp(t0);
+    f.get_header().set_extra_data("radiation_ran", true);
     diag->set_required_field(f.get_const());
     input_fields.emplace(name,f);
   }

--- a/components/eamxx/src/physics/rrtmgp/eamxx_rrtmgp_process_interface.cpp
+++ b/components/eamxx/src/physics/rrtmgp/eamxx_rrtmgp_process_interface.cpp
@@ -1245,11 +1245,26 @@ void RRTMGPRadiation::run_impl (const double dt) {
     "cldfrac_tot_at_cldtop",
     "cdnc_at_cldtop",
     "eff_radius_qc_at_cldtop",
-    "eff_radius_qi_at_cldtop"
+    "eff_radius_qi_at_cldtop",
+    "cosine_solar_zenith_angle"
   };
 
   for (auto& name : rad_computed_fields) {
     auto f = get_field_out(name);
+    f.get_header().set_extra_data("radiation_ran",update_rad);
+    if (not update_rad) {
+      f.deep_copy(constants::DefaultFillValue<Real>().value);
+    }
+  }
+
+  // Also need to fill computed gas volume mixing ratios
+  for (auto& name : m_gas_names) {
+    // We read o3 in as a vmr already. Also, n2 and co are currently set
+    // as a constant value, read from file during init. Skip these.
+    if (name=="o3" or name == "n2" or name == "co") continue;
+    // The rest are computed by RRTMGP from prescribed surface values, but only when rad updates.
+    // Set to fillvalue here when rad does not run for consistency across restart between update steps
+    auto f = get_field_out(name + "_volume_mix_ratio");
     f.get_header().set_extra_data("radiation_ran",update_rad);
     if (not update_rad) {
       f.deep_copy(constants::DefaultFillValue<Real>().value);

--- a/components/eamxx/tests/multi-process/dynamics_physics/model_restart/input.yaml
+++ b/components/eamxx/tests/multi-process/dynamics_physics/model_restart/input.yaml
@@ -63,6 +63,7 @@ atmosphere_processes:
       rrtmgp_coefficients_file_lw: ${SCREAM_DATA_DIR}/init/rrtmgp-data-lw-g128-210809.nc
       rrtmgp_cloud_optics_file_sw: ${SCREAM_DATA_DIR}/init/rrtmgp-cloud-optics-coeffs-sw.nc
       rrtmgp_cloud_optics_file_lw: ${SCREAM_DATA_DIR}/init/rrtmgp-cloud-optics-coeffs-lw.nc
+      rad_frequency: 3
 
 grids_manager:
   type: homme

--- a/components/eamxx/tests/multi-process/dynamics_physics/model_restart/output.yaml
+++ b/components/eamxx/tests/multi-process/dynamics_physics/model_restart/output.yaml
@@ -2,6 +2,8 @@
 ---
 filename_prefix: model_output_${SUFFIX}
 averaging_type: average
+track_avg_cnt: true
+fill_threshold: 0.25
 fields:
   physics_gll:
     field_names:


### PR DESCRIPTION
When radiation does not run, fill the rad output fields with FillValue; also fill with FillValue the diagnostics ShortwaveCloudForcing and LongwaveCloudForcing in those steps.

[non-BFB for rrtmgp output and rad diagnostics only]

---

NOTE: due to how we handle IO, unless the user _asks_ for avg count, we are NOT ignoring the filled fields during IO accumulation. PR #7397 will make things a tad better (in the sense that, provided we call `fill_aware_combine`, entries equal to FillValue are _ignored_), but won't fix this yet, since there is no metadata in these fields that signal that a fill-aware combine should be done.

We should work on issue #6803 in order to more uniformly (and automatically) handle filled-variables. This PR is just a "stop gap" for ERS tests.

Edit: I put this together super quick. Testing may reveal it does not work. If so, an even more short-term hacky solution would be to remove ShortwaveCloudForcing from the output list in the `eamxx/output/*` testmods... It would not fix the problem, but would remove the fails from the dashboard.