### PR TITLE
Fix bug associated with unassociated x2g_gx pointer

### DIFF
--- a/driver-mct/main/cime_comp_mod.F90
+++ b/driver-mct/main/cime_comp_mod.F90
@@ -3083,7 +3083,7 @@ contains
           if (glcrun_alarm) then
              call cime_run_glc_setup_send(lnd2glc_averaged_now, prep_glc_accum_avg_called)
           else
-             call prep_glc_zero_fields()
+             if (iamin_CPLID) call prep_glc_zero_fields()
           endif
        endif
 

--- a/driver-mct/main/prep_glc_mod.F90
+++ b/driver-mct/main/prep_glc_mod.F90
@@ -1127,11 +1127,16 @@ contains
     type(mct_avect), pointer :: x2g_gx
     !---------------------------------------------------------------
 
-
     do egi = 1,num_inst_glc
        x2g_gx => component_get_x2c_cx(glc(egi))
-       call mct_aVect_zero(x2g_gx)
+       if (associated(x2g_gx)) then
+          call mct_aVect_zero(x2g_gx)
+       else
+          write(logunit,*) ' '
+          write(logunit,*) 'Warning: x2g_gx not associated for glc(', egi, ')'
+       end if
     end do
+
   end subroutine prep_glc_zero_fields
 
   !================================================================================================


### PR DESCRIPTION
Minor corrections to two subroutines in driver-mct/main to ensure that calls to prep_glc_zero_fields() only occur from processors associated with coupler and to write a warning to log file in the event that doing so results in an unassociated pointer.