### PR TITLE
Moves three snow grain growth parameters to namelist

### DIFF
--- a/components/mpas-seaice/bld/build-namelist
+++ b/components/mpas-seaice/bld/build-namelist
@@ -846,6 +846,9 @@ add_default($nl, 'config_shortwave_redistribution_threshold');
 
 add_default($nl, 'config_snow_redistribution_scheme');
 add_default($nl, 'config_fallen_snow_radius');
+add_default($nl, 'config_snow_growth_wet_factor');
+add_default($nl, 'config_minimum_snow_growth_factor');
+add_default($nl, 'config_snow_liq_saturation');
 add_default($nl, 'config_use_snow_liquid_ponds');
 add_default($nl, 'config_new_snow_density');
 add_default($nl, 'config_max_snow_density');

--- a/components/mpas-seaice/bld/build-namelist-section
+++ b/components/mpas-seaice/bld/build-namelist-section
@@ -359,6 +359,9 @@ add_default($nl, 'config_shortwave_redistribution_threshold');
 
 add_default($nl, 'config_snow_redistribution_scheme');
 add_default($nl, 'config_fallen_snow_radius');
+add_default($nl, 'config_snow_growth_wet_factor');
+add_default($nl, 'config_minimum_snow_growth_factor');
+add_default($nl, 'config_snow_liq_saturation');
 add_default($nl, 'config_use_snow_liquid_ponds');
 add_default($nl, 'config_new_snow_density');
 add_default($nl, 'config_max_snow_density');

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -391,6 +391,9 @@
 <!-- snow -->
 <config_snow_redistribution_scheme>'ITDrdg'</config_snow_redistribution_scheme>
 <config_fallen_snow_radius>54.526</config_fallen_snow_radius>
+<config_snow_growth_wet_factor>4.22e5</config_snow_growth_wet_factor>
+<config_minimum_snow_growth_factor>0.0</config_minimum_snow_growth_factor>
+<config_snow_liq_saturation>0.033</config_snow_liq_saturation>
 <config_use_snow_liquid_ponds>true</config_use_snow_liquid_ponds>
 <config_new_snow_density>100.0</config_new_snow_density>
 <config_max_snow_density>450.0</config_max_snow_density>

--- a/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_definition_mpassi.xml
@@ -2225,6 +2225,30 @@ Valid values: positive real
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_snow_growth_wet_factor" type="real"
+	category="snow" group="snow">
+wet metamorphism parameter
+
+Valid values: positive real
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_minimum_snow_growth_factor" type="real"
+	category="snow" group="snow">
+minimum snow grain growth factor
+
+Valid values: positive real
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_snow_liq_saturation" type="real"
+	category="snow" group="snow">
+irreducible saturation fraction
+
+Valid values: positive real
+Default: Defined in namelist_defaults.xml
+</entry>
+
 <entry id="config_use_snow_liquid_ponds" type="logical"
 	category="snow" group="snow">
 use snow liquid tracer for ponds

--- a/components/mpas-seaice/src/Registry.xml
+++ b/components/mpas-seaice/src/Registry.xml
@@ -1588,6 +1588,21 @@
 			possible_values="positive real"
 			icepack_name="rsnw_fall"
 		/>
+		<nml_option name="config_snow_growth_wet_factor" type="real" default_value="4.22e5" units="um3 s-1"
+			description="wet metamorphism parameter"
+			possible_values="positive real"
+			icepack_name="snw_growth_wet"
+		/>
+		<nml_option name="config_minimum_snow_growth_factor" type="real" default_value="0.0" units="1"
+			description="minimum snow grain growth factor"
+			possible_values="positive real"
+			icepack_name="drsnw_min"
+		/>
+		<nml_option name="config_snow_liq_saturation" type="real" default_value="0.033" units="1"
+			description="irreducible saturation fraction"
+			possible_values="positive real"
+			icepack_name="snwliq_max"
+		/>
 		<nml_option name="config_use_snow_liquid_ponds" type="logical" default_value="false" units="none"
 			description="use snow liquid tracer for ponds"
 			possible_values="true or false"

--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -10329,6 +10329,9 @@ contains
          config_DMSP_to_DMS_conversion_time, &
          config_DMS_oxidation_time, &
          config_fallen_snow_radius, &
+         config_snow_growth_wet_factor, &
+         config_minimum_snow_growth_factor, &
+         config_snow_liq_saturation, &
          config_new_snow_density, &
          config_max_snow_density, &
          config_minimum_wind_compaction, &
@@ -10537,6 +10540,9 @@ contains
     call MPAS_pool_get_config(domain % configs, "config_DMS_oxidation_time", config_DMS_oxidation_time)
     call MPAS_pool_get_config(domain % configs, "config_snow_redistribution_scheme", config_snow_redistribution_scheme)
     call MPAS_pool_get_config(domain % configs, "config_fallen_snow_radius", config_fallen_snow_radius)
+    call MPAS_pool_get_config(domain % configs, "config_snow_growth_wet_factor", config_snow_growth_wet_factor)
+    call MPAS_pool_get_config(domain % configs, "config_minimum_snow_growth_factor", config_minimum_snow_growth_factor)
+    call MPAS_pool_get_config(domain % configs, "config_snow_liq_saturation", config_snow_liq_saturation)
     call MPAS_pool_get_config(domain % configs, "config_use_snow_liquid_ponds", config_use_snow_liquid_ponds)
     call MPAS_pool_get_config(domain % configs, "config_new_snow_density", config_new_snow_density)
     call MPAS_pool_get_config(domain % configs, "config_max_snow_density", config_max_snow_density)
@@ -10869,6 +10875,9 @@ contains
          snwredist_in            = config_snow_redistribution_scheme, &
          use_smliq_pnd_in        = config_use_snow_liquid_ponds, &
          rsnw_fall_in            = config_fallen_snow_radius, &
+         snw_growth_wet_in       = config_snow_growth_wet_factor, &
+         drsnw_min_in            = config_minimum_snow_growth_factor, &
+         snwliq_max_in           = config_snow_liq_saturation, &
          rsnw_tmax_in            = config_max_dry_snow_radius, &
          rhosnew_in              = config_new_snow_density, &
          rhosmax_in              = config_max_snow_density, &
@@ -11774,6 +11783,18 @@ contains
     ! rsnw_fall:
     ! fallen snow grain radius (um)
     ! rsnw_fall = config_fallen_snow_radius
+
+    ! snw_growth_wet:
+    ! wet metamorphism parameter (um3 s-1)
+    ! snw_growth_wet = config_snow_growth_wet_factor
+
+    ! drsnw_min:
+    ! minimum snow grain growth factor (1)
+    ! drsnw_min = config_minimum_snow_growth_factor
+
+    ! snwliq_max:
+    ! irreducible saturation fraction (1)
+    ! snwliq_max = config_snow_liq_saturation
 
     ! rsnw_tmax:
     ! maximum dry metamorphism snow grain radius (um)


### PR DESCRIPTION
Cherry picks commit ec7ad9c298b8dfd5a84b8fe74063d6174fc60b80 from  CICE-Consortium/Icepack

Adds new parameters for adjusting snow grain growth rate: config_snow_growth_wet_factor - proportional to the wet metamorphism growth rate config_minimum_snow_growth_factor - the minimum growth rate at 0 liquid water content config_snow_liq_saturation - the irreducible saturation of snow grains

BFB