### PR TITLE
EAMXX: User control over the are four factors that control in cloud and below cloud activation.

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -379,7 +379,12 @@ be lost if SCREAM_HACK_XML is not enabled.
     </mam4_optics>
 
     <!-- MAM4xx-Wetscav -->
-    <mam4_wetscav inherit="mam4_atm_proc_base" />
+    <mam4_wetscav inherit="mam4_atm_proc_base">
+      <sol_facti_cloud_borne type="real" doc="In-cloud scavenging fraction [fraction]">1.0</sol_facti_cloud_borne>
+      <sol_factic_cloud_borne type="real" doc="In-cloud convective scavenging fraction [fraction]">0.0</sol_factic_cloud_borne>
+      <sol_factb_below_cloud type="real" doc="Below-cloud scavenging fraction [fraction]">0.03</csol_factb_below_cloud>
+      <f_act_conv_below_cloud type="real" doc="Convection activation fraction [fraction]">0.4</f_act_conv_below_cloud>
+    </mam4_wetscav>
 
     <!-- MAM4xx-Surface-Emissions -->
     <mam4_srf_online_emiss inherit="mam4_atm_proc_base">

--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -380,10 +380,10 @@ be lost if SCREAM_HACK_XML is not enabled.
 
     <!-- MAM4xx-Wetscav -->
     <mam4_wetscav inherit="mam4_atm_proc_base">
-      <sol_facti_cloud_borne type="real" doc="In-cloud scavenging fraction [fraction]">1.0</sol_facti_cloud_borne>
-      <sol_factic_cloud_borne type="real" doc="In-cloud convective scavenging fraction [fraction]">0.0</sol_factic_cloud_borne>
-      <sol_factb_below_cloud type="real" doc="Below-cloud scavenging fraction [fraction]">0.03</sol_factb_below_cloud>
-      <f_act_conv_below_cloud type="real" doc="Convection activation fraction [fraction]">0.4</f_act_conv_below_cloud>
+      <scav_fraction_in_cloud_strat type="real" doc="In-cloud scavenging fraction has a physical basis and reflects activation fraction [fraction]">1.0</scav_fraction_in_cloud_strat>
+      <scav_fraction_in_cloud_conv type="real" doc="In-cloud convective scavenging fraction has a physical basis and reflects activation fraction [fraction]">0.0</scav_fraction_in_cloud_conv>
+      <scav_fraction_below_cloud_strat type="real" doc="Below-cloud scavenging fraction is basically a tuning factor [fraction]">0.03</scav_fraction_below_cloud_strat>
+      <activation_fraction_in_cloud_conv type="real" doc="Convection activation fraction [fraction]">0.4</activation_fraction_in_cloud_conv>
     </mam4_wetscav>
 
     <!-- MAM4xx-Surface-Emissions -->

--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -382,7 +382,7 @@ be lost if SCREAM_HACK_XML is not enabled.
     <mam4_wetscav inherit="mam4_atm_proc_base">
       <sol_facti_cloud_borne type="real" doc="In-cloud scavenging fraction [fraction]">1.0</sol_facti_cloud_borne>
       <sol_factic_cloud_borne type="real" doc="In-cloud convective scavenging fraction [fraction]">0.0</sol_factic_cloud_borne>
-      <sol_factb_below_cloud type="real" doc="Below-cloud scavenging fraction [fraction]">0.03</csol_factb_below_cloud>
+      <sol_factb_below_cloud type="real" doc="Below-cloud scavenging fraction [fraction]">0.03</sol_factb_below_cloud>
       <f_act_conv_below_cloud type="real" doc="Convection activation fraction [fraction]">0.4</f_act_conv_below_cloud>
     </mam4_wetscav>
 

--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -379,12 +379,7 @@ be lost if SCREAM_HACK_XML is not enabled.
     </mam4_optics>
 
     <!-- MAM4xx-Wetscav -->
-    <mam4_wetscav inherit="mam4_atm_proc_base">
-      <scav_fraction_in_cloud_strat type="real" doc="In-cloud scavenging fraction has a physical basis and reflects activation fraction [fraction]">1.0</scav_fraction_in_cloud_strat>
-      <scav_fraction_in_cloud_conv type="real" doc="In-cloud convective scavenging fraction has a physical basis and reflects activation fraction [fraction]">0.0</scav_fraction_in_cloud_conv>
-      <scav_fraction_below_cloud_strat type="real" doc="Below-cloud scavenging fraction is basically a tuning factor [fraction]">0.03</scav_fraction_below_cloud_strat>
-      <activation_fraction_in_cloud_conv type="real" doc="Convection activation fraction [fraction]">0.4</activation_fraction_in_cloud_conv>
-    </mam4_wetscav>
+    <mam4_wetscav inherit="mam4_atm_proc_base" />
 
     <!-- MAM4xx-Surface-Emissions -->
     <mam4_srf_online_emiss inherit="mam4_atm_proc_base">

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -998,7 +998,6 @@ void MAMMicrophysics::run_impl(const double dt) {
         const auto work_set_het_icol = ekat::subview(work_set_het, icol);
 
         mam4::MicrophysDiagnosticArrays diag_arrays;
-
         if (extra_mam4_aero_microphys_diags) {
           diag_arrays.dqdt_so4_aqueous_chemistry = ekat::subview(dqdt_so4_aqueous_chemistry, icol);
           diag_arrays.dqdt_h2so4_uptake          = ekat::subview(dqdt_h2so4_uptake, icol);
@@ -1014,8 +1013,6 @@ void MAMMicrophysics::run_impl(const double dt) {
           diag_arrays.gas_aero_exchange_coagulation = ekat::subview(gas_aero_exchange_coagulation, icol);
           diag_arrays.gas_aero_exchange_renaming_cloud_borne = ekat::subview(gas_aero_exchange_renaming_cloud_borne, icol);
         }
-
-
         // Wind speed at the surface
         const Real wind_speed =
             haero::sqrt(u_wind(icol, surface_lev) * u_wind(icol, surface_lev) +

--- a/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.cpp
@@ -21,6 +21,10 @@ MAMWetscav::MAMWetscav(const ekat::Comm &comm,
    */
   check_fields_intervals_ =
       m_params.get<bool>("create_fields_interval_checks", false);
+  sol_facti_cloud_borne_  = m_params.get<Real>("sol_facti_cloud_borne",  1.00);   
+  sol_factic_cloud_borne_ = m_params.get<Real>("sol_factic_cloud_borne", 0.00);
+  sol_factb_below_cloud_  = m_params.get<Real>("sol_factb_below_cloud",  0.03);
+  f_act_conv_below_cloud_ = m_params.get<Real>("f_act_conv_below_cloud", 0.40);
 }
 
 // ================================================================
@@ -429,7 +433,10 @@ void MAMWetscav::run_impl(const double dt) {
   const auto &calsize_data  = calsize_data_;
   const auto &scavimptblnum = scavimptblnum_;
   const auto &scavimptblvol = scavimptblvol_;
-
+  const Real sol_facti_cloud_borne  = sol_facti_cloud_borne_;   
+  const Real sol_factic_cloud_borne = sol_factic_cloud_borne_;
+  const Real sol_factb_below_cloud  = sol_factb_below_cloud_;
+  const Real f_act_conv_below_cloud = f_act_conv_below_cloud_;
   // Loop over atmosphere columns
   Kokkos::parallel_for(
       policy, KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -479,6 +486,10 @@ void MAMWetscav::run_impl(const double dt) {
 
         mam4::wetdep::aero_model_wetdep(
             team, atm, progs, tends, dt,
+            sol_facti_cloud_borne,
+            sol_factic_cloud_borne,
+            sol_factb_below_cloud,
+            f_act_conv_below_cloud,
             // inputs
             cldt_icol, rprdsh_icol, rprddp_icol, evapcdp_icol, evapcsh_icol,
             dp_frac_icol, sh_frac_icol, icwmrdp_col, icwmrsh_icol, nevapr_icol,

--- a/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.cpp
@@ -10,40 +10,42 @@ NOTES:
 3. Add assert statements to check output ranges
 */
 
-namespace scream {
+namespace scream
+{
 
 // =========================================================================================
-MAMWetscav::MAMWetscav(const ekat::Comm &comm,
-                       const ekat::ParameterList &params)
-    : MAMGenericInterface(comm, params) {
+MAMWetscav::MAMWetscav(const ekat::Comm &comm, const ekat::ParameterList &params)
+ : MAMGenericInterface(comm, params)
+{
   /* Anything that can be initialized without grid information can be
    * initialized here. Like universal constants, mam wetscav options.
    */
-  check_fields_intervals_ =
-      m_params.get<bool>("create_fields_interval_checks", false);
-  scav_fraction_in_cloud_strat_  = m_params.get<Real>("scav_fraction_in_cloud_strat",  1.00);   
-  scav_fraction_in_cloud_conv_ = m_params.get<Real>("scav_fraction_in_cloud_conv", 0.00);
-  scav_fraction_below_cloud_strat_  = m_params.get<Real>("scav_fraction_below_cloud_strat",  0.03);
-  activation_fraction_in_cloud_conv_ = m_params.get<Real>("activation_fraction_in_cloud_conv", 0.40);
+  check_fields_intervals_          = m_params.get<bool>("create_fields_interval_checks", false);
+  scav_fraction_in_cloud_strat_    = m_params.get<Real>("scav_fraction_in_cloud_strat", 1.00);
+  scav_fraction_in_cloud_conv_     = m_params.get<Real>("scav_fraction_in_cloud_conv", 0.00);
+  scav_fraction_below_cloud_strat_ = m_params.get<Real>("scav_fraction_below_cloud_strat", 0.03);
+  activation_fraction_in_cloud_conv_ =
+      m_params.get<Real>("activation_fraction_in_cloud_conv", 0.40);
 }
 
 // ================================================================
 //  SET_GRIDS
 // ================================================================
-void MAMWetscav::set_grids(
-    const std::shared_ptr<const GridsManager> grids_manager) {
+void
+MAMWetscav::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
+{
   using namespace ekat::units;
 
   grid_                 = grids_manager->get_grid("physics");
   const auto &grid_name = grid_->name();
 
-  ncol_ = grid_->get_num_local_dofs();       // Number of columns on this rank
-  nlev_ = grid_->get_num_vertical_levels();  // Number of levels per column
+  ncol_                = grid_->get_num_local_dofs();      // Number of columns on this rank
+  nlev_                = grid_->get_num_vertical_levels(); // Number of levels per column
   len_temporary_views_ = get_len_temporary_views();
   buffer_.set_len_temporary_views(len_temporary_views_);
   buffer_.set_num_scratch(num_2d_scratch_);
 
-  const int nmodes    = mam4::AeroConfig::num_modes();  // Number of modes
+  const int nmodes    = mam4::AeroConfig::num_modes(); // Number of modes
   constexpr int pcnst = mam4::aero_model::pcnst;
 
   // layout for 3D (2d horiz X 1d vertical) variables at level
@@ -55,12 +57,11 @@ void MAMWetscav::set_grids(
   FieldLayout scalar2d = grid_->get_2d_scalar_layout();
 
   // layout for 3D (ncol, nmodes, nlevs)
-  FieldLayout scalar3d_mid_nmodes = grid_->get_3d_vector_layout(
-      true, nmodes, mam_coupling::num_modes_tag_name());
+  FieldLayout scalar3d_mid_nmodes =
+      grid_->get_3d_vector_layout(true, nmodes, mam_coupling::num_modes_tag_name());
 
   // layout for 2D (ncol, pcnst)
-  FieldLayout scalar2d_pcnst =
-      grid_->get_2d_vector_layout(pcnst, "num_phys_constituents");
+  FieldLayout scalar2d_pcnst = grid_->get_2d_vector_layout(pcnst, "num_phys_constituents");
 
   // --------------------------------------------------------------------------
   // These variables are "required" or pure inputs for the process
@@ -72,9 +73,9 @@ void MAMWetscav::set_grids(
   add_fields_dry_atm();
 
   // cloud liquid number mixing ratio [1/kg]
-  auto n_unit           = 1 / kg;   // units of number mixing ratios of tracers
+  auto n_unit = 1 / kg; // units of number mixing ratios of tracers
   add_tracer<Required>("nc", grid_, n_unit);
-  
+
   static constexpr auto m2 = m * m;
   static constexpr auto s2 = s * s;
 
@@ -87,8 +88,7 @@ void MAMWetscav::set_grids(
   add_field<Required>("nevapr", scalar3d_mid, kg / kg / s, grid_name);
 
   // Stratiform rain production rate [kg/kg/s]
-  add_field<Required>("precip_total_tend", scalar3d_mid, kg / kg / s,
-                      grid_name);
+  add_field<Required>("precip_total_tend", scalar3d_mid, kg / kg / s, grid_name);
 
   // For variables that are non dimensional (e.g., fractions etc.)
   static constexpr auto nondim = Units::nondimensional();
@@ -106,20 +106,16 @@ void MAMWetscav::set_grids(
   // for the land model
 
   // Wet deposition of hydrophilic black carbon [kg/m2/s]
-  add_field<Updated>("wetdep_hydrophilic_bc", scalar3d_mid, kg / m2 / s,
-                     grid_name);
+  add_field<Updated>("wetdep_hydrophilic_bc", scalar3d_mid, kg / m2 / s, grid_name);
 
   // Dry deposition of hydrophilic black carbon [kg/m2/s]
-  add_field<Updated>("drydep_hydrophilic_bc", scalar3d_mid, kg / m2 / s,
-                     grid_name);
+  add_field<Updated>("drydep_hydrophilic_bc", scalar3d_mid, kg / m2 / s, grid_name);
 
   // Wet deposition of hydrophilic organic carbon [kg/m2/s]
-  add_field<Updated>("wetdep_hydrophilic_oc", scalar3d_mid, kg / m2 / s,
-                     grid_name);
+  add_field<Updated>("wetdep_hydrophilic_oc", scalar3d_mid, kg / m2 / s, grid_name);
 
   // Dry deposition of hydrophilic organic carbon [kg/m2/s]
-  add_field<Updated>("drydep_hydrophilic_oc", scalar3d_mid, kg / m2 / s,
-                     grid_name);
+  add_field<Updated>("drydep_hydrophilic_oc", scalar3d_mid, kg / m2 / s, grid_name);
 
   // Wet deposition of dust (bin1) [kg/m2/s]
   add_field<Updated>("wetdep_dust_bin1", scalar3d_mid, kg / m2 / s, grid_name);
@@ -178,7 +174,9 @@ void MAMWetscav::set_grids(
 // ON HOST, initializeѕ the Buffer type with sufficient memory to store
 // intermediate (dry) quantities on the given number of columns with the given
 // number of vertical levels. Returns the number of bytes allocated.
-void MAMWetscav::init_buffers(const ATMBufferManager &buffer_manager) {
+void
+MAMWetscav::init_buffers(const ATMBufferManager &buffer_manager)
+{
   EKAT_REQUIRE_MSG(
       buffer_manager.allocated_bytes() >= requested_buffer_size_in_bytes(),
       "Error! Insufficient buffer size.\n");

--- a/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.cpp
@@ -21,10 +21,10 @@ MAMWetscav::MAMWetscav(const ekat::Comm &comm,
    */
   check_fields_intervals_ =
       m_params.get<bool>("create_fields_interval_checks", false);
-  sol_facti_cloud_borne_  = m_params.get<Real>("sol_facti_cloud_borne",  1.00);   
-  sol_factic_cloud_borne_ = m_params.get<Real>("sol_factic_cloud_borne", 0.00);
-  sol_factb_below_cloud_  = m_params.get<Real>("sol_factb_below_cloud",  0.03);
-  f_act_conv_below_cloud_ = m_params.get<Real>("f_act_conv_below_cloud", 0.40);
+  scav_fraction_in_cloud_strat_  = m_params.get<Real>("scav_fraction_in_cloud_strat",  1.00);   
+  scav_fraction_in_cloud_conv_ = m_params.get<Real>("scav_fraction_in_cloud_conv", 0.00);
+  scav_fraction_below_cloud_strat_  = m_params.get<Real>("scav_fraction_below_cloud_strat",  0.03);
+  activation_fraction_in_cloud_conv_ = m_params.get<Real>("activation_fraction_in_cloud_conv", 0.40);
 }
 
 // ================================================================
@@ -433,10 +433,10 @@ void MAMWetscav::run_impl(const double dt) {
   const auto &calsize_data  = calsize_data_;
   const auto &scavimptblnum = scavimptblnum_;
   const auto &scavimptblvol = scavimptblvol_;
-  const Real sol_facti_cloud_borne  = sol_facti_cloud_borne_;   
-  const Real sol_factic_cloud_borne = sol_factic_cloud_borne_;
-  const Real sol_factb_below_cloud  = sol_factb_below_cloud_;
-  const Real f_act_conv_below_cloud = f_act_conv_below_cloud_;
+  const Real scav_fraction_in_cloud_strat  = scav_fraction_in_cloud_strat_;   
+  const Real scav_fraction_in_cloud_conv = scav_fraction_in_cloud_conv_;
+  const Real scav_fraction_below_cloud_strat  = scav_fraction_below_cloud_strat_;
+  const Real activation_fraction_in_cloud_conv = activation_fraction_in_cloud_conv_;
   // Loop over atmosphere columns
   Kokkos::parallel_for(
       policy, KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -486,10 +486,10 @@ void MAMWetscav::run_impl(const double dt) {
 
         mam4::wetdep::aero_model_wetdep(
             team, atm, progs, tends, dt,
-            sol_facti_cloud_borne,
-            sol_factic_cloud_borne,
-            sol_factb_below_cloud,
-            f_act_conv_below_cloud,
+            scav_fraction_in_cloud_strat,
+            scav_fraction_in_cloud_conv,
+            scav_fraction_below_cloud_strat,
+            activation_fraction_in_cloud_conv,
             // inputs
             cldt_icol, rprdsh_icol, rprddp_icol, evapcdp_icol, evapcsh_icol,
             dp_frac_icol, sh_frac_icol, icwmrdp_col, icwmrsh_icol, nevapr_icol,

--- a/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.hpp
@@ -121,11 +121,17 @@ class MAMWetscav : public MAMGenericInterface {
   void init_temporary_views();
   int len_temporary_views_{0};
 
+  // sol_facti_cloud_borne_ is in-cloud scavenging fraction
+  Real sol_facti_cloud_borne_ = 1.00;
 
-  Real sol_facti_cloud_borne_ = 0;
-  Real sol_factic_cloud_borne_ = 0;
-  Real sol_factb_below_cloud_ = 0;
-  Real f_act_conv_below_cloud_ = 0;
+  // sol_factic_cloud_borne_ is in-cloud convective scavenging fraction
+  Real sol_factic_cloud_borne_ = 0.00;
+
+  // sol_factb_below_cloud_ is below-cloud scavenging fraction
+  Real sol_factb_below_cloud_ = 0.03;
+
+  // f_act_conv_below_cloud_ is convection activation fraction
+  Real f_act_conv_below_cloud_ = 0.40;
 
 };  // class MAMWetscav
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.hpp
@@ -121,6 +121,12 @@ class MAMWetscav : public MAMGenericInterface {
   void init_temporary_views();
   int len_temporary_views_{0};
 
+
+  Real sol_facti_cloud_borne_ = 0;
+  Real sol_factic_cloud_borne_ = 0;
+  Real sol_factb_below_cloud_ = 0;
+  Real f_act_conv_below_cloud_ = 0;
+
 };  // class MAMWetscav
 
 }  // namespace scream

--- a/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.hpp
@@ -121,17 +121,17 @@ class MAMWetscav : public MAMGenericInterface {
   void init_temporary_views();
   int len_temporary_views_{0};
 
-  // sol_facti_cloud_borne_ is in-cloud scavenging fraction
-  Real sol_facti_cloud_borne_ = 1.00;
+  // scav_fraction_in_cloud_strat_ is in-cloud scavenging fraction
+  Real scav_fraction_in_cloud_strat_ = 1.00;
 
-  // sol_factic_cloud_borne_ is in-cloud convective scavenging fraction
-  Real sol_factic_cloud_borne_ = 0.00;
+  // scav_fraction_in_cloud_conv_ is in-cloud convective scavenging fraction
+  Real scav_fraction_in_cloud_conv_ = 0.00;
 
-  // sol_factb_below_cloud_ is below-cloud scavenging fraction
-  Real sol_factb_below_cloud_ = 0.03;
+  // scav_fraction_below_cloud_strat_ is below-cloud scavenging fraction
+  Real scav_fraction_below_cloud_strat_ = 0.03;
 
-  // f_act_conv_below_cloud_ is convection activation fraction
-  Real f_act_conv_below_cloud_ = 0.40;
+  // activation_fraction_in_cloud_conv_ is convection activation fraction
+  Real activation_fraction_in_cloud_conv_ = 0.40;
 
 };  // class MAMWetscav
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.hpp
@@ -10,7 +10,8 @@
 // For component name
 #include <string>
 
-namespace scream {
+namespace scream
+{
 
 /*
  * The class responsible to handle the aerosol wetscavenging
@@ -20,7 +21,8 @@ namespace scream {
  *
  */
 
-class MAMWetscav : public MAMGenericInterface {
+class MAMWetscav : public MAMGenericInterface
+{
   using KT           = ekat::KokkosTypes<DefaultDevice>;
   using view_2d      = typename KT::template view_2d<Real>;
   using view_2d_host = typename KT::template view_2d<Real>::HostMirror;
@@ -29,23 +31,27 @@ class MAMWetscav : public MAMGenericInterface {
   // a thread team dispatched to a single vertical column
   using ThreadTeam = mam4::ThreadTeam;
 
- public:
+public:
   // Constructor
   MAMWetscav(const ekat::Comm &comm, const ekat::ParameterList &params);
 
   // The name of the subcomponent
-  std::string name() const override { return "mam4_wetscav"; }
+  std::string
+  name() const override
+  {
+    return "mam4_wetscav";
+  }
 
   // Set the grid and input output variables
-  void set_grids(
-      const std::shared_ptr<const GridsManager> grids_manager) override;
+  void set_grids(const std::shared_ptr<const GridsManager> grids_manager) override;
 
   // management of common atm process memory
   // ON HOST, returns the number of bytes of device memory needed by the above
   // Buffer type given the number of columns and vertical levels
-  size_t requested_buffer_size_in_bytes() const override {
-    return mam_coupling::buffer_size(ncol_, nlev_, num_2d_scratch_,
-                                     len_temporary_views_);
+  size_t
+  requested_buffer_size_in_bytes() const override
+  {
+    return mam_coupling::buffer_size(ncol_, nlev_, num_2d_scratch_, len_temporary_views_);
   }
   void init_buffers(const ATMBufferManager &buffer_manager) override;
 
@@ -56,9 +62,9 @@ class MAMWetscav : public MAMGenericInterface {
   void run_impl(const double dt) override;
 
   // Finalize
-  void finalize_impl() override{/*Do nothing*/};
+  void finalize_impl() override { /*Do nothing*/ };
 
- private:
+private:
   // -----------------------------------------------
   // Local variables
   // ------------------------------------------------
@@ -133,8 +139,8 @@ class MAMWetscav : public MAMGenericInterface {
   // activation_fraction_in_cloud_conv_ is convection activation fraction
   Real activation_fraction_in_cloud_conv_ = 0.40;
 
-};  // class MAMWetscav
+}; // class MAMWetscav
 
-}  // namespace scream
+} // namespace scream
 
-#endif  // EAMXX_MAM_WETSCAV_HPP
+#endif // EAMXX_MAM_WETSCAV_HPP


### PR DESCRIPTION
Adds 4 tuning parameters to the EAMxx namelist:
sol_factb_below_cloud -below-cloud scavenging fraction is basically a tuning factor.
sol_facti_cloud_borne - in-cloud scavenging fraction has a physical basis and reflects activation fraction.
sol_factic_cloud_borne - in-cloud convective scavenging fraction has a physical basis and reflects activation fraction
f_act_conv_below_cloud - convection activation fraction.

The defaults are the same as have always been used, so this is a BFB change:

[BFB]