### PR TITLE
Fix the abort routines in mpas-framework to use shr_sys_abort when coupled

### DIFF
--- a/components/mpas-framework/src/framework/framework.cmake
+++ b/components/mpas-framework/src/framework/framework.cmake
@@ -1,4 +1,5 @@
 # framework
+list(APPEND CPPDEFS "-Dcoupled")
 list(APPEND COMMON_RAW_SOURCES
   framework/mpas_kind_types.F
   framework/mpas_framework.F

--- a/components/mpas-framework/src/framework/mpas_abort.F
+++ b/components/mpas-framework/src/framework/mpas_abort.F
@@ -29,6 +29,10 @@ module mpas_abort
       use mpas_kind_types, only : StrKIND
       use mpas_io_units, only : mpas_new_unit
       use mpas_threading, only : mpas_threading_get_thread_num
+
+#ifdef coupled
+      use shr_sys_mod, only : shr_sys_abort
+#endif
    
 #ifdef _MPI
 #ifndef NOMPIMOD
@@ -93,10 +97,14 @@ module mpas_abort
       end if
    
       if (.not. local_deferredAbort) then
-#ifdef _MPI
-         call MPI_Abort(MPI_COMM_WORLD, mpi_errcode, mpi_ierr)
+#ifdef coupled
+      call shr_sys_abort('MPAS framework abort')
 #else
-         stop
+  #ifdef _MPI
+      call MPI_Abort(MPI_COMM_WORLD, mpi_errcode, mpi_ierr)
+  #else
+      stop
+  #endif
 #endif
       end if
    

--- a/components/mpas-framework/src/framework/mpas_log.F
+++ b/components/mpas-framework/src/framework/mpas_log.F
@@ -846,11 +846,7 @@ module mpas_log
       deallocate(mpas_log_info % outputLog)
       deallocate(mpas_log_info)
 
-#ifdef _MPI
-      call MPI_Abort(MPI_COMM_WORLD, mpi_errcode, mpi_ierr)
-#else
-      stop
-#endif
+      call mpas_dmpar_global_abort('Log_abort')
 
    !--------------------------------------------------------------------
    end subroutine log_abort

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -338,6 +338,9 @@ add_default($nl, 'config_coef_3rd_order');
 add_default($nl, 'config_flux_limiter');
 add_default($nl, 'config_remap_limiter');
 add_default($nl, 'config_thickness_flux_type');
+add_default($nl, 'config_use_spatially_variable_upwind');
+add_default($nl, 'config_spatially_variable_upwind_hmin');
+add_default($nl, 'config_spatially_variable_upwind_hmax');
 
 ###############################
 # Namelist group: bottom_drag #

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -509,6 +509,9 @@
 <config_flux_limiter>'monotonic'</config_flux_limiter>
 <config_remap_limiter>'monotonic'</config_remap_limiter>
 <config_thickness_flux_type>'centered'</config_thickness_flux_type>
+<config_use_spatially_variable_upwind>.false.</config_use_spatially_variable_upwind>
+<config_spatially_variable_upwind_hmin>5.0</config_spatially_variable_upwind_hmin>
+<config_spatially_variable_upwind_hmax>10.0</config_spatially_variable_upwind_hmax>
 
 <!-- bottom_drag -->
 <config_bottom_drag_mode>'implicit'</config_bottom_drag_mode>

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -1841,6 +1841,30 @@ Valid values: 'upwind', 'centered', 'constant'
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_use_spatially_variable_upwind" type="logical"
+	category="advection" group="advection">
+If true, use upwindFactor to scale layerThickEdgeFlux by centered and upwind values.
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_spatially_variable_upwind_hmin" type="real"
+	category="advection" group="advection">
+Column thickness above which we start weighting upwind with centered advection.
+
+Valid values: Any positive real
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_spatially_variable_upwind_hmax" type="real"
+	category="advection" group="advection">
+Column thickness above which advection is no longer upwinded.
+
+Valid values: Any positive real
+Default: Defined in namelist_defaults.xml
+</entry>
+
 
 <!-- bottom_drag -->
 

--- a/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/upwind_advection/user_nl_mpaso
+++ b/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/upwind_advection/user_nl_mpaso
@@ -1,1 +1,4 @@
  config_thickness_flux_type = 'upwind'
+ config_use_spatially_variable_upwind = .true.
+ config_spatially_variable_upwind_hmin = 10.0
+ config_spatially_variable_upwind_hmax = 50.0

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1148,6 +1148,18 @@
 					description="If 'upwind', use upwind to evaluate the edge-value for layerThickness, i.e., layerThickEdgeFlux.  The standard MPAS-O approach is 'centered'. For 'constant', uses constant thickness in time from restingThickness, for linear test problems. Note that these two flags are set together for linearized test cases: config_thickness_flux_type = 'constant' linearizes the thickness equation, and config_disable_vel_hadv = .true. linearizes the momentum equation if there is no assumed mean background velocity."
 					possible_values="'upwind', 'centered', 'constant'"
 		/>
+		<nml_option name="config_use_spatially_variable_upwind" type="logical" default_value=".false."
+					description="If true, use upwindFactor to scale layerThickEdgeFlux by centered and upwind values."
+					possible_values=".true. or .false."
+		/>
+		<nml_option name="config_spatially_variable_upwind_hmin" type="real" default_value="5.0"
+					description="Column thickness above which we start weighting upwind with centered advection."
+					possible_values="Any positive real"
+		/>
+		<nml_option name="config_spatially_variable_upwind_hmax" type="real" default_value="10.0"
+					description="Column thickness above which advection is no longer upwinded."
+					possible_values="Any positive real"
+		/>
 	</nml_record>
 	<nml_record name="bottom_drag" mode="forward">
 		<nml_option name="config_bottom_drag_mode" type="character" default_value="implicit"
@@ -1805,6 +1817,7 @@
 			<var name="fCell"/>
 			<var name="bed_elevation"/>
 			<var name="LTSRegion"/>
+			<var name="upwindFactor"/>
 		</stream>
 
 		<stream name="output_init"
@@ -1839,6 +1852,7 @@
 			<var name="landIceFloatingMask"/>
 			<var name="landIceFloatingFraction"/>
 			<var name="LTSRegion"/>
+			<var name="upwindFactor"/>
 		</stream>
 
 		<stream name="forcing_data_init"
@@ -3074,6 +3088,11 @@
 			 missing_value="FILLVAL" missing_value_mask="vertexMask"
 			 packages="forwardMode;analysisMode"
 		/>
+		<!-- Input fields from initial condition for spatially variable upwinding -->
+		<var name="upwindFactor" type="real" dimensions="nEdges Time" units="1"
+			description="The fraction of horizontal advection that is upwinded. Range from 0 (centered) to 1 (fully upwind)"
+		/>
+
 
 		<var name="kineticEnergyCell" type="real" dimensions="nVertLevels nCells Time" units="m^2 s^-2"
 			 description="kinetic energy of horizontal velocity on cells"

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -857,7 +857,7 @@ contains
          iEdge, k,     &! edge and vertical loop indices
          cell1, cell2, &! neighbor cell indices across an edge
          kmin, kmax     ! min,max active vertical levels
-
+      real(kind=RKIND) :: columnThickness
       ! End preamble
       !-----------------------------------------------------------------
       ! Begin code
@@ -985,7 +985,43 @@ contains
 #endif
 
         end if
-
+        if (config_use_spatially_variable_upwind) then
+#ifdef MPAS_OPENACC
+            !$acc parallel loop &
+            !$acc    present(layerThickEdgeMean, layerThickEdgeFlux, &
+            !$acc            minLevelEdgeBot, maxLevelEdgeTop, &
+            !$acc            upwindFactor) &
+            !$acc    private(k, kmin, kmax, columnThickness)
+#else
+            !$omp parallel
+            !$omp do schedule(runtime) private(k, kmin, kmax, cell1, cell2, columnThickness)
+#endif
+            do iEdge = 1, nEdgesAll
+              cell1 = cellsOnEdge(1,iEdge)
+              cell2 = cellsOnEdge(2,iEdge)
+              columnThickness = min(bottomDepth(cell1) + ssh(cell1), &
+                                    bottomDepth(cell2) + ssh(cell2))
+              if (columnThickness <= config_spatially_variable_upwind_hmin) then
+                upwindFactor(iEdge) = 1.0_RKIND
+              elseif (columnThickness >= config_spatially_variable_upwind_hmax) then
+                upwindFactor(iEdge) = 0.0_RKIND
+              else
+                upwindFactor(iEdge) = 1.0_RKIND - &
+                                      (columnThickness - config_spatially_variable_upwind_hmin) / &
+                                      (config_spatially_variable_upwind_hmax - config_spatially_variable_upwind_hmin)
+              end if
+              kmin = minLevelEdgeBot(iEdge)
+              kmax = maxLevelEdgeTop(iEdge)
+              do k = kmin,kmax
+                 layerThickEdgeFlux(k,iEdge) = (1.0_RKIND - upwindFactor(iEdge)) * layerThickEdgeMean(k,iEdge) &
+                                             + upwindFactor(iEdge)* layerThickEdgeFlux(k,iEdge)
+              end do
+            end do
+#ifndef MPAS_OPENACC
+            !$omp end do
+            !$omp end parallel
+#endif
+        endif
       case (thickEdgeFluxConstant)
          ! Use linearized version H*u where H is constant in time
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics_variables.F
@@ -70,6 +70,7 @@ module ocn_diagnostics_variables
    real (kind=RKIND), dimension(:,:), pointer :: RiTopOfCell
    real (kind=RKIND), dimension(:,:), pointer :: RiTopOfEdge
 
+   real (kind=RKIND), dimension(:), pointer :: upwindFactor
    real (kind=RKIND), dimension(:), pointer :: gradSSH
    real (kind=RKIND), dimension(:), pointer :: pressureAdjustedSSH
    real (kind=RKIND), dimension(:), pointer :: pgf_sal
@@ -289,6 +290,10 @@ contains
                    layerThicknessCellWetDry)
          call mpas_pool_get_array(diagnosticsPool, 'sshCellWetDry', &
                    sshCellWetDry)
+      end if
+      if (config_use_spatially_variable_upwind) then
+         call mpas_pool_get_array(diagnosticsPool, 'upwindFactor', &
+                   upwindFactor)
       end if
 
       if (config_use_GM.or.config_use_Redi) then
@@ -811,6 +816,7 @@ contains
          !$acc                   GMStreamFuncX,                   &
          !$acc                   GMStreamFuncY,                   &
          !$acc                   GMStreamFuncZ,                   &
+         !$acc                   upwindFactor,                    &
          !$acc                   layerThickEdgeDrag,              &
          !$acc                   layerThickEdgeFlux,              &
          !$acc                   layerThickEdgeMean,              &
@@ -1072,6 +1078,7 @@ contains
          !$acc                   GMStreamFuncX,                   &
          !$acc                   GMStreamFuncY,                   &
          !$acc                   GMStreamFuncZ,                   &
+         !$acc                   upwindFactor,                    &
          !$acc                   layerThickEdgeDrag,              &
          !$acc                   layerThickEdgeFlux,              &
          !$acc                   layerThickEdgeMean,              &
@@ -1280,6 +1287,7 @@ contains
                  GMStreamFuncX,                   &
                  GMStreamFuncY,                   &
                  GMStreamFuncZ,                   &
+                 upwindFactor,                    &
                  layerThickEdgeDrag,              &
                  layerThickEdgeFlux,              &
                  layerThickEdgeMean,              &


### PR DESCRIPTION
Fix the about routines in mpas-framework so that log_abort calls mpas_dmpar_global_abort and mpas_dmpar_global_abort itself uses shr_sys_abort when running as a coupled model.

Fixes #7447 
[BFB]