### PR TITLE
Port gwd_compute_tendencies_from_stress_divergence to CXX

### DIFF
--- a/components/eam/src/physics/cam/gw/gw_common.F90
+++ b/components/eam/src/physics/cam/gw/gw_common.F90
@@ -141,6 +141,7 @@ subroutine gw_common_init(pver_in, pgwv_in, dc_in, cref_in, &
   pver = pver_in
   pgwv = pgwv_in
   dc = dc_in
+  if (allocated(cref)) deallocate(cref)
   allocate(cref(-pgwv:pgwv), stat=ierr, errmsg=errstring)
   if (ierr /= 0) return
   cref = cref_in
@@ -154,6 +155,7 @@ subroutine gw_common_init(pver_in, pgwv_in, dc_in, cref_in, &
   kwv = kwv_in
   gravit = gravit_in
   rair = rair_in
+  if (allocated(alpha)) deallocate(alpha)
   allocate(alpha(0:pver), stat=ierr, errmsg=errstring)
   if (ierr /= 0) return
   alpha = alpha_in

--- a/components/eamxx/src/physics/gw/CMakeLists.txt
+++ b/components/eamxx/src/physics/gw/CMakeLists.txt
@@ -31,6 +31,7 @@ if (NOT EAMXX_ENABLE_GPU OR Kokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE OR Kokkos
     eti/gw_gw_ediff.cpp
     eti/gw_gw_diff_tend.cpp
     eti/gw_gw_oro_src.cpp
+    eti/gw_gw_common_init.cpp
   ) # GW ETI SRCS
 endif()
 

--- a/components/eamxx/src/physics/gw/eti/gw_gw_common_init.cpp
+++ b/components/eamxx/src/physics/gw/eti/gw_gw_common_init.cpp
@@ -1,0 +1,14 @@
+#include "impl/gw_gw_common_init_impl.hpp"
+
+namespace scream {
+namespace gw {
+
+/*
+ * Explicit instantiation for doing gw_common_init on Reals using the
+ * default device.
+ */
+
+template struct Functions<Real,DefaultDevice>;
+
+} // namespace gw
+} // namespace scream

--- a/components/eamxx/src/physics/gw/gw_functions.hpp
+++ b/components/eamxx/src/physics/gw/gw_functions.hpp
@@ -22,12 +22,6 @@ template <typename ScalarT, typename DeviceT>
 struct Functions
 {
   //
-  // ---------- GW constants ---------
-  //
-  struct GWC {
-  };
-
-  //
   // ------- Types --------
   //
 
@@ -54,16 +48,125 @@ struct Functions
   using view_1d = typename KT::template view_1d<S>;
   template <typename S>
   using view_2d = typename KT::template view_2d<S>;
+  template <typename S>
+  using view_3d = typename KT::template view_3d<S>;
 
   template <typename S>
   using uview_1d = typename ekat::template Unmanaged<view_1d<S> >;
   template <typename S>
   using uview_2d = typename ekat::template Unmanaged<view_2d<S> >;
+  template <typename S>
+  using uview_3d = typename ekat::template Unmanaged<view_3d<S> >;
 
   using MemberType = typename KT::MemberType;
 
   using WorkspaceManager = typename ekat::WorkspaceManager<Spack, Device>;
   using Workspace        = typename WorkspaceManager::Workspace;
+
+  //
+  // ---------- GW constants ---------
+  //
+  struct GWC {
+    // Index the cardinal directions.
+    static inline constexpr int west = 0;
+    static inline constexpr int east = 1;
+    static inline constexpr int south = 2;
+    static inline constexpr int north = 3;
+
+    // rair/gravit
+    static inline constexpr Real rog = C::Rair / C::gravit;
+
+    // Background diffusivity.
+    static inline constexpr Real dback = 0.05;
+
+    // Minimum non-zero stress.
+    static inline constexpr Real taumin = 1.e-10;
+
+    // Maximum allowed change in u-c (before efficiency applied).
+    static inline constexpr Real umcfac = 0.5;
+
+    // Minimum value of (u-c)**2.
+    static inline constexpr Real ubmc2mn = 0.01;
+  };
+
+  //
+  // --------- Structs for organizing data ---------
+  //
+
+  struct GwCommonInit {
+    GwCommonInit() : initialized(false) {}
+
+    // Tell us if initialize has been called
+    bool initialized;
+
+    // This flag preserves answers for vanilla CAM by making a few changes (e.g.
+    // order of operations) when only orographic waves are on.
+    bool orographic_only; // = .false.
+
+    // Number of levels in the atmosphere.
+    int pver;
+
+    // Maximum number of waves allowed (i.e. wavenumbers are -pgwv:pgwv).
+    int pgwv;
+
+    // Bin width for spectrum.
+    Real dc; // = huge(1._r8)
+
+    // Reference speeds for the spectrum.
+    view_1d<Real> cref;
+
+    // Whether or not molecular diffusion is being done, and bottom level where
+    // it is done.
+    bool do_molec_diff; // = .false.
+    int nbot_molec; // = huge(1)
+
+    // Whether or not to enforce an upper boundary condition of tau = 0.
+    bool tau_0_ubc; // = .false.
+
+    // Critical Froude number.
+    Real fcrit2; // = huge(1._r8)
+
+    // Effective horizontal wave number.
+    Real kwv; // = huge(1._r8)
+
+    // Interface levels for gravity wave sources.
+    int ktop; // = huge(1)
+    int kbotbg; // = huge(1)
+
+    // Effective wavenumber.
+    Real effkwv; // = huge(1._r8)
+
+    // Newtonian cooling coefficients.
+    view_1d<Real> alpha;
+
+    // Maximum wind tendency from stress divergence (before efficiency applied).
+    Real tndmax; // = huge(1._r8)
+  };
+
+  //
+  // --------- Init/Finalize Functions ---------
+  //
+  static void gw_common_init(
+    // Inputs
+    const Int& pver_in,
+    const Int& pgwv_in,
+    const Real& dc_in,
+    const uview_1d<const Real>& cref_in,
+    const bool& orographic_only_in,
+    const bool& do_molec_diff_in,
+    const bool& tau_0_ubc_in,
+    const Int& nbot_molec_in,
+    const Int& ktop_in,
+    const Int& kbotbg_in,
+    const Real& fcrit2_in,
+    const Real& kwv_in,
+    const uview_1d<const Real>& alpha_in);
+
+  static void gw_common_finalize()
+  {
+    s_common_init.cref  = decltype(s_common_init.cref)();
+    s_common_init.alpha = decltype(s_common_init.alpha)();
+  }
 
   //
   // --------- Functions ---------
@@ -77,24 +180,24 @@ struct Functions
     const Int& pgwv,
     const Int& ngwv,
     const bool& do_taper,
-    const Spack& dt,
-    const Spack& effgw,
+    const Real& dt,
+    const Real& effgw,
     const uview_1d<const Int>& tend_level,
-    const uview_1d<const Spack>& lat,
-    const uview_1d<const Spack>& dpm,
-    const uview_1d<const Spack>& rdpm,
-    const uview_1d<const Spack>& c,
-    const uview_1d<const Spack>& ubm,
-    const uview_1d<const Spack>& t,
-    const uview_1d<const Spack>& nm,
-    const uview_1d<const Spack>& xv,
-    const uview_1d<const Spack>& yv,
+    const uview_1d<const Real>& lat,
+    const uview_2d<const Real>& dpm,
+    const uview_2d<const Real>& rdpm,
+    const uview_2d<const Real>& c,
+    const uview_2d<const Real>& ubm,
+    const uview_2d<const Real>& t,
+    const uview_2d<const Real>& nm,
+    const uview_1d<const Real>& xv,
+    const uview_1d<const Real>& yv,
     // Inputs/Outputs
-    const uview_1d<Spack>& tau,
+    const uview_3d<Real>& tau,
     // Outputs
-    const uview_1d<Spack>& gwut,
-    const uview_1d<Spack>& utgw,
-    const uview_1d<Spack>& vtgw);
+    const uview_3d<Real>& gwut,
+    const uview_2d<Real>& utgw,
+    const uview_2d<Real>& vtgw);
 
   KOKKOS_FUNCTION
   static void gw_prof(
@@ -436,6 +539,12 @@ struct Functions
     const uview_1d<Spack>& xv,
     const uview_1d<Spack>& yv,
     const uview_1d<Spack>& c);
+
+  //
+  // --------- Members ---------
+  //
+  inline static GwCommonInit s_common_init;
+
 }; // struct Functions
 
 } // namespace gw
@@ -463,5 +572,6 @@ struct Functions
 # include "impl/gw_gw_ediff_impl.hpp"
 # include "impl/gw_gw_diff_tend_impl.hpp"
 # include "impl/gw_gw_oro_src_impl.hpp"
+# include "impl/gw_gw_common_init_impl.hpp"
 #endif // GPU && !KOKKOS_ENABLE_*_RELOCATABLE_DEVICE_CODE
 #endif // P3_FUNCTIONS_HPP

--- a/components/eamxx/src/physics/gw/impl/gw_gw_common_init_impl.hpp
+++ b/components/eamxx/src/physics/gw/impl/gw_gw_common_init_impl.hpp
@@ -1,0 +1,55 @@
+#ifndef GW_GW_COMMON_INIT_IMPL_HPP
+#define GW_GW_COMMON_INIT_IMPL_HPP
+
+#include "gw_functions.hpp" // for ETI only but harmless for GPU
+
+namespace scream {
+namespace gw {
+
+/*
+ * Implementation of gw gw_common_init. Clients should NOT
+ * #include this file, but include gw_functions.hpp instead.
+ */
+
+template<typename S, typename D>
+KOKKOS_FUNCTION
+void Functions<S,D>::gw_common_init(
+// Inputs
+  const Int& pver_in,
+  const Int& pgwv_in,
+  const Real& dc_in,
+  const uview_1d<const Real>& cref_in,
+  const bool& orographic_only_in,
+  const bool& do_molec_diff_in,
+  const bool& tau_0_ubc_in,
+  const Int& nbot_molec_in,
+  const Int& ktop_in,
+  const Int& kbotbg_in,
+  const Real& fcrit2_in,
+  const Real& kwv_in,
+  const uview_1d<const Real>& alpha_in)
+{
+  s_common_init.initialized = true;
+  s_common_init.pver = pver_in;
+  s_common_init.pgwv = pgwv_in;
+  s_common_init.dc = dc_in;
+  s_common_init.cref = view_1d<Real>("cref", cref_in.size());
+  Kokkos::deep_copy(s_common_init.cref, cref_in);
+  s_common_init.orographic_only = orographic_only_in;
+  s_common_init.do_molec_diff = do_molec_diff_in;
+  s_common_init.tau_0_ubc = tau_0_ubc_in;
+  s_common_init.nbot_molec = nbot_molec_in;
+  s_common_init.ktop = ktop_in;
+  s_common_init.kbotbg = kbotbg_in;
+  s_common_init.fcrit2 = fcrit2_in;
+  s_common_init.kwv = kwv_in;
+  s_common_init.alpha = view_1d<Real>("alpha", alpha_in.size());
+  Kokkos::deep_copy(s_common_init.alpha, alpha_in);
+  s_common_init.effkwv = kwv_in * fcrit2_in;
+  s_common_init.tndmax = orographic_only_in ? 500. / 86400. : 400. / 86400.;
+}
+
+} // namespace gw
+} // namespace scream
+
+#endif

--- a/components/eamxx/src/physics/gw/impl/gw_gwd_compute_tendencies_from_stress_divergence_impl.hpp
+++ b/components/eamxx/src/physics/gw/impl/gw_gwd_compute_tendencies_from_stress_divergence_impl.hpp
@@ -2,6 +2,7 @@
 #define GW_GWD_COMPUTE_TENDENCIES_FROM_STRESS_DIVERGENCE_IMPL_HPP
 
 #include "gw_functions.hpp" // for ETI only but harmless for GPU
+#include <cmath>
 
 namespace scream {
 namespace gw {
@@ -10,6 +11,12 @@ namespace gw {
  * Implementation of gw gwd_compute_tendencies_from_stress_divergence. Clients should NOT
  * #include this file, but include gw_functions.hpp instead.
  */
+
+// TODO: Move to common area
+template <typename T>
+T sign(T a, T b) {
+    return (b >= 0) ? std::abs(a) : -std::abs(a);
+}
 
 template<typename S, typename D>
 KOKKOS_FUNCTION
@@ -20,27 +27,150 @@ void Functions<S,D>::gwd_compute_tendencies_from_stress_divergence(
   const Int& pgwv,
   const Int& ngwv,
   const bool& do_taper,
-  const Spack& dt,
-  const Spack& effgw,
+  const Real& dt,
+  const Real& effgw,
   const uview_1d<const Int>& tend_level,
-  const uview_1d<const Spack>& lat,
-  const uview_1d<const Spack>& dpm,
-  const uview_1d<const Spack>& rdpm,
-  const uview_1d<const Spack>& c,
-  const uview_1d<const Spack>& ubm,
-  const uview_1d<const Spack>& t,
-  const uview_1d<const Spack>& nm,
-  const uview_1d<const Spack>& xv,
-  const uview_1d<const Spack>& yv,
+  const uview_1d<const Real>& lat,
+  const uview_2d<const Real>& dpm,
+  const uview_2d<const Real>& rdpm,
+  const uview_2d<const Real>& c,
+  const uview_2d<const Real>& ubm,
+  const uview_2d<const Real>& t,
+  const uview_2d<const Real>& nm,
+  const uview_1d<const Real>& xv,
+  const uview_1d<const Real>& yv,
   // Inputs/Outputs
-  const uview_1d<Spack>& tau,
+  const uview_3d<Real>& tau,
   // Outputs
-  const uview_1d<Spack>& gwut,
-  const uview_1d<Spack>& utgw,
-  const uview_1d<Spack>& vtgw)
+  const uview_3d<Real>& gwut,
+  const uview_2d<Real>& utgw,
+  const uview_2d<Real>& vtgw)
 {
-  // TODO
-  // Note, argument types may need tweaking. Generator is not always able to tell what needs to be packed
+  // Temporary ubar tendencies (overall, at wave l, and at saturation).
+  // These should probably come from workspace manager
+  view_2d<Real> ubt("ubt", ncol, s_common_init.pver);
+  view_1d<Real> ubtl("ubtl", ncol), ubtlsat("ubtlsat", ncol);
+
+  // Polar taper.
+  view_1d<Real> ptaper("ptaper", ncol);
+
+  if (do_taper) { // taper CM only
+    for (int i = 0; i < ncol; ++i) {
+      ptaper(i) = std::cos(lat(i));
+    }
+  }
+  else { //  do not taper other cases
+    Kokkos::deep_copy(ptaper, 1.);
+  }
+
+  // Force tau at the top of the model to zero, if requested.
+  if (s_common_init.tau_0_ubc) {
+    for (size_t i = 0; i < tau.extent(0); ++i) {
+      for (size_t j = 0; j < tau.extent(1); ++j) {
+        tau(i,j,0) = 0.;
+      }
+    }
+  }
+
+  // Find max
+  int maxval = -999999;
+  for (int i = 0; i < ncol; ++i) {
+    if (tend_level(i) > maxval) maxval = tend_level(i);
+  }
+
+  // Loop over levels from top to bottom
+  for (int k = s_common_init.ktop; k <= maxval; ++k) {
+    //  Accumulate the mean wind tendency over wavenumber.
+    for (int i = 0; i < ncol; ++i) {
+      ubt(i,k) = 0.;
+    }
+
+    for (int l = -ngwv; l <= ngwv; ++l) { // loop over wave
+      int nl_idx = l + ngwv; // 0-based idx for -ngwv:ngwv arrays
+      int pl_idx = nl_idx + (pgwv - ngwv); // 0-based idx -pgwv:pgwv arrays
+
+      // Determine the wind tendency, including excess stress carried down
+      // from above.
+      for (int i = 0; i < ncol; ++i) {
+        ubtl(i) = C::gravit * (tau(i,pl_idx,k+1)-tau(i,pl_idx,k)) * rdpm(i,k);
+      }
+
+      if (s_common_init.orographic_only) {
+        // Require that the tendency be no larger than the analytic
+        // solution for a saturated region [proportional to (u-c)^3].
+        for (int i = 0; i < ncol; ++i) {
+          Real temp = c(i,pl_idx)-ubm(i,k);
+          temp = temp * temp * temp; // BFB with fortran **3
+          ubtlsat(i) = s_common_init.effkwv * std::abs(temp) / (2*GWC::rog*t(i,k)*nm(i,k));
+          ubtl(i) = std::min(ubtl(i), ubtlsat(i));
+        }
+      }
+
+      // Apply tendency limits to maintain numerical stability.
+      // 1. du/dt < |c-u|/dt  so u-c cannot change sign
+      //    (u^n+1 = u^n + du/dt * dt)
+      // 2. du/dt < tndmax    so that ridicuously large tendencies are not
+      //    permitted
+      for (int i = 0; i < ncol; ++i) {
+        ubtl(i) = std::min(ubtl(i), GWC::umcfac * std::abs(c(i,pl_idx)-ubm(i,k)) / dt);
+        ubtl(i) = std::min(ubtl(i), s_common_init.tndmax);
+      }
+
+      for (int i = 0; i < ncol; ++i) {
+        if (k <= tend_level(i)) {
+          // Save tendency for each wave (for later computation of kzz),
+          // applying efficiency and taper:
+          gwut(i,k,nl_idx) = sign(ubtl(i), c(i,pl_idx)-ubm(i,k)) * effgw * ptaper(i);
+        }
+      }
+
+      if (!s_common_init.orographic_only) {
+        for (int i = 0; i < ncol; ++i) {
+          if (k <= tend_level(i)) {
+            ubt(i,k) = ubt(i,k) + gwut(i,k,nl_idx);
+          }
+        }
+      }
+      else {
+        for (int i = 0; i < ncol; ++i) {
+          if (k <= tend_level(i)) {
+            ubt(i,k) = ubt(i,k) + sign(ubtl(i), c(i,pl_idx)-ubm(i,k));
+          }
+        }
+      }
+
+      for (int i = 0; i < ncol; ++i) {
+        if (k <= tend_level(i)) {
+          // Redetermine the effective stress on the interface below from
+          // the wind tendency. If the wind tendency was limited above,
+          // then the new stress will be smaller than the old stress,
+          // causing stress divergence in the next layer down. This
+          // smoothes large stress divergences downward while conserving
+          // total stress.
+          tau(i,pl_idx,k+1) = tau(i,pl_idx,k) + ubtl(i) * dpm(i,k) / C::gravit;
+        }
+      }
+    }
+
+    // Project the mean wind tendency onto the components.
+    if (!s_common_init.orographic_only) {
+      for (int i = 0; i < ncol; ++i) {
+        if (k <= tend_level(i)) {
+          utgw(i,k) = ubt(i,k) * xv(i);
+          vtgw(i,k) = ubt(i,k) * yv(i);
+        }
+      }
+    }
+    else {
+      for (int i = 0; i < ncol; ++i) {
+        if (k <= tend_level(i)) {
+          utgw(i,k) = ubt(i,k) * xv(i) * effgw * ptaper(i);
+          vtgw(i,k) = ubt(i,k) * yv(i) * effgw * ptaper(i);
+        }
+      }
+    }
+
+  }
 }
 
 } // namespace gw

--- a/components/eamxx/src/physics/gw/tests/gw_gwd_compute_tendencies_from_stress_divergence_tests.cpp
+++ b/components/eamxx/src/physics/gw/tests/gw_gwd_compute_tendencies_from_stress_divergence_tests.cpp
@@ -22,10 +22,10 @@ struct UnitWrap::UnitTest<D>::TestGwdComputeTendenciesFromStressDivergence : pub
     // Set up init data
     GwInit init_data[] = {
           // pver, pgwv,   dc, orog_only, molec_diff, tau_0_ubc, nbot_molec, ktop, kbotbg, fcrit2, kwv
-      GwInit(  72,   20, 0.75,     false,      false,     false,         16,   60,     16,    .67, 6.28e-5),
-      GwInit(  72,   20, 0.75,     true ,      false,     true ,         16,   60,     16,    .67, 6.28e-5),
-      GwInit(  72,   20, 0.75,     false,      true ,     true ,         16,   60,     16,    .67, 6.28e-5),
-      GwInit(  72,   20, 0.75,     true ,      true ,     false,         16,   60,     16,    .67, 6.28e-5),
+      GwInit(  72,   20, 0.75,     false,      false,     false,         16,   8,     66,    .67, 6.28e-5),
+      GwInit(  72,   20, 0.75,     true ,      false,     true ,         16,   6,     68,    .67, 6.28e-5),
+      GwInit(  72,   20, 0.75,     false,      true ,     true ,         16,   3,     70,    .67, 6.28e-5),
+      GwInit(  72,   20, 0.75,     true ,      true ,     false,         16,   0,     72,    .67, 6.28e-5),
     };
 
     for (auto& d : init_data) {
@@ -36,17 +36,18 @@ struct UnitWrap::UnitTest<D>::TestGwdComputeTendenciesFromStressDivergence : pub
     GwdComputeTendenciesFromStressDivergenceData baseline_data[] = {
       //                                        ncol, ngwv, do_taper,   dt, effgw, init
       GwdComputeTendenciesFromStressDivergenceData(2,   10,    false,  0.4,   0.3, init_data[0]),
-      GwdComputeTendenciesFromStressDivergenceData(3,   10,    false,  0.4,   0.3, init_data[1]),
-      GwdComputeTendenciesFromStressDivergenceData(4,   10,    true ,  0.4,   0.3, init_data[2]),
-      GwdComputeTendenciesFromStressDivergenceData(5,   10,    true ,  0.4,   0.3, init_data[3]),
+      GwdComputeTendenciesFromStressDivergenceData(3,   12,    false,  0.4,   0.3, init_data[1]),
+      GwdComputeTendenciesFromStressDivergenceData(4,   17,    true ,  0.4,   0.3, init_data[2]),
+      GwdComputeTendenciesFromStressDivergenceData(5,   20,    true ,  0.4,   0.3, init_data[3]),
     };
 
     static constexpr Int num_runs = sizeof(baseline_data) / sizeof(GwdComputeTendenciesFromStressDivergenceData);
 
     // Generate random input data
     // Alternatively, you can use the baseline_data construtors/initializer lists to hardcode data
-    for (auto& d : baseline_data) {
-      d.randomize(engine);
+    for (Int i = 0; i < num_runs; ++i) {
+      GwdComputeTendenciesFromStressDivergenceData& d = baseline_data[i];
+      d.randomize(engine,  { {d.tend_level, {init_data[i].ktop+1, init_data[i].kbotbg}} });
     }
 
     // Create copies of data for use by test. Needs to happen before read calls so that
@@ -67,7 +68,12 @@ struct UnitWrap::UnitTest<D>::TestGwdComputeTendenciesFromStressDivergence : pub
 
     // Get data from test
     for (auto& d : test_data) {
-      gwd_compute_tendencies_from_stress_divergence(d);
+      if (this->m_baseline_action == GENERATE) {
+        gwd_compute_tendencies_from_stress_divergence_f(d);
+      }
+      else {
+        gwd_compute_tendencies_from_stress_divergence(d);
+      }
     }
 
     // Verify BFB results, all data should be in C layout
@@ -75,21 +81,20 @@ struct UnitWrap::UnitTest<D>::TestGwdComputeTendenciesFromStressDivergence : pub
       for (Int i = 0; i < num_runs; ++i) {
         GwdComputeTendenciesFromStressDivergenceData& d_baseline = baseline_data[i];
         GwdComputeTendenciesFromStressDivergenceData& d_test = test_data[i];
+        REQUIRE(d_baseline.total(d_baseline.tau) == d_test.total(d_test.tau));
         for (Int k = 0; k < d_baseline.total(d_baseline.tau); ++k) {
-          REQUIRE(d_baseline.total(d_baseline.tau) == d_test.total(d_test.tau));
           REQUIRE(d_baseline.tau[k] == d_test.tau[k]);
         }
+        REQUIRE(d_baseline.total(d_baseline.gwut) == d_test.total(d_test.gwut));
         for (Int k = 0; k < d_baseline.total(d_baseline.gwut); ++k) {
-          REQUIRE(d_baseline.total(d_baseline.gwut) == d_test.total(d_test.gwut));
           REQUIRE(d_baseline.gwut[k] == d_test.gwut[k]);
         }
+        REQUIRE(d_baseline.total(d_baseline.utgw) == d_test.total(d_test.utgw));
+        REQUIRE(d_baseline.total(d_baseline.utgw) == d_test.total(d_test.vtgw));
         for (Int k = 0; k < d_baseline.total(d_baseline.utgw); ++k) {
-          REQUIRE(d_baseline.total(d_baseline.utgw) == d_test.total(d_test.utgw));
           REQUIRE(d_baseline.utgw[k] == d_test.utgw[k]);
-          REQUIRE(d_baseline.total(d_baseline.utgw) == d_test.total(d_test.vtgw));
           REQUIRE(d_baseline.vtgw[k] == d_test.vtgw[k]);
         }
-
       }
     }
     else if (this->m_baseline_action == GENERATE) {

--- a/components/eamxx/src/physics/gw/tests/infra/gw_test_data.cpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_test_data.cpp
@@ -74,12 +74,60 @@ void gw_init(GwInit& init)
   gw_init_c(init.pver, init.pgwv, init.dc, init.cref, init.orographic_only, init.do_molec_diff, init.tau_0_ubc, init.nbot_molec, init.ktop, init.kbotbg, init.fcrit2, init.kwv, GWC::gravit, GWC::Rair, init.alpha);
 }
 
-void gwd_compute_tendencies_from_stress_divergence(GwdComputeTendenciesFromStressDivergenceData& d)
+// Wrapper around gw_init for cxx
+void gw_init_cxx(GwInit& init)
+{
+  using uview_1d = typename GWF::uview_1d<Real>;
+  GWF::gw_common_init(
+    init.pver,
+    init.pgwv,
+    init.dc,
+    uview_1d(init.cref, init.pgwv*2 + 1),
+    init.orographic_only,
+    init.do_molec_diff,
+    init.tau_0_ubc,
+    init.nbot_molec,
+    init.ktop,
+    init.kbotbg,
+    init.fcrit2,
+    init.kwv,
+    uview_1d(init.alpha, init.pver + 1));
+}
+
+void gw_finalize_cxx(GwInit& init)
+{
+  GWF::gw_common_finalize();
+}
+
+void gwd_compute_tendencies_from_stress_divergence_f(GwdComputeTendenciesFromStressDivergenceData& d)
 {
   gw_init(d.init);
   d.transpose<ekat::TransposeDirection::c2f>();
   gwd_compute_tendencies_from_stress_divergence_c(d.ncol, d.ngwv, d.do_taper, d.dt, d.effgw, d.tend_level, d.lat, d.dpm, d.rdpm, d.c, d.ubm, d.t, d.nm, d.xv, d.yv, d.tau, d.gwut, d.utgw, d.vtgw);
   d.transpose<ekat::TransposeDirection::f2c>();
+}
+
+void gwd_compute_tendencies_from_stress_divergence(GwdComputeTendenciesFromStressDivergenceData& d)
+{
+  gw_init_cxx(d.init);
+  GWF::gwd_compute_tendencies_from_stress_divergence(
+    d.ncol, d.init.pver, d.init.pgwv, d.ngwv, d.do_taper, d.dt, d.effgw,
+    GWF::uview_1d<Int>(d.tend_level, d.ncol),
+    GWF::uview_1d<Real>(d.lat, d.ncol),
+    GWF::uview_2d<Real>(d.dpm, d.ncol, d.init.pver),
+    GWF::uview_2d<Real>(d.rdpm, d.ncol, d.init.pver),
+    GWF::uview_2d<Real>(d.c, d.ncol, 2*d.init.pgwv + 1),
+    GWF::uview_2d<Real>(d.ubm, d.ncol, d.init.pver),
+    GWF::uview_2d<Real>(d.t, d.ncol, d.init.pver),
+    GWF::uview_2d<Real>(d.nm, d.ncol, d.init.pver),
+    GWF::uview_1d<Real>(d.xv, d.ncol),
+    GWF::uview_1d<Real>(d.yv, d.ncol),
+    GWF::uview_3d<Real>(d.tau, d.ncol, 2*d.init.pgwv + 1, d.init.pver + 1),
+    GWF::uview_3d<Real>(d.gwut, d.ncol, d.init.pver, 2*d.ngwv + 1),
+    GWF::uview_2d<Real>(d.utgw,d.ncol, d.init.pver),
+    GWF::uview_2d<Real>(d.vtgw, d.ncol, d.init.pver)
+  );
+  gw_finalize_cxx(d.init);
 }
 
 void gw_prof(GwProfData& d)

--- a/components/eamxx/src/physics/gw/tests/infra/gw_test_data.hpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_test_data.hpp
@@ -39,12 +39,12 @@ struct GwInit : public PhysicsTestData {
     pver(pver_), pgwv(pgwv_), dc(dc_), orographic_only(orographic_only_), do_molec_diff(do_molec_diff_), tau_0_ubc(tau_0_ubc_), nbot_molec(nbot_molec_), ktop(ktop_), kbotbg(kbotbg_), fcrit2(fcrit2_), kwv(kwv_)
   {
     // Assert valid init data?
-    assert(ktop <= pver);
-    assert(kbotbg >= 0);
-    assert(kbotbg <= ktop);
+    assert(kbotbg <= pver);
+    assert(ktop >= 0);
+    assert(kbotbg >= ktop);
     assert(pgwv > 0);
     assert(nbot_molec >= 0);
-    assert(nbot_molec <= ktop);
+    assert(nbot_molec >= ktop);
   }
 
   PTD_STD_DEF(GwInit, 11, pver, pgwv, dc, orographic_only, do_molec_diff, tau_0_ubc, nbot_molec, ktop, kbotbg, fcrit2, kwv);
@@ -672,6 +672,7 @@ struct GwOroSrcData : public PhysicsTestData {
 
 // Glue functions to call fortran from from C++ with the Data struct
 void gwd_compute_tendencies_from_stress_divergence(GwdComputeTendenciesFromStressDivergenceData& d);
+void gwd_compute_tendencies_from_stress_divergence_f(GwdComputeTendenciesFromStressDivergenceData& d);
 void gw_prof(GwProfData& d);
 void momentum_energy_conservation(MomentumEnergyConservationData& d);
 void gwd_compute_stress_profiles_and_diffusivities(GwdComputeStressProfilesAndDiffusivitiesData& d);


### PR DESCRIPTION
Change list:
1) Main change: Fill out CXX impl of gwd_compute_tendencies_from_stress_divergence
2) gw_common_init: Allow it to be called multiple times be deallocating cref and alpha if
   they had been previously allocated.
3) Begin to fill in constants needed by GW
4) Create struct for containing common init data in C++
5) Add C++ version of gw_common_init and gw_common_finalize
6) Don't just assume all C++ data is packed. Just have it all unpacked for now
7) Fix randomized test data for gwd_compute_tendencies_from_stress_divergence so
   that some actual interesting computations happen.
8) For now, have a f90 and cxx bridge available for this function and use the f90
   one for baseline generation. Once we are sure we have things working, the f90
   calls can be removed.

Discussion items:
* The current CXX is an exact 1:1 port of the fortran, which is not what we want long term
* Like in p3, should we assume these GW functions are called from kernel that is already parallelizing over columns? So, any fortran array like a 3d (ncol, X, Y) becomes a CXX 2d view (X, Y) because we will be passing in subviews for specific columns?
* Should we assume all vertical column data is packed?
* Since I wasn't 100% sure about where these GW will sit in the parallel hierarchy, the C++ impl is fully serial right now which will obviously need to be changed.