### PR TITLE
Fix the abort routines in mpas-framework to use shr_sys_abort when coupled

### DIFF
--- a/components/mpas-framework/src/framework/framework.cmake
+++ b/components/mpas-framework/src/framework/framework.cmake
@@ -1,4 +1,5 @@
 # framework
+list(APPEND CPPDEFS "-Dcoupled")
 list(APPEND COMMON_RAW_SOURCES
   framework/mpas_kind_types.F
   framework/mpas_framework.F

--- a/components/mpas-framework/src/framework/mpas_abort.F
+++ b/components/mpas-framework/src/framework/mpas_abort.F
@@ -102,11 +102,11 @@ module mpas_abort
 #ifdef coupled
       call shr_sys_abort('MPAS framework abort')
 #else
-  #ifdef _MPI
+#ifdef _MPI
       call MPI_Abort(MPI_COMM_WORLD, mpi_errcode, mpi_ierr)
-  #else
+#else
       stop
-  #endif
+#endif
 #endif
       end if
    

--- a/components/mpas-framework/src/framework/mpas_abort.F
+++ b/components/mpas-framework/src/framework/mpas_abort.F
@@ -29,6 +29,10 @@ module mpas_abort
       use mpas_kind_types, only : StrKIND
       use mpas_io_units, only : mpas_new_unit
       use mpas_threading, only : mpas_threading_get_thread_num
+
+#ifdef coupled
+      use shr_sys_mod, only : shr_sys_abort
+#endif
    
 #ifdef _MPI
 #ifndef NOMPIMOD
@@ -93,10 +97,14 @@ module mpas_abort
       end if
    
       if (.not. local_deferredAbort) then
-#ifdef _MPI
-         call MPI_Abort(MPI_COMM_WORLD, mpi_errcode, mpi_ierr)
+#ifdef coupled
+      call shr_sys_abort('MPAS framework abort')
 #else
-         stop
+  #ifdef _MPI
+      call MPI_Abort(MPI_COMM_WORLD, mpi_errcode, mpi_ierr)
+  #else
+      stop
+  #endif
 #endif
       end if
    

--- a/components/mpas-framework/src/framework/mpas_abort.F
+++ b/components/mpas-framework/src/framework/mpas_abort.F
@@ -48,7 +48,7 @@ module mpas_abort
 #endif
 #endif
    
-      character(len=*), intent(in) :: mesg !< Input: Abort message
+      character(len=*), intent(in), optional :: mesg !< Input: Abort message
       logical, intent(in), optional :: deferredAbort !< Input: Defer call to abort until later
    
       integer :: threadNum
@@ -67,33 +67,35 @@ module mpas_abort
          local_deferredAbort = .false.
       end if
    
-      threadNum = mpas_threading_get_thread_num()
+      if (present(mesg)) then
+         threadNum = mpas_threading_get_thread_num()
    
 #ifdef _MPI
-      call MPI_Comm_rank(MPI_COMM_WORLD, my_proc_id, mpi_ierr)
-      call MPI_Comm_size(MPI_COMM_WORLD, nprocs, mpi_ierr)
-      if (nprocs < 1E4) then
-         write(errorFile,fmt='(a,i4.4,a)') 'log.', my_proc_id, '.abort'
-      else if (nprocs < 1E5) then
-         write(errorFile,fmt='(a,i5.5,a)') 'log.', my_proc_id, '.abort'
-      else if (nprocs < 1E6) then
-         write(errorFile,fmt='(a,i6.6,a)') 'log.', my_proc_id, '.abort'
-      else if (nprocs < 1E7) then
-         write(errorFile,fmt='(a,i7.7,a)') 'log.', my_proc_id, '.abort'
-      else if (nprocs < 1E8) then
-         write(errorFile,fmt='(a,i8.8,a)') 'log.', my_proc_id, '.abort'
-      else
-         write(errorFile,fmt='(a,i9.9,a)') 'log.', my_proc_id, '.abort'
-      end if
+         call MPI_Comm_rank(MPI_COMM_WORLD, my_proc_id, mpi_ierr)
+         call MPI_Comm_size(MPI_COMM_WORLD, nprocs, mpi_ierr)
+         if (nprocs < 1E4) then
+            write(errorFile,fmt='(a,i4.4,a)') 'log.', my_proc_id, '.abort'
+         else if (nprocs < 1E5) then
+            write(errorFile,fmt='(a,i5.5,a)') 'log.', my_proc_id, '.abort'
+         else if (nprocs < 1E6) then
+            write(errorFile,fmt='(a,i6.6,a)') 'log.', my_proc_id, '.abort'
+         else if (nprocs < 1E7) then
+            write(errorFile,fmt='(a,i7.7,a)') 'log.', my_proc_id, '.abort'
+         else if (nprocs < 1E8) then
+            write(errorFile,fmt='(a,i8.8,a)') 'log.', my_proc_id, '.abort'
+         else
+            write(errorFile,fmt='(a,i9.9,a)') 'log.', my_proc_id, '.abort'
+         end if
 #else
-      errorFile = 'log.abort'
+         errorFile = 'log.abort'
 #endif
    
-      if ( threadNum == 0 ) then
-         call mpas_new_unit(errorUnit)
-         open(unit=errorUnit, file=trim(errorFile), form='formatted', position='append')
-         write(errorUnit,*) trim(mesg)
-         close(errorUnit)
+         if ( threadNum == 0 ) then
+            call mpas_new_unit(errorUnit)
+            open(unit=errorUnit, file=trim(errorFile), form='formatted', position='append')
+            write(errorUnit,*) trim(mesg)
+            close(errorUnit)
+         end if
       end if
    
       if (.not. local_deferredAbort) then

--- a/components/mpas-framework/src/framework/mpas_log.F
+++ b/components/mpas-framework/src/framework/mpas_log.F
@@ -846,7 +846,7 @@ module mpas_log
       deallocate(mpas_log_info % outputLog)
       deallocate(mpas_log_info)
 
-      call mpas_dmpar_global_abort('Log_abort')
+      call mpas_dmpar_global_abort()
 
    !--------------------------------------------------------------------
    end subroutine log_abort

--- a/components/mpas-framework/src/framework/mpas_log.F
+++ b/components/mpas-framework/src/framework/mpas_log.F
@@ -846,11 +846,7 @@ module mpas_log
       deallocate(mpas_log_info % outputLog)
       deallocate(mpas_log_info)
 
-#ifdef _MPI
-      call MPI_Abort(MPI_COMM_WORLD, mpi_errcode, mpi_ierr)
-#else
-      stop
-#endif
+      call mpas_dmpar_global_abort('Log_abort')
 
    !--------------------------------------------------------------------
    end subroutine log_abort


### PR DESCRIPTION
Fix the abort routines in mpas-framework so that log_abort calls mpas_dmpar_global_abort and mpas_dmpar_global_abort itself uses shr_sys_abort when running as a coupled model.

Fixes https://github.com/E3SM-Project/E3SM/issues/7447
[BFB]