### PR TITLE
EAMxx: fix bugs related to ZonalMean diagnostic

### DIFF
--- a/components/eamxx/src/share/grid/abstract_grid.cpp
+++ b/components/eamxx/src/share/grid/abstract_grid.cpp
@@ -81,7 +81,7 @@ get_vertical_layout (const bool midpoints,
 {
   using namespace ShortFieldTagsNames;
   auto l = get_vertical_layout(midpoints);
-  l.append_dim(CMP,vector_dim,vec_dim_name);
+  l.prepend_dim(CMP,vector_dim,vec_dim_name);
   return l;
 }
 
@@ -257,9 +257,10 @@ is_valid_layout (const FieldLayout& layout) const
     case LayoutType::Tensor0D:
       // 0d quantities are always ok
       return true;
-    case LayoutType::Scalar1D: [[fallthrough]];
-    case LayoutType::Vector1D:
+    case LayoutType::Scalar1D:
       return layout.congruent(get_vertical_layout(midpoints));
+    case LayoutType::Vector1D:
+        return layout.congruent(get_vertical_layout(midpoints,layout.get_vector_dim()));
     case LayoutType::Scalar2D:
       return layout.congruent(get_2d_scalar_layout());
     case LayoutType::Vector2D:

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -946,7 +946,7 @@ get_var_dimnames (const FieldLayout& layout) const
     auto tag_name = m_io_grid->has_special_tag_name(t)
                   ? m_io_grid->get_special_tag_name(t)
                   : layout.names()[i];
-    if (tag_name=="dim") {
+    if (tag_name=="dim" or tag_name=="bin") {
       tag_name += std::to_string(layout.dim(i));
     }
     dims.push_back(tag_name); // Add dimensions string to vector of dims.


### PR DESCRIPTION
One bug was introduced by PR #7397 , while two other bugs was pre-dating that PR.

---

@cjvogl If you don't like the nano fix to your ZonalMean diag, another possible solution would be to make the bins span [-90.001,90.001], to ensure that ALL points are inside the bins (and avoid the call to `max`). I _think_ that for even values of ne, unit tests using np4 (gll) grid for physics will always get a column at the north/south poles. Of course, production grids are virtually always using pg2, for which is impossible to get a col exactly at the pole (it would be possible for pg3, but we don't use that).

Fixes #7511 