### PR TITLE
Fix a couple sources of uninitialized memory errors in cam/gw

### DIFF
--- a/components/eam/src/physics/cam/gw/gw_common.F90
+++ b/components/eam/src/physics/cam/gw/gw_common.F90
@@ -752,10 +752,8 @@ subroutine gwd_precalc_rhoi(ncol, ngwv, dt, tend_level, pmid, pint, t, gwut, ubm
 
   ! Calculate tendency on each constituent.
   do m = 1, size(q,3)
-
      call gw_diff_tend(ncol, pver, kbotbg, ktop, q(:,:,m), dt, &
           decomp, qtgw(:,:,m))
-
   enddo
 
   ! Calculate tendency from diffusing dry static energy (dttdf).

--- a/components/eam/src/physics/cam/gw/gw_front.F90
+++ b/components/eam/src/physics/cam/gw/gw_front.F90
@@ -227,7 +227,7 @@ subroutine gw_cm_src(ncol, ngwv, kbot, u, v, frontgf, &
 
   ! Set phase speeds as reference speeds plus the wind speed at the source
   ! level.
-  c = spread(cref, 1, ncol) + spread(abs(ubi(:,kbot)),2,2*ngwv+1)
+  c = spread(cref, 1, ncol) + spread(abs(ubi(:,kbot)),2,2*pgwv+1)
 
 end subroutine gw_cm_src
 

--- a/components/eam/src/physics/cam/vdiff_lu_solver.F90
+++ b/components/eam/src/physics/cam/vdiff_lu_solver.F90
@@ -226,6 +226,8 @@ subroutine vd_lu_solve(pcols, pver,   ncol, &
   ! Main Computation Begins !
   ! ----------------------- !
 
+  zf = 0.0_r8
+
   ! Calculate zf(k). Terms zf(k) and ze(k) are required in solution of
   ! tridiagonal matrix defined by implicit diffusion equation.
   ! Note that only levels ntop through nbot need be solved for.
@@ -276,6 +278,12 @@ pure function lu_decomp_alloc(ncol, pver) result(new_decomp)
   allocate(new_decomp%cc(ncol,pver))
   allocate(new_decomp%dnom(ncol,pver))
   allocate(new_decomp%ze(ncol,pver))
+
+  ! Initialize to zero
+  new_decomp%ca   = 0.0_r8
+  new_decomp%cc   = 0.0_r8
+  new_decomp%dnom = 0.0_r8
+  new_decomp%ze   = 0.0_r8
 
 end function lu_decomp_alloc
 


### PR DESCRIPTION
vdiff_lu_solver had a couple places where uninitialized memory was being used. We just need to be sure to initialize arrays when they are created and this problem goes away.

gw_front::gw_cm_src was trickier, the second spread call was producing an array that had inconsistent size in dim2 `(-ngwv:ngwv)` compared to `c` and `cref` which are `(-pgwv:pgwv)`.


[BFB]