### PR TITLE
EAMxx: fix define_var call for avg count var in IO

### DIFF
--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -758,8 +758,7 @@ register_variables(const std::string& filename,
       // Note, unlike with regular output variables, for the average counting
       // variables we don't need to add all of the extra metadata.  So we simply
       // define the variable.
-      scorpio::define_var(filename, name, unitless, dimnames,
-                          "real",fp_precision, m_add_time_dim);
+      scorpio::define_var(filename, name, dimnames, "int", m_add_time_dim);
     }
   }
 } // register_variables


### PR DESCRIPTION
This bug was somehow causing ERS/ERP fails, since avg count vars were full of zeros in restart files.

[BFB]

---

I am not entirely sure why pm-cpu was failing while mappy wasn't. I also am not entirely sure why we were getting 0's in the restart file, as scorpio _should_ handle the conversion int->double internally when calling PIOc_write_darray. Either way, there's no point writing avg count vars with double data type, so this change is an improvement nevertheless.

Note: I verified this fixes things on pm-cpu with a small ne4 test. I am currently running ne30 to see if there's some other issue other than this.