### PR TITLE
land-data ocean one-way coupling

### DIFF
--- a/components/data_comps/docn/cime_config/config_component.xml
+++ b/components/data_comps/docn/cime_config/config_component.xml
@@ -13,7 +13,7 @@
        This file may have ocn desc entries.
   -->
   <description modifier_mode="1">
-    <desc ocn="DOCN[%NULL][%DOM][%SOM][%RSO][%SOMAQP][%IAF][%SST_AQUAP][%AQP1][%AQP2][%AQP3][%AQP4][%AQP5][%AQP6][%AQP7][%AQP8][%AQP9][%AQP10][%AQP11][%AQP12][%AQP13][%AQP14][%AQP15][%AQPFILE][%AQPCONST]">DOCN </desc>
+    <desc ocn="DOCN[%NULL][%DOM][%SOM][%RSO][%SOMAQP][%IAF][%SST_AQUAP][%AQP1][%AQP2][%AQP3][%AQP4][%AQP5][%AQP6][%AQP7][%AQP8][%AQP9][%AQP10][%AQP11][%AQP12][%AQP13][%AQP14][%AQP15][%AQPFILE][%AQPCONST][%GTSM]">DOCN </desc>
     <desc option="NULL">  null mode</desc>
     <desc option="DOM">  prescribed ocean mode</desc>
     <desc option="SOM">  slab ocean mode</desc>
@@ -33,6 +33,7 @@
     <desc option="AQP10">  analytic aquaplanet sst - option 10</desc>
     <desc option="AQPFILE">  file input aquaplanet sst </desc>
     <desc option="AQPCONST">  globally constant SST for idealized experiments, such as RCE </desc>
+    <desc option="GTSM">  coastal inundation estimated with bathtub method with GTSM sea water level </desc>
   </description>
 
   <entry id="COMP_OCN">
@@ -46,7 +47,7 @@
 
   <entry id="DOCN_MODE">
     <type>char</type>
-    <valid_values>prescribed,sst_aquap1,sst_aquap2,sst_aquap3,sst_aquap4,sst_aquap5,sst_aquap6,sst_aquap7,sst_aquap8,sst_aquap9,sst_aquap10,sst_aquap11,sst_aquap12,sst_aquap13,sst_aquap14,sst_aquap15,sst_aquapfile,som,rso,som_aquap,sst_aquap_constant,interannual,null</valid_values>
+    <valid_values>prescribed,sst_aquap1,sst_aquap2,sst_aquap3,sst_aquap4,sst_aquap5,sst_aquap6,sst_aquap7,sst_aquap8,sst_aquap9,sst_aquap10,sst_aquap11,sst_aquap12,sst_aquap13,sst_aquap14,sst_aquap15,sst_aquapfile,som,rso,som_aquap,sst_aquap_constant,interannual,GTSM,null</valid_values>
     <default_value>prescribed</default_value>
     <values match="last">
       <value compset="_DOCN%NULL_">null</value>
@@ -73,6 +74,7 @@
       <value compset="_DOCN%AQP15_">sst_aquap15</value>
       <value compset="_DOCN%AQPFILE_">sst_aquapfile</value>
       <value compset="_DOCN%AQPCONST_">sst_aquap_constant</value>
+      <value compset="_DOCN%GTSM_">GTSM</value>
     </values>
     <group>run_component_docn</group>
     <file>env_run.xml</file>
@@ -137,6 +139,19 @@
     <default_value>UNSET</default_value>
     <values match="last">
       <value compset="_DOCN%AQPFILE">sst_c4aquasom_0.9x1.25_clim.c170512.nc</value>
+    </values>
+    <group>run_component_docn</group>
+    <file>env_run.xml</file>
+    <desc>Sets aquaplanet forcing filename instead of using an analytic form.
+    This is only used when DOCN_MODE=sst_aquapfile.</desc>
+  </entry>
+
+  <entry id="DOCN_GTSM_FILENAME">
+    <type>char</type>
+    <valid_values></valid_values>
+    <default_value>UNSET</default_value>
+    <values match="last">
+      <value compset="_DOCN%GTSM">coastal_inundation.$SSTICE_YEAR_START-01.nc</value>
     </values>
     <group>run_component_docn</group>
     <file>env_run.xml</file>
@@ -264,6 +279,7 @@
       <value compset="2010_SCREAM%DYAMOND-1">2016</value>
       <value compset="2010_SCREAM%DYAMOND-2">2020</value>
       <value compset="20TR_EAM%CHEMUCI">1869</value>
+      <value compset="_DOCN%GTSM">1950</value>
     </values>
     <group>run_component_cam_sstice</group>
     <file>env_run.xml</file>
@@ -293,6 +309,7 @@
       <value compset="2010_SCREAM%DYAMOND-1">2016</value>
       <value compset="2010_SCREAM%DYAMOND-2">2020</value>
       <value compset="20TR_EAM%CHEMUCI">1869</value>
+      <value compset="_DOCN%GTSM">1950</value>
     </values>
     <group>run_component_cam_sstice</group>
     <file>env_run.xml</file>
@@ -316,6 +333,7 @@
       <value compset="2010_SCREAM%DYAMOND-1">2016</value>
       <value compset="2010_SCREAM%DYAMOND-2">2020</value>
       <value compset="20TR_EAM%CHEMUCI">2016</value>
+      <value compset="_DOCN%GTSM">2014</value>
     </values>
     <group>run_component_cam_sstice</group>
     <file>env_run.xml</file>

--- a/components/data_comps/docn/cime_config/namelist_definition_docn.xml
+++ b/components/data_comps/docn/cime_config/namelist_definition_docn.xml
@@ -63,6 +63,7 @@
       <value docn_mode="rso">rso</value>
       <value docn_mode="som_aquap">som</value>
       <value docn_mode="interannual">interannual</value>
+      <value docn_mode="GTSM">GTSM</value>
     </values>
   </entry>
 
@@ -97,6 +98,7 @@
       <value stream="som">$DIN_LOC_ROOT/ocn/docn7/SOM</value>
       <value stream="rso">/</value> <!-- use this for $SSTICE_GRID_FILENAME -->
       <value stream="interannual">$DIN_LOC_ROOT/atm/cam/sst</value>
+      <value stream="GTSM">$DIN_LOC_ROOT/ocn/docn7/GTSM</value>
     </values>
   </entry>
 
@@ -111,6 +113,7 @@
       <value stream="som">$DOCN_SOM_FILENAME</value>
       <value stream="rso">$SSTICE_GRID_FILENAME</value>
       <value stream="interannual">sst_HadOIBl_bc_1x1_1850_2014_c150416.nc</value>
+      <value stream="GTSM">$DOCN_GTSM_FILENAME</value>
     </values>
   </entry>
 
@@ -137,6 +140,14 @@
         lon     lon
         lat     lat
       </value>
+      <value stream="GTSM">
+        time    time
+        xc      lon
+        yc      lat
+        area    area
+        mask    mask
+        frac    frac
+      </value>
     </values>
   </entry>
 
@@ -151,6 +162,7 @@
       <value stream="som">$DIN_LOC_ROOT/ocn/docn7/SOM</value>
       <value stream="rso">/</value> <!-- use this for $SSTICE_DATA_FILENAME -->
       <value stream="interannual">$DIN_LOC_ROOT/atm/cam/sst</value>
+      <value stream="GTSM">$DIN_LOC_ROOT/ocn/docn7/GTSM</value>
     </values>
   </entry>
 
@@ -165,6 +177,7 @@
       <value stream="som">$DOCN_SOM_FILENAME</value>
       <value stream="rso">$SSTICE_DATA_FILENAME</value>
       <value stream="interannual">sst_HadOIBl_bc_1x1_1850_2014_c150416.nc</value>
+      <value stream="GTSM">coastal_inundation.%ym.nc</value>
     </values>
   </entry>
 
@@ -200,6 +213,10 @@
       <value stream="aquapfile">
         SST_cpl t
       </value>
+      <value stream="GTSM">
+        T t
+        Inund frac_h2oocn
+      </value>
     </values>
   </entry>
 
@@ -225,6 +242,7 @@
       <value stream="som">1</value>
       <value stream="rso">$SSTICE_YEAR_ALIGN</value>
       <value stream="interannual">1</value>
+      <value stream="GTSM">$SSTICE_YEAR_ALIGN</value>
     </values>
   </entry>
 
@@ -240,6 +258,7 @@
       <value stream="som">1</value>
       <value stream="rso">$SSTICE_YEAR_START</value>
       <value stream="interannual">1850</value>
+      <value stream="GTSM">$SSTICE_YEAR_START</value>
     </values>
   </entry>
 
@@ -255,6 +274,7 @@
       <value stream="som">1</value>
       <value stream="rso">$SSTICE_YEAR_END</value>
       <value stream="interannual">2014</value>
+      <value stream="GTSM">$SSTICE_YEAR_END</value>
     </values>
   </entry>
 
@@ -270,7 +290,7 @@
     <type>char</type>
     <category>streams</category>
     <group>shr_strdata_nml</group>
-    <valid_values>SSTDATA,SST_AQUAP1,SST_AQUAP2,SST_AQUAP3,SST_AQUAP4,SST_AQUAP5,SST_AQUAP6,SST_AQUAP7,SST_AQUAP8,SST_AQUAP9,SST_AQUAP10,SST_AQUAP11,SST_AQUAP12,SST_AQUAP13,SST_AQUAP14,SST_AQUAP15,SST_AQUAPFILE,SST_AQUAP_CONSTANT,SOM,RSO,SOM_AQUAP,IAF,NULL,COPYALL</valid_values>
+    <valid_values>SSTDATA,SST_AQUAP1,SST_AQUAP2,SST_AQUAP3,SST_AQUAP4,SST_AQUAP5,SST_AQUAP6,SST_AQUAP7,SST_AQUAP8,SST_AQUAP9,SST_AQUAP10,SST_AQUAP11,SST_AQUAP12,SST_AQUAP13,SST_AQUAP14,SST_AQUAP15,SST_AQUAPFILE,SST_AQUAP_CONSTANT,SOM,RSO,SOM_AQUAP,IAF,GTSM,NULL,COPYALL</valid_values>
     <desc>
       General method that operates on the data. This is generally
       implemented in the data models but is set in the strdata method for
@@ -347,6 +367,7 @@
       <value docn_mode="rso$">RSO</value>
       <value docn_mode="som_aquap">SOM_AQUAP</value>
       <value docn_mode="interannual">IAF</value>
+      <value docn_mode="GTSM">GTSM</value>
     </values>
   </entry>
 

--- a/components/data_comps/docn/cime_config/namelist_definition_docn.xml
+++ b/components/data_comps/docn/cime_config/namelist_definition_docn.xml
@@ -216,6 +216,7 @@
       <value stream="GTSM">
         T t
         Inund frac_h2oocn
+        SSH ssh
       </value>
     </values>
   </entry>

--- a/components/data_comps/docn/src/docn_comp_mod.F90
+++ b/components/data_comps/docn/src/docn_comp_mod.F90
@@ -69,7 +69,7 @@ module docn_comp_mod
   real(R8),parameter :: latice  = shr_const_latice      ! latent heat of fusion
   real(R8),parameter :: ocnsalt = shr_const_ocn_ref_sal ! ocean reference salinity
 
-  integer(IN)   :: kt,ks,ku,kv,kdhdx,kdhdy,kq,kswp  ! field indices
+  integer(IN)   :: kt,ks,ku,kv,kdhdx,kdhdy,kq,kswp,kh2o ! field indices
   integer(IN)   :: kswnet,klwup,klwdn,ksen,klat,kmelth,ksnow,krofi
   integer(IN)   :: kh,kqbot,kfraz
   integer(IN)   :: k10uu           ! index for u10
@@ -90,13 +90,15 @@ module docn_comp_mod
 #endif
 
   !--------------------------------------------------------------------------
-  integer(IN)     , parameter :: ktrans = 8
-  character(12)   , parameter :: avifld(1:ktrans) = &
-       (/ "t           ","u           ","v           ","dhdx        ",&
-          "dhdy        ","s           ","h           ","qbot        "/)
-  character(12)   , parameter  :: avofld(1:ktrans) = &
-       (/ "So_t        ","So_u        ","So_v        ","So_dhdx     ",&
-          "So_dhdy     ","So_s        ","strm_h      ","strm_qbot   "/)
+  integer(IN)     , parameter :: ktrans = 9
+  character(14)   , parameter :: avifld(1:ktrans) = &
+       (/ "t             ","u             ","v             ","dhdx          ",&
+          "dhdy          ","s             ","h             ","qbot          ",&
+          "frac_h2oocn   "/)
+  character(14)   , parameter  :: avofld(1:ktrans) = &
+       (/ "So_t          ","So_u          ","So_v          ","So_dhdx       ",&
+          "So_dhdy       ","So_s          ","strm_h        ","strm_qbot     ",&
+          "So_frac_h2oocn"/)
   character(len=*),parameter :: flds_strm = 'strm_h:strm_qbot:So_t'
   !--------------------------------------------------------------------------
 
@@ -227,6 +229,8 @@ CONTAINS
            datamode == 'SOM_AQUAP' .or. datamode == 'SST_AQUAP_CONSTANT' ) then
           ! Special logic for either prescribed or som aquaplanet - overwrite and
           call shr_strdata_init(SDOCN,mpicom,compid,name='ocn', calendar=calendar, reset_domain_mask=.true.)
+       elseif (trim(datamode) == 'GTSM') then
+          call shr_strdata_init(SDOCN,mpicom,compid,name='ocn', calendar=calendar, dmodel_domain_fracname_from_stream='frac')
        else
           call shr_strdata_init(SDOCN,mpicom,compid,name='ocn', calendar=calendar)
        end if
@@ -287,6 +291,7 @@ CONTAINS
     kswp  = mct_aVect_indexRA(o2x,'So_fswpen', perrwith='quiet')
     kq    = mct_aVect_indexRA(o2x,'Fioo_q') ! ocn freezing melting potential
     kfraz = mct_aVect_indexRA(o2x,'Fioo_frazil') ! ocn frazil
+    kh2o  = mct_aVect_indexRA(o2x,'So_frac_h2oocn', perrwith='quiet')
 
     call mct_aVect_init(x2o, rList=seq_flds_x2o_fields, lsize=lsize)
     call mct_aVect_zero(x2o)
@@ -643,6 +648,9 @@ CONTAINS
        o2x%rAttr(kq   ,n) = 0.0_R8
 ! make sure frazil is 0. MPAS-seaice will still use it.
        o2x%rAttr(kfraz,n) = 0.0_R8
+       if (kh2o /= 0) then
+         o2x%rAttr(kh2o, n) = 0.0_R8
+       endif
        if (kswp /= 0) then
           o2x%rAttr(kswp ,n) = swp
        end if
@@ -884,7 +892,30 @@ CONTAINS
              somtp(n) = o2x%rAttr(kt,n)                                        ! save temp
           enddo
        endif   ! firstcall
-
+    case('GTSM')
+       lsize = mct_avect_lsize(o2x)
+       do n = 1,lsize
+          if (ksomask /= 0) then
+             o2x%rAttr(ksomask, n) = ggrid%data%rAttr(kfrac,n)
+          end if
+          o2x%rAttr(kt   ,n) = o2x%rAttr(kt,n) + TkFrz
+          o2x%rAttr(ks   ,n) = ocnsalt
+          o2x%rAttr(ku   ,n) = 0.0_R8
+          o2x%rAttr(kv   ,n) = 0.0_R8
+          o2x%rAttr(kdhdx,n) = 0.0_R8
+          o2x%rAttr(kdhdy,n) = 0.0_R8
+          o2x%rAttr(kq   ,n) = 0.0_R8
+          if (kh2o /= 0) then
+             if (o2x%rAttr(kh2o, n) < 0.0_R8) then
+                o2x%rAttr(kh2o, n) = 0.0_R8 ! Inundation cannot be negative
+             else
+                o2x%rAttr(kh2o, n) = o2x%rAttr(kh2o, n)
+             endif
+          endif
+          if (kswp /= 0) then
+             o2x%rAttr(kswp ,n) = swp
+          end if
+       enddo
     end select
 
     call t_stopf('docn_datamode')

--- a/components/data_comps/docn/src/docn_comp_mod.F90
+++ b/components/data_comps/docn/src/docn_comp_mod.F90
@@ -69,7 +69,7 @@ module docn_comp_mod
   real(R8),parameter :: latice  = shr_const_latice      ! latent heat of fusion
   real(R8),parameter :: ocnsalt = shr_const_ocn_ref_sal ! ocean reference salinity
 
-  integer(IN)   :: kt,ks,ku,kv,kdhdx,kdhdy,kq,kswp,kh2o ! field indices
+  integer(IN)   :: kt,ks,ku,kv,kdhdx,kdhdy,kq,kswp,kssh,kh2o ! field indices
   integer(IN)   :: kswnet,klwup,klwdn,ksen,klat,kmelth,ksnow,krofi
   integer(IN)   :: kh,kqbot,kfraz
   integer(IN)   :: k10uu           ! index for u10
@@ -90,16 +90,17 @@ module docn_comp_mod
 #endif
 
   !--------------------------------------------------------------------------
-  integer(IN)     , parameter :: ktrans = 9
+  integer(IN)     , parameter :: ktrans = 10
   character(14)   , parameter :: avifld(1:ktrans) = &
        (/ "t             ","u             ","v             ","dhdx          ",&
           "dhdy          ","s             ","h             ","qbot          ",&
-          "frac_h2oocn   "/)
+          "ssh           ","frac_h2oocn   "/)
   character(14)   , parameter  :: avofld(1:ktrans) = &
        (/ "So_t          ","So_u          ","So_v          ","So_dhdx       ",&
           "So_dhdy       ","So_s          ","strm_h        ","strm_qbot     ",&
-          "So_frac_h2oocn"/)
+          "So_ssh        ","So_frac_h2oocn"/)
   character(len=*),parameter :: flds_strm = 'strm_h:strm_qbot:So_t'
+
   !--------------------------------------------------------------------------
 
   !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -291,6 +292,7 @@ CONTAINS
     kswp  = mct_aVect_indexRA(o2x,'So_fswpen', perrwith='quiet')
     kq    = mct_aVect_indexRA(o2x,'Fioo_q') ! ocn freezing melting potential
     kfraz = mct_aVect_indexRA(o2x,'Fioo_frazil') ! ocn frazil
+    kssh  = mct_aVect_indexRa(o2x,'So_ssh', perrwith='quiet')
     kh2o  = mct_aVect_indexRA(o2x,'So_frac_h2oocn', perrwith='quiet')
 
     call mct_aVect_init(x2o, rList=seq_flds_x2o_fields, lsize=lsize)
@@ -649,6 +651,9 @@ CONTAINS
 ! make sure frazil is 0. MPAS-seaice will still use it.
        o2x%rAttr(kfraz,n) = 0.0_R8
        if (kh2o /= 0) then
+         o2x%rAttr(kssh, n) = 0.0_R8
+       endif
+       if (kh2o /= 0) then
          o2x%rAttr(kh2o, n) = 0.0_R8
        endif
        if (kswp /= 0) then
@@ -905,6 +910,9 @@ CONTAINS
           o2x%rAttr(kdhdx,n) = 0.0_R8
           o2x%rAttr(kdhdy,n) = 0.0_R8
           o2x%rAttr(kq   ,n) = 0.0_R8
+          if (kssh /= 0) then
+            o2x%rAttr(kssh, n) = o2x%rAttr(kssh, n)
+          endif
           if (kh2o /= 0) then
              if (o2x%rAttr(kh2o, n) < 0.0_R8) then
                 o2x%rAttr(kh2o, n) = 0.0_R8 ! Inundation cannot be negative

--- a/components/data_comps/docn/src/docn_shr_mod.F90
+++ b/components/data_comps/docn/src/docn_shr_mod.F90
@@ -161,7 +161,8 @@ CONTAINS
         trim(datamode) == 'IAF'                 .or. &
         trim(datamode) == 'SOM'                 .or. & ! Traditional slab ocean
         trim(datamode) == 'RSO'                 .or. & ! Relaxed slab ocean
-        trim(datamode) == 'SOM_AQUAP') then            ! Aquaplanet slab ocean
+        trim(datamode) == 'SOM_AQUAP'           .or. & ! Aquaplanet slab ocean
+        trim(datamode) == 'GTSM') then
        if (my_task == master_task) then
           write(logunit,F00) ' docn datamode = ',trim(datamode)
        end if

--- a/components/elm/cime_config/config_compsets.xml
+++ b/components/elm/cime_config/config_compsets.xml
@@ -982,6 +982,13 @@
     <lname>2000_DATM%1PT_ELM%SP_SICE_SOCN_MOSART_SGLC_SWAV</lname>
   </compset>	  
 
+  <!---One way OCN to LND   -->
+
+  <compset>
+    <alias>GTSM2ELM</alias>
+    <lname>2000_DATM%GSWP3v1_ELM_SICE_DOCN%GTSM_SROF_SGLC_SWAV</lname>
+  </compset>    
+
   <entries>
     <entry id="RUN_STARTDATE">
       <values>

--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/lnd_docn_1way/shell_commands
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/lnd_docn_1way/shell_commands
@@ -1,0 +1,16 @@
+./xmlchange DATM_MODE=CLMGSWP3v1
+./xmlchange LND_DOMAIN_FILE=domain_global_coastline_merit_90m.nc
+./xmlchange ATM_DOMAIN_FILE=domain_global_coastline_merit_90m.nc
+./xmlchange LND_DOMAIN_PATH=/compyfs/xudo627/lnd-docn-1way/inputdata
+./xmlchange ATM_DOMAIN_PATH=/compyfs/xudo627/lnd-docn-1way/inputdata
+
+./xmlchange --file env_run.xml --id SSTICE_YEAR_START     --val 1980
+./xmlchange --file env_run.xml --id SSTICE_YEAR_END       --val 1981
+./xmlchange --file env_run.xml --id SSTICE_YEAR_ALIGN     --val 1980
+
+./xmlchange --file env_run.xml --id DATM_CLMNCEP_YR_START --val 1980
+./xmlchange --file env_run.xml --id DATM_CLMNCEP_YR_END   --val 1981
+./xmlchange --file env_run.xml --id DATM_CLMNCEP_YR_ALIGN --val 1980
+
+./xmlchange PIO_TYPENAME_OCN=netcdf # pnetcdf doesn't support NETCDF4
+./xmlchange NTASKS=600

--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/lnd_docn_1way/user_nl_cpl
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/lnd_docn_1way/user_nl_cpl
@@ -1,0 +1,1 @@
+ocn_lnd_one_way = .true.

--- a/components/elm/cime_config/testdefs/testmods_dirs/elm/lnd_docn_1way/user_nl_elm
+++ b/components/elm/cime_config/testdefs/testmods_dirs/elm/lnd_docn_1way/user_nl_elm
@@ -1,0 +1,2 @@
+fsurdat = '/compyfs/xudo627/lnd-docn-1way/inputdata/surfdata_global_coastline_merit_90m_calibrated_c221109.nc'
+flndtopo = '/compyfs/xudo627/lnd-docn-1way/inputdata/surfdata_global_coastline_merit_90m_fd2.5_c221109.nc'

--- a/components/elm/src/biogeophys/BalanceCheckMod.F90
+++ b/components/elm/src/biogeophys/BalanceCheckMod.F90
@@ -252,6 +252,7 @@ contains
           snow_sinks                 =>    col_wf%snow_sinks              , & ! Output: [real(r8) (:)   ]  snow sinks (mm H2O /s)
           qflx_lateral               =>    col_wf%qflx_lateral            , & ! Input:  [real(r8) (:)   ]  lateral flux of water to neighboring column (mm H2O /s)
           qflx_h2orof_drain          =>    col_wf%qflx_h2orof_drain       , & ! Input:  [real(r8) (:)   ] drainange from floodplain inundation volume (mm H2O/s) 
+          qflx_h2oocn_drain          =>    col_wf%qflx_h2oocn_drain       , & ! Input:  [real(r8) (:)   ] drainange from floodplain inundation volume (mm H2O/s) 
 
           eflx_lwrad_out             =>    veg_ef%eflx_lwrad_out       , & ! Input:  [real(r8) (:)   ]  emitted infrared (longwave) radiation (W/m**2)
           eflx_lwrad_net             =>    veg_ef%eflx_lwrad_net       , & ! Input:  [real(r8) (:)   ]  net infrared (longwave) rad (W/m**2) [+ = to atm]
@@ -336,7 +337,7 @@ contains
                   + qflx_surf_irrig_col(c) + qflx_over_supply_col(c) &
                   - qflx_evap_tot(c) - qflx_surf(c)  - qflx_h2osfc_surf(c) - qflx_to_downhill(c) &
                   - qflx_qrgwl(c) - qflx_drain(c) - qflx_drain_perched(c) - qflx_snwcp_ice(c) - qflx_ice_runoff_xs(c) &
-                  - qflx_lateral(c) + qflx_h2orof_drain(c)) * dtime
+                  - qflx_lateral(c) + qflx_h2orof_drain(c) + qflx_h2oocn_drain(c)) * dtime
              dwb(c) = (endwb(c)-begwb(c))/dtime
 
           else
@@ -407,7 +408,8 @@ contains
              write(iulog,*)'qflx_lateral               = ',qflx_lateral(indexc)
              write(iulog,*)'total_plant_stored_h2o_col = ',total_plant_stored_h2o_col(indexc)
              write(iulog,*)'qflx_h2orof_drain          = ',qflx_h2orof_drain(indexc)
-             write(iulog,*)'qflx_ice_runoff_xs          = ',qflx_ice_runoff_xs(indexc)
+             write(iulog,*)'qflx_ice_runoff_xs         = ',qflx_ice_runoff_xs(indexc)
+             write(iulog,*)'qflx_h2oocn_drain          = ',qflx_h2oocn_drain(indexc)
              write(iulog,*)'elm model is stopping'
              call endrun(decomp_index=indexc, elmlevel=namec, msg=errmsg(__FILE__, __LINE__))
 
@@ -438,7 +440,8 @@ contains
              write(iulog,*)'qflx_lateral               = ',qflx_lateral(indexc)
              write(iulog,*)'total_plant_stored_h2o_col = ',total_plant_stored_h2o_col(indexc)
              write(iulog,*)'qflx_h2orof_drain          = ',qflx_h2orof_drain(indexc)
-             write(iulog,*)'qflx_ice_runoff_xs          = ',qflx_ice_runoff_xs(indexc)
+             write(iulog,*)'qflx_ice_runoff_xs         = ',qflx_ice_runoff_xs(indexc)
+             write(iulog,*)'qflx_h2oocn_drain          = ',qflx_h2oocn_drain(indexc)
              write(iulog,*)'elm model is stopping'
              call endrun(decomp_index=indexc, elmlevel=namec, msg=errmsg(__FILE__, __LINE__))
           end if

--- a/components/elm/src/biogeophys/BalanceCheckMod.F90
+++ b/components/elm/src/biogeophys/BalanceCheckMod.F90
@@ -251,8 +251,9 @@ contains
           snow_sources               =>    col_wf%snow_sources            , & ! Output: [real(r8) (:)   ]  snow sources (mm H2O /s)
           snow_sinks                 =>    col_wf%snow_sinks              , & ! Output: [real(r8) (:)   ]  snow sinks (mm H2O /s)
           qflx_lateral               =>    col_wf%qflx_lateral            , & ! Input:  [real(r8) (:)   ]  lateral flux of water to neighboring column (mm H2O /s)
-          qflx_h2orof_drain          =>    col_wf%qflx_h2orof_drain       , & ! Input:  [real(r8) (:)   ] drainange from floodplain inundation volume (mm H2O/s) 
-          qflx_h2oocn_drain          =>    col_wf%qflx_h2oocn_drain       , & ! Input:  [real(r8) (:)   ] drainange from floodplain inundation volume (mm H2O/s) 
+          qflx_lnd2ocn               =>    col_wf%qflx_lnd2ocn            , & ! Input:  [real(r8) (:)   ]  lateral flow from lnd to ocn (mm H2O /s)
+          qflx_h2orof_drain          =>    col_wf%qflx_h2orof_drain       , & ! Input:  [real(r8) (:)   ]  drainange from floodplain inundation volume (mm H2O/s) 
+          qflx_h2oocn_drain          =>    col_wf%qflx_h2oocn_drain       , & ! Input:  [real(r8) (:)   ]  drainange from floodplain inundation volume (mm H2O/s) 
 
           eflx_lwrad_out             =>    veg_ef%eflx_lwrad_out       , & ! Input:  [real(r8) (:)   ]  emitted infrared (longwave) radiation (W/m**2)
           eflx_lwrad_net             =>    veg_ef%eflx_lwrad_net       , & ! Input:  [real(r8) (:)   ]  net infrared (longwave) rad (W/m**2) [+ = to atm]
@@ -337,7 +338,8 @@ contains
                   + qflx_surf_irrig_col(c) + qflx_over_supply_col(c) &
                   - qflx_evap_tot(c) - qflx_surf(c)  - qflx_h2osfc_surf(c) - qflx_to_downhill(c) &
                   - qflx_qrgwl(c) - qflx_drain(c) - qflx_drain_perched(c) - qflx_snwcp_ice(c) - qflx_ice_runoff_xs(c) &
-                  - qflx_lateral(c) + qflx_h2orof_drain(c) + qflx_h2oocn_drain(c)) * dtime
+                  - qflx_lateral(c) + qflx_h2orof_drain(c) - qflx_lnd2ocn(c) + qflx_h2oocn_drain(c)) * dtime
+
              dwb(c) = (endwb(c)-begwb(c))/dtime
 
           else
@@ -406,6 +408,7 @@ contains
              write(iulog,*)'qflx_drain                 = ',qflx_drain(indexc)
              write(iulog,*)'qflx_snwcp_ice             = ',qflx_snwcp_ice(indexc)
              write(iulog,*)'qflx_lateral               = ',qflx_lateral(indexc)
+             write(iulog,*)'qflx_lnd2ocn               = ',qflx_lnd2ocn(indexc)
              write(iulog,*)'total_plant_stored_h2o_col = ',total_plant_stored_h2o_col(indexc)
              write(iulog,*)'qflx_h2orof_drain          = ',qflx_h2orof_drain(indexc)
              write(iulog,*)'qflx_ice_runoff_xs         = ',qflx_ice_runoff_xs(indexc)
@@ -438,6 +441,7 @@ contains
              write(iulog,*)'qflx_glcice_melt           = ',qflx_glcice_melt(indexc)
              write(iulog,*)'qflx_glcice_frz            = ',qflx_glcice_frz(indexc)
              write(iulog,*)'qflx_lateral               = ',qflx_lateral(indexc)
+             write(iulog,*)'qflx_lnd2ocn               = ',qflx_lnd2ocn(indexc)
              write(iulog,*)'total_plant_stored_h2o_col = ',total_plant_stored_h2o_col(indexc)
              write(iulog,*)'qflx_h2orof_drain          = ',qflx_h2orof_drain(indexc)
              write(iulog,*)'qflx_ice_runoff_xs         = ',qflx_ice_runoff_xs(indexc)

--- a/components/elm/src/biogeophys/HydrologyNoDrainageMod.F90
+++ b/components/elm/src/biogeophys/HydrologyNoDrainageMod.F90
@@ -10,10 +10,11 @@ Module HydrologyNoDrainageMod
   use elm_varctl        , only : iulog, use_vichydro, use_extrasnowlayers, use_firn_percolation_and_compaction
   use elm_varcon        , only : e_ice, denh2o, denice, rpi, spval
   use atm2lndType       , only : atm2lnd_type
+  use ocn2lndType       , only : ocn2lnd_type
   use lnd2atmType       , only : lnd2atm_type
   use AerosolType       , only : aerosol_type
   use EnergyFluxType    , only : energyflux_type
-  use CanopyStateType  , only  : canopystate_type
+  use CanopyStateType   , only  : canopystate_type
   use SoilHydrologyType , only : soilhydrology_type
   use SoilStateType     , only : soilstate_type
   use LandunitType      , only : lun_pp
@@ -44,7 +45,7 @@ contains
        num_urbanc, filter_urbanc, &
        num_snowc, filter_snowc, &
        num_nosnowc, filter_nosnowc, canopystate_vars, &
-       atm2lnd_vars, lnd2atm_vars, soilstate_vars,    &
+       atm2lnd_vars, ocn2lnd_vars, lnd2atm_vars, soilstate_vars, &
        energyflux_vars, soilhydrology_vars, aerosol_vars)
     ! !DESCRIPTION:
     ! This is the main subroutine to execute the calculation of soil/snow
@@ -93,6 +94,7 @@ contains
     integer                  , intent(inout) :: num_nosnowc          ! number of column non-snow points
     integer                  , intent(inout) :: filter_nosnowc(:)    ! column filter for non-snow points
     type(atm2lnd_type)       , intent(in)    :: atm2lnd_vars
+    type(ocn2lnd_type)       , intent(in)    :: ocn2lnd_vars
     type(lnd2atm_type)       , intent(in)    :: lnd2atm_vars
     type(soilstate_type)     , intent(inout) :: soilstate_vars
     type(energyflux_type)    , intent(in)    :: energyflux_vars
@@ -194,15 +196,16 @@ contains
       !------------------------------------------------------------------------------------
       if (use_pflotran .and. pf_hmode) then
 
-        call Infiltration(bounds, num_hydrononsoic, filter_hydrononsoic, &
-             num_urbanc, filter_urbanc, atm2lnd_vars, lnd2atm_vars,      &
+        call Infiltration(bounds, num_hydrononsoic, filter_hydrononsoic,          &
+             num_urbanc, filter_urbanc, atm2lnd_vars, ocn2lnd_vars, lnd2atm_vars, &
              energyflux_vars, soilhydrology_vars, soilstate_vars, dtime)
 
       else
       !------------------------------------------------------------------------------------
 
-        call Infiltration(bounds, num_hydrologyc, filter_hydrologyc, num_urbanc, filter_urbanc, &
-             atm2lnd_vars, lnd2atm_vars, energyflux_vars, soilhydrology_vars, soilstate_vars, dtime)
+        call Infiltration(bounds, num_hydrologyc, filter_hydrologyc,              &
+             num_urbanc, filter_urbanc, atm2lnd_vars, ocn2lnd_vars, lnd2atm_vars, &
+             energyflux_vars, soilhydrology_vars, soilstate_vars, dtime)
 
       !------------------------------------------------------------------------------------
       end if

--- a/components/elm/src/biogeophys/LakeHydrologyMod.F90
+++ b/components/elm/src/biogeophys/LakeHydrologyMod.F90
@@ -199,6 +199,7 @@ contains
          qflx_rsub_sat        =>  col_wf%qflx_rsub_sat      , & ! Output: [real(r8) (:)   ]  soil saturation excess [mm h2o/s]
          qflx_surf            =>  col_wf%qflx_surf          , & ! Output: [real(r8) (:)   ]  surface runoff (mm H2O /s)
          qflx_drain           =>  col_wf%qflx_drain         , & ! Output: [real(r8) (:)   ]  sub-surface runoff (mm H2O /s)
+         qflx_lnd2ocn         =>  col_wf%qflx_lnd2ocn       , & ! Output: [real(r8) (:)   ] lateral flow from lnd to ocn (mm H2O /s)
          qflx_infl            =>  col_wf%qflx_infl          , & ! Output: [real(r8) (:)   ]  infiltration (mm H2O /s)
          qflx_qrgwl           =>  col_wf%qflx_qrgwl         , & ! Output: [real(r8) (:)   ]  qflx_surf at glaciers, wetlands, lakes
          qflx_runoff          =>  col_wf%qflx_runoff        , & ! Output: [real(r8) (:)   ]  total runoff (qflx_drain+qflx_surf+qflx_qrgwl) (mm H2O /s)
@@ -712,6 +713,7 @@ contains
          qflx_infl(c)          = 0._r8
          qflx_surf(c)          = 0._r8
          qflx_drain(c)         = 0._r8
+         qflx_lnd2ocn(c)       = 0._r8
          qflx_irrig(p)         = 0._r8
          qflx_irrig_col(c)     = 0._r8
 

--- a/components/elm/src/biogeophys/SoilHydrologyMod.F90
+++ b/components/elm/src/biogeophys/SoilHydrologyMod.F90
@@ -1891,17 +1891,17 @@ contains
              enddo
              T2 = 1.e-3_r8*hksat(c,nlevbed)*f
           else
-             ! SSH is below the soil column
+             ! SSH or ZWT is below the soil column
              if (ldomain%topo(g)-zwt(c) > ocn2lnd_vars%ssh_grc(g)) then
-                T2 = 1.e-3_r8*hksat(c,nlevbed)*f*exp((ocn2lnd_vars%ssh_grc(g)-(ldomain%topo(g)-80._r8))/f)
+                T2 = 1.e-3_r8*hksat(c,nlevbed)*f*exp(-((ldomain%topo(g)-zi(c,nlevbed))-ocn2lnd_vars%ssh_grc(g))/f)
              else
-                T2 = 1.e-3_r8*hksat(c,nlevbed)*f*exp((80._r8 - zwt(c))/f)
+                T2 = 1.e-3_r8*hksat(c,nlevbed)*f*exp(-(zwt(c)-zi(c,nlevbed))/f)
              endif
           endif
           ! positive: lnd->ocn, negative: ocn->lnd
           if (ldomain%topo(g) - ocn2lnd_vars%ssh_grc(g) < 80._r8) then
              head = ldomain%topo(g) - zwt(c) - ocn2lnd_vars%ssh_grc(g);
-             qflx_lnd2ocn(c) = imped*2._r8*(T1+T2)*(head)/ (ldomain%frac(g) * ldomain%area(g) * 1.e6_r8) * 1.e3_r8
+             qflx_lnd2ocn(c) = imped*2._r8*(T1+T2)*(head)/ (ldomain%frac(g) * ldomain%area(g) * 1.e6_r8) * 1.e3_r8 ! [mm H2O/s]
           else
              ! Land surface is much higher than the SSH, then there is no lateral flow
              qflx_lnd2ocn(c) = 0._r8

--- a/components/elm/src/biogeophys/SoilHydrologyMod.F90
+++ b/components/elm/src/biogeophys/SoilHydrologyMod.F90
@@ -1865,9 +1865,9 @@ contains
           ! Lateral flow to ocean
           T1 = 0._r8
           if (col_pp%topo_slope(c) > 0.16_r8) then
-             f = 5._r8
+             f = 1._r8
           else
-             f = 120._r8/(1._r8 + 150._r8*col_pp%topo_slope(c))
+             f = 20._r8/(1._r8 + 125._r8*col_pp%topo_slope(c))
           endif
 
           if (ldomain%topo(g)-zwt(c) > ocn2lnd_vars%ssh_grc(g)) then
@@ -1961,15 +1961,15 @@ contains
 
                    lateral_tot   = lateral_tot - lateral_layer
                    if (lateral_tot >= 0.) then
-                      zwt(c) = zwt(c) - lateral_layer/s_y/1000._r8/rous
-                      qflx_lnd2ocn(c) = qflx_lnd2ocn(c) + lateral_tot/dtime
                       exit
                    else
                       zwt(c) = zi(c,j)
                    endif
 
                 enddo
-                !if (lateral_tot > 0.) zwt(c) = zwt(c) - lateral_tot/1000._r8/rous
+                if (lateral_tot > 0.) then
+                   zwt(c) = zwt(c) - lateral_tot/1000._r8/rous
+                endif
                 if (lateral_tot < -1.e-14_r8) then 
                    qflx_lnd2ocn(c) = qflx_lnd2ocn(c) + lateral_tot/dtime
                 endif 

--- a/components/elm/src/biogeophys/SoilHydrologyType.F90
+++ b/components/elm/src/biogeophys/SoilHydrologyType.F90
@@ -67,7 +67,9 @@ Module SoilHydrologyType
      real(r8), pointer :: ice_col           (:,:)   => null()! col VIC soil ice (kg/m2) for VIC soil layers
      real(r8), pointer :: fover             (:)     => null()! decay factor for surface runoff
      real(r8), pointer :: pc                (:)     => null()! surface water threshold probability
-     
+
+     real(r8), pointer :: ar_col            (:,:)   => null()! col anisotropic ratio
+
    contains
 
      procedure, public  :: Init
@@ -159,6 +161,8 @@ contains
     
     allocate(this%fover             (begg:endg))                 ; this%fover             (:)     = spval
     allocate(this%pc                (begg:endg))                 ; this%pc                (:)     = spval
+
+    allocate(this%ar_col            (begc:endc,nlevgrnd))        ; this%ar_col            (:,:)   = 25.0_r8
 
   end subroutine InitAllocate
 
@@ -466,7 +470,7 @@ contains
                 ! do nothing
              else if (lun_pp%urbpoi(l) .and. (col_pp%itype(c) /= icol_road_perv) .and. (col_pp%itype(c) /= icol_road_imperv) )then
                 ! do nothing
-             else			    
+             else  
                   do lev = 1,nlevgrnd
                     if ( more_vertlayers )then
                       ! duplicate clay and sand values from last soil layer
@@ -504,6 +508,8 @@ contains
                    claycol(c,lev)    = clay
                    sandcol(c,lev)    = sand
                    om_fraccol(c,lev) = om_frac
+
+                   this%ar_col(c,lev)= clay
                 end do
              end if
           end if ! end of if not lake

--- a/components/elm/src/cpl/elm_cpl_indices.F90
+++ b/components/elm/src/cpl/elm_cpl_indices.F90
@@ -120,6 +120,7 @@ module elm_cpl_indices
   integer, public ::index_x2l_Flrr_deficit    ! rtm->lnd supply deficit
   integer, public ::index_x2l_Sr_h2orof       ! rtm->lnd floodplain inundation volume
   integer, public ::index_x2l_Sr_frac_h2orof  ! rtm->lnd floodplain inundation fraction
+  integer, public ::index_x2l_So_frac_h2oocn  ! ocn->lnd coastal inundation fraction
 
   ! In the following, index 0 is bare land, other indices are glc elevation classes
   integer, public ::index_x2l_Sg_frac(0:glc_nec_max)   = 0   ! Fraction of glacier from glc model
@@ -144,7 +145,7 @@ contains
     !
     ! !USES:
     use seq_flds_mod   , only: seq_flds_x2l_fields, seq_flds_l2x_fields,       &
-                               lnd_rof_two_way, rof_sed
+                               lnd_rof_two_way, ocn_lnd_one_way, rof_sed
     use mct_mod        , only: mct_aVect, mct_aVect_init, mct_avect_indexra
     use mct_mod        , only: mct_aVect_clean, mct_avect_nRattr
     use seq_drydep_mod , only: drydep_fields_token, lnd_drydep
@@ -300,6 +301,9 @@ contains
     if (lnd_rof_two_way) then
        index_x2l_Sr_h2orof     = mct_avect_indexra(x2l,'Sr_h2orof')
        index_x2l_Sr_frac_h2orof= mct_avect_indexra(x2l,'Sr_frac_h2orof')
+    endif
+    if (ocn_lnd_one_way) then
+       index_x2l_So_frac_h2oocn= mct_avect_indexra(x2l,'So_frac_h2oocn')
     endif
 
     !-------------------------------------------------------------

--- a/components/elm/src/cpl/elm_cpl_indices.F90
+++ b/components/elm/src/cpl/elm_cpl_indices.F90
@@ -120,6 +120,7 @@ module elm_cpl_indices
   integer, public ::index_x2l_Flrr_deficit    ! rtm->lnd supply deficit
   integer, public ::index_x2l_Sr_h2orof       ! rtm->lnd floodplain inundation volume
   integer, public ::index_x2l_Sr_frac_h2orof  ! rtm->lnd floodplain inundation fraction
+  integer, public ::index_x2l_So_ssh          ! ocn->lnd sea surface height
   integer, public ::index_x2l_So_frac_h2oocn  ! ocn->lnd coastal inundation fraction
 
   ! In the following, index 0 is bare land, other indices are glc elevation classes
@@ -303,6 +304,7 @@ contains
        index_x2l_Sr_frac_h2orof= mct_avect_indexra(x2l,'Sr_frac_h2orof')
     endif
     if (ocn_lnd_one_way) then
+       index_x2l_So_ssh        = mct_avect_indexra(x2l,'So_ssh')
        index_x2l_So_frac_h2oocn= mct_avect_indexra(x2l,'So_frac_h2oocn')
     endif
 

--- a/components/elm/src/cpl/lnd_comp_mct.F90
+++ b/components/elm/src/cpl/lnd_comp_mct.F90
@@ -89,9 +89,11 @@ contains
                                   seq_infodata_start_type_start, seq_infodata_start_type_cont,   &
                                   seq_infodata_start_type_brnch
     use seq_comm_mct     , only : seq_comm_suffix, seq_comm_inst, seq_comm_name
-    use seq_flds_mod     , only : seq_flds_x2l_fields, seq_flds_l2x_fields, lnd_rof_two_way
+    use seq_flds_mod     , only : seq_flds_x2l_fields, seq_flds_l2x_fields
+    use seq_flds_mod     , only : lnd_rof_two_way, ocn_lnd_one_way
     use spmdMod          , only : masterproc, npes, spmd_init
-    use elm_varctl       , only : nsrStartup, nsrContinue, nsrBranch, use_lnd_rof_two_way
+    use elm_varctl       , only : nsrStartup, nsrContinue, nsrBranch
+    use elm_varctl       , only : use_lnd_rof_two_way, use_ocn_lnd_one_way
     use elm_cpl_indices  , only : elm_cpl_indices_set
     use perf_mod         , only : t_startf, t_stopf
     use mct_mod
@@ -285,6 +287,7 @@ contains
                         hostname_in=hostname, username_in=username)
 
     use_lnd_rof_two_way = lnd_rof_two_way
+    use_ocn_lnd_one_way = ocn_lnd_one_way
     
     ! Read namelist, grid and surface data
 
@@ -312,6 +315,7 @@ contains
     call get_proc_bounds( bounds )
 
     call lnd_SetgsMap_mct( bounds, mpicom_lnd, LNDID, gsMap_lnd )
+
     lsz = mct_gsMap_lsize(gsMap_lnd, mpicom_lnd)
 
     call lnd_domain_mct( bounds, lsz, gsMap_lnd, dom_l )
@@ -368,7 +372,7 @@ contains
 
     ! Fill in infodata settings
 
-    call seq_infodata_PutData(infodata, lnd_prognostic=.true.)
+    call seq_infodata_PutData(infodata, lnd_prognostic=.true., lndocn_prognostic=use_ocn_lnd_one_way)
     call seq_infodata_PutData(infodata, lnd_nx=ldomain%ni, lnd_ny=ldomain%nj, precip_downscaling_method = precip_downscaling_method)
 
 #ifdef HAVE_MOAB
@@ -424,7 +428,8 @@ contains
     !
     ! !USES:
     use shr_kind_mod    ,  only : r8 => shr_kind_r8
-    use elm_instMod     , only : lnd2atm_vars, atm2lnd_vars, lnd2glc_vars, glc2lnd_vars
+    use elm_instMod     ,  only : lnd2atm_vars, atm2lnd_vars, lnd2glc_vars, glc2lnd_vars
+    use elm_instMod     ,  only : ocn2lnd_vars
     use elm_driver      ,  only : elm_drv
     use elm_time_manager,  only : get_curr_date, get_nstep, get_curr_calday, get_step_size
     use elm_time_manager,  only : advance_timestep, set_nextsw_cday,update_rad_dtime
@@ -544,7 +549,8 @@ contains
     ! Map to elm (only when state and/or fluxes need to be updated)
 
     call t_startf ('lc_lnd_import')
-    call lnd_import( bounds, x2l_l%rattr, atm2lnd_vars, glc2lnd_vars, lnd2atm_vars)
+    
+    call lnd_import( bounds, x2l_l%rattr, atm2lnd_vars, glc2lnd_vars, ocn2lnd_vars, lnd2atm_vars)
     
 #ifdef HAVE_MOAB
     ! first call moab import 

--- a/components/elm/src/cpl/lnd_import_export.F90
+++ b/components/elm/src/cpl/lnd_import_export.F90
@@ -7,6 +7,7 @@ module lnd_import_export
   use lnd2glcMod   , only: lnd2glc_type
   use atm2lndType  , only: atm2lnd_type
   use glc2lndMod   , only: glc2lnd_type
+  use ocn2lndType  , only: ocn2lnd_type
   use GridcellType , only: grc_pp          ! for access to gridcell topology
   use TopounitDataType , only: top_as, top_af  ! atmospheric state and flux variables  
   use elm_cpl_indices
@@ -19,7 +20,7 @@ module lnd_import_export
 contains
 
   !===============================================================================
-  subroutine lnd_import( bounds, x2l, atm2lnd_vars, glc2lnd_vars, lnd2atm_vars)
+  subroutine lnd_import( bounds, x2l, atm2lnd_vars, glc2lnd_vars, ocn2lnd_vars, lnd2atm_vars)
 
     !---------------------------------------------------------------------------
     ! !DESCRIPTION:
@@ -49,6 +50,7 @@ contains
     real(r8)           , intent(in)    :: x2l(:,:) ! driver import state to land model
     type(atm2lnd_type) , intent(inout) :: atm2lnd_vars      ! clm internal input data type
     type(glc2lnd_type) , intent(inout) :: glc2lnd_vars      ! clm internal input data type
+    type(ocn2lnd_type) , intent(inout) :: ocn2lnd_vars
     type(lnd2atm_type) , intent(in)    :: lnd2atm_vars
     !
     ! !LOCAL VARIABLES:
@@ -198,6 +200,10 @@ contains
        if (index_x2l_Sr_h2orof /= 0) then
          atm2lnd_vars%h2orof_grc(g)      = x2l(index_x2l_Sr_h2orof,i)
          atm2lnd_vars%frac_h2orof_grc(g) = x2l(index_x2l_Sr_frac_h2orof,i)
+       endif
+
+       if (index_x2l_So_frac_h2oocn /= 0) then
+         ocn2lnd_vars%frac_h2oocn_grc(g) = x2l(index_x2l_So_frac_h2oocn,i)
        endif
 
        ! Determine required receive fields

--- a/components/elm/src/cpl/lnd_import_export.F90
+++ b/components/elm/src/cpl/lnd_import_export.F90
@@ -202,6 +202,10 @@ contains
          atm2lnd_vars%frac_h2orof_grc(g) = x2l(index_x2l_Sr_frac_h2orof,i)
        endif
 
+       if (index_x2l_So_ssh /= 0) then
+         ocn2lnd_vars%ssh_grc(g) = x2l(index_x2l_So_ssh,i)
+       endif
+
        if (index_x2l_So_frac_h2oocn /= 0) then
          ocn2lnd_vars%frac_h2oocn_grc(g) = x2l(index_x2l_So_frac_h2oocn,i)
        endif

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -520,6 +520,7 @@ module ColumnDataType
     real(r8), pointer :: qflx_h2osfc2topsoi   (:)   => null() ! liquid water coming from surface standing water top soil (mm H2O/s)
     real(r8), pointer :: qflx_snow2topsoi     (:)   => null() ! liquid water coming from residual snow to topsoil (mm H2O/s)
     real(r8), pointer :: qflx_lateral         (:)   => null() ! lateral subsurface flux (mm H2O /s)
+    real(r8), pointer :: qflx_lnd2ocn         (:)   => null() ! lateral flux between water table and sea surface height (mm H2O/s)
     real(r8), pointer :: snow_sources         (:)   => null() ! snow sources (mm H2O/s)
     real(r8), pointer :: snow_sinks           (:)   => null() ! snow sinks (mm H2O/s)
 
@@ -5832,6 +5833,7 @@ contains
     allocate(this%qflx_h2osfc2topsoi     (begc:endc))             ; this%qflx_h2osfc2topsoi   (:)   = spval
     allocate(this%qflx_snow2topsoi       (begc:endc))             ; this%qflx_snow2topsoi     (:)   = spval
     allocate(this%qflx_lateral           (begc:endc))             ; this%qflx_lateral         (:)   = 0._r8
+    allocate(this%qflx_lnd2ocn           (begc:endc))             ; this%qflx_lnd2ocn         (:)   = spval
     allocate(this%snow_sources           (begc:endc))             ; this%snow_sources         (:)   = spval
     allocate(this%snow_sinks             (begc:endc))             ; this%snow_sinks           (:)   = spval
     allocate(this%qflx_irrig             (begc:endc))             ; this%qflx_irrig           (:)   = spval
@@ -5897,6 +5899,11 @@ contains
     call hist_addfld1d (fname='QDRAI',  units='mm/s',  &
          avgflag='A', long_name='sub-surface drainage', &
          ptr_col=this%qflx_drain, c2l_scale_type='urbanf')
+
+    this%qflx_lnd2ocn(begc:endc) = spval
+    call hist_addfld1d (fname='QLND2OCN',  units='mm/s',  &
+         avgflag='A', long_name='land to ocean drainage', &
+         ptr_col=this%qflx_lnd2ocn, c2l_scale_type='urbanf')
 
     this%qflx_irr_demand(begc:endc) = spval
     call hist_addfld1d (fname='QIRRIG_WM',  units='mm/s',  &
@@ -6043,6 +6050,7 @@ contains
        if (lun_pp%itype(l) == istsoil .or. lun_pp%itype(l) == istcrop) then
           this%qflx_drain(c) = 0._r8
           this%qflx_surf(c)  = 0._r8
+          this%qflx_lnd2ocn(c) = 0._r8
        end if
     end do
 

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -30,6 +30,7 @@ module ColumnDataType
   use elm_varctl      , only : pf_hmode, nu_com
   use elm_varctl      , only : use_extrasnowlayers, use_polygonal_tundra
   use elm_varctl      , only : use_fan
+  use elm_varctl      , only : use_ocn_lnd_one_way
   use ch4varcon       , only : allowlakeprod
   use pftvarcon       , only : VMAX_MINSURF_P_vr, KM_MINSURF_P_vr, pinit_beta1, pinit_beta2
   use soilorder_varcon, only : smax, ks_sorption
@@ -5900,14 +5901,16 @@ contains
          avgflag='A', long_name='sub-surface drainage', &
          ptr_col=this%qflx_drain, c2l_scale_type='urbanf')
 
-    call hist_addfld1d (fname='QH2OOCN',  units='mm/s',  &
-         avgflag='A', long_name='Ocean inundation infiltration', &
-         ptr_col=this%qflx_h2oocn_drain, c2l_scale_type='urbanf')
+    if (use_ocn_lnd_one_way) then
+      call hist_addfld1d (fname='QH2OOCN',  units='mm/s',  &
+           avgflag='A', long_name='Ocean inundation infiltration', &
+           ptr_col=this%qflx_h2oocn_drain, c2l_scale_type='urbanf')
 
-    this%qflx_lnd2ocn(begc:endc) = spval
-    call hist_addfld1d (fname='QLND2OCN',  units='mm/s',  &
-         avgflag='A', long_name='land to ocean drainage', &
-         ptr_col=this%qflx_lnd2ocn, c2l_scale_type='urbanf')
+      this%qflx_lnd2ocn(begc:endc) = spval
+      call hist_addfld1d (fname='QLND2OCN',  units='mm/s',  &
+           avgflag='A', long_name='land to ocean drainage', &
+           ptr_col=this%qflx_lnd2ocn, c2l_scale_type='urbanf')
+    endif
 
     this%qflx_irr_demand(begc:endc) = spval
     call hist_addfld1d (fname='QIRRIG_WM',  units='mm/s',  &

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -169,6 +169,7 @@ module ColumnDataType
     real(r8), pointer :: vsfm_soilp_col_1d  (:)   => null() ! 1D soil liquid pressure from VSFM [Pa]
     real(r8), pointer :: h2orof             (:)   => null() ! floodplain inundation volume received from rof (mm)
     real(r8), pointer :: frac_h2orof        (:)   => null() ! floodplain inundation fraction received from rof (-)
+    real(r8), pointer :: frac_h2oocn        (:)   => null() ! coastal inundation fraction received from ocn (-)
    ! polygonal tundra (NGEE Arctic IM1)
     real(r8), pointer :: iwp_microrel     (:) => null() ! ice wedge polygon microtopographic relief (m)
     real(r8), pointer :: iwp_exclvol      (:) => null() ! ice wedge polygon excluded volume (m)
@@ -528,6 +529,7 @@ module ColumnDataType
     real(r8), pointer :: qflx_irr_demand      (:)   => null() ! col surface irrigation demand (mm H2O /s)
     real(r8), pointer :: qflx_over_supply     (:)   => null() ! col over supplied irrigation
     real(r8), pointer :: qflx_h2orof_drain    (:)   => null() ! drainage from floodplain inundation volume (mm H2O/s))
+    real(r8), pointer :: qflx_h2oocn_drain    (:)   => null() ! drainage from coastal inundation volume (mm H2O/s)
     real(r8), pointer :: qflx_from_uphill     (:)   => null() ! input to top soil layer from uphill topounit(s) (mm H2O/s))
     real(r8), pointer :: qflx_to_downhill     (:)   => null() ! output from column to the downhill topounit (mm H2O/s))
 
@@ -1461,6 +1463,7 @@ contains
     allocate(this%vsfm_soilp_col_1d  (ncells))                        ; this%vsfm_soilp_col_1d  (:)   = spval
     allocate(this%h2orof             (begc:endc))                     ; this%h2orof             (:)   = spval
     allocate(this%frac_h2orof        (begc:endc))                     ; this%frac_h2orof        (:)   = spval
+    allocate(this%frac_h2oocn        (begc:endc))                     ; this%frac_h2oocn        (:)   = nan
     if (use_polygonal_tundra) then
       ! polygonal tundra/ice wedge polygons:
       allocate(this%iwp_microrel       (begc:endc))                   ; this%iwp_microrel     (:) = spval
@@ -1690,6 +1693,7 @@ contains
        this%frac_h2osfc_act(c)        = 0._r8
        this%h2orof(c)                 = 0._r8
        this%frac_h2orof(c)            = 0._r8
+       this%frac_h2oocn(c)            = 0._r8
 
        if (lun_pp%urbpoi(l)) then
           ! From Bonan 1996 (LSM technical note)
@@ -5836,6 +5840,7 @@ contains
     allocate(this%qflx_over_supply       (begc:endc))             ; this%qflx_over_supply     (:)   = spval
     allocate(this%qflx_irr_demand        (begc:endc))             ; this%qflx_irr_demand      (:)   = spval
     allocate(this%qflx_h2orof_drain      (begc:endc))             ; this%qflx_h2orof_drain    (:)   = spval
+    allocate(this%qflx_h2oocn_drain      (begc:endc))             ; this%qflx_h2oocn_drain    (:)   = spval
     allocate(this%qflx_from_uphill       (begc:endc))             ; this%qflx_from_uphill     (:)   = spval
     allocate(this%qflx_to_downhill       (begc:endc))             ; this%qflx_to_downhill     (:)   = spval
 
@@ -6027,8 +6032,11 @@ contains
     this%qflx_grnd_irrig(begc:endc) = 0._r8
     this%qflx_over_supply(begc:endc) = 0._r8
     this%qflx_h2orof_drain(begc:endc)= 0._r8
+    this%qflx_h2oocn_drain(begc:endc)= 0._r8
+
     this%qflx_from_uphill(begc:endc) = 0._r8
     this%qflx_to_downhill(begc:endc) = 0._r8
+
     ! needed for CNNLeaching
     do c = begc, endc
        l = col_pp%landunit(c)

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -5900,6 +5900,10 @@ contains
          avgflag='A', long_name='sub-surface drainage', &
          ptr_col=this%qflx_drain, c2l_scale_type='urbanf')
 
+    call hist_addfld1d (fname='QH2OOCN',  units='mm/s',  &
+         avgflag='A', long_name='Ocean inundation infiltration', &
+         ptr_col=this%qflx_h2oocn_drain, c2l_scale_type='urbanf')
+
     this%qflx_lnd2ocn(begc:endc) = spval
     call hist_addfld1d (fname='QLND2OCN',  units='mm/s',  &
          avgflag='A', long_name='land to ocean drainage', &

--- a/components/elm/src/main/controlMod.F90
+++ b/components/elm/src/main/controlMod.F90
@@ -1019,12 +1019,13 @@ contains
     ! land river two way coupling
     call mpi_bcast (use_lnd_rof_two_way   , 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (lnd_rof_coupling_nstep, 1, MPI_INTEGER, 0, mpicom, ier)
+    ! ocean land one way coupling
+    call mpi_bcast (use_ocn_lnd_one_way   , 1, MPI_LOGICAL, 0, mpicom, ier)
 
     !SNICAR-AD
     call mpi_bcast (snow_shape, len(snow_shape), MPI_CHARACTER, 0, mpicom, ier)
     call mpi_bcast (snicar_atm_type, len(snicar_atm_type), MPI_CHARACTER, 0, mpicom, ier)
     call mpi_bcast (use_dust_snow_internal_mixing, 1, MPI_LOGICAL, 0, mpicom, ier)
-	
     call mpi_bcast (mpi_sync_nstep_freq, 1, MPI_INTEGER, 0, mpicom, ier)
     
     ! use modified infiltration scheme in surface water storage
@@ -1312,6 +1313,9 @@ contains
     ! land river two way coupling
     write(iulog,*) '    use_lnd_rof_two_way    = ', use_lnd_rof_two_way
     write(iulog,*) '    lnd_rof_coupling_nstep = ', lnd_rof_coupling_nstep
+
+    write(iulog,*) '    use_ocn_lnd_one_way    = ', use_ocn_lnd_one_way
+
     write(iulog,*) '    mpi_sync_nstep_freq    = ', mpi_sync_nstep_freq
     
     write(iulog,*) '    use_modified_infil = ', use_modified_infil

--- a/components/elm/src/main/elm_driver.F90
+++ b/components/elm/src/main/elm_driver.F90
@@ -1221,7 +1221,7 @@ contains
             filter(nc)%num_hydrononsoic, filter(nc)%hydrononsoic, &
             filter(nc)%num_urbanc, filter(nc)%urbanc,             &
             filter(nc)%num_do_smb_c, filter(nc)%do_smb_c,         &
-            atm2lnd_vars, glc2lnd_vars,        &
+            atm2lnd_vars, glc2lnd_vars, ocn2lnd_vars,             &
             soilhydrology_vars, soilstate_vars)
 
        else
@@ -1231,7 +1231,7 @@ contains
             filter(nc)%num_hydrologyc, filter(nc)%hydrologyc, &
             filter(nc)%num_urbanc, filter(nc)%urbanc,         &
             filter(nc)%num_do_smb_c, filter(nc)%do_smb_c,     &
-            atm2lnd_vars, glc2lnd_vars,      &
+            atm2lnd_vars, glc2lnd_vars, ocn2lnd_vars,         &
             soilhydrology_vars, soilstate_vars)
 
        end if

--- a/components/elm/src/main/elm_driver.F90
+++ b/components/elm/src/main/elm_driver.F90
@@ -122,6 +122,7 @@ module elm_driver
   use elm_instMod            , only : waterflux_vars
   use elm_instMod            , only : waterstate_vars
   use elm_instMod            , only : atm2lnd_vars
+  use elm_instMod            , only : ocn2lnd_vars
   use elm_instMod            , only : lnd2atm_vars
   use elm_instMod            , only : glc2lnd_vars
   use elm_instMod            , only : lnd2glc_vars
@@ -901,8 +902,8 @@ contains
             filter(nc)%num_urbanc, filter(nc)%urbanc,                        &
             filter(nc)%num_snowc, filter(nc)%snowc,                          &
             filter(nc)%num_nosnowc, filter(nc)%nosnowc,canopystate_vars,     &
-            atm2lnd_vars, lnd2atm_vars, soilstate_vars, energyflux_vars,     &
-            soilhydrology_vars, aerosol_vars )
+            atm2lnd_vars, ocn2lnd_vars, lnd2atm_vars, soilstate_vars,        &
+            energyflux_vars, soilhydrology_vars, aerosol_vars )
 
        !  Calculate column-integrated aerosol masses, and
        !  mass concentrations for radiative calculations and output

--- a/components/elm/src/main/elm_instMod.F90
+++ b/components/elm/src/main/elm_instMod.F90
@@ -42,6 +42,7 @@ module elm_instMod
   use VOCEmissionMod             , only : vocemis_type
   use atm2lndType                , only : atm2lnd_type
   use lnd2atmType                , only : lnd2atm_type
+  use ocn2lndType                , only : ocn2lnd_type
   use lnd2glcMod                 , only : lnd2glc_type
   use glc2lndMod                 , only : glc2lnd_type
   use glcDiagnosticsMod          , only : glc_diagnostics_type
@@ -118,6 +119,7 @@ module elm_instMod
   type(surfalb_type)                                  :: surfalb_vars
   type(surfrad_type)                                  :: surfrad_vars
   type(atm2lnd_type)                                  :: atm2lnd_vars
+  type(ocn2lnd_type)                                  :: ocn2lnd_vars
   type(glc2lnd_type)                                  :: glc2lnd_vars
   type(lnd2atm_type)                                  :: lnd2atm_vars
   type(lnd2glc_type)                                  :: lnd2glc_vars
@@ -387,6 +389,8 @@ contains
 
     call atm2lnd_vars%Init( bounds_proc )
     call lnd2atm_vars%Init( bounds_proc )
+
+    call ocn2lnd_vars%Init( bounds_proc )
 
     ! Initialize glc2lnd and lnd2glc even if running without create_glacier_mec_landunit,
     ! because at least some variables (such as the icemask) are referred to in code that

--- a/components/elm/src/main/elm_varctl.F90
+++ b/components/elm/src/main/elm_varctl.F90
@@ -564,6 +564,11 @@ module elm_varctl
    !----------------------------------------------------------
    logical, public :: use_lnd_rof_two_way = .false.
    integer, public :: lnd_rof_coupling_nstep = 0
+
+   !----------------------------------------------------------
+   ! ocean land one way coupling
+   !----------------------------------------------------------
+   logical, public :: use_ocn_lnd_one_way = .false.
    
    
    !----------------------------------------------------------

--- a/components/elm/src/main/ocn2lndType.F90
+++ b/components/elm/src/main/ocn2lndType.F90
@@ -28,7 +28,8 @@ module ocn2lndType
   !
   type, public :: ocn2lnd_type
 
-      real(r8), pointer :: frac_h2oocn_grc(:)   => null() ! sea surface height [m]
+      real(r8), pointer :: frac_h2oocn_grc(:)   => null() ! coastal inundation fraction [-]
+      real(r8), pointer :: ssh_grc(:)           => null() ! sea surface height [m]
 
     contains
 
@@ -70,17 +71,18 @@ module ocn2lndType
       integer  :: begg, endg
       integer  :: begc, endc
       integer  :: begp, endp
-      !------------------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
       begg = bounds%begg; endg= bounds%endg
       begc = bounds%begc; endc= bounds%endc
       begp = bounds%begp; endp= bounds%endp
 
-      allocate(this%frac_h2oocn_grc(begg:endg)); this%frac_h2oocn_grc(:)   = ival
+      allocate(this%frac_h2oocn_grc(begg:endg)); this%frac_h2oocn_grc(:)  = ival
+      allocate(this%ssh_grc(begg:endg));         this%ssh_grc(:)          = ival
 
     end subroutine InitAllocate
 
-    !------------------------------------------------------------------------
+    !---------------------------------------------------------------------------
     subroutine InitHistory(this, bounds)
       !
       ! !USES:
@@ -93,12 +95,17 @@ module ocn2lndType
       ! !LOCAL VARIABLES:
       integer  :: begg, endg
       integer  :: begp, endp
-      !---------------------------------------------------------------------
+      !-------------------------------------------------------------------------
 
       begg = bounds%begg; endg= bounds%endg
       begp = bounds%begp; endp= bounds%endp
 
       if (ocn_lnd_one_way) then
+         this%ssh_grc(begg:endg) = spval
+         call hist_addfld1d (fname='SSH',  units='meter'          , &
+              avgflag='A', long_name='sea surface height'         , &
+              ptr_lnd=this%ssh_grc)
+
          this%frac_h2oocn_grc(begg:endg) = spval
          call hist_addfld1d (fname='FRAC_H2OOCN',  units='-'      , &
               avgflag='A', long_name='coastal inundation fraction', &

--- a/components/elm/src/main/ocn2lndType.F90
+++ b/components/elm/src/main/ocn2lndType.F90
@@ -1,0 +1,131 @@
+module ocn2lndType
+
+  !-----------------------------------------------------------------------
+  ! !DESCRIPTION:
+  ! Handle ocn2lnd, lnd2ocn mapping
+  !
+  ! !USES:
+  use shr_kind_mod  , only : r8 => shr_kind_r8
+  use shr_infnan_mod, only : nan => shr_infnan_nan, assignment(=)
+  use shr_log_mod   , only : errMsg => shr_log_errMsg
+  use shr_megan_mod , only : shr_megan_mechcomps_n
+  use elm_varpar    , only : numrad, ndst, nlevgrnd !ndst = number of dust bins.
+  use elm_varcon    , only : rair, grav, cpair, hfus, tfrz, spval
+  use elm_varctl    , only : iulog
+  use seq_drydep_mod, only : n_drydep, drydep_method, DD_XLND
+  use decompMod     , only : bounds_type
+  use abortutils    , only : endrun
+  use seq_flds_mod  , only : ocn_lnd_one_way
+  !
+  ! !PUBLIC TYPES:
+  implicit none
+  private
+  save
+  !
+  ! !PUBLIC DATA TYPES
+  !----------------------------------------------------
+  ! ocean -> land variables structure
+  !
+  type, public :: ocn2lnd_type
+
+      real(r8), pointer :: frac_h2oocn_grc(:)   => null() ! sea surface height [m]
+
+    contains
+
+      procedure, public  :: Init
+      procedure, private :: InitAllocate 
+      procedure, private :: InitHistory  
+      procedure, public  :: Restart
+
+   end type ocn2lnd_type
+
+  contains
+
+    !------------------------------------------------------------------------
+    subroutine Init(this, bounds)
+
+      class(ocn2lnd_type) :: this
+      type(bounds_type), intent(in) :: bounds  
+
+      call this%InitAllocate(bounds)
+      call this%InitHistory(bounds)
+
+    end subroutine Init
+
+    !------------------------------------------------------------------------
+    subroutine InitAllocate(this, bounds)
+      !
+      ! !DESCRIPTION:
+      ! Initialize ocn2lnd derived type
+      !
+      ! !ARGUMENTS:
+      class(ocn2lnd_type) :: this
+      type(bounds_type), intent(in) :: bounds  
+      !
+      ! !LOCAL VARIABLES:
+      real(r8) :: ival  = 0.0_r8  ! initial value
+      real     :: ival_float = 0.0
+      integer  :: ival_int = 0
+      integer*2 :: ival_short = 0
+      integer  :: begg, endg
+      integer  :: begc, endc
+      integer  :: begp, endp
+      !------------------------------------------------------------------------
+
+      begg = bounds%begg; endg= bounds%endg
+      begc = bounds%begc; endc= bounds%endc
+      begp = bounds%begp; endp= bounds%endp
+
+      allocate(this%frac_h2oocn_grc(begg:endg)); this%frac_h2oocn_grc(:)   = ival
+
+    end subroutine InitAllocate
+
+    !------------------------------------------------------------------------
+    subroutine InitHistory(this, bounds)
+      !
+      ! !USES:
+      use histFileMod, only : hist_addfld1d
+      !
+      ! !ARGUMENTS:
+      class(ocn2lnd_type) :: this
+      type(bounds_type), intent(in) :: bounds  
+      !
+      ! !LOCAL VARIABLES:
+      integer  :: begg, endg
+      integer  :: begp, endp
+      !---------------------------------------------------------------------
+
+      begg = bounds%begg; endg= bounds%endg
+      begp = bounds%begp; endp= bounds%endp
+
+      if (ocn_lnd_one_way) then
+         this%frac_h2oocn_grc(begg:endg) = spval
+         call hist_addfld1d (fname='FRAC_H2OOCN',  units='-'      , &
+              avgflag='A', long_name='coastal inundation fraction', &
+              ptr_lnd=this%frac_h2oocn_grc)
+      endif
+
+    end subroutine InitHistory
+
+    !------------------------------------------------------------------------
+    subroutine Restart(this, bounds, ncid, flag)
+      ! 
+      ! !USES:
+      use restUtilMod
+      use ncdio_pio
+      !
+      ! !ARGUMENTS:
+      class(ocn2lnd_type) :: this
+      type(bounds_type), intent(in) :: bounds  
+      type(file_desc_t), intent(inout) :: ncid   
+      character(len=*) , intent(in)    :: flag   
+      !
+      ! !LOCAL VARIABLES:
+      logical            :: readvar 
+      !------------------------------------------------------------------------
+
+      ! TODO: do we need restart for ocean-land one way coupling?
+
+    end subroutine Restart
+
+end module ocn2lndType

--- a/components/mpas-ocean/driver/mpaso_cpl_indices.F
+++ b/components/mpas-ocean/driver/mpaso_cpl_indices.F
@@ -26,6 +26,7 @@ module mpaso_cpl_indices
   integer :: index_o2x_Faoo_fco2_ocn
   integer :: index_o2x_Faoo_fdms_ocn
   integer :: index_o2x_So_ssh
+  integer :: index_o2x_So_frac_h2oocn
   integer :: index_o2x_Foxo_ismw
   integer :: index_o2x_Foxo_rrofl
   integer :: index_o2x_Foxo_rrofi
@@ -210,6 +211,9 @@ contains
     index_o2x_Faoo_fco2_ocn = mct_avect_indexra(o2x,'Faoo_fco2_ocn',perrWith='quiet')
     index_o2x_Faoo_fdms_ocn = mct_avect_indexra(o2x,'Faoo_fdms_ocn',perrWith='quiet')
     index_o2x_So_ssh        = mct_avect_indexra(o2x,'So_ssh')
+    if (ocn_lnd_one_way) then
+      index_o2x_So_frac_h2oocn= mct_avect_indexra(o2x,'So_ssh')
+    endif
 
     index_o2x_Foxo_ismw     = mct_avect_indexra(o2x,'Foxo_ismw',perrWith='quiet')
     index_o2x_Foxo_rrofl    = mct_avect_indexra(o2x,'Foxo_rrofl',perrWith='quiet')

--- a/driver-mct/cime_config/buildnml
+++ b/driver-mct/cime_config/buildnml
@@ -265,6 +265,10 @@ def write_seq_maps_file(case, nmlgen, confdir):
                         if "rof2ocn_" in name:
                             if case.get_value("COMP_OCN") == 'docn':
                                 logger.warning("   NOTE: ignoring setting of {}=idmap in seq_maps.rc".format(name))
+                        elif "ocn2lnd_" in name: 
+                            logger.warning("   NOTE: ignoring setting of {}=idmap in seq_maps.rc".format(name))
+                        elif "lnd2ocn_" in name: 
+                            logger.warning("   NOTE: ignoring setting of {}=idmap in seq_maps.rc".format(name))
                         else:
                             expect(gridvalue[component1] == gridvalue[component2],
                                    "Need to provide valid mapping file between {} and {} in xml variable {} ".\

--- a/driver-mct/cime_config/config_component.xml
+++ b/driver-mct/cime_config/config_component.xml
@@ -2088,6 +2088,74 @@
     <desc>iac2lnd state mapping file decomp type</desc>
   </entry>
 
+  <entry id="OCN2LND_SMAPNAME">
+    <type>char</type>
+    <default_value>idmap</default_value>
+    <group>run_domain</group>
+    <file>env_run.xml</file>
+    <desc>ocn2lnd state mapping file</desc>
+  </entry>
+
+  <entry id="OCN2LND_SMAPTYPE">
+    <type>char</type>
+    <valid_values>X,Y</valid_values>
+    <default_value>Y</default_value>
+    <group>run_domain</group>
+    <file>env_run.xml</file>
+    <desc>ocn2lnd state mapping file decomp type</desc>
+  </entry>
+
+  <entry id="OCN2LND_FMAPNAME">
+    <type>char</type>
+    <default_value>idmap</default_value>
+    <group>run_domain</group>
+    <file>env_run.xml</file>
+    <desc>ocn2lnd flux mapping file</desc>
+  </entry>
+
+  <entry id="OCN2LND_FMAPTYPE">
+    <type>char</type>
+    <valid_values>X,Y</valid_values>
+    <default_value>Y</default_value>
+    <group>run_domain</group>
+    <file>env_run.xml</file>
+    <desc>ocn2lnd flux mapping file decomp type</desc>
+  </entry>
+
+  <entry id="LND2OCN_SMAPNAME">
+    <type>char</type>
+    <default_value>idmap</default_value>
+    <group>run_domain</group>
+    <file>env_run.xml</file>
+    <desc>lnd2ocn state mapping file</desc>
+  </entry>
+
+  <entry id="LND2OCN_SMAPTYPE">
+    <type>char</type>
+    <valid_values>X,Y</valid_values>
+    <default_value>Y</default_value>
+    <group>run_domain</group>
+    <file>env_run.xml</file>
+    <desc>lnd2ocn state mapping file decomp type</desc>
+  </entry>
+
+  <entry id="LND2OCN_FMAPNAME">
+    <type>char</type>
+    <default_value>idmap</default_value>
+    <group>run_domain</group>
+    <file>env_run.xml</file>
+    <desc>lnd2ocn flux mapping file</desc>
+  </entry>
+
+  <entry id="LND2OCN_FMAPTYPE">
+    <type>char</type>
+    <valid_values>X,Y</valid_values>
+    <default_value>Y</default_value>
+    <group>run_domain</group>
+    <file>env_run.xml</file>
+    <desc>lnd2ocn flux mapping file decomp type</desc>
+  </entry>
+  
   <entry id="VECT_MAP">
     <type>char</type>
     <valid_values>none,npfix,cart3d,cart3d_diag,cart3d_uvw,cart3d_uvw_diag</valid_values>

--- a/driver-mct/cime_config/namelist_definition_drv.xml
+++ b/driver-mct/cime_config/namelist_definition_drv.xml
@@ -303,6 +303,18 @@
     </values>
   </entry>
 
+  <entry id="ocn_lnd_one_way">
+    <type>logical</type>
+    <category>seq_flds</category>
+    <group>seq_cplflds_inparm</group>
+    <desc>
+      If set to .true., adds fields needed to calculate ocean-land one-way coupling
+    </desc>
+    <values>
+      <value>.false.</value>
+    </values>
+  </entry>
+
   <entry id="rof_sed">
     <type>logical</type>
     <category>seq_flds</category>
@@ -326,6 +338,7 @@
       <value WAV_OCN_COUP="twoway">twoway</value>
     </values>
   </entry>
+
   <!-- =========================== -->
   <!-- -group seq_cplflds_custom   -->
   <!-- =========================== -->
@@ -5226,6 +5239,126 @@
     </desc>
     <values>
       <value>$OCN2ROF_SMAPTYPE</value>
+      <value bfbflag="on">X</value>
+    </values>
+  </entry>
+
+  <entry id="ocn2lnd_smapname"    modify_via_xml="OCN2LND_SMAPNAME">
+    <type>char</type>
+    <category>mapping</category>
+    <input_pathname>abs</input_pathname>
+    <group>seq_maps</group>
+    <desc>
+      ocn to lnd mapping file for states
+    </desc>
+    <values>
+      <value>$OCN2LND_SMAPNAME</value>
+    </values>
+  </entry>
+
+  <entry id="ocn2lnd_smaptype"    modify_via_xml="OCN2LND_SMAPTYPE">
+    <type>char</type>
+    <category>mapping</category>
+    <group>seq_maps</group>
+    <desc>
+      The type of mapping desired, either "source" or "destination" mapping.
+      X is associated with rearrangement of the source grid to the
+      destination grid and then local mapping.  Y is associated with mapping
+      on the source grid and then rearrangement and sum to the destination
+      grid.
+    </desc>
+    <values>
+      <value>$OCN2LND_SMAPTYPE</value>
+      <value bfbflag="on">X</value>
+    </values>
+  </entry>
+
+  <entry id="ocn2lnd_fmapname"    modify_via_xml="OCN2LND_FMAPNAME">
+    <type>char</type>
+    <category>mapping</category>
+    <input_pathname>abs</input_pathname>
+    <group>seq_maps</group>
+    <desc>
+      ocn to rof mapping file for fluxes
+    </desc>
+    <values>
+      <value>$OCN2LND_FMAPNAME</value>
+    </values>
+  </entry>
+
+  <entry id="ocn2lnd_fmaptype"    modify_via_xml="OCN2LND_FMAPTYPE">
+    <type>char</type>
+    <category>mapping</category>
+    <group>seq_maps</group>
+    <desc>
+      The type of mapping desired, either "source" or "destination" mapping.
+      X is associated with rearrangement of the source grid to the
+      destination grid and then local mapping.  Y is associated with mapping
+      on the source grid and then rearrangement and sum to the destination
+      grid.
+    </desc>
+    <values>
+      <value>$OCN2LND_FMAPTYPE</value>
+      <value bfbflag="on">X</value>
+    </values>
+  </entry>
+
+  <entry id="lnd2ocn_smapname"    modify_via_xml="LND2OCN_SMAPNAME">
+    <type>char</type>
+    <category>mapping</category>
+    <input_pathname>abs</input_pathname>
+    <group>seq_maps</group>
+    <desc>
+      ocn to rof mapping file for states
+    </desc>
+    <values>
+      <value>$LND2OCN_SMAPNAME</value>
+    </values>
+  </entry>
+
+  <entry id="lnd2ocn_smaptype"    modify_via_xml="LND2OCN_SMAPTYPE">
+    <type>char</type>
+    <category>mapping</category>
+    <group>seq_maps</group>
+    <desc>
+      The type of mapping desired, either "source" or "destination" mapping.
+      X is associated with rearrangement of the source grid to the
+      destination grid and then local mapping.  Y is associated with mapping
+      on the source grid and then rearrangement and sum to the destination
+      grid.
+    </desc>
+    <values>
+      <value>$LND2OCN_SMAPTYPE</value>
+      <value bfbflag="on">X</value>
+    </values>
+  </entry>
+
+  <entry id="lnd2ocn_fmapname"    modify_via_xml="LND2OCN_FMAPNAME">
+    <type>char</type>
+    <category>mapping</category>
+    <input_pathname>abs</input_pathname>
+    <group>seq_maps</group>
+    <desc>
+      ocn to rof mapping file for fluxes
+    </desc>
+    <values>
+      <value>$LND2OCN_FMAPNAME</value>
+    </values>
+  </entry>
+
+  <entry id="lnd2ocn_fmaptype"    modify_via_xml="LND2OCN_FMAPTYPE">
+    <type>char</type>
+    <category>mapping</category>
+    <group>seq_maps</group>
+    <desc>
+      The type of mapping desired, either "source" or "destination" mapping.
+      X is associated with rearrangement of the source grid to the
+      destination grid and then local mapping.  Y is associated with mapping
+      on the source grid and then rearrangement and sum to the destination
+      grid.
+    </desc>
+    <values>
+      <value>$LND2OCN_FMAPTYPE</value>
       <value bfbflag="on">X</value>
     </values>
   </entry>

--- a/driver-mct/main/prep_lnd_mod.F90
+++ b/driver-mct/main/prep_lnd_mod.F90
@@ -6,7 +6,7 @@ module prep_lnd_mod
   use shr_kind_mod    , only: cxx => SHR_KIND_CXX
   use shr_sys_mod     , only: shr_sys_abort, shr_sys_flush
   use seq_comm_mct    , only: num_inst_atm, num_inst_rof, num_inst_glc
-  use seq_comm_mct    , only: num_inst_lnd, num_inst_frc
+  use seq_comm_mct    , only: num_inst_lnd, num_inst_frc, num_inst_ocn
   use seq_comm_mct    , only: CPLID, LNDID, logunit
   use seq_comm_mct    , only: seq_comm_getData=>seq_comm_setptrs
   use seq_infodata_mod, only: seq_infodata_type, seq_infodata_getdata
@@ -17,7 +17,7 @@ module prep_lnd_mod
   use mct_mod
   use perf_mod
   use component_type_mod, only: component_get_x2c_cx, component_get_c2x_cx
-  use component_type_mod, only: lnd, atm, rof, glc
+  use component_type_mod, only: lnd, atm, rof, glc, ocn
   use map_glc2lnd_mod   , only: map_glc2lnd_ec
 
   implicit none
@@ -31,10 +31,14 @@ module prep_lnd_mod
   public :: prep_lnd_init
   public :: prep_lnd_mrg
 
+  public :: prep_lnd_accum_ocn
+  public :: prep_lnd_accum_avg
+
   public :: prep_lnd_calc_a2x_lx
   public :: prep_lnd_calc_r2x_lx
   public :: prep_lnd_calc_g2x_lx
   public :: prep_lnd_calc_z2x_lx
+  public :: prep_lnd_calc_o2x_lx
 
   public :: prep_lnd_get_a2x_lx
   public :: prep_lnd_get_r2x_lx
@@ -64,12 +68,19 @@ module prep_lnd_mod
   type(seq_map), pointer :: mapper_Fr2l           ! needed in seq_frac_mct.F90
   type(seq_map), pointer :: mapper_Sg2l           ! currently unused (all g2l mappings use the flux mapper)
   type(seq_map), pointer :: mapper_Fg2l
+  type(seq_map), pointer :: mapper_So2l
+  type(seq_map), pointer :: mapper_Fo2l
 
   ! attribute vectors
   type(mct_aVect), pointer :: a2x_lx(:) ! Atm export, lnd grid, cpl pes - allocated in driver
   type(mct_aVect), pointer :: r2x_lx(:) ! Rof export, lnd grid, lnd pes - allocated in lnd gc
   type(mct_aVect), pointer :: g2x_lx(:) ! Glc export, lnd grid, cpl pes - allocated in driver
   type(mct_aVect), pointer :: z2x_lx(:) ! Iac export, lnd grid, cpl pes - allocated in driver
+  type(mct_aVect), pointer :: o2x_lx(:) ! Ocn export, lnd grid, cpl pes - allocated in 
+
+  ! accumulation variables
+  type(mct_aVect), pointer :: o2lacc_ox(:)  ! Ocn export, ocn grid, cpl pes
+  integer        , target  :: o2lacc_ox_cnt ! o2lacc_ox: number of time samples accumulated
 
   ! seq_comm_getData variables
   integer :: mpicom_CPLID                         ! MPI cpl communicator
@@ -89,7 +100,7 @@ contains
 
   !================================================================================================
 
-  subroutine prep_lnd_init(infodata, atm_c2_lnd, rof_c2_lnd, glc_c2_lnd, iac_c2_lnd)
+  subroutine prep_lnd_init(infodata, atm_c2_lnd, rof_c2_lnd, glc_c2_lnd, iac_c2_lnd, ocn_c2_lnd)
 
     !---------------------------------------------------------------
     ! Description
@@ -102,21 +113,27 @@ contains
     logical                 , intent(in)    :: rof_c2_lnd ! .true.  => rof to lnd coupling on
     logical                 , intent(in)    :: glc_c2_lnd ! .true.  => glc to lnd coupling on
     logical                 , intent(in)    :: iac_c2_lnd ! .true.  => iac to lnd coupling on
+    logical                 , intent(in)    :: ocn_c2_lnd ! .true.  => ocn to lnd coupling on
     !
     ! Local Variables
-    integer                  :: lsize_l
-    integer                  :: eai, eri, egi
+    integer                  :: lsize_l, lsize_o
+    integer                  :: eai, eri, egi, eoi
     logical                  :: samegrid_al   ! samegrid atm and land
     logical                  :: samegrid_lr   ! samegrid land and rof
     logical                  :: samegrid_lg   ! samegrid land and glc
+    logical                  :: samegrid_ol   ! samegrid ocn and land
     logical                  :: esmf_map_flag ! .true. => use esmf for mapping
     logical                  :: lnd_present   ! .true. => land is present
+    logical                  :: ocn_present   ! .true. => ocean is present
     logical                  :: iamroot_CPLID ! .true. => CPLID masterproc
     character(CL)            :: atm_gnam      ! atm grid
     character(CL)            :: lnd_gnam      ! lnd grid
     character(CL)            :: rof_gnam      ! rof grid
     character(CL)            :: glc_gnam      ! glc grid
+    character(CL)            :: ocn_gnam      ! ocn grid 
     type(mct_avect), pointer :: l2x_lx
+    type(mct_avect), pointer :: o2x_ox 
+    type(mct_avect), pointer :: x2l_lx
     character(*), parameter  :: subname = '(prep_lnd_init)'
     character(*), parameter  :: F00 = "('"//subname//" : ', 4A )"
     !---------------------------------------------------------------
@@ -126,6 +143,8 @@ contains
          lnd_present=lnd_present,       &
          atm_gnam=atm_gnam,             &
          lnd_gnam=lnd_gnam,             &
+         ocn_present=ocn_present,       &
+         ocn_gnam=ocn_gnam,             &
          rof_gnam=rof_gnam,             &
          glc_gnam=glc_gnam)
 
@@ -134,6 +153,8 @@ contains
     allocate(mapper_Fr2l)
     allocate(mapper_Sg2l)
     allocate(mapper_Fg2l)
+    allocate(mapper_So2l)
+    allocate(mapper_Fo2l)
 
     if (lnd_present) then
 
@@ -158,6 +179,45 @@ contains
           call mct_aVect_init(g2x_lx(egi), rList=seq_flds_x2l_fields_from_glc, lsize=lsize_l)
           call mct_aVect_zero(g2x_lx(egi))
        end do
+
+       if (ocn_present) then
+          o2x_ox => component_get_c2x_cx(ocn(1))
+          x2l_lx => component_get_x2c_cx(lnd(1))
+          lsize_o = mct_aVect_lsize(o2x_ox)
+          allocate(o2lacc_ox(num_inst_ocn))
+          do eoi = 1,num_inst_ocn
+             call mct_aVect_initSharedFields(o2x_ox, x2l_lx, o2lacc_ox(eoi), lsize=lsize_o)
+             call mct_aVect_zero(o2lacc_ox(eoi))
+          end do
+          o2lacc_ox_cnt = 0
+
+          allocate(o2x_lx(num_inst_ocn))
+          do eoi = 1,num_inst_ocn
+             call mct_aVect_init(o2x_lx(eoi), rlist=seq_flds_o2x_fields_to_lnd, lsize=lsize_l)
+             call mct_aVect_zero(o2x_lx(eoi))
+          end do
+
+          samegrid_ol = .true. 
+          if (trim(ocn_gnam) /= trim(lnd_gnam)) samegrid_ol = .false.
+
+          if (ocn_c2_lnd) then
+             if (iamroot_CPLID) then
+                write(logunit,*) ' '
+                write(logunit,F00) 'Initializing mapper_So2l'
+             end if
+             call seq_map_init_rcfile(mapper_So2l, ocn(1), lnd(1), &
+                  'seq_maps.rc','ocn2lnd_smapname:','ocn2lnd_smaptype:',samegrid_ol, &
+                  string='mapper_So2l initialization', esmf_map=esmf_map_flag)
+
+             call seq_map_init_rcfile(mapper_Fo2l, ocn(1), lnd(1), &
+                  'seq_maps.rc','ocn2lnd_fmapname:','ocn2lnd_fmaptype:',samegrid_ol, &
+                  string='mapper_Fo2l initialization', esmf_map=esmf_map_flag)
+
+          endif
+
+          call shr_sys_flush(logunit)
+
+       endif
 
        samegrid_al = .true.
        samegrid_lr = .true.
@@ -275,7 +335,7 @@ contains
     character(len=*)     , intent(in)    :: timer_mrg
     !
     ! Local Variables
-    integer                  :: eai, eri, egi, eli
+    integer                  :: eai, eri, egi, eoi, eli
     type(mct_aVect), pointer :: x2l_lx
     character(*), parameter  :: subname = '(prep_lnd_mrg)'
     !---------------------------------------------------------------
@@ -286,9 +346,10 @@ contains
        eai = mod((eli-1),num_inst_atm) + 1
        eri = mod((eli-1),num_inst_rof) + 1
        egi = mod((eli-1),num_inst_glc) + 1
+       eoi = mod((eli-1),num_inst_ocn) + 1
 
        x2l_lx => component_get_x2c_cx(lnd(eli))  ! This is actually modifying x2l_lx
-       call prep_lnd_merge( a2x_lx(eai), r2x_lx(eri), g2x_lx(egi), x2l_lx )
+       call prep_lnd_merge( a2x_lx(eai), r2x_lx(eri), g2x_lx(egi), o2x_lx(eoi), x2l_lx )
     enddo
     call t_drvstopf (trim(timer_mrg))
 
@@ -296,7 +357,7 @@ contains
 
   !================================================================================================
 
-  subroutine prep_lnd_merge( a2x_l, r2x_l, g2x_l, x2l_l )
+  subroutine prep_lnd_merge( a2x_l, r2x_l, g2x_l, o2x_l, x2l_l )
     !---------------------------------------------------------------
     ! Description
     ! Create input land state directly from atm, runoff and glc outputs
@@ -305,6 +366,7 @@ contains
     type(mct_aVect), intent(in)     :: a2x_l
     type(mct_aVect), intent(in)     :: r2x_l
     type(mct_aVect), intent(in)     :: g2x_l
+    type(mct_aVect), intent(in)     :: o2x_l
     type(mct_aVect), intent(inout)  :: x2l_l
     !-----------------------------------------------------------------------
     integer       :: nflds,i,i1,o1
@@ -315,6 +377,7 @@ contains
     type(mct_aVect_sharedindices),save :: a2x_sharedindices
     type(mct_aVect_sharedindices),save :: r2x_sharedindices
     type(mct_aVect_sharedindices),save :: g2x_sharedindices
+    type(mct_aVect_sharedindices),save :: o2x_sharedindices
     character(*), parameter   :: subname = '(prep_lnd_merge) '
 
     !-----------------------------------------------------------------------
@@ -333,6 +396,7 @@ contains
        call mct_aVect_setSharedIndices(a2x_l, x2l_l, a2x_SharedIndices)
        call mct_aVect_setSharedIndices(r2x_l, x2l_l, r2x_SharedIndices)
        call mct_aVect_setSharedIndices(g2x_l, x2l_l, g2x_SharedIndices)
+       call mct_aVect_setSharedIndices(o2x_l, x2l_l, o2x_SharedIndices)
 
        !--- document copy operations ---
        do i=1,a2x_SharedIndices%shared_real%num_indices
@@ -353,11 +417,18 @@ contains
           field = mct_aVect_getRList2c(i1, g2x_l)
           mrgstr(o1) = trim(mrgstr(o1))//' = g2x%'//trim(field)
        enddo
+       do i=1,o2x_SharedIndices%shared_real%num_indices
+          i1=o2x_SharedIndices%shared_real%aVindices1(i)
+          o1=o2x_SharedIndices%shared_real%aVindices2(i)
+          field = mct_aVect_getRList2c(i1, o2x_l)
+          mrgstr(o1) = trim(mrgstr(o1))//' = o2x%'//trim(field)
+       enddo
     endif
 
     call mct_aVect_copy(aVin=a2x_l, aVout=x2l_l, vector=mct_usevector, sharedIndices=a2x_SharedIndices)
     call mct_aVect_copy(aVin=r2x_l, aVout=x2l_l, vector=mct_usevector, sharedIndices=r2x_SharedIndices)
     call mct_aVect_copy(aVin=g2x_l, aVout=x2l_l, vector=mct_usevector, sharedIndices=g2x_SharedIndices)
+    call mct_aVect_copy(aVin=o2x_l, aVout=x2l_l, vector=mct_usevector, sharedIndices=o2x_SharedIndices)
 
     if (first_time) then
        if (iamroot) then
@@ -501,6 +572,91 @@ contains
 
   !================================================================================================
 
+  subroutine prep_lnd_calc_o2x_lx(timer)
+    !---------------------------------------------------------------
+    ! Description
+    ! Create o2x_lx (note that 2x_lx is a local module variable)
+    !
+    ! Arguments
+    character(len=*), intent(in) :: timer
+    !
+    ! Local Variables
+    integer :: eli, eoi
+    type(mct_avect), pointer :: l2x_lx
+    character(*), parameter :: subname = '(prep_lnd_calc_o2x_lx)'
+    !---------------------------------------------------------------
+
+    call t_drvstartf (trim(timer),barrier=mpicom_CPLID)
+    do eli = 1,num_inst_lnd
+       eoi = mod((eli-1),num_inst_ocn) + 1
+       l2x_lx => component_get_c2x_cx(lnd(eli))
+       call seq_map_map(mapper_So2l, o2lacc_ox(eoi), o2x_lx(eli), fldlist=seq_flds_o2x_states_to_lnd, norm=.true.)
+    end do
+    call t_drvstopf  (trim(timer))
+
+  end subroutine prep_lnd_calc_o2x_lx
+
+  !================================================================================================
+
+  subroutine prep_lnd_accum_ocn(timer)
+    !---------------------------------------------------------------
+    ! Description
+    ! Accumulate ocean input to land component
+    !
+    ! Arguments
+    character(len=*), intent(in) :: timer
+    !
+    ! Local Variables
+    integer :: eoi
+    type(mct_aVect), pointer :: o2x_ox
+    character(*), parameter  :: subname = '(prep_lnd_accum_ocn)'
+    !---------------------------------------------------------------
+
+    call t_drvstartf (trim(timer),barrier=mpicom_CPLID)
+
+    do eoi = 1,num_inst_ocn
+       o2x_ox => component_get_c2x_cx(ocn(eoi))
+       if (o2lacc_ox_cnt == 0) then
+          call mct_avect_copy(o2x_ox, o2lacc_ox(eoi))
+       else
+          call mct_avect_accum(o2x_ox, o2lacc_ox(eoi))
+       endif
+    end do
+    o2lacc_ox_cnt = o2lacc_ox_cnt + 1
+
+    call t_drvstopf (trim(timer))
+  end subroutine prep_lnd_accum_ocn
+
+  !================================================================================================
+
+  subroutine prep_lnd_accum_avg(timer)
+    !---------------------------------------------------------------
+    ! Description
+    ! Finalize accumulation of ocean input to land component
+    !
+    ! Arguments
+    character(len=*), intent(in) :: timer
+    !
+    ! Local Variables
+    integer :: eli, eoi
+    character(*), parameter :: subname = '(prep_lnd_accum_avg)'
+    !---------------------------------------------------------------
+
+    call t_drvstartf (trim(timer),barrier=mpicom_CPLID)
+    if(o2lacc_ox_cnt > 1) then
+       do eli = 1,num_inst_lnd
+          eoi = mod((eli-1),num_inst_ocn) + 1
+          call mct_avect_avg(o2lacc_ox(eoi),o2lacc_ox_cnt)
+       enddo
+    endif
+    o2lacc_ox_cnt = 0
+
+    call t_drvstopf (trim(timer))
+
+  end subroutine prep_lnd_accum_avg
+
+  !================================================================================================
+  
   function prep_lnd_get_a2x_lx()
     type(mct_aVect), pointer :: prep_lnd_get_a2x_lx(:)
     prep_lnd_get_a2x_lx => a2x_lx(:)

--- a/driver-mct/main/prep_lnd_mod.F90
+++ b/driver-mct/main/prep_lnd_mod.F90
@@ -179,7 +179,12 @@ contains
           call mct_aVect_init(g2x_lx(egi), rList=seq_flds_x2l_fields_from_glc, lsize=lsize_l)
           call mct_aVect_zero(g2x_lx(egi))
        end do
-
+       allocate(o2x_lx(num_inst_ocn))
+       do eoi = 1,num_inst_ocn
+          call mct_aVect_init(o2x_lx(eoi), rlist=seq_flds_o2x_fields_to_lnd, lsize=lsize_l)
+          call mct_aVect_zero(o2x_lx(eoi))
+       end do
+       
        if (ocn_present) then
           o2x_ox => component_get_c2x_cx(ocn(1))
           x2l_lx => component_get_x2c_cx(lnd(1))
@@ -190,12 +195,6 @@ contains
              call mct_aVect_zero(o2lacc_ox(eoi))
           end do
           o2lacc_ox_cnt = 0
-
-          allocate(o2x_lx(num_inst_ocn))
-          do eoi = 1,num_inst_ocn
-             call mct_aVect_init(o2x_lx(eoi), rlist=seq_flds_o2x_fields_to_lnd, lsize=lsize_l)
-             call mct_aVect_zero(o2x_lx(eoi))
-          end do
 
           samegrid_ol = .true. 
           if (trim(ocn_gnam) /= trim(lnd_gnam)) samegrid_ol = .false.
@@ -396,7 +395,6 @@ contains
        call mct_aVect_setSharedIndices(a2x_l, x2l_l, a2x_SharedIndices)
        call mct_aVect_setSharedIndices(r2x_l, x2l_l, r2x_SharedIndices)
        call mct_aVect_setSharedIndices(g2x_l, x2l_l, g2x_SharedIndices)
-       call mct_aVect_setSharedIndices(o2x_l, x2l_l, o2x_SharedIndices)
 
        !--- document copy operations ---
        do i=1,a2x_SharedIndices%shared_real%num_indices
@@ -417,19 +415,24 @@ contains
           field = mct_aVect_getRList2c(i1, g2x_l)
           mrgstr(o1) = trim(mrgstr(o1))//' = g2x%'//trim(field)
        enddo
-       do i=1,o2x_SharedIndices%shared_real%num_indices
-          i1=o2x_SharedIndices%shared_real%aVindices1(i)
-          o1=o2x_SharedIndices%shared_real%aVindices2(i)
-          field = mct_aVect_getRList2c(i1, o2x_l)
-          mrgstr(o1) = trim(mrgstr(o1))//' = o2x%'//trim(field)
-       enddo
+       
+       if (ocn_lnd_one_way) then
+          call mct_aVect_setSharedIndices(o2x_l, x2l_l, o2x_SharedIndices)
+          do i=1,o2x_SharedIndices%shared_real%num_indices
+             i1=o2x_SharedIndices%shared_real%aVindices1(i)
+             o1=o2x_SharedIndices%shared_real%aVindices2(i)
+             field = mct_aVect_getRList2c(i1, o2x_l)
+             mrgstr(o1) = trim(mrgstr(o1))//' = o2x%'//trim(field)
+          enddo
+       endif
     endif
 
     call mct_aVect_copy(aVin=a2x_l, aVout=x2l_l, vector=mct_usevector, sharedIndices=a2x_SharedIndices)
     call mct_aVect_copy(aVin=r2x_l, aVout=x2l_l, vector=mct_usevector, sharedIndices=r2x_SharedIndices)
     call mct_aVect_copy(aVin=g2x_l, aVout=x2l_l, vector=mct_usevector, sharedIndices=g2x_SharedIndices)
-    call mct_aVect_copy(aVin=o2x_l, aVout=x2l_l, vector=mct_usevector, sharedIndices=o2x_SharedIndices)
-
+    if (ocn_lnd_one_way) then
+       call mct_aVect_copy(aVin=o2x_l, aVout=x2l_l, vector=mct_usevector, sharedIndices=o2x_SharedIndices)
+    endif
     if (first_time) then
        if (iamroot) then
           write(logunit,'(A)') subname//' Summary:'

--- a/driver-mct/shr/seq_flds_mod.F90
+++ b/driver-mct/shr/seq_flds_mod.F90
@@ -1762,6 +1762,16 @@ contains
     attname  = 'So_ssh'
     call metadata_set(attname, longname, stdname, units)
 
+    ! ocn -> lnd one-way coupling
+    call seq_flds_add(o2x_states,"So_ssh")
+    call seq_flds_add(x2l_states,"So_ssh")
+    call seq_flds_add(o2x_states_to_lnd,"So_ssh")
+    longname = 'Sea surface height'
+    stdname  = 'sea_surface_height'
+    units    = 'm'
+    attname  = 'So_ssh'
+    call metadata_set(attname, longname, stdname, units)
+
     call seq_flds_add(o2x_states,"So_frac_h2oocn")
     call seq_flds_add(x2l_states,"So_frac_h2oocn")
     call seq_flds_add(o2x_states_to_lnd,"So_frac_h2oocn")

--- a/driver-mct/shr/seq_flds_mod.F90
+++ b/driver-mct/shr/seq_flds_mod.F90
@@ -1755,8 +1755,10 @@ contains
     call seq_flds_add(o2x_states,"So_ssh")
     call seq_flds_add(x2r_states,"So_ssh")
     call seq_flds_add(o2x_states_to_rof,"So_ssh")
-    call seq_flds_add(x2l_states,"So_ssh") ! ocn -> lnd one-way coupling
-    call seq_flds_add(o2x_states_to_lnd,"So_ssh")
+    if (ocn_lnd_one_way) then
+      call seq_flds_add(x2l_states,"So_ssh") ! ocn -> lnd one-way coupling
+      call seq_flds_add(o2x_states_to_lnd,"So_ssh")
+    endif
     if (wav_ocn_coup .ne. 'none') call seq_flds_add(x2w_states,'So_ssh')
     longname = 'Sea surface height'
     stdname  = 'sea_surface_height'
@@ -1764,14 +1766,16 @@ contains
     attname  = 'So_ssh'
     call metadata_set(attname, longname, stdname, units)
 
-    call seq_flds_add(o2x_states,"So_frac_h2oocn")
-    call seq_flds_add(x2l_states,"So_frac_h2oocn")
-    call seq_flds_add(o2x_states_to_lnd,"So_frac_h2oocn")
-    longname = 'Oceanic inundation fraction'
-    stdname  = 'oceanic_inundation_fraction'
-    units    = '-'
-    attname  = 'So_frac_h2oocn'
-    call metadata_set(attname, longname, stdname, units)
+    if (ocn_lnd_one_way) then
+      call seq_flds_add(o2x_states,"So_frac_h2oocn")
+      call seq_flds_add(x2l_states,"So_frac_h2oocn")
+      call seq_flds_add(o2x_states_to_lnd,"So_frac_h2oocn")
+      longname = 'Oceanic inundation fraction'
+      stdname  = 'oceanic_inundation_fraction'
+      units    = '-'
+      attname  = 'So_frac_h2oocn'
+      call metadata_set(attname, longname, stdname, units)
+    endif
 
     ! Meridional sea surface slope
     call seq_flds_add(o2x_states,"So_dhdy")

--- a/driver-mct/shr/seq_flds_mod.F90
+++ b/driver-mct/shr/seq_flds_mod.F90
@@ -1755,17 +1755,9 @@ contains
     call seq_flds_add(o2x_states,"So_ssh")
     call seq_flds_add(x2r_states,"So_ssh")
     call seq_flds_add(o2x_states_to_rof,"So_ssh")
-    if (wav_ocn_coup .ne. 'none') call seq_flds_add(x2w_states,'So_ssh')
-    longname = 'Sea surface height'
-    stdname  = 'sea_surface_height'
-    units    = 'm'
-    attname  = 'So_ssh'
-    call metadata_set(attname, longname, stdname, units)
-
-    ! ocn -> lnd one-way coupling
-    call seq_flds_add(o2x_states,"So_ssh")
-    call seq_flds_add(x2l_states,"So_ssh")
+    call seq_flds_add(x2l_states,"So_ssh") ! ocn -> lnd one-way coupling
     call seq_flds_add(o2x_states_to_lnd,"So_ssh")
+    if (wav_ocn_coup .ne. 'none') call seq_flds_add(x2w_states,'So_ssh')
     longname = 'Sea surface height'
     stdname  = 'sea_surface_height'
     units    = 'm'

--- a/driver-mct/shr/seq_flds_mod.F90
+++ b/driver-mct/shr/seq_flds_mod.F90
@@ -160,6 +160,7 @@ module seq_flds_mod
   logical            :: rof2ocn_nutrients   ! .true. if the runoff model passes nutrient fields to the ocn
   logical            :: lnd_rof_two_way     ! .true. if land-river two-way coupling turned on
   logical            :: ocn_rof_two_way     ! .true. if river-ocean two-way coupling turned on
+  logical            :: ocn_lnd_one_way     ! .true. if ocean to land one-way coupling turned on
   logical            :: rof_sed             ! .true. if river model includes sediment
 
   character(len=CS)  :: wav_ocn_coup     ! 'twoway' if wave-ocean two-way coupling turned on
@@ -205,6 +206,8 @@ module seq_flds_mod
   character(CXX) :: seq_flds_x2o_fluxes
   character(CXX) :: seq_flds_o2x_states_to_rof
   character(CXX) :: seq_flds_o2x_fluxes_to_rof
+  character(CXX) :: seq_flds_o2x_states_to_lnd
+  character(CXX) :: seq_flds_o2x_fluxes_to_lnd
 
   character(CXX) :: seq_flds_g2x_states
   character(CXX) :: seq_flds_g2x_states_to_lnd
@@ -266,6 +269,7 @@ module seq_flds_mod
   character(CXX) :: seq_flds_w2x_fields
   character(CXX) :: seq_flds_x2w_fields
   character(CXX) :: seq_flds_o2x_fields_to_rof
+  character(CXX) :: seq_flds_o2x_fields_to_lnd
 
   !----------------------------------------------------------------------------
   ! component names
@@ -341,6 +345,8 @@ contains
     character(CXX) :: o2x_fluxes = ''
     character(CXX) :: o2x_states_to_rof = ''
     character(CXX) :: o2x_fluxes_to_rof = ''
+    character(CXX) :: o2x_states_to_lnd = ''
+    character(CXX) :: o2x_fluxes_to_lnd = ''
     character(CXX) :: x2o_states = ''
     character(CXX) :: x2o_fluxes = ''
     character(CXX) :: g2x_states = ''
@@ -393,7 +399,7 @@ contains
          flds_co2a, flds_co2b, flds_co2c, flds_co2_dmsa, flds_wiso, flds_polar, flds_tf, &
          glc_nec, glc_nzoc, ice_ncat, seq_flds_i2o_per_cat, flds_bgc_oi, &
          nan_check_component_fields, rof_heat, atm_flux_method, atm_gustiness, &
-         rof2ocn_nutrients, lnd_rof_two_way, ocn_rof_two_way, rof_sed, &
+         rof2ocn_nutrients, lnd_rof_two_way, ocn_rof_two_way, ocn_lnd_one_way, rof_sed, &
          wav_ocn_coup
 
     ! user specified new fields
@@ -438,6 +444,7 @@ contains
        rof2ocn_nutrients = .false.
        lnd_rof_two_way   = .false.
        ocn_rof_two_way   = .false.
+       ocn_lnd_one_way   = .false.
        rof_sed   = .false.
        wav_ocn_coup = 'none'
 
@@ -475,6 +482,7 @@ contains
     call shr_mpi_bcast(rof2ocn_nutrients, mpicom)
     call shr_mpi_bcast(lnd_rof_two_way,   mpicom)
     call shr_mpi_bcast(ocn_rof_two_way,   mpicom)
+    call shr_mpi_bcast(ocn_lnd_one_way,   mpicom)
     call shr_mpi_bcast(rof_sed,   mpicom)
     call shr_mpi_bcast(wav_ocn_coup, mpicom)
 
@@ -1752,6 +1760,15 @@ contains
     stdname  = 'sea_surface_height'
     units    = 'm'
     attname  = 'So_ssh'
+    call metadata_set(attname, longname, stdname, units)
+
+    call seq_flds_add(o2x_states,"So_frac_h2oocn")
+    call seq_flds_add(x2l_states,"So_frac_h2oocn")
+    call seq_flds_add(o2x_states_to_lnd,"So_frac_h2oocn")
+    longname = 'Oceanic inundation fraction'
+    stdname  = 'oceanic_inundation_fraction'
+    units    = '-'
+    attname  = 'So_frac_h2oocn'
     call metadata_set(attname, longname, stdname, units)
 
     ! Meridional sea surface slope
@@ -4019,6 +4036,8 @@ contains
     seq_flds_r2o_ice_fluxes = trim(r2o_ice_fluxes)
     seq_flds_o2x_states_to_rof = trim(o2x_states_to_rof)
     seq_flds_o2x_fluxes_to_rof = trim(o2x_fluxes_to_rof)
+    seq_flds_o2x_states_to_lnd = trim(o2x_states_to_lnd)
+    seq_flds_o2x_fluxes_to_lnd = trim(o2x_fluxes_to_lnd)
 
     if (seq_comm_iamroot(ID)) then
        write(logunit,*) subname//': seq_flds_a2x_states= ',trim(seq_flds_a2x_states)
@@ -4070,6 +4089,7 @@ contains
        write(logunit,*) subname//': seq_flds_x2w_states= ',trim(seq_flds_x2w_states)
        write(logunit,*) subname//': seq_flds_x2w_fluxes= ',trim(seq_flds_x2w_fluxes)
        write(logunit,*) subname//': seq_flds_o2x_states_to_rof=',trim(seq_flds_o2x_states_to_rof)
+       write(logunit,*) subname//': seq_flds_o2x_states_to_lnd=',trim(seq_flds_o2x_states_to_lnd)
     end if
 
     call catFields(seq_flds_dom_fields, seq_flds_dom_coord , seq_flds_dom_other )
@@ -4095,6 +4115,7 @@ contains
     call catFields(seq_flds_w2x_fields, seq_flds_w2x_states, seq_flds_w2x_fluxes)
     call catFields(seq_flds_x2w_fields, seq_flds_x2w_states, seq_flds_x2w_fluxes)
     call catFields(seq_flds_o2x_fields_to_rof, seq_flds_o2x_states_to_rof, seq_flds_o2x_fluxes_to_rof)
+    call catFields(seq_flds_o2x_fields_to_lnd, seq_flds_o2x_states_to_lnd, seq_flds_o2x_fluxes_to_lnd)
 
   end subroutine seq_flds_set
 

--- a/driver-mct/shr/seq_infodata_mod.F90
+++ b/driver-mct/shr/seq_infodata_mod.F90
@@ -199,6 +199,7 @@ MODULE seq_infodata_mod
      logical                 :: rofice_present  ! does rof have iceberg coupling on
      logical                 :: rof_prognostic  ! does rof component need input data
      logical                 :: rofocn_prognostic ! does component need ocn data
+     logical                 :: lndocn_prognostic ! does component need ocn data
      logical                 :: flood_present   ! does rof have flooding on
      logical                 :: ocn_present     ! does component model exist
      logical                 :: ocn_prognostic  ! does component model need input data from driver
@@ -769,6 +770,7 @@ CONTAINS
        infodata%lnd_prognostic = .false.
        infodata%rof_prognostic = .false.
        infodata%rofocn_prognostic = .false.
+       infodata%lndocn_prognostic = .false.
        infodata%ocn_prognostic = .false.
        infodata%ocnrof_prognostic = .false.
        infodata%ocn_c2_glcshelf = .false.
@@ -1014,7 +1016,7 @@ CONTAINS
        single_column, scmlat,scmlon,logFilePostFix, outPathRoot,&
        scm_multcols, scm_nx, scm_ny,                                      &
        atm_present, atm_prognostic,                                       &
-       lnd_present, lnd_prognostic,                                       &
+       lnd_present, lnd_prognostic, lndocn_prognostic,                    &
        rof_present, rof_prognostic, rofocn_prognostic,                    &
        ocn_present, ocn_prognostic, ocnrof_prognostic,                    &
        ocn_c2_glcshelf, ocn_c2_glctf,                                     &
@@ -1185,6 +1187,7 @@ CONTAINS
     logical,                optional, intent(OUT) :: atm_prognostic          ! need data
     logical,                optional, intent(OUT) :: lnd_present
     logical,                optional, intent(OUT) :: lnd_prognostic
+    logical,                optional, intent(OUT) :: lndocn_prognostic
     logical,                optional, intent(OUT) :: rof_present
     logical,                optional, intent(OUT) :: rofice_present
     logical,                optional, intent(OUT) :: rof_prognostic
@@ -1375,6 +1378,7 @@ CONTAINS
     if ( present(atm_prognostic) ) atm_prognostic = infodata%atm_prognostic
     if ( present(lnd_present)    ) lnd_present    = infodata%lnd_present
     if ( present(lnd_prognostic) ) lnd_prognostic = infodata%lnd_prognostic
+    if ( present(lndocn_prognostic) ) lndocn_prognostic = infodata%lndocn_prognostic
     if ( present(rof_present)    ) rof_present    = infodata%rof_present
     if ( present(rofice_present) ) rofice_present = infodata%rofice_present
     if ( present(rof_prognostic) ) rof_prognostic = infodata%rof_prognostic
@@ -1577,7 +1581,7 @@ CONTAINS
        single_column, scmlat,scmlon,logFilePostFix, outPathRoot,          &
        scm_multcols, scm_nx, scm_ny,                                      &
        atm_present, atm_prognostic,                                       &
-       lnd_present, lnd_prognostic,                                       &
+       lnd_present, lnd_prognostic, lndocn_prognostic,                    &
        rof_present, rof_prognostic, rofocn_prognostic,                    &
        ocn_present, ocn_prognostic, ocnrof_prognostic,                    &
        ocn_c2_glcshelf, ocn_c2_glctf,                                     &
@@ -1748,6 +1752,7 @@ CONTAINS
     logical,                optional, intent(IN)    :: atm_prognostic     ! need data
     logical,                optional, intent(IN)    :: lnd_present
     logical,                optional, intent(IN)    :: lnd_prognostic
+    logical,                optional, intent(IN)    :: lndocn_prognostic
     logical,                optional, intent(IN)    :: rof_present
     logical,                optional, intent(IN)    :: rofice_present
     logical,                optional, intent(IN)    :: rof_prognostic
@@ -1937,6 +1942,7 @@ CONTAINS
     if ( present(atm_prognostic) ) infodata%atm_prognostic = atm_prognostic
     if ( present(lnd_present)    ) infodata%lnd_present    = lnd_present
     if ( present(lnd_prognostic) ) infodata%lnd_prognostic = lnd_prognostic
+    if ( present(lndocn_prognostic) ) infodata%lndocn_prognostic = lndocn_prognostic
     if ( present(rof_present)    ) infodata%rof_present    = rof_present
     if ( present(rofice_present) ) infodata%rofice_present = rofice_present
     if ( present(rof_prognostic) ) infodata%rof_prognostic = rof_prognostic
@@ -2253,6 +2259,7 @@ CONTAINS
     call shr_mpi_bcast(infodata%atm_prognostic,          mpicom)
     call shr_mpi_bcast(infodata%lnd_present,             mpicom)
     call shr_mpi_bcast(infodata%lnd_prognostic,          mpicom)
+    call shr_mpi_bcast(infodata%lndocn_prognostic,       mpicom)
     call shr_mpi_bcast(infodata%rof_present,             mpicom)
     call shr_mpi_bcast(infodata%rofice_present,          mpicom)
     call shr_mpi_bcast(infodata%rof_prognostic,          mpicom)
@@ -2524,6 +2531,7 @@ CONTAINS
     if (lnd2cpli) then
        call shr_mpi_bcast(infodata%lnd_present,        mpicom, pebcast=cmppe)
        call shr_mpi_bcast(infodata%lnd_prognostic,     mpicom, pebcast=cmppe)
+       call shr_mpi_bcast(infodata%lndocn_prognostic,  mpicom, pebcast=cmppe)
        call shr_mpi_bcast(infodata%lnd_nx,             mpicom, pebcast=cmppe)
        call shr_mpi_bcast(infodata%lnd_ny,             mpicom, pebcast=cmppe)
        ! dead_comps is true if it's ever set to true
@@ -2620,6 +2628,7 @@ CONTAINS
        call shr_mpi_bcast(infodata%atm_prognostic,     mpicom, pebcast=cplpe)
        call shr_mpi_bcast(infodata%lnd_present,        mpicom, pebcast=cplpe)
        call shr_mpi_bcast(infodata%lnd_prognostic,     mpicom, pebcast=cplpe)
+       call shr_mpi_bcast(infodata%lndocn_prognostic,  mpicom, pebcast=cplpe)
        call shr_mpi_bcast(infodata%rof_present,        mpicom, pebcast=cplpe)
        call shr_mpi_bcast(infodata%rofice_present,     mpicom, pebcast=cplpe)
        call shr_mpi_bcast(infodata%rof_prognostic,     mpicom, pebcast=cplpe)
@@ -2982,6 +2991,7 @@ CONTAINS
     write(logunit,F0L) subname,'atm_prognostic           = ', infodata%atm_prognostic
     write(logunit,F0L) subname,'lnd_present              = ', infodata%lnd_present
     write(logunit,F0L) subname,'lnd_prognostic           = ', infodata%lnd_prognostic
+    write(logunit,F0L) subname,'lndocn_prognostic        = ', infodata%lndocn_prognostic
     write(logunit,F0L) subname,'rof_present              = ', infodata%rof_present
     write(logunit,F0L) subname,'rofice_present           = ', infodata%rofice_present
     write(logunit,F0L) subname,'rof_prognostic           = ', infodata%rof_prognostic


### PR DESCRIPTION
This PR develops a lnd-docn one-way coupling. A study uses this one-way coupling to evaluate the impact of sea-level rise can be found at https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2024EF004479.

Specifically, we develop new data ocean stream and registered new fields in coupler to read sea-level rise from Global Tide and Surge Model simulations. We implemented vertical infiltration from the ocean inundation and lateral flux due to the water gradient between the ocean water level and groundwater table. 

I run the ``e3sm_land_developer `` test suites and got error ``BASELINE 2862834: ERROR Could not interpret CPRNC output``. However, checking the ``cprnc.out`` file in the run directory, it shows IDENTIFICAL compared to baseline test. 

We also added a new test for the lnd-docn coupling simulation. 