### PR TITLE
Set default value of fminval in python version of gen_domain to 1.0e-08

### DIFF
--- a/tools/generate_domain_files/generate_domain_files_E3SM.py
+++ b/tools/generate_domain_files/generate_domain_files_E3SM.py
@@ -94,7 +94,7 @@ parser.add_option('--date-stamp',
                   help='Creation date stamp for domain files')
 parser.add_option('--fminval',
                   dest='fminval',
-                  default=1e-3,
+                  default=1e-8,
                   help='Minimum allowable land fraction (reset to 0 below fminval)')
 parser.add_option('--fmaxval',
                   dest='fmaxval',


### PR DESCRIPTION
The current version of gen_domain has a default value of 0.001 for the min allowable land fraction. That is too large and shows up in the cpl area budget for e3sm runs. The fminval can be overwritten on the command line but rarely is, so it seems safer to make the default much smaller (1e-8) instead. The resulting domain files will have a different number of lnd cells, so it would be complicated to regenerate domain files for all supported mesh configurations. But at least any new domain files should be corrected.

Partially fixes #7465 -- the Fortran version in CIME also has the same issue
[non-BFB] for any new domain files