### PR TITLE
Add support for trigrid Arctic RRM

### DIFF
--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -2637,6 +2637,16 @@
       <mask>oARRM60to10</mask>
     </model_grid>
 
+     <model_grid alias="arcticx4v1pg2_r025_ARRM10to60E2r1">
+      <grid name="atm">ne0np4_arcticx4v1.pg2</grid>
+      <grid name="lnd">r025</grid>
+      <grid name="ocnice">ARRM10to60E2r1</grid>
+      <grid name="rof">r025</grid>
+      <grid name="glc">null</grid>
+      <grid name="wav">null</grid>
+      <mask>ARRM10to60E2r1</mask>
+    </model_grid>
+
     <model_grid alias="ne30pg2_r05_EC30to60E2r2">
       <grid name="atm">ne30np4.pg2</grid>
       <grid name="lnd">r05</grid>
@@ -3616,6 +3626,7 @@
       <ny>720</ny>
       <file grid="atm|lnd" mask="IcoswISC30E3r5">$DIN_LOC_ROOT/share/domains/domain.lnd.r025_IcoswISC30E3r5.240129.nc</file>
       <file grid="atm|lnd" mask="RRSwISC6to18E3r5">$DIN_LOC_ROOT/share/domains/domain.lnd.r025_RRSwISC6to18E3r5.250216.nc</file>
+      <file grid="atm|lnd" mask="ARRM10to60E2r1">$DIN_LOC_ROOT/share/domains/domain.lnd.r025_ARRM10to60E2r1.250617.nc</file>
       <desc>r025 is 1/4 degree river routing grid:</desc>
     </domain>
 
@@ -3790,8 +3801,8 @@
       <ny>1</ny>
       <file grid="atm|lnd" mask="oARRM60to10">$DIN_LOC_ROOT/share/domains/domain.lnd.arcticx4v1pg2_oARRM60to10.210630.nc</file>
       <file grid="ice|ocn" mask="oARRM60to10">$DIN_LOC_ROOT/share/domains/domain.ocn.arcticx4v1pg2_oARRM60to10.210630.nc</file>
-      <file grid="atm|lnd" mask="ARRM10to60E2r1">$DIN_LOC_ROOT/share/domains/domain.lnd.arcticx4v1pg2_ARRM10to60E2r1.220802.nc</file>
-      <file grid="ice|ocn" mask="ARRM10to60E2r1">$DIN_LOC_ROOT/share/domains/domain.ocn.arcticx4v1pg2_ARRM10to60E2r1.220802.nc</file>
+      <file grid="atm|lnd" mask="ARRM10to60E2r1">$DIN_LOC_ROOT/share/domains/domain.lnd.arcticx4v1pg2_ARRM10to60E2r1.240708.nc</file>
+      <file grid="ice|ocn" mask="ARRM10to60E2r1">$DIN_LOC_ROOT/share/domains/domain.ocn.arcticx4v1pg2_ARRM10to60E2r1.240708.nc</file>
       <desc>1-deg with 1/4-deg over Arctic (version 1) pg2:</desc>
     </domain>
 
@@ -4737,11 +4748,11 @@
     </gridmap>
 
     <gridmap atm_grid="ne0np4_arcticx4v1.pg2" ocn_grid="ARRM10to60E2r1">
-      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/arcticx4v1pg2/map_arcticx4v1pg2_to_ARRM10to60E2r1_mono.220802.nc</map>
-      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/arcticx4v1pg2/map_arcticx4v1pg2_to_ARRM10to60E2r1_bilin.220802.nc</map>
-      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/arcticx4v1pg2/map_arcticx4v1pg2_to_ARRM10to60E2r1_bilin.220802.nc</map>
-      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/ARRM10to60E2r1/map_ARRM10to60E2r1_to_arcticx4v1pg2_mono.220802.nc</map>
-      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/ARRM10to60E2r1/map_ARRM10to60E2r1_to_arcticx4v1pg2_mono.220802.nc</map>
+      <map name="ATM2OCN_FMAPNAME">cpl/gridmaps/arcticx4v1pg2/map_arcticx4v1pg2_to_ARRM10to60E2r1_traave.20240820.nc</map>
+      <map name="ATM2OCN_VMAPNAME">cpl/gridmaps/arcticx4v1pg2/map_arcticx4v1pg2_to_ARRM10to60E2r1_traave.20240820.nc</map>
+      <map name="ATM2OCN_SMAPNAME">cpl/gridmaps/arcticx4v1pg2/map_arcticx4v1pg2_to_ARRM10to60E2r1_traave.20240820.nc</map>
+      <map name="OCN2ATM_FMAPNAME">cpl/gridmaps/ARRM10to60E2r1/map_ARRM10to60E2r1_to_arcticx4v1pg2_traave.20240820.nc</map>
+      <map name="OCN2ATM_SMAPNAME">cpl/gridmaps/ARRM10to60E2r1/map_ARRM10to60E2r1_to_arcticx4v1pg2_traave.20240820.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne0np4_arcticx4v1.pg2" lnd_grid="r0125">
@@ -4749,6 +4760,13 @@
       <map name="ATM2LND_SMAPNAME">cpl/gridmaps/arcticx4v1pg2/map_arcticx4v1pg2_to_r0125_mono.20210517.nc</map>
       <map name="LND2ATM_FMAPNAME">cpl/gridmaps/r0125/map_r0125_to_arcticx4v1pg2_mono.20210517.nc</map>
       <map name="LND2ATM_SMAPNAME">cpl/gridmaps/r0125/map_r0125_to_arcticx4v1pg2_mono.20210517.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ne0np4_arcticx4v1.pg2" lnd_grid="r025">
+      <map name="ATM2LND_FMAPNAME">cpl/gridmaps/arcticx4v1pg2/map_arcticx4v1pg2_to_r025_traave.20240820.nc</map>
+      <map name="ATM2LND_SMAPNAME">cpl/gridmaps/arcticx4v1pg2/map_arcticx4v1pg2_to_r025_trbilin.20240820.nc</map>
+      <map name="LND2ATM_FMAPNAME">cpl/gridmaps/r025/map_r025_to_arcticx4v1pg2_traave.20240820.nc</map>
+      <map name="LND2ATM_SMAPNAME">cpl/gridmaps/r025/map_r025_to_arcticx4v1pg2_traave.20240820.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne0np4_arcticx4v1.pg2" lnd_grid="r05">
@@ -4761,6 +4779,11 @@
     <gridmap atm_grid="ne0np4_arcticx4v1.pg2" rof_grid="r0125">
       <map name="ATM2ROF_FMAPNAME">cpl/gridmaps/arcticx4v1pg2/map_arcticx4v1pg2_to_r0125_mono.20210517.nc</map>
       <map name="ATM2ROF_SMAPNAME">cpl/gridmaps/arcticx4v1pg2/map_arcticx4v1pg2_to_r0125_mono.20210517.nc</map>
+    </gridmap>
+
+    <gridmap atm_grid="ne0np4_arcticx4v1.pg2" rof_grid="r025">
+      <map name="ATM2ROF_FMAPNAME">cpl/gridmaps/arcticx4v1pg2/map_arcticx4v1pg2_to_r025_traave.20240820.nc</map>
+      <map name="ATM2ROF_SMAPNAME">cpl/gridmaps/arcticx4v1pg2/map_arcticx4v1pg2_to_r025_traave.20240820.nc</map>
     </gridmap>
 
     <gridmap atm_grid="ne0np4_arcticx4v1.pg2" rof_grid="r05">
@@ -5479,6 +5502,11 @@
       <map name="ROF2LND_FMAPNAME">cpl/gridmaps/r0125/map_r0125_to_arcticx4v1pg2_mono.20210517.nc</map>
     </gridmap>
 
+    <gridmap lnd_grid="ne0np4_arcticx4v1.pg2" rof_grid="r025">
+      <map name="LND2ROF_FMAPNAME">cpl/gridmaps/arcticx4v1pg2/map_arcticx4v1pg2_to_r025_traave.20240820.nc</map>
+      <map name="ROF2LND_FMAPNAME">cpl/gridmaps/r025/map_r025_to_arcticx4v1pg2_traave.20240820.nc</map>
+    </gridmap>
+
     <gridmap lnd_grid="ne0np4_arcticx4v1.pg2" rof_grid="r05">
       <map name="LND2ROF_FMAPNAME">cpl/gridmaps/arcticx4v1pg2/map_arcticx4v1pg2_to_r05_mono.20210706.nc</map>
       <map name="ROF2LND_FMAPNAME">cpl/gridmaps/r05/map_r05_to_arcticx4v1pg2_mono.20210706.nc</map>
@@ -5954,6 +5982,11 @@
     <gridmap ocn_grid="RRSwISC6to18E3r5" rof_grid="r025">
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r025_to_RRSwISC6to18E3r5.cstmnn.r250e1250_58NS.20240328.nc</map>
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r025_to_RRSwISC6to18E3r5_cstmnn.r50e100.20250325.nc</map>
+    </gridmap>
+
+    <gridmap ocn_grid="ARRM10to60E2r1" rof_grid="r025">
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/cpl6/map_r025_to_ARRM10to60E2r1_cstmnn.r150e300.20240814.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/cpl6/map_r025_to_ARRM10to60E2r1_cstmnn.r150e300.20240814.nc</map>
     </gridmap>
 
     <gridmap ocn_grid="WC14to60E2r3" rof_grid="r0125">

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -120,6 +120,7 @@
 <ncdata dyn="se" hgrid="ne0np4_northamericax4v1"          nlev="72"                 >atm/cam/inic/homme/cami_0001-01-01_northamericax4v1_c190709.nc</ncdata>
 <ncdata dyn="se" hgrid="ne0np4_antarcticax4v1"            nlev="72"                 >atm/cam/inic/homme/cami_mam3_Linoz_0000-01-antarcticax4v1_L72_topoadj_c20200507.nc</ncdata>
 <ncdata dyn="se" hgrid="ne0np4_arcticx4v1"                nlev="72"                 >atm/cam/inic/homme/eam_i_mam4_Linoz_0011-01-arcticx4v1np4_L72_c20220127.nc</ncdata>
+<ncdata dyn="se" hgrid="ne0np4_arcticx4v1"                nlev="80"                 >atm/cam/inic/homme/eam_i_mam4_Linoz_0011-01-arcticx4v1np4_L80_c20250617.nc</ncdata>
 <ncdata dyn="se" hgrid="ne0np4_svalbard_x8v1_lowcon"      nlev="30"                 >atm/cam/inic/homme/cami-mam3_0000-01-01_svalbardx8v1np4_L30_c141107.nc</ncdata>
 <ncdata dyn="se" hgrid="ne0np4_svalbard_x8v1_lowcon"      nlev="30" ocn="aquaplanet">atm/cam/inic/homme/cami_0003-01-01_svalbardx8v1np4_L30_ape_c000000.nc</ncdata>
 <ncdata dyn="se" hgrid="ne0np4_sooberingoa_x4x8v1_lowcon" nlev="30"                 >atm/cam/inic/homme/cami-mam3_0000-01-01_sooberingoax4x8v1np4_L30_c141110.nc</ncdata>


### PR DESCRIPTION
Adds grid alias, domain and mapping files for `arcticx4v1pg2_r025_ARRM10to60E2r1` resolution. All support files are staged in public inputdata and world readable.

Adds new default 80 layer `ncdata` for `arcticx4v1pg2` atmosphere mesh (h/t @whannah1 ).

[BFB]