### PR TITLE
Replace a local error_tol in GridCBalanceCheck with common balance_check_tolerance

### DIFF
--- a/components/elm/src/biogeochem/EcosystemBalanceCheckMod.F90
+++ b/components/elm/src/biogeochem/EcosystemBalanceCheckMod.F90
@@ -860,7 +860,6 @@ contains
     !
     integer             :: g, nstep
     real(r8)            :: dt
-    real(r8), parameter :: error_tol = 1.e-8_r8
     !-----------------------------------------------------------------------
 
     associate(                                                       &
@@ -978,7 +977,7 @@ contains
 
          grc_errcb(g) = (grc_cinputs(g) - grc_coutputs(g))*dt - (end_totc(g) - beg_totc(g))
 
-         if (abs(grc_errcb(g)) > error_tol .and. nstep > 1) then
+         if (abs(grc_errcb(g)) > balance_check_tolerance .and. nstep > 1) then
             write(iulog,*)'grid cbalance error = ', grc_errcb(g), g
             write(iulog,*)'Latdeg,Londeg       = ', grc_pp%latdeg(g), grc_pp%londeg(g)
             write(iulog,*)'input               = ', grc_cinputs(g)*dt


### PR DESCRIPTION
PR #6651 increased the tolerance for column and grid balance check for C, N, and P.
However, subroutine GridCBalanceCheck uses a separate error_tol that was not similarly
increased. The lower tolerance is exceeded in an SSP370 simulation (#7423), causing the 
simulation to be aborted. This PR replaces the local error_tol with the common 
balance_check_tolerance for EcosystemBalanceCheckMod.F90.

Fixes #7423 

[BFB] If a simulation were to be impacted, it would have failed when exceeding the lower tolerance.

--------------------------

Note: It is not necessarily a bug but loosely labelled as a bug fix PR.