### PR TITLE
EAMxx: fix bug in physics unit tests baselines handling

### DIFF
--- a/components/eamxx/src/physics/p3/tests/p3_run_and_cmp.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_run_and_cmp.cpp
@@ -203,13 +203,13 @@ private:
       EKAT_REQUIRE_MSG(dim == f.dim,
                       "For field " << f.name << " read expected dim " <<
                       f.dim << " but got " << dim);
-      std::vector<int> ds(dim);
-      impl::read_scalars(ifile,ds);
+      int extents[3];
+      impl::read_scalars(ifile,extents);
       for (int i = 0; i < dim; ++i)
-        EKAT_REQUIRE_MSG(ds[i] == f.extent[i],
+        EKAT_REQUIRE_MSG(extents[i] == f.extent[i],
                         "For field " << f.name << " read expected dim "
                         << i << " to have extent " << f.extent[i] << " but got "
-                        << ds[i]);
+                        << extents[i]);
       impl::read_scalars(ifile,f.data, f.size);
     // The code below is to force a result difference. This is used by the
     // scream/scripts internal testing to verify that various DIFFs are detected.

--- a/components/eamxx/src/physics/share/physics_test_read_write_helpers.hpp
+++ b/components/eamxx/src/physics/share/physics_test_read_write_helpers.hpp
@@ -5,13 +5,22 @@
 #include <vector>
 #include <type_traits>
 
+#ifdef EAMXX_ASCII_BASELINES
+#include <iomanip>
+#include <limits>
+#endif
+
 namespace scream {
 namespace impl {
 
 template <typename T>
 void read_scalars(std::ifstream& ifile, T& data)
 {
+#ifdef EAMXX_ASCII_BASELINES
+  ifile >> data;
+#else
   ifile.read(reinterpret_cast<char*>(&data),sizeof(data));
+#endif
 }
 
 template <typename T>
@@ -47,7 +56,15 @@ void read_scalars(std::ifstream& ifile, T& data, S&... tail)
 template <typename T>
 void write_scalars(std::ofstream& ofile, const T& data)
 {
+#ifdef EAMXX_ASCII_BASELINES
+  if constexpr (std::is_floating_point_v<T>) {
+    ofile << std::fixed << std::setprecision(std::numeric_limits<T>::digits10+1) << data << " ";
+  } else {
+    ofile << data << " ";
+  }
+#else
   ofile.write(reinterpret_cast<const char*>(&data),sizeof(data));
+#endif
 }
 
 template <typename T>

--- a/components/eamxx/src/physics/share/physics_test_read_write_helpers.hpp
+++ b/components/eamxx/src/physics/share/physics_test_read_write_helpers.hpp
@@ -84,7 +84,7 @@ void write_scalars(std::ofstream& ofile, const T (&data)[N]) {
 
 template <typename T, typename I>
 std::enable_if_t<std::is_integral<I>::value>
-write_scalars(std::ofstream& ofile, const T* const data, I N) {
+write_scalars(std::ofstream& ofile, T* const data, I N) {
   for (I i=0; i<N; ++i) {
     write_scalars(ofile,data[i]);
   }

--- a/components/eamxx/src/share/CMakeLists.txt
+++ b/components/eamxx/src/share/CMakeLists.txt
@@ -143,6 +143,14 @@ target_compile_options(scream_share PUBLIC
 if (SCREAM_CIME_BUILD)
   target_compile_definitions (scream_share PUBLIC SCREAM_CIME_BUILD)
 endif()
+
+# When dealing with subtle bugs in read/write of unit tests baselines,
+# using ascii baselines can help inspect that the file indeed looks as expected
+option (EAMXX_ASCII_BASELINES "Whether physics units tests should assume ascii (instead of binary) format for baselines" OFF)
+if (EAMXX_ASCII_BASELINES)
+  target_compile_definitions (scream_share PUBLIC EAMXX_ASCII_BASELINES)
+endif()
+
 # We have some issues with RDC and repeated libraries in the link line.
 # It's a known issue, and nvcc_wrapper has a flag for handling this.
 if (Kokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE)


### PR DESCRIPTION
Fix a template overload resolution. Also, add possibility to generate ASCII baselines (for debug purposes only).

[BFB]

---

Note: the ASCII baselines are NOT to be used for baselines comparison, as we inevitably truncate periodic numbers, causing diffs when they are re-read in. They are just meant to be used for visually inspecting the baselines. For instance, it allowed me to see that one entry was in hex format rather than an integer, which allowed me to spot a bug (where a pointer instead of the pointed value was written).