### PR TITLE
Move dqdt_so4_aqueous_chemistry and dqdt_h2so4_uptake to the standard mam4xx diagnostic struct.

### DIFF
--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -210,10 +210,6 @@ void MAMMicrophysics::set_grids(
     const FieldLayout vector2d_nmodes =
       grid_->get_2d_vector_layout(nmodes, "nmodes");
 
-    // Register computed diagnostic fields
-    add_field<Computed>("dqdt_so4_aqueous_chemistry", vector2d_nmodes, kg/m2/s,  grid_name);
-    add_field<Computed>("dqdt_h2so4_uptake", vector2d_nmodes, kg/m2/s,  grid_name);
-
     // Diagnostics: tendencies due to gas phase chemistry [mixed units: kg/kg/s or #/kg/s]
     add_field<Computed>("mam4_microphysics_tendency_gas_phase_chemistry", vector3d_num_gas_aerosol_constituents, nondim, grid_name);
 
@@ -225,6 +221,12 @@ void MAMMicrophysics::set_grids(
 
     // Diagnostics: H2SO4 in-cloud tendencies [mixed units: kg/kg/s or #/kg/s]
     add_field<Computed>("mam4_microphysics_tendency_aqh2so4", vector3d_mid_nmodes, nondim, grid_name);
+
+    // Register computed diagnostic fields
+    //(NOTE: dqdt_so4_aqueous_chemistry is the vertically reduced field of "mam4_microphysics_tendency_aqso4")
+    add_field<Computed>("dqdt_so4_aqueous_chemistry", vector2d_nmodes, kg/m2/s,  grid_name);
+    //(NOTE: dqdt_h2so4_uptake is the vertically reduced field of "mam4_microphysics_tendency_aqh2so4")
+    add_field<Computed>("dqdt_h2so4_uptake", vector2d_nmodes, kg/m2/s,  grid_name);
 
     // Diagnostics: tendencies due to aerosol microphysics (gas aerosol exchange) [mixed units: mol/mol/s or #/mol/s]
     add_field<Computed>("mam4_microphysics_tendency_condensation", vector3d_num_gas_aerosol_constituents, nondim, grid_name);

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -199,14 +199,6 @@ void MAMMicrophysics::set_grids(
   // - extfrc: 3D instantaneous forcing rate [kg/m³/s]
   add_field<Computed>("mam4_external_forcing", vector3d_extcnt, kg / m3 / s, grid_name);
 
-  // Diagnostic fluxes
-  const FieldLayout vector2d_nmodes =
-      grid_->get_2d_vector_layout(nmodes, "nmodes");
-
-  // Register computed diagnostic fields
-  add_field<Computed>("dqdt_so4_aqueous_chemistry", vector2d_nmodes, kg/m2/s,  grid_name);
-  add_field<Computed>("dqdt_h2so4_uptake", vector2d_nmodes, kg/m2/s,  grid_name);
-
   // Diagnostic fields for aerosol microphysics
 
   //Flag to indicate if we want to compute extra diagnostics
@@ -214,6 +206,13 @@ void MAMMicrophysics::set_grids(
   if (extra_mam4_aero_microphys_diags_) {
     const FieldLayout vector3d_num_gas_aerosol_constituents =
         grid_->get_3d_vector_layout(true, mam_coupling::gas_pcnst(), "num_gas_aerosol_constituents");
+
+    const FieldLayout vector2d_nmodes =
+      grid_->get_2d_vector_layout(nmodes, "nmodes");
+
+    // Register computed diagnostic fields
+    add_field<Computed>("dqdt_so4_aqueous_chemistry", vector2d_nmodes, kg/m2/s,  grid_name);
+    add_field<Computed>("dqdt_h2so4_uptake", vector2d_nmodes, kg/m2/s,  grid_name);
 
     // Diagnostics: tendencies due to gas phase chemistry [mixed units: kg/kg/s or #/kg/s]
     add_field<Computed>("mam4_microphysics_tendency_gas_phase_chemistry", vector3d_num_gas_aerosol_constituents, nondim, grid_name);
@@ -490,7 +489,6 @@ void MAMMicrophysics::initialize_impl(const RunType run_type) {
       {"sfc_alb_dir_vis", {-1e10, 1e10}},       // FIXME
       {"snow_depth_land", {-1e10, 1e10}},       // FIXME
       {"surf_radiative_T", {-1e10, 1e10}},      // FIXME
-      {"dqdt_so4_aqueous_chemistry", {-1e10, 1e10}},      // FIXME
       {"dqdt_h2so4_uptake", {-1e10, 1e10}}       // FIXME
   };
   set_ranges_process(ranges_microphysics);
@@ -711,11 +709,8 @@ void MAMMicrophysics::run_impl(const double dt) {
   const const_view_1d snow_depth_land =
       get_field_in("snow_depth_land").get_view<const Real *>();
 
-  // Constituent fluxes
-  view_2d aqso4_flx = get_field_out("dqdt_so4_aqueous_chemistry").get_view<Real **>();
-  view_2d aqh2so4_flx = get_field_out("dqdt_h2so4_uptake").get_view<Real **>();
-
   // - dvmr/dt: Tendencies for mixing ratios  [kg/kg/s]
+  view_2d dqdt_so4_aqueous_chemistry, dqdt_h2so4_uptake;
   view_3d gas_phase_chemistry_dvmrdt, aqueous_chemistry_dvmrdt;
   view_3d aqso4_incloud_mmr_tendency, aqh2so4_incloud_mmr_tendency;
   view_3d gas_aero_exchange_condensation, gas_aero_exchange_renaming,
@@ -723,6 +718,8 @@ void MAMMicrophysics::run_impl(const double dt) {
           gas_aero_exchange_renaming_cloud_borne;
 
   if (extra_mam4_aero_microphys_diags_) {
+    dqdt_so4_aqueous_chemistry = get_field_out("dqdt_so4_aqueous_chemistry").get_view<Real **>();
+    dqdt_h2so4_uptake = get_field_out("dqdt_h2so4_uptake").get_view<Real **>();
     gas_phase_chemistry_dvmrdt = get_field_out("mam4_microphysics_tendency_gas_phase_chemistry").get_view<Real ***>();
     aqueous_chemistry_dvmrdt = get_field_out("mam4_microphysics_tendency_aqueous_chemistry").get_view<Real ***>();
     aqso4_incloud_mmr_tendency   = get_field_out("mam4_microphysics_tendency_aqso4").get_view<Real ***>();
@@ -997,9 +994,11 @@ void MAMMicrophysics::run_impl(const double dt) {
         mam4::MicrophysDiagnosticArrays diag_arrays;
 
         if (extra_mam4_aero_microphys_diags) {
-	        diag_arrays.gas_phase_chemistry_dvmrdt = ekat::subview(gas_phase_chemistry_dvmrdt, icol);
+          diag_arrays.dqdt_so4_aqueous_chemistry = ekat::subview(dqdt_so4_aqueous_chemistry, icol);
+          diag_arrays.dqdt_h2so4_uptake          = ekat::subview(dqdt_h2so4_uptake, icol);
+          diag_arrays.gas_phase_chemistry_dvmrdt = ekat::subview(gas_phase_chemistry_dvmrdt, icol);
 
-	        diag_arrays.aqueous_chemistry_dvmrdt   = ekat::subview(aqueous_chemistry_dvmrdt, icol);
+          diag_arrays.aqueous_chemistry_dvmrdt   = ekat::subview(aqueous_chemistry_dvmrdt, icol);
           diag_arrays.aqso4_incloud_mmr_tendency = ekat::subview(aqso4_incloud_mmr_tendency, icol);
           diag_arrays.aqh2so4_incloud_mmr_tendency = ekat::subview(aqh2so4_incloud_mmr_tendency, icol);
 
@@ -1008,7 +1007,7 @@ void MAMMicrophysics::run_impl(const double dt) {
           diag_arrays.gas_aero_exchange_nucleation = ekat::subview(gas_aero_exchange_nucleation, icol);
           diag_arrays.gas_aero_exchange_coagulation = ekat::subview(gas_aero_exchange_coagulation, icol);
           diag_arrays.gas_aero_exchange_renaming_cloud_borne = ekat::subview(gas_aero_exchange_renaming_cloud_borne, icol);
-	      }
+        }
 
 
         // Wind speed at the surface
@@ -1053,8 +1052,6 @@ void MAMMicrophysics::run_impl(const double dt) {
           }
         }
         // These output values need to be put somewhere:
-        const auto aqso4_flx_col = ekat::subview(aqso4_flx, icol);  // deposition flux of so4 [mole/mole/s]
-        const auto aqh2so4_flx_col = ekat::subview(aqh2so4_flx, icol);  // deposition flux of h2so4 [mole/mole/s]
         Real dflx_col[num_gas_aerosol_constituents] = {};  // deposition velocity [1/cm/s]
         Real dvel_col[num_gas_aerosol_constituents] = {};  // deposition flux [1/cm^2/s]
         // Output: values are dvel, dflx
@@ -1073,8 +1070,7 @@ void MAMMicrophysics::run_impl(const double dt) {
             offset_aerosol,
             dry_diameter_icol, wet_diameter_icol,
             wetdens_icol, dry_atm.phis(icol), cmfdqr, prain_icol, nevapr_icol,
-            work_set_het_icol, drydep_data, aqso4_flx_col,  aqh2so4_flx_col,
-            diag_arrays, dvel_col, dflx_col, progs);
+            work_set_het_icol, drydep_data, diag_arrays, dvel_col, dflx_col, progs);
 
         team.team_barrier();
         // Update constituent fluxes with gas drydep fluxes (dflx)


### PR DESCRIPTION
The column integrated modal values of the deposition flux of 
aqueous SO4 and the deposition flux of aqueous H2SO4 were 
always added to the Field Manager (FM) to be available for the 
output. This PR hides these diagnostics under a flag.
Since EAMxx doesn't output any fields by default, this change 
will be BFB.

[BFB]