### PR TITLE
EAMxx dycore defaults should match EAMv3 defaults

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -822,12 +822,6 @@ be lost if SCREAM_HACK_XML is not enabled.
     <dt_remap_factor constraints="ge 1">2</dt_remap_factor>
     <dt_tracer_factor constraints="ge 1">1</dt_tracer_factor>
     <hv_ref_profiles>6</hv_ref_profiles>                <!-- Default (rough topography) -->
-    <hv_ref_profiles hgrid="ne4np4">0</hv_ref_profiles> <!-- Value for smooth topography/aquaplanet -->
-    <hv_ref_profiles hgrid="ne120np4">0</hv_ref_profiles>
-    <hv_ref_profiles hgrid="ne512np4">0</hv_ref_profiles>
-    <hv_ref_profiles hgrid="ne0np4_conus_x4v1_lowcon">0</hv_ref_profiles>
-    <hv_ref_profiles hgrid="ne0np4_CAx32v1">0</hv_ref_profiles>
-    <hv_ref_profiles COMPSET=".*SCREAM%AQUA.*">0</hv_ref_profiles>
     <hypervis_order>2</hypervis_order>
     <hypervis_scaling>3.0</hypervis_scaling>
     <hypervis_subcycle>1</hypervis_subcycle>
@@ -846,12 +840,6 @@ be lost if SCREAM_HACK_XML is not enabled.
     <nu_top COMPSET=".*DP-EAMxx">1.0e4</nu_top>
     <nu_top hgrid="ne0np4_conus_x4v1_lowcon">100000.0</nu_top>
     <pgrad_correction>1</pgrad_correction>                <!-- Default (rough topography) -->
-    <pgrad_correction hgrid="ne4np4">0</pgrad_correction> <!-- Value for smooth topography/aquaplanet -->
-    <pgrad_correction hgrid="ne120np4">0</pgrad_correction>
-    <pgrad_correction hgrid="ne512np4">0</pgrad_correction>
-    <pgrad_correction hgrid="ne0np4_conus_x4v1_lowcon">0</pgrad_correction>
-    <pgrad_correction hgrid="ne0np4_CAx32v1">0</pgrad_correction>
-    <pgrad_correction COMPSET=".*SCREAM%AQUA.*">0</pgrad_correction>
     <se_ftype valid_values="0,2">0</se_ftype>
     <se_geometry>sphere</se_geometry>
     <se_geometry COMPSET=".*DP-EAMxx">plane</se_geometry>


### PR DESCRIPTION
EAMxx has funky resolution-specific settings for pgrad_correction and hv_ref_profiles


[BFB] for most resolutions (NE30, NE256, NE1024)
[CC] for some tests, like ne4. Also NE120, NE512 cases.