### PR TITLE
EAMxx: enforce a single value for "fill_value" across all eamxx

### DIFF
--- a/components/eamxx/src/diagnostics/aodvis.cpp
+++ b/components/eamxx/src/diagnostics/aodvis.cpp
@@ -48,9 +48,6 @@ void AODVis::initialize_impl(const RunType /*run_type*/) {
   auto nondim = ekat::units::Units::nondimensional();
   const auto &grid_name =
       m_diagnostic_output.get_header().get_identifier().get_grid_name();
-  const auto var_fill_value = constants::fill_value<Real>;
-
-  m_mask_val = m_params.get<double>("mask_value", var_fill_value);
 
   std::string mask_name = name() + " mask";
   FieldLayout mask_layout({COL}, {m_ncols});
@@ -58,8 +55,7 @@ void AODVis::initialize_impl(const RunType /*run_type*/) {
   Field diag_mask(mask_fid);
   diag_mask.allocate_view();
 
-  m_diagnostic_output.get_header().set_extra_data("mask_data", diag_mask);
-  m_diagnostic_output.get_header().set_extra_data("mask_value", m_mask_val);
+  m_diagnostic_output.get_header().set_extra_data("mask_field", diag_mask);
 }
 
 void AODVis::compute_diagnostic_impl() {
@@ -68,9 +64,11 @@ void AODVis::compute_diagnostic_impl() {
   using TPF = ekat::TeamPolicyFactory<typename KT::ExeSpace>;
   using RU  = ekat::ReductionUtils<typename KT::ExeSpace>;
 
+  constexpr auto fill_value = constants::fill_value<Real>;
+
   const auto aod     = m_diagnostic_output.get_view<Real *>();
   const auto mask    = m_diagnostic_output.get_header()
-                        .get_extra_data<Field>("mask_data")
+                        .get_extra_data<Field>("mask_field")
                         .get_view<Real *>();
   const auto tau_vis = get_field_in("aero_tau_sw")
                            .subfield(1, m_vis_bnd)
@@ -78,13 +76,12 @@ void AODVis::compute_diagnostic_impl() {
   const auto sunlit = get_field_in("sunlit").get_view<const Real *>();
 
   const auto num_levs = m_nlevs;
-  const auto var_fill_value = m_mask_val;
   const auto policy   = TPF::get_default_team_policy(m_ncols, m_nlevs);
   Kokkos::parallel_for(
       "Compute " + m_diagnostic_output.name(), policy, KOKKOS_LAMBDA(const MT &team) {
         const int icol = team.league_rank();
         if(sunlit(icol) == 0.0) {
-          aod(icol) = var_fill_value;
+          aod(icol) = fill_value;
           Kokkos::single(Kokkos::PerTeam(team), [&] { mask(icol) = 0; });
         } else {
           auto tau_icol = ekat::subview(tau_vis, icol);

--- a/components/eamxx/src/diagnostics/aodvis.hpp
+++ b/components/eamxx/src/diagnostics/aodvis.hpp
@@ -36,8 +36,6 @@ class AODVis : public AtmosphereDiagnostic {
 
   int m_swbands = eamxx_swbands();
   int m_vis_bnd = eamxx_vis_swband_idx();
-
-  Real m_mask_val;
 };
 
 }  // namespace scream

--- a/components/eamxx/src/diagnostics/atm_backtend.cpp
+++ b/components/eamxx/src/diagnostics/atm_backtend.cpp
@@ -61,7 +61,6 @@ void AtmBackTendDiag::init_timestep(const util::TimeStamp &start_of_step) {
 }
 
 void AtmBackTendDiag::compute_diagnostic_impl() {
-  Real var_fill_value = constants::fill_value<Real>;
   std::int64_t dt;
 
   const auto &f       = get_field_in(m_name);
@@ -77,7 +76,7 @@ void AtmBackTendDiag::compute_diagnostic_impl() {
   } else {
     // This is the first time we evaluate this diag. We cannot compute a tend
     // yet, so fill with an invalid value
-    m_diagnostic_output.deep_copy(var_fill_value);
+    m_diagnostic_output.deep_copy(constants::fill_value<Real>);
   }
 }
 

--- a/components/eamxx/src/diagnostics/field_at_pressure_level.hpp
+++ b/components/eamxx/src/diagnostics/field_at_pressure_level.hpp
@@ -37,8 +37,6 @@ protected:
 
   Real                m_pressure_level;
   int                 m_num_levs;
-  Real                m_mask_val;
-
 }; // class FieldAtPressureLevel
 
 } //namespace scream

--- a/components/eamxx/src/diagnostics/tests/aodvis_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/aodvis_test.cpp
@@ -32,8 +32,6 @@ TEST_CASE("aodvis") {
   using namespace ShortFieldTagsNames;
   using namespace ekat::units;
 
-  Real var_fill_value = constants::fill_value<Real>;
-
   Real some_limit = 0.0025;
 
   // A world comm
@@ -121,7 +119,7 @@ TEST_CASE("aodvis") {
 
     for(int icol = 0; icol < grid->get_num_local_dofs(); ++icol) {
       if(sun_h(icol) < some_limit) {
-        aod_t(icol) = var_fill_value;
+        aod_t(icol) = constants::fill_value<Real>;
       } else {
         for(int ilev = 0; ilev < nlevs; ++ilev) {
           aod_t(icol) += tau_h(icol, swvis, ilev);

--- a/components/eamxx/src/diagnostics/tests/atm_backtend_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/atm_backtend_test.cpp
@@ -65,8 +65,6 @@ TEST_CASE("atm_backtend") {
   REQUIRE_THROWS(diag_factory.create("AtmBackTendDiag", comm,
                                      params));  // No 'tendency_name'
 
-  Real var_fill_value = constants::fill_value<Real>;
-
   // Set time for qc and randomize its values
   qc.get_header().get_tracking().update_time_stamp(t0);
   randomize(qc, engine, pdf);
@@ -83,9 +81,9 @@ TEST_CASE("atm_backtend") {
   diag->compute_diagnostic();
   auto diag_f = diag->get_diagnostic();
 
-  // Check result: diag should be filled with var_fill_value
+  // Check result: diag should be filled with fill_value
   auto some_field = qc.clone();
-  some_field.deep_copy(var_fill_value);
+  some_field.deep_copy(constants::fill_value<Real>);
   REQUIRE(views_are_equal(diag_f, some_field));
 
   const Real a_day = 24.0 * 60.0 * 60.0;  // seconds

--- a/components/eamxx/src/diagnostics/tests/field_at_pressure_level_tests.cpp
+++ b/components/eamxx/src/diagnostics/tests/field_at_pressure_level_tests.cpp
@@ -104,7 +104,7 @@ TEST_CASE("field_at_pressure_level_p2")
       diag_f.sync_to_host();
       auto test2_diag_v = diag_f.get_view<const Real*, Host>();
       // Check the mask field inside the diag_f
-      auto mask_f = diag_f.get_header().get_extra_data<Field>("mask_data");
+      auto mask_f = diag_f.get_header().get_extra_data<Field>("mask_field");
       mask_f.sync_to_host();
       auto test2_mask_v = mask_f.get_view<const Real*, Host>();
       //
@@ -125,13 +125,12 @@ TEST_CASE("field_at_pressure_level_p2")
       diag_f.sync_to_host();
       auto test2_diag_v = diag_f.get_view<const Real*, Host>();
       // Check the mask field inside the diag_f
-      auto mask_f = diag_f.get_header().get_extra_data<Field>("mask_data");
+      auto mask_f = diag_f.get_header().get_extra_data<Field>("mask_field");
       mask_f.sync_to_host();
       auto test2_mask_v = mask_f.get_view<const Real*, Host>();
-      auto mask_val = diag_f.get_header().get_extra_data<Real>("mask_value");
-      //
+
       for (int icol=0;icol<ncols;icol++) {
-        REQUIRE(approx(test2_diag_v(icol),Real(mask_val)));
+        REQUIRE(approx(test2_diag_v(icol),constants::fill_value<Real>));
         REQUIRE(approx(test2_mask_v(icol),Real(0.0)));
       }
     }

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -344,21 +344,17 @@ void Nudging::run_impl (const double dt)
     const auto fl = f.get_header().get_identifier().get_layout();
     const auto v  = f.get_view<Real**>();
 
-    Real var_fill_value = constants::fill_value<Real>;
-    // Query the helper field for the fill value, if not present use default
-    if (f.get_header().has_extra_data("mask_value")) {
-      var_fill_value = f.get_header().get_extra_data<Real>("mask_value");
-    }
+    constexpr Real fill_value = constants::fill_value<Real>;
 
     const int ncols = fl.dim(0);
     const int nlevs = fl.dim(1);
-    const auto thresh = std::abs(var_fill_value)*0.0001;
+    const auto thresh = std::abs(fill_value)*0.0001;
     auto lambda = KOKKOS_LAMBDA(const int icol) {
       int first_good = nlevs;
       int last_good = -1;
       for (int k=0; k<nlevs; ++k) {
-        if (std::abs(v(icol,k)-var_fill_value)>thresh) {
-          // This entry is substantially different from var_fill_value, so it's good
+        if (std::abs(v(icol,k)-fill_value)>thresh) {
+          // This entry is substantially different from fill_value, so it's good
           first_good = ekat::impl::min(first_good,k);
           last_good  = ekat::impl::max(last_good,k);
         }

--- a/components/eamxx/src/physics/nudging/tests/nudging_tests_helpers.hpp
+++ b/components/eamxx/src/physics/nudging/tests/nudging_tests_helpers.hpp
@@ -13,7 +13,6 @@ constexpr int nlevs_data   = 20;
 constexpr int nsteps_data  = 5;
 constexpr int dt_data      = 100;
 constexpr int nlevs_filled = 2;
-constexpr double fill_val  = 1e30;
 
 util::TimeStamp get_t0 () {
   return  util::TimeStamp ({2000,1,1},{12,0,0});
@@ -89,27 +88,27 @@ void compute_field (Field f,
     const auto f_h = f.get_view<Real**, Host>();
     for (int icol=0;icol<ncols;++icol) {
       for (int ilev=0; ilev<lev_beg; ++ilev) {
-        f_h(icol,ilev) = fill_val;
+        f_h(icol,ilev) = constants::fill_value<Real>;
       }
       for (int ilev=lev_beg;ilev<lev_end;++ilev) {
         f_h(icol,ilev) = step + (offset+icol)*nlevs + ilev + 1;
       }
       for (int ilev=lev_end; ilev<nlevs; ++ilev) {
-        f_h(icol,ilev) = fill_val;
+        f_h(icol,ilev) = constants::fill_value<Real>;
       }
     }
   } else {
     const auto f_h = f.get_view<Real***, Host>();
     for (int icol=0;icol<ncols;++icol) {
       for (int ilev=0; ilev<lev_beg; ++ilev) {
-        f_h(icol,0,ilev) = f_h(icol,1,ilev) = fill_val;
+        f_h(icol,0,ilev) = f_h(icol,1,ilev) = constants::fill_value<Real>;
       }
       for (int ilev=lev_beg;ilev<lev_end;++ilev) {
         f_h(icol,0,ilev) = step + (offset+icol)*2*nlevs + ilev + 1;
         f_h(icol,1,ilev) = step + (offset+icol)*2*nlevs + ilev + 1;
       }
       for (int ilev=lev_end; ilev<nlevs; ++ilev) {
-        f_h(icol,0,ilev) = f_h(icol,1,ilev) = fill_val;
+        f_h(icol,0,ilev) = f_h(icol,1,ilev) = constants::fill_value<Real>;
       }
     }
   }
@@ -150,7 +149,6 @@ create_om (const std::string& filename_prefix,
   params.set<std::string>("filename_prefix",filename_prefix);
   params.set<std::string>("floating_point_precision","real");
   params.set("field_names",strvec_t{"p_mid","U","V"});
-  params.set("fill_value",fill_val);
 
   auto& ctrl_pl = params.sublist("output_control");
   ctrl_pl.set<std::string>("frequency_units","nsteps");

--- a/components/eamxx/src/share/field/field_header.hpp
+++ b/components/eamxx/src/share/field/field_header.hpp
@@ -87,6 +87,9 @@ public:
   //   - they have the same tracking, alloc_prop and extra data (they were created by alias above)
   //   - they have the same parent field and their subview info (form alloc prop) are the same
   bool is_aliasing (const FieldHeader& rhs) const;
+
+  bool may_be_filled () const { return has_extra_data("may_be_filled") and get_extra_data<bool>("may_be_filled"); }
+  void set_may_be_filled (const bool value) { set_extra_data("may_be_filled",value); }
 protected:
 
   // Friend this function, so it can set up a subfield header

--- a/components/eamxx/src/share/field/field_impl_details.hpp
+++ b/components/eamxx/src/share/field/field_impl_details.hpp
@@ -10,7 +10,7 @@ namespace scream
 
 namespace details {
 
-template<CombineMode CM, bool use_fill, typename LhsView, typename RhsView, typename ST>
+template<CombineMode CM, bool FillAware, typename LhsView, typename RhsView, typename ST>
 struct CombineViewsHelper {
 
   using exec_space = typename LhsView::traits::execution_space;
@@ -52,77 +52,54 @@ struct CombineViewsHelper {
 
   KOKKOS_INLINE_FUNCTION
   void operator() (int i) const {
-    if constexpr (use_fill)
-      if constexpr (N==0)
-        fill_aware_combine<CM>(rhs(),lhs(),fill_val,alpha,beta);
-      else
-        fill_aware_combine<CM>(rhs(i),lhs(i),fill_val,alpha,beta);
+    if constexpr (N==0)
+      combine<CM,FillAware>(rhs(),lhs(),alpha,beta);
     else
-      if constexpr (N==0)
-        combine<CM>(rhs(),lhs(),alpha,beta);
-      else
-        combine<CM>(rhs(i),lhs(i),alpha,beta);
+      combine<CM,FillAware>(rhs(i),lhs(i),alpha,beta);
   }
 
   KOKKOS_INLINE_FUNCTION
   void operator() (int i, int j) const {
-    if constexpr (use_fill)
-      fill_aware_combine<CM>(rhs(i,j),lhs(i,j),fill_val,alpha,beta);
-    else
-      combine<CM>(rhs(i,j),lhs(i,j),alpha,beta);
+    combine<CM,FillAware>(rhs(i,j),lhs(i,j),alpha,beta);
   }
 
   KOKKOS_INLINE_FUNCTION
   void operator() (int i, int j, int k) const {
-    if constexpr (use_fill)
-      fill_aware_combine<CM>(rhs(i,j,k),lhs(i,j,k),fill_val,alpha,beta);
-    else
-      combine<CM>(rhs(i,j,k),lhs(i,j,k),alpha,beta);
+    combine<CM,FillAware>(rhs(i,j,k),lhs(i,j,k),alpha,beta);
   }
 
   KOKKOS_INLINE_FUNCTION
   void operator() (int i, int j, int k, int l) const {
-    if constexpr (use_fill)
-      fill_aware_combine<CM>(rhs(i,j,k,l),lhs(i,j,k,l),fill_val,alpha,beta);
-    else
-      combine<CM>(rhs(i,j,k,l),lhs(i,j,k,l),alpha,beta);
+    combine<CM,FillAware>(rhs(i,j,k,l),lhs(i,j,k,l),alpha,beta);
   }
 
   KOKKOS_INLINE_FUNCTION
   void operator() (int i, int j, int k, int l, int m) const {
-    if constexpr (use_fill)
-      fill_aware_combine<CM>(rhs(i,j,k,l,m),lhs(i,j,k,l,m),fill_val,alpha,beta);
-    else
-      combine<CM>(rhs(i,j,k,l,m),lhs(i,j,k,l,m),alpha,beta);
+    combine<CM,FillAware>(rhs(i,j,k,l,m),lhs(i,j,k,l,m),alpha,beta);
   }
 
   KOKKOS_INLINE_FUNCTION
   void operator() (int i, int j, int k, int l, int m, int n) const {
-    if constexpr (use_fill)
-      fill_aware_combine<CM>(rhs(i,j,k,l,m,n),lhs(i,j,k,l,m,n),fill_val,alpha,beta);
-    else
-      combine<CM>(rhs(i,j,k,l,m,n),lhs(i,j,k,l,m,n),alpha,beta);
+    combine<CM,FillAware>(rhs(i,j,k,l,m,n),lhs(i,j,k,l,m,n),alpha,beta);
   }
 
   ST alpha;
   ST beta;
   LhsView lhs;
   RhsView rhs;
-  typename LhsView::traits::value_type fill_val;
 };
 
-template<CombineMode CM, bool use_fill, typename LhsView, typename RhsView, typename ST>
+template<CombineMode CM, bool FillAware, typename LhsView, typename RhsView, typename ST>
 void
 cvh (LhsView lhs, RhsView rhs,
-     ST alpha, ST beta, typename RhsView::traits::value_type fill_val,
+     ST alpha, ST beta,
      const std::vector<int>& dims)
 {
-  CombineViewsHelper <CM, use_fill, LhsView, RhsView,  ST> helper;
+  CombineViewsHelper <CM, FillAware, LhsView, RhsView,  ST> helper;
   helper.lhs = lhs;
   helper.rhs = rhs;
   helper.alpha = alpha;
   helper.beta = beta;
-  helper.fill_val = fill_val;
   helper.run(dims);
 }
 

--- a/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
@@ -85,15 +85,6 @@ set_extrapolation_type (const ExtrapType etype, const TopBot where)
 }
 
 void VerticalRemapper::
-set_mask_value (const Real mask_val)
-{
-  EKAT_REQUIRE_MSG (not Kokkos::isnan(mask_val),
-      "[VerticalRemapper::set_mask_value] Error! Input mask value must be a valid number.\n");
-
-  m_mask_val = mask_val;
-}
-
-void VerticalRemapper::
 set_source_pressure (const Field& p, const ProfileType ptype)
 {
   set_pressure (p, "source", ptype);
@@ -230,33 +221,28 @@ registration_ends_impl ()
           }
         }
 
-        EKAT_REQUIRE_MSG(not tgt.get_header().has_extra_data("mask_data"),
+        EKAT_REQUIRE_MSG(not tgt.get_header().has_extra_data("mask_field"),
             "[VerticalRemapper::registration_ends_impl] Error! Target field already has mask data assigned.\n"
-            " - tgt field name: " + tgt.name() + "\n");
-        EKAT_REQUIRE_MSG(not tgt.get_header().has_extra_data("mask_value"),
-            "[VerticalRemapper::registration_ends_impl] Error! Target field already has mask value assigned.\n"
             " - tgt field name: " + tgt.name() + "\n");
 
-        tgt.get_header().set_extra_data("mask_data",tgt_mask);
-        tgt.get_header().set_extra_data("mask_value",m_mask_val);
+        tgt.get_header().set_extra_data("mask_field",tgt_mask);
+
+        // Since we do mask (at top and/or bot), the tgt field MAY be contain fill_value entries
+        tgt.get_header().set_may_be_filled(true);
       }
     } else {
-      // If a field does not have LEV or ILEV it may still have mask tracking assigned from somewhere else.
+      // If a field does not have LEV or ILEV it may still have fill_value tracking assigned from somewhere else.
       // For instance, this could be a 2d field computed by FieldAtPressureLevel diagnostic.
-      // In those cases we want to copy that mask tracking to the target field.
-      if (src.get_header().has_extra_data("mask_data")) {
-        EKAT_REQUIRE_MSG(not tgt.get_header().has_extra_data("mask_data"),
+      // In those cases we want to copy that fill_value tracking to the target field.
+      if (src.get_header().has_extra_data("mask_field")) {
+        EKAT_REQUIRE_MSG(not tgt.get_header().has_extra_data("mask_field"),
             "[VerticalRemapper::registration_ends_impl] Error! Target field already has mask data assigned.\n"
             " - tgt field name: " + tgt.name() + "\n");
-        auto src_mask = src.get_header().get_extra_data<Field>("mask_data");
-        tgt.get_header().set_extra_data("mask_data",src_mask);
+        auto src_mask = src.get_header().get_extra_data<Field>("mask_field");
+        tgt.get_header().set_extra_data("mask_field",src_mask);
       }
-      if (src.get_header().has_extra_data("mask_value")) {
-        EKAT_REQUIRE_MSG(not tgt.get_header().has_extra_data("mask_value"),
-            "[VerticalRemapper::registration_ends_impl] Error! Target field already has mask value assigned.\n"
-            " - tgt field name: " + tgt.name() + "\n");
-        auto src_mask_val = src.get_header().get_extra_data<Real>("mask_value");
-        tgt.get_header().set_extra_data("mask_value",src_mask_val);
+      if (src.get_header().may_be_filled()) {
+        tgt.get_header().set_may_be_filled(true);
       }
     }
   }
@@ -427,23 +413,23 @@ void VerticalRemapper::remap_fwd_impl ()
         } else {
           apply_vertical_interpolation(*m_lin_interp_mid_scalar,f_src,f_tgt,m_src_pmid,m_tgt_pmid);
         }
-        extrapolate(f_src,f_tgt,m_src_pmid,m_tgt_pmid,m_mask_val);
+        extrapolate(f_src,f_tgt,m_src_pmid,m_tgt_pmid);
       } else {
         if (type.packed) {
           apply_vertical_interpolation(*m_lin_interp_int_packed,f_src,f_tgt,m_src_pint,m_tgt_pint);
         } else {
           apply_vertical_interpolation(*m_lin_interp_int_scalar,f_src,f_tgt,m_src_pint,m_tgt_pint);
         }
-        extrapolate(f_src,f_tgt,m_src_pint,m_tgt_pint,m_mask_val);
+        extrapolate(f_src,f_tgt,m_src_pint,m_tgt_pint);
       }
     } else {
       // There is nothing to do, this field does not need vertical interpolation,
       // so just copy it over.  Note, if this field has its own mask data make
       // sure that is copied too.
       f_tgt.deep_copy(f_src);
-      if (f_tgt.get_header().has_extra_data("mask_data")) {
-        auto f_tgt_mask = f_tgt.get_header().get_extra_data<Field>("mask_data");
-        auto f_src_mask = f_src.get_header().get_extra_data<Field>("mask_data");
+      if (f_tgt.get_header().has_extra_data("mask_field")) {
+        auto f_tgt_mask = f_tgt.get_header().get_extra_data<Field>("mask_field");
+        auto f_src_mask = f_src.get_header().get_extra_data<Field>("mask_field");
         f_tgt_mask.deep_copy(f_src_mask);
       }
     }
@@ -462,14 +448,14 @@ void VerticalRemapper::remap_fwd_impl ()
       } else {
         apply_vertical_interpolation(*m_lin_interp_mid_scalar,f_src,f_tgt,m_src_pmid,m_tgt_pmid);
       }
-      extrapolate(f_src,f_tgt,m_src_pmid,m_tgt_pmid,0);
+      extrapolate(f_src,f_tgt,m_src_pmid,m_tgt_pmid);
     } else {
       if (type.packed) {
         apply_vertical_interpolation(*m_lin_interp_int_packed,f_src,f_tgt,m_src_pint,m_tgt_pint);
       } else {
         apply_vertical_interpolation(*m_lin_interp_int_scalar,f_src,f_tgt,m_src_pint,m_tgt_pint);
       }
-      extrapolate(f_src,f_tgt,m_src_pint,m_tgt_pint,0);
+      extrapolate(f_src,f_tgt,m_src_pint,m_tgt_pint);
     }
   }
 }
@@ -621,13 +607,14 @@ void VerticalRemapper::
 extrapolate (const Field& f_src,
              const Field& f_tgt,
              const Field& p_src,
-             const Field& p_tgt,
-             const Real mask_val) const
+             const Field& p_tgt) const
 {
   using TPF = ekat::TeamPolicyFactory<DefaultDevice::execution_space>;
 
   using view2d = typename KokkosTypes<DefaultDevice>::view<const Real**>;
   using view1d = typename KokkosTypes<DefaultDevice>::view<const Real*>;
+
+  constexpr auto fill_val = constants::fill_value<Real>;
 
   auto src1d = p_src.rank()==1;
   auto tgt1d = p_tgt.rank()==1;
@@ -686,7 +673,7 @@ extrapolate (const Field& f_src,
               if (ebot==P0) {
                 y_tgt[ilev] = y_src[nlevs_src-1];
               } else {
-                y_tgt[ilev] = mask_val;
+                y_tgt[ilev] = fill_val;
               }
             }
           } else {
@@ -695,7 +682,7 @@ extrapolate (const Field& f_src,
               if (etop==P0) {
                 y_tgt[ilev] = y_src[0];
               } else {
-                y_tgt[ilev] = mask_val;
+                y_tgt[ilev] = fill_val;
               }
             }
           }
@@ -737,7 +724,7 @@ extrapolate (const Field& f_src,
               if (ebot==P0) {
                 y_tgt[ilev] = y_src[nlevs_src-1];
               } else {
-                y_tgt[ilev] = mask_val;
+                y_tgt[ilev] = fill_val;
               }
             }
           } else {
@@ -746,7 +733,7 @@ extrapolate (const Field& f_src,
               if (etop==P0) {
                 y_tgt[ilev] = y_src[0];
               } else {
-                y_tgt[ilev] = mask_val;
+                y_tgt[ilev] = fill_val;
               }
             }
           }

--- a/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.cpp
@@ -160,8 +160,7 @@ registration_ends_impl ()
     const auto& src = m_src_fields[i];
           auto& tgt = m_tgt_fields[i];
 
-    // Clone src layout, since we may strip dims later for mask creation
-    auto src_layout = src.get_header().get_identifier().get_layout().clone();
+    const auto& src_layout = src.get_header().get_identifier().get_layout().clone();
 
     if (src_layout.has_tag(LEV) or src_layout.has_tag(ILEV)) {
       // Determine if this field can be handled with packs, and whether it's at midpoints
@@ -185,47 +184,30 @@ registration_ends_impl ()
         // NOTE: for now we assume that masking is determined only by the COL,LEV location in space
         //       and that fields with multiple components will have the same masking for each component
         //       at a specific COL,LEV
-        src_layout.strip_dims({CMP});
+
+        auto src_layout_no_cmp = src_layout.clone();
+        src_layout_no_cmp.strip_dims({CMP});
+        auto tgt_layout = create_tgt_layout(src_layout_no_cmp);
 
         // I this mask has already been created, retrieve it, otherwise create it
-        const auto mask_name = m_tgt_grid->name() + "_" + ekat::join(src_layout.names(),"_") + "_mask";
-        Field tgt_mask;
-        if (m_field2type.count(mask_name)==0) {
+        // CAVEAT: the tgt layout ALWAYS has LEV as vertical dim tag. But we NEED different masks for
+        // src fields defined at LEV and ILEV. So use src_layout_no_cmp to craft the mask name
+        const auto mask_name = m_tgt_grid->name() + "_" + ekat::join(src_layout_no_cmp.names(),"_") + "_mask";
+        auto& mask = m_masks[mask_name];
+        if (not mask.is_allocated()) {
           auto nondim = ekat::units::Units::nondimensional();
           // Create this src/tgt mask fields, and assign them to these src/tgt fields extra data
 
-          FieldIdentifier src_mask_fid (mask_name, src_layout, nondim, m_src_grid->name() );
-          FieldIdentifier tgt_mask_fid = create_tgt_fid(src_mask_fid);
-
-          Field src_mask (src_mask_fid);
-          src_mask.allocate_view();
-
-          tgt_mask  = Field (tgt_mask_fid);
-          tgt_mask.allocate_view();
-
-          // Initialize the src mask values to 1.0
-          src_mask.deep_copy(1.0);
-
-          m_src_masks.push_back(src_mask);
-          m_tgt_masks.push_back(tgt_mask);
-
-          auto& mt = m_field2type[src_mask_fid.name()];
-          mt.packed = false;
-          mt.midpoints = src_layout.has_tag(LEV);
-        } else {
-          for (size_t i=0; i<m_tgt_masks.size(); ++i) {
-            if (m_tgt_masks[i].name()==mask_name) {
-              tgt_mask = m_tgt_masks[i];
-              break;
-            }
-          }
+          FieldIdentifier mask_fid (mask_name, tgt_layout, nondim, m_tgt_grid->name() );
+          mask  = Field (mask_fid);
+          mask.allocate_view();
         }
 
         EKAT_REQUIRE_MSG(not tgt.get_header().has_extra_data("mask_field"),
             "[VerticalRemapper::registration_ends_impl] Error! Target field already has mask data assigned.\n"
             " - tgt field name: " + tgt.name() + "\n");
 
-        tgt.get_header().set_extra_data("mask_field",tgt_mask);
+        tgt.get_header().set_extra_data("mask_field",mask);
 
         // Since we do mask (at top and/or bot), the tgt field MAY be contain fill_value entries
         tgt.get_header().set_may_be_filled(true);
@@ -383,6 +365,8 @@ create_layout (const FieldLayout& from_layout,
 
 void VerticalRemapper::remap_fwd_impl ()
 {
+  using namespace ShortFieldTagsNames;
+
   // 1. Setup any interp object that was created (if nullptr, no fields need it)
   if (m_lin_interp_mid_packed) {
     setup_lin_interp(*m_lin_interp_mid_packed,m_src_pmid,m_tgt_pmid);
@@ -397,9 +381,12 @@ void VerticalRemapper::remap_fwd_impl ()
     setup_lin_interp(*m_lin_interp_int_scalar,m_src_pint,m_tgt_pint);
   }
 
-  using namespace ShortFieldTagsNames;
+  // 2. Init all masks fields (if any) to 1 (signaling no masked entries)
+  for (auto& [name, mask] : m_masks) {
+    mask.deep_copy(1);
+  }
 
-  // 2. Interpolate the fields
+  // 3. Interpolate the fields
   for (int i=0; i<m_num_fields; ++i) {
     const auto& f_src    = m_src_fields[i];
           auto& f_tgt    = m_tgt_fields[i];
@@ -435,29 +422,6 @@ void VerticalRemapper::remap_fwd_impl ()
     }
   }
 
-  // 3. Interpolate the mask fields
-  for (unsigned i=0; i<m_tgt_masks.size(); ++i) {
-          auto& f_src = m_src_masks[i];
-          auto& f_tgt = m_tgt_masks[i];
-    const auto& type = m_field2type.at(f_src.name());
-
-    // Dispatch interpolation to the proper lin interp object
-    if (type.midpoints) {
-      if (type.packed) {
-        apply_vertical_interpolation(*m_lin_interp_mid_packed,f_src,f_tgt,m_src_pmid,m_tgt_pmid);
-      } else {
-        apply_vertical_interpolation(*m_lin_interp_mid_scalar,f_src,f_tgt,m_src_pmid,m_tgt_pmid);
-      }
-      extrapolate(f_src,f_tgt,m_src_pmid,m_tgt_pmid);
-    } else {
-      if (type.packed) {
-        apply_vertical_interpolation(*m_lin_interp_int_packed,f_src,f_tgt,m_src_pint,m_tgt_pint);
-      } else {
-        apply_vertical_interpolation(*m_lin_interp_int_scalar,f_src,f_tgt,m_src_pint,m_tgt_pint);
-      }
-      extrapolate(f_src,f_tgt,m_src_pint,m_tgt_pint);
-    }
-  }
 }
 
 template<int Packsize>
@@ -641,6 +605,12 @@ extrapolate (const Field& f_src,
   auto etop = m_etype_top;
   auto ebot = m_etype_bot;
   auto mid = nlevs_tgt / 2;
+  auto do_mask = etop==Mask or ebot==Mask;
+  decltype(f_tgt.get_view<Real**>()) mask_v;
+  if (do_mask) {
+    mask_v = f_tgt.get_header().get_extra_data<Field>("mask_field").get_view<Real**>();
+  }
+
   switch(f_src.rank()) {
     case 2:
     {
@@ -674,6 +644,7 @@ extrapolate (const Field& f_src,
                 y_tgt[ilev] = y_src[nlevs_src-1];
               } else {
                 y_tgt[ilev] = fill_val;
+                mask_v(icol,ilev) = 0;
               }
             }
           } else {
@@ -683,6 +654,7 @@ extrapolate (const Field& f_src,
                 y_tgt[ilev] = y_src[0];
               } else {
                 y_tgt[ilev] = fill_val;
+                mask_v(icol,ilev) = 0;
               }
             }
           }
@@ -725,6 +697,7 @@ extrapolate (const Field& f_src,
                 y_tgt[ilev] = y_src[nlevs_src-1];
               } else {
                 y_tgt[ilev] = fill_val;
+                mask_v(icol,ilev) = 0;
               }
             }
           } else {
@@ -734,6 +707,7 @@ extrapolate (const Field& f_src,
                 y_tgt[ilev] = y_src[0];
               } else {
                 y_tgt[ilev] = fill_val;
+                mask_v(icol,ilev) = 0;
               }
             }
           }

--- a/components/eamxx/src/share/grid/remap/vertical_remapper.hpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.hpp
@@ -112,9 +112,8 @@ protected:
 
   ekat::Comm            m_comm;
 
-  // Source and target fields
-  std::vector<Field>    m_src_masks;
-  std::vector<Field>    m_tgt_masks;
+  // Tgt grid masks (in case extrap type at top or bot is Mask)
+  std::map<std::string,Field>    m_masks;
 
   // Vertical profile fields, both for source and target
   Field                 m_src_pmid;

--- a/components/eamxx/src/share/grid/remap/vertical_remapper.hpp
+++ b/components/eamxx/src/share/grid/remap/vertical_remapper.hpp
@@ -47,7 +47,6 @@ public:
   ~VerticalRemapper () = default;
 
   void set_extrapolation_type (const ExtrapType etype, const TopBot where = TopAndBot);
-  void set_mask_value (const Real mask_val);
 
   void set_source_pressure (const Field& p, const ProfileType ptype);
   void set_target_pressure (const Field& p, const ProfileType ptype);
@@ -95,8 +94,7 @@ public:
                                      const Field& p_src, const Field& p_tgt) const;
 
   void extrapolate (const Field& f_src, const Field& f_tgt,
-                    const Field& p_src, const Field& p_tgt,
-                    const Real mask_val) const;
+                    const Field& p_src, const Field& p_tgt) const;
 
   template<int N>
   void setup_lin_interp (const ekat::LinInterp<Real,N>& lin_interp,
@@ -135,7 +133,6 @@ protected:
   // Extrapolation settings at top/bottom. Default to P0 extrapolation
   ExtrapType            m_etype_top = P0;
   ExtrapType            m_etype_bot = P0;
-  Real                  m_mask_val = std::numeric_limits<Real>::quiet_NaN();
 
   // We need to remap mid/int fields separately, and we want to use packs if possible,
   // so we need to divide input fields into 4 separate categories

--- a/components/eamxx/src/share/io/scorpio_output.hpp
+++ b/components/eamxx/src/share/io/scorpio_output.hpp
@@ -219,13 +219,6 @@ protected:
 
   DefaultMetadata                       m_default_metadata;
 
-  // Use float, so that if output fp_precision=float, this is a representable value.
-  // Otherwise, you would get an error from Netcdf, like
-  //   NetCDF: Numeric conversion not representable
-  // Also, by default, don't pick max float, to avoid any overflow if the value
-  // is used inside other calculation and/or remap.
-  float m_fill_value = constants::fill_value<float>;
-
   bool m_add_time_dim;
   bool m_track_avg_cnt = false;
   std::string m_decomp_dimname = "";

--- a/components/eamxx/src/share/io/tests/io_filled.cpp
+++ b/components/eamxx/src/share/io/tests/io_filled.cpp
@@ -100,6 +100,7 @@ get_fm (const std::shared_ptr<const AbstractGrid>& grid,
     f.allocate_view();
     f.deep_copy(0.0); // For the "filled" field we start with a filled value.
     f.get_header().get_tracking().update_time_stamp(t0);
+    f.get_header().set_may_be_filled(true);
     fm->add_field(f);
   }
 

--- a/components/eamxx/src/share/io/tests/io_filled.cpp
+++ b/components/eamxx/src/share/io/tests/io_filled.cpp
@@ -26,7 +26,7 @@
 namespace scream {
 
 constexpr int num_output_steps = 5;
-constexpr Real FillValue = constants::fill_value<Real>;
+constexpr Real fill_value = constants::fill_value<Real>;
 constexpr Real fill_threshold = 0.5;
 
 void set (const Field& f, const double v) {
@@ -100,7 +100,6 @@ get_fm (const std::shared_ptr<const AbstractGrid>& grid,
     f.allocate_view();
     f.deep_copy(0.0); // For the "filled" field we start with a filled value.
     f.get_header().get_tracking().update_time_stamp(t0);
-    f.get_header().set_extra_data("mask_value",FillValue);
     fm->add_field(f);
   }
 
@@ -131,7 +130,6 @@ void write (const std::string& avg_type, const std::string& freq_units,
   om_pl.set("filename_prefix",std::string("io_filled"));
   om_pl.set("field_names",fnames);
   om_pl.set("averaging_type", avg_type);
-  om_pl.set<double>("fill_value",FillValue);
   om_pl.set<Real>("fill_threshold",fill_threshold);
   om_pl.set("track_avg_cnt",true);
   auto& ctrl_pl = om_pl.sublist("output_control");
@@ -152,10 +150,10 @@ void write (const std::string& avg_type, const std::string& freq_units,
     // Update time
     t += dt;
 
-    // Set fields to n+1 or the FillValue, depending on step:
+    // Set fields to n+1 or the fill_value, depending on step:
     //  - n+1 if n+1 is odd
-    //  - FillValue if n+1 is even
-    Real setval = ((n+1) % 2 == 0) ? 1.0*(n+1) : FillValue;
+    //  - fill_value if n+1 is even
+    Real setval = ((n+1) % 2 == 0) ? 1.0*(n+1) : fill_value;
     for (const auto& n : fnames) {
       auto f = fm->get_field(n);
       set(f,setval);
@@ -206,7 +204,7 @@ void read (const std::string& avg_type, const std::string& freq_units,
   reader_pl.set("field_names",fnames);
   AtmosphereInput reader(reader_pl,fm);
 
-  // We set the value n to each input field for each odd valued timestep and FillValue for each even valued timestep
+  // We set the value n to each input field for each odd valued timestep and fill_value for each even valued timestep
   // Hence, at output step N = snap*freq, we should get
   //  avg=INSTANT: output = N if (N%2=0), else Fillvalue
   //  avg=MAX:     output = N if (N%2=0), else N-1
@@ -232,7 +230,7 @@ void read (const std::string& avg_type, const std::string& freq_units,
         set(f0,test_val);
         REQUIRE (views_are_equal(f,f0));
       } else if (avg_type=="INSTANT") {
-        Real test_val = (n*freq%2==0) ? n*freq : FillValue;
+        Real test_val = (n*freq%2==0) ? n*freq : fill_value;
         set(f0,test_val);
         REQUIRE (views_are_equal(f,f0));
       } else { // Is avg_type = AVERAGE
@@ -243,7 +241,7 @@ void read (const std::string& avg_type, const std::string& freq_units,
         Real test_val;
         Real M = freq/2 + (n%2==0 ? 0.0 :  1.0);
         Real a = n*freq + (n%2==0 ? 0.0 : -1.0);
-        test_val = (M/freq > fill_threshold) ? a + (M+1.0) : FillValue;
+        test_val = (M/freq > fill_threshold) ? a + (M+1.0) : fill_value;
         set(f0,test_val);
         REQUIRE (views_are_equal(f,f0));
       }

--- a/components/eamxx/src/share/io/tests/io_remap_test.cpp
+++ b/components/eamxx/src/share/io/tests/io_remap_test.cpp
@@ -675,7 +675,6 @@ ekat::ParameterList set_output_params(const std::string& name, const std::string
 
   params.set<std::string>("filename_prefix",name);
   params.set<std::string>("averaging_type","instant");
-  params.set<int>("max_snapshots_per_file",1);
   params.set<std::string>("floating_point_precision","real");
   auto& oc = params.sublist("output_control");
   oc.set<int>("frequency",1);

--- a/components/eamxx/src/share/io/tests/io_remap_test.cpp
+++ b/components/eamxx/src/share/io/tests/io_remap_test.cpp
@@ -16,6 +16,7 @@ namespace {
 using namespace scream;
 
 constexpr int packsize = SCREAM_SMALL_PACK_SIZE;
+constexpr Real fill_val = constants::fill_value<Real>;
 using         Pack     = ekat::Pack<Real,packsize>;
 using stratts_t = std::map<std::string,std::string>;
 
@@ -284,8 +285,6 @@ TEST_CASE("io_remap_test","io_remap_test")
   //                                    ---  Vertical Remapping ---
   {
     // Note, the vertical remapper defaults to a mask value of std numeric limits scaled by 0.1;
-    const float mask_val = vert_remap_control.isParameter("Fill Value")
-                         ? vert_remap_control.get<double>("Fill Value") : constants::fill_value<Real>;
     print ("    -> vertical remap ... \n",io_comm);
     auto gm_vert   = get_test_gm(io_comm,ncols_src,nlevs_tgt);
     auto grid_vert = gm_vert->get_grid("point_grid");
@@ -332,7 +331,7 @@ TEST_CASE("io_remap_test","io_remap_test")
 
     for (int ii=0; ii<ncols_src_l; ii++) {
       const bool ref_masked = (p_ref>pi_v(ii,nlevs_src) || p_ref<pi_v(ii,0));
-      const Real test_val = ref_masked ? mask_val : calculate_output(p_ref,ii,0);
+      const Real test_val = ref_masked ? fill_val : calculate_output(p_ref,ii,0);
       REQUIRE(approx(Ys_v_vert(ii),test_val));
 
       REQUIRE(approx(Yf_v_vert(ii), Yf_v(ii)));
@@ -340,11 +339,11 @@ TEST_CASE("io_remap_test","io_remap_test")
         auto p_jj = p_tgt[jj];
         const bool mid_masked = (p_jj>pm_v(ii,nlevs_src-1) || p_jj<pm_v(ii,0));
         const bool int_masked = (p_jj>pi_v(ii,nlevs_src)   || p_jj<pi_v(ii,0));
-        REQUIRE(approx(Ym_v_vert(ii,jj),(mid_masked ? mask_val : calculate_output(p_jj,ii,0))));
-        REQUIRE(approx(Yi_v_vert(ii,jj),(int_masked ? mask_val : calculate_output(p_jj,ii,0))));
+        REQUIRE(approx(Ym_v_vert(ii,jj),(mid_masked ? fill_val : calculate_output(p_jj,ii,0))));
+        REQUIRE(approx(Yi_v_vert(ii,jj),(int_masked ? fill_val : calculate_output(p_jj,ii,0))));
         for (int cc=0; cc<2; cc++) {
-          REQUIRE(approx(Vm_v_vert(ii,cc,jj), (mid_masked ? mask_val : calculate_output(p_jj,ii,cc+1))));
-          REQUIRE(approx(Vi_v_vert(ii,cc,jj), (int_masked ? mask_val : calculate_output(p_jj,ii,cc+1))));
+          REQUIRE(approx(Vm_v_vert(ii,cc,jj), (mid_masked ? fill_val : calculate_output(p_jj,ii,cc+1))));
+          REQUIRE(approx(Vi_v_vert(ii,cc,jj), (int_masked ? fill_val : calculate_output(p_jj,ii,cc+1))));
         }
       }
     }
@@ -354,8 +353,6 @@ TEST_CASE("io_remap_test","io_remap_test")
   //                                    ---  Horizontal Remapping ---
   {
     // Note, the vertical remapper defaults to a mask value of std numeric limits scaled by 0.1;
-    const float mask_val = horiz_remap_control.isParameter("Fill Value")
-                         ? horiz_remap_control.get<double>("Fill Value") : constants::fill_value<Real>;
     print ("    -> horizontal remap ... \n",io_comm);
     auto gm_horiz   = get_test_gm(io_comm,ncols_tgt,nlevs_src);
     auto grid_horiz = gm_horiz->get_grid("point_grid");
@@ -431,7 +428,7 @@ TEST_CASE("io_remap_test","io_remap_test")
       if (found) {
         Ys_exp /= Ys_wgt;
       } else {
-        Ys_exp = mask_val;
+        Ys_exp = fill_val;
       }
       REQUIRE(approx(Ys_v_horiz(ii), Ys_exp));
     }
@@ -440,8 +437,6 @@ TEST_CASE("io_remap_test","io_remap_test")
   // ------------------------------------------------------------------------------------------------------
   //                                ---  Vertical + Horizontal Remapping ---
   {
-    const float mask_val = vert_horiz_remap_control.isParameter("Fill Value")
-                         ? vert_horiz_remap_control.get<double>("Fill Value") : constants::fill_value<Real>;
     print ("    -> vertical + horizontal remap ... \n",io_comm);
     auto gm_vh   = get_test_gm(io_comm,ncols_tgt,nlevs_tgt);
     auto grid_vh = gm_vh->get_grid("point_grid");
@@ -502,13 +497,13 @@ TEST_CASE("io_remap_test","io_remap_test")
           test_mid = (mid_mask_1*calculate_output(p_jj,col1,0)*wgt + mid_mask_2*calculate_output(p_jj,col2,0)*(1-wgt))/(mid_mask_1*wgt + mid_mask_2*(1-wgt));
         } else {
           // This point is completely masked out, assign masked value
-          test_mid = mask_val;
+          test_mid = fill_val;
         }
         if (int_mask_1 + int_mask_2 > 0.0) {
           test_int = (int_mask_1*calculate_output(p_jj,col1,0)*wgt + int_mask_2*calculate_output(p_jj,col2,0)*(1-wgt))/(int_mask_1*wgt + int_mask_2*(1-wgt));
         } else {
           // This point is completely masked out, assign masked value
-          test_int = mask_val;
+          test_int = fill_val;
         }
         REQUIRE(approx(Ym_v_vh(ii,jj), test_mid));
         REQUIRE(approx(Yi_v_vh(ii,jj), test_int));
@@ -517,13 +512,13 @@ TEST_CASE("io_remap_test","io_remap_test")
             test_mid = (mid_mask_1*calculate_output(p_jj,col1,cc+1)*wgt + mid_mask_2*calculate_output(p_jj,col2,cc+1)*(1-wgt))/(mid_mask_1*wgt + mid_mask_2*(1-wgt));
           } else {
             // This point is completely masked out, assign masked value
-            test_mid = mask_val;
+            test_mid = fill_val;
           }
           if (int_mask_1 + int_mask_2 > 0.0) {
             test_int = (int_mask_1*calculate_output(p_jj,col1,cc+1)*wgt + int_mask_2*calculate_output(p_jj,col2,cc+1)*(1-wgt))/(int_mask_1*wgt + int_mask_2*(1-wgt));
           } else {
             // This point is completely masked out, assign masked value
-            test_int = mask_val;
+            test_int = fill_val;
           }
           REQUIRE(approx(Vm_v_vh(ii,cc,jj), test_mid));
           REQUIRE(approx(Vi_v_vh(ii,cc,jj), test_int));
@@ -546,7 +541,7 @@ TEST_CASE("io_remap_test","io_remap_test")
       if (found) {
         Ys_exp /= Ys_wgt;
       } else {
-        Ys_exp = mask_val;
+        Ys_exp = fill_val;
       }
       REQUIRE(approx(Ys_v_vh(ii), Ys_exp));
     }

--- a/components/eamxx/src/share/io/tests/output_restart.cpp
+++ b/components/eamxx/src/share/io/tests/output_restart.cpp
@@ -25,7 +25,7 @@
 
 namespace scream {
 
-constexpr Real FillValue = constants::fill_value<Real>;
+constexpr Real fill_value = constants::fill_value<Real>;
 
 std::shared_ptr<FieldManager>
 get_test_fm(const std::shared_ptr<const AbstractGrid>& grid);
@@ -75,7 +75,6 @@ TEST_CASE("output_restart","io")
   ekat::ParameterList output_params;
   output_params.set<std::string>("floating_point_precision","real");
   output_params.set<std::vector<std::string>>("field_names",{"field_1", "field_2", "field_3", "field_4","field_5"});
-  output_params.set<double>("fill_value",FillValue);
   output_params.set<int>("flush_frequency",1);
   output_params.sublist("restart").set<bool>("force_new_file",false);
   output_params.sublist("output_control").set<std::string>("frequency_units","nsteps");
@@ -272,8 +271,8 @@ void time_advance (const FieldManager& fm,
                 if (fname == "field_5") {
                   // field_5 is used to test restarts w/ filled values, so
                   // we cycle between filled and unfilled states.
-                  v(i,j,k) = (v(i,j,k)==FillValue) ? dt :
-                    ( (v(i,j,k)==1.0) ? 2.0*dt : FillValue );
+                  v(i,j,k) = (v(i,j,k)==fill_value) ? dt :
+                    ( (v(i,j,k)==1.0) ? 2.0*dt : fill_value );
                 } else {
                               v(i,j,k) += dt;
                 }

--- a/components/eamxx/src/share/tests/combine_ops.cpp
+++ b/components/eamxx/src/share/tests/combine_ops.cpp
@@ -20,7 +20,6 @@ TEST_CASE ("combine_ops") {
   constexpr auto Divide    = CombineMode::Divide;
   constexpr auto Max       = CombineMode::Max;
   constexpr auto Min       = CombineMode::Min;
-  constexpr auto fv_val    = constants::fill_value<Real>;
 
   const pack_type two (2.0);
   const pack_type four (4.0);
@@ -37,7 +36,7 @@ TEST_CASE ("combine_ops") {
 
   combine<Update>(two,x,2.0,1.0);
   REQUIRE ( (x==six).all() );
-  fill_aware_combine<Update>(fv,x,fv_val,2.0,1.0);
+  combine<Update,true>(fv,x,2.0,1.0);
   if (not (x==six).all() ) {
     std::cout << "x: " << x << "\n";
     std::cout << " x[0]: " << std::setprecision(18) << x[0] << "\n";
@@ -48,26 +47,26 @@ TEST_CASE ("combine_ops") {
   x = two;
   combine<Multiply>(two,x,1,1);
   REQUIRE ( (x==four).all() );
-  fill_aware_combine<Multiply>(fv,x,fv_val,1,1);
+  combine<Multiply,true>(fv,x,1,1);
   REQUIRE ( (x==four).all() );
 
   x = four;
   combine<Divide>(two,x,1,1);
   REQUIRE ( (x==two).all() );
-  fill_aware_combine<Divide>(fv,x,fv_val,1,1);
+  combine<Divide,true>(fv,x,1,1);
   REQUIRE ( (x==two).all() );
 
   x = two;
   combine<Max>(four,x,1,1);
   REQUIRE ( (x==four).all() );
-  fill_aware_combine<Max>(fv,x,fv_val,1,1);
+  combine<Max,true>(fv,x,1,1);
   REQUIRE ( (x==four).all() );
 
   x = four;
   combine<Min>(two,x,1,1);
   REQUIRE ( (x==two).all() );
   x = fv_times_ten;
-  fill_aware_combine<Min>(fv,x,fv_val,1,1);
+  combine<Min,true>(fv,x,1,1);
   REQUIRE ( (x==fv_times_ten).all() );
 }
 

--- a/components/eamxx/src/share/tests/field_tests.cpp
+++ b/components/eamxx/src/share/tests/field_tests.cpp
@@ -890,7 +890,7 @@ TEST_CASE ("update") {
 
       // Check that updating with rhs==fill_value ignores the rhs
       f3.deep_copy(constants::fill_value<Real>);
-      f3.get_header().set_extra_data("mask_value",constants::fill_value<Real>);
+      f3.get_header().set_may_be_filled(true);
       f2.deep_copy(1.0);
       f2.max(f3);
       REQUIRE (views_are_equal(f2,one));
@@ -914,7 +914,7 @@ TEST_CASE ("update") {
 
       // Check that updating with rhs==fill_value ignores the rhs
       f3.deep_copy(constants::fill_value<int>);
-      f3.get_header().set_extra_data("mask_value",constants::fill_value<int>);
+      f3.get_header().set_may_be_filled(true);
       f2.deep_copy(1);
       f2.max(f3);
       REQUIRE (views_are_equal(f2,one));
@@ -969,7 +969,7 @@ TEST_CASE ("update") {
       one.deep_copy(1.0);
 
       f3.deep_copy(constants::fill_value<Real>);
-      f3.get_header().set_extra_data("mask_value",constants::fill_value<Real>);
+      f3.get_header().set_may_be_filled(true);
       f2.deep_copy(1.0);
       f2.update(f3,1,1);
       if (not views_are_equal(f2,one)) {
@@ -1001,7 +1001,7 @@ TEST_CASE ("update") {
       one.deep_copy(1);
 
       f3.deep_copy(constants::fill_value<int>);
-      f3.get_header().set_extra_data("mask_value",constants::fill_value<int>);
+      f3.get_header().set_may_be_filled(true);
       f2.deep_copy(1);
       f2.update(f3,1,1);
       REQUIRE (views_are_equal(f2,one));

--- a/components/eamxx/src/share/tests/vertical_remapper_tests.cpp
+++ b/components/eamxx/src/share/tests/vertical_remapper_tests.cpp
@@ -15,7 +15,7 @@ constexpr auto Mask = VerticalRemapper::Mask;
 constexpr auto Top = VerticalRemapper::Top;
 constexpr auto Bot = VerticalRemapper::Bot;
 constexpr auto TopBot = VerticalRemapper::TopAndBot;
-constexpr Real mask_val = -99999.0;
+constexpr Real fill_val = constants::fill_value<Real>;
 
 template<typename... Args>
 void print (const std::string& fmt, const ekat::Comm& comm, Args&&... args) {
@@ -174,9 +174,9 @@ void extrapolate (const Field& p_src, const Field& p_tgt, const Field& f,
         for (int j=0; j<nlevs; ++j) {
           auto p = pval(p1d_tgt,p2d_tgt,i,j,p_tgt.rank());
           if (p>pmax) {
-            v(i,j) = etype_bot==Mask ? mask_val : data_func(i,0,pmax);
+            v(i,j) = etype_bot==Mask ? fill_val : data_func(i,0,pmax);
           } else if (p<pmin) {
-            v(i,j) = etype_top==Mask ? mask_val : data_func(i,0,pmin);
+            v(i,j) = etype_top==Mask ? fill_val : data_func(i,0,pmin);
           }
       }}
     } break;
@@ -190,9 +190,9 @@ void extrapolate (const Field& p_src, const Field& p_tgt, const Field& f,
           for (int k=0; k<nlevs; ++k) {
             auto p = pval(p1d_tgt,p2d_tgt,i,k,p_tgt.rank());
             if (p>pmax) {
-              v(i,j,k) = etype_bot==Mask ? mask_val : data_func(i,j,pmax);
+              v(i,j,k) = etype_bot==Mask ? fill_val : data_func(i,j,pmax);
             } else if (p<pmin) {
-              v(i,j,k) = etype_top==Mask ? mask_val : data_func(i,j,pmin);
+              v(i,j,k) = etype_top==Mask ? fill_val : data_func(i,j,pmin);
             }
       }}}
     } break;
@@ -390,7 +390,6 @@ TEST_CASE ("vertical_remapper") {
 
   const Real ptop_src = 50;
   const Real pbot_src = 1000;
-  const Real mask_val = -99999.0;
 
   // Test tgt grid with 2x and 0.5x as many levels as src grid
   for (int nlevs_tgt : {nlevs_src/2, 2*nlevs_src}) {
@@ -455,8 +454,6 @@ TEST_CASE ("vertical_remapper") {
             remap->set_target_pressure (pmid_tgt, pint_tgt);
             remap->set_extrapolation_type(etype_top,Top);
             remap->set_extrapolation_type(etype_bot,Bot);
-            REQUIRE_THROWS (remap->set_mask_value(std::numeric_limits<Real>::quiet_NaN()));
-            remap->set_mask_value(mask_val); // Only needed if top and/or bot use etype=Mask
 
             remap->register_field(src_s2d,  tgt_s2d);
             remap->register_field(src_v2d,  tgt_v2d);

--- a/components/eamxx/src/share/tests/vertical_remapper_tests.cpp
+++ b/components/eamxx/src/share/tests/vertical_remapper_tests.cpp
@@ -48,7 +48,10 @@ build_grid(const ekat::Comm& comm, const int nldofs, const int nlevs)
 
 // Helper function to create fields
 Field
-create_field(const std::string& name, const std::shared_ptr<const AbstractGrid>& grid, const bool twod, const bool vec, const bool mid = false, const int ps = 1)
+create_field(const std::string& name,
+             const std::shared_ptr<const AbstractGrid>& grid,
+             const bool create_mask, const bool twod,
+             const bool vec, const bool mid = false, const int ps = 1)
 {
   using namespace ShortFieldTagsNames;
   constexpr int vec_dim = 3;
@@ -62,6 +65,15 @@ create_field(const std::string& name, const std::shared_ptr<const AbstractGrid>&
   Field f(fid);
   f.get_header().get_alloc_properties().request_allocation(ps);
   f.allocate_view();
+
+  if (create_mask) {
+    // Set a mask (1=filled, 0=valid) to be used in testing the results
+    FieldIdentifier mask_id("mask",fl,units,grid->name(),DataType::IntType);
+    Field mask(mask_id);
+    mask.allocate_view();
+    mask.deep_copy(0); // Init with "all good"
+    f.get_header().set_extra_data("mask",mask);
+  }
   return f;
 }
 
@@ -161,28 +173,43 @@ void extrapolate (const Field& p_src, const Field& p_tgt, const Field& f,
   const int ncols = l.dims().front();
   const int nlevs = l.dims().back();
   const int nlevs_src = p_src.get_header().get_identifier().get_layout().dims().back();
-  // print_field_hyperslab(p_src);
+  auto mask = f.get_header().get_extra_data<Field>("mask");
+
   switch (l.type()) {
     case LayoutType::Scalar2D: break;
     case LayoutType::Vector2D: break;
     case LayoutType::Scalar3D:
     {
       const auto v = f.get_view<Real**,Host>();
+      const auto m = mask.get_view<int**,Host>();
+
       for (int i=0; i<ncols; ++i) {
         auto pmin = pval(p1d_src,p2d_src,i,0,p_src.rank());
         auto pmax = pval(p1d_src,p2d_src,i,nlevs_src-1,p_src.rank());
         for (int j=0; j<nlevs; ++j) {
           auto p = pval(p1d_tgt,p2d_tgt,i,j,p_tgt.rank());
           if (p>pmax) {
-            v(i,j) = etype_bot==Mask ? fill_val : data_func(i,0,pmax);
+            if (etype_bot==Mask) {
+              v(i,j) = fill_val;
+              m(i,j) = 1;
+            } else {
+              v(i,j) = data_func(i,0,pmax);
+            }
           } else if (p<pmin) {
-            v(i,j) = etype_top==Mask ? fill_val : data_func(i,0,pmin);
+            if (etype_top==Mask) {
+              v(i,j) = fill_val;
+              m(i,j) = 1;
+            } else {
+              v(i,j) = data_func(i,0,pmin);
+            }
           }
       }}
     } break;
     case LayoutType::Vector3D:
     {
       const auto v = f.get_view<Real***,Host>();
+      const auto m = mask.get_view<int***,Host>();
+
       for (int i=0; i<ncols; ++i) {
         auto pmin = pval(p1d_src,p2d_src,i,0,p_src.rank());
         auto pmax = pval(p1d_src,p2d_src,i,nlevs_src-1,p_src.rank());
@@ -190,9 +217,19 @@ void extrapolate (const Field& p_src, const Field& p_tgt, const Field& f,
           for (int k=0; k<nlevs; ++k) {
             auto p = pval(p1d_tgt,p2d_tgt,i,k,p_tgt.rank());
             if (p>pmax) {
-              v(i,j,k) = etype_bot==Mask ? fill_val : data_func(i,j,pmax);
+              if (etype_bot==Mask) {
+                v(i,j,k) = fill_val;
+                m(i,j,k) = 1;
+              } else {
+                v(i,j,k) = data_func(i,j,pmax);
+              }
             } else if (p<pmin) {
-              v(i,j,k) = etype_top==Mask ? fill_val : data_func(i,j,pmin);
+              if (etype_top==Mask) {
+                v(i,j,k) = fill_val;
+                m(i,j,k) = 1;
+              } else {
+                v(i,j,k) = data_func(i,j,pmin);
+              }
             }
       }}}
     } break;
@@ -200,6 +237,8 @@ void extrapolate (const Field& p_src, const Field& p_tgt, const Field& f,
       EKAT_ERROR_MSG ("Unexpected layout.\n");
   }
   f.sync_to_dev();
+
+  mask.sync_to_dev();
 }
 
 // Helper function to create a remap file
@@ -422,26 +461,27 @@ TEST_CASE ("vertical_remapper") {
             print (" -> creating src/tgt pressure fields ... done!\n",comm);
 
             print (" -> creating fields ... done!\n",comm);
-            auto src_s2d   = create_field("s2d",  src_grid,true,false);
-            auto src_v2d   = create_field("v2d",  src_grid,true,true);
-            auto src_s3d_m = create_field("s3d_m",src_grid,false,false,true, 1);
-            auto src_s3d_i = create_field("s3d_i",src_grid,false,false,false,SCREAM_PACK_SIZE);
-            auto src_v3d_m = create_field("v3d_m",src_grid,false,true ,true, 1);
-            auto src_v3d_i = create_field("v3d_i",src_grid,false,true ,false,SCREAM_PACK_SIZE);
+            auto src_s2d   = create_field("s2d",  src_grid,false,true,false);
+            auto src_v2d   = create_field("v2d",  src_grid,false,true,true);
+            auto src_s3d_m = create_field("s3d_m",src_grid,false,false,false,true, 1);
+            auto src_s3d_i = create_field("s3d_i",src_grid,false,false,false,false,SCREAM_PACK_SIZE);
+            auto src_v3d_m = create_field("v3d_m",src_grid,false,false,true ,true, 1);
+            auto src_v3d_i = create_field("v3d_i",src_grid,false,false,true ,false,SCREAM_PACK_SIZE);
 
-            auto tgt_s2d   = create_field("s2d",  tgt_grid,true,false);
-            auto tgt_v2d   = create_field("v2d",  tgt_grid,true,true);
-            auto tgt_s3d_m = create_field("s3d_m",tgt_grid,false,false,true, 1);
-            auto tgt_s3d_i = create_field("s3d_i",tgt_grid,false,false,true, SCREAM_PACK_SIZE);
-            auto tgt_v3d_m = create_field("v3d_m",tgt_grid,false,true ,true, 1);
-            auto tgt_v3d_i = create_field("v3d_i",tgt_grid,false,true ,true, SCREAM_PACK_SIZE);
+            auto tgt_s2d   = create_field("s2d",  tgt_grid,false,true,false);
+            auto tgt_v2d   = create_field("v2d",  tgt_grid,false,true,true);
+            auto tgt_s3d_m = create_field("s3d_m",tgt_grid,false,false,false,true, 1);
+            auto tgt_s3d_i = create_field("s3d_i",tgt_grid,false,false,false,true, SCREAM_PACK_SIZE);
+            auto tgt_v3d_m = create_field("v3d_m",tgt_grid,false,false,true ,true, 1);
+            auto tgt_v3d_i = create_field("v3d_i",tgt_grid,false,false,true ,true, SCREAM_PACK_SIZE);
 
-            auto expected_s2d   = tgt_s2d.clone();
-            auto expected_v2d   = tgt_v2d.clone();
-            auto expected_s3d_m = tgt_s3d_m.clone();
-            auto expected_s3d_i = tgt_s3d_i.clone();
-            auto expected_v3d_m = tgt_v3d_m.clone();
-            auto expected_v3d_i = tgt_v3d_i.clone();
+            // For expected fields, also create the mask extra data
+            auto expected_s2d   = create_field("s2d",  tgt_grid,true,true,false);
+            auto expected_v2d   = create_field("v2d",  tgt_grid,true,true,true);
+            auto expected_s3d_m = create_field("s3d_m",tgt_grid,true,false,false,true, 1);
+            auto expected_s3d_i = create_field("s3d_i",tgt_grid,true,false,false,true, SCREAM_PACK_SIZE);
+            auto expected_v3d_m = create_field("v3d_m",tgt_grid,true,false,true ,true, 1);
+            auto expected_v3d_i = create_field("v3d_i",tgt_grid,true,false,true ,true, SCREAM_PACK_SIZE);
             print (" -> creating fields ... done!\n",comm);
 
             // -------------------------------------- //
@@ -510,43 +550,25 @@ TEST_CASE ("vertical_remapper") {
             using namespace Catch::Matchers;
             Real tol = 10*std::numeric_limits<Real>::epsilon();
 
+            auto check = [&](const Field& computed, Field& expected) {
+              auto diff = computed.clone("diff");
+              diff.update(expected,1,-1);
+
+              // Now set expected=0 where it's filled, so we can compute the norm
+              // (summing x[i]*x[i] would overflow in SP, causing NaN's)
+              auto mask = expected.get_header().get_extra_data<Field>("mask");
+              expected.deep_copy(0,mask);
+              auto ex_norm = frobenius_norm<Real>(expected);
+              REQUIRE (frobenius_norm<Real>(diff)<tol*ex_norm);
+            };
+
             print (" -> check tgt fields ...\n",comm);
-            {
-              auto diff = tgt_s2d.clone("diff");
-              auto ex_norm = frobenius_norm<Real>(expected_s2d);
-              diff.update(expected_s2d,1/ex_norm,-1/ex_norm);
-              REQUIRE (frobenius_norm<Real>(diff)<tol);
-            }
-            {
-              auto diff = tgt_v2d.clone("diff");
-              auto ex_norm = frobenius_norm<Real>(expected_v2d);
-              diff.update(expected_v2d,1/ex_norm,-1/ex_norm);
-              REQUIRE (frobenius_norm<Real>(diff)<tol);
-            }
-            {
-              auto diff = tgt_s3d_m.clone("diff");
-              auto ex_norm = frobenius_norm<Real>(expected_s3d_m);
-              diff.update(expected_s3d_m,1/ex_norm,-1/ex_norm);
-              REQUIRE (frobenius_norm<Real>(diff)<tol);
-            }
-            {
-              auto diff = tgt_s3d_i.clone("diff");
-              auto ex_norm = frobenius_norm<Real>(expected_s3d_i);
-              diff.update(expected_s3d_i,1/ex_norm,-1/ex_norm);
-              REQUIRE (frobenius_norm<Real>(diff)<tol);
-            }
-            {
-              auto diff = tgt_v3d_m.clone("diff");
-              auto ex_norm = frobenius_norm<Real>(expected_v3d_m);
-              diff.update(expected_v3d_m,1 / ex_norm,-1 / ex_norm);
-              REQUIRE (frobenius_norm<Real>(diff)<tol);
-            }
-            {
-              auto diff = tgt_v3d_i.clone("diff");
-              auto ex_norm = frobenius_norm<Real>(expected_v3d_i);
-              diff.update(expected_v3d_i,1 / ex_norm,-1 / ex_norm);
-              REQUIRE (frobenius_norm<Real>(diff)<tol);
-            }
+            check(tgt_s2d,expected_s2d);
+            check(tgt_v2d,expected_v2d);
+            check(tgt_s3d_m,expected_s3d_m);
+            check(tgt_v3d_m,expected_v3d_m);
+            check(tgt_s3d_i,expected_s3d_i);
+            check(tgt_v3d_i,expected_v3d_i);
             print (" -> check tgt fields ... done!\n",comm);
           }
         }

--- a/components/eamxx/src/share/tests/vertical_remapper_tests.cpp
+++ b/components/eamxx/src/share/tests/vertical_remapper_tests.cpp
@@ -68,11 +68,11 @@ create_field(const std::string& name,
 
   if (create_mask) {
     // Set a mask (1=filled, 0=valid) to be used in testing the results
-    FieldIdentifier mask_id("mask",fl,units,grid->name(),DataType::IntType);
+    FieldIdentifier mask_id("is_filled",fl,units,grid->name(),DataType::IntType);
     Field mask(mask_id);
     mask.allocate_view();
     mask.deep_copy(0); // Init with "all good"
-    f.get_header().set_extra_data("mask",mask);
+    f.get_header().set_extra_data("is_filled",mask);
   }
   return f;
 }
@@ -173,7 +173,7 @@ void extrapolate (const Field& p_src, const Field& p_tgt, const Field& f,
   const int ncols = l.dims().front();
   const int nlevs = l.dims().back();
   const int nlevs_src = p_src.get_header().get_identifier().get_layout().dims().back();
-  auto mask = f.get_header().get_extra_data<Field>("mask");
+  auto mask = f.get_header().get_extra_data<Field>("is_filled");
 
   switch (l.type()) {
     case LayoutType::Scalar2D: break;
@@ -556,7 +556,7 @@ TEST_CASE ("vertical_remapper") {
 
               // Now set expected=0 where it's filled, so we can compute the norm
               // (summing x[i]*x[i] would overflow in SP, causing NaN's)
-              auto mask = expected.get_header().get_extra_data<Field>("mask");
+              auto mask = expected.get_header().get_extra_data<Field>("is_filled");
               expected.deep_copy(0,mask);
               auto ex_norm = frobenius_norm<Real>(expected);
               REQUIRE (frobenius_norm<Real>(diff)<tol*ex_norm);

--- a/components/eamxx/src/share/util/eamxx_combine_ops.hpp
+++ b/components/eamxx/src/share/util/eamxx_combine_ops.hpp
@@ -46,90 +46,80 @@ enum class CombineMode {
 //    result = (op beta*result alpha*newVal) (where op can be +, *, /, max, min)
 // This routine should have no overhead compared to a manual
 // update (assuming you call it with the proper CM)
-
-template<CombineMode CM, typename ScalarIn, typename ScalarOut,
-         typename CoeffType = typename ekat::ScalarTraits<ScalarIn>::scalar_type>
-KOKKOS_FORCEINLINE_FUNCTION
-void combine (const ScalarIn& newVal, ScalarOut& result,
-              const CoeffType alpha, const CoeffType beta)
-{
-  using ekat::impl::max;
-  using ekat::impl::min;
-  switch (CM) {
-    case CombineMode::Replace:
-      result = alpha*newVal;
-      break;
-    case CombineMode::Update:
-      result *= beta;
-      result += alpha*newVal;
-      break;
-    case CombineMode::Multiply:
-      result *= (alpha*beta)*newVal;
-      break;
-    case CombineMode::Divide:
-      result /= (alpha/beta) * newVal;
-      break;
-    case CombineMode::Max:
-      result  = max(beta*result,static_cast<const ScalarOut&>(alpha*newVal));
-      break;
-    case CombineMode::Min:
-      result  = min(beta*result,static_cast<const ScalarOut&>(alpha*newVal));
-      break;
-  }
-}
-
-// Special version of combine that ignores newVal if newVal==fill_value.
-// Replace is the only combine mode that is allowed to consider fill_val values.
-// This is b/c it's the only way we can use this function inside Field method/utils
-// in order to set all entries of a Field to fill_val. You can also think of fill_val
-// as a special number for which the arithmetic operations are not defined.
-// All CM except for Replace involve an arithmetic op between of two numbers,
-// so combining with fill_val makes no sense. However, it makes sense to set
-// an output variable to fill_val.
-template<CombineMode CM, typename ScalarIn, typename ScalarOut,
-         typename CoeffType = typename ekat::ScalarTraits<ScalarIn>::scalar_type>
-KOKKOS_FORCEINLINE_FUNCTION
-std::enable_if_t<ekat::ScalarTraits<ScalarIn>::is_simd or
-                 ekat::ScalarTraits<ScalarOut>::is_simd>
-fill_aware_combine (const ScalarIn& newVal, ScalarOut& result,
-                    const typename ekat::ScalarTraits<ScalarIn>::scalar_type fill_val,
-                    const CoeffType alpha, const CoeffType beta)
-{
-  if constexpr (CM==CombineMode::Replace) {
-    return combine<CM>(newVal,result,alpha,beta);
-  }
-
-  // The where object will perform the assignment ONLY where the mask is true
-  auto where = ekat::where(newVal!=fill_val,result);
-  if (where.any()) {
-    // TODO: I thought about doing the switch manually, and do stuff like (e.g., for Update)
-    //  where *= beta;
-    //  where += alpha*newVal
-    // but there is no packed version of where.max(rhs), only a scalar version
-    // (meaning a version where rhs is a scalar, not a pack).
-    // If ekat::where_expression ever implements a packed overload for max/min,
-    // we can get rid of the temporary by doing a manual switch.
-    auto tmp = result;
-    combine<CM>(newVal,tmp,alpha,beta);
-    where = tmp;
-  }
-}
-
-template<CombineMode CM, typename ScalarIn, typename ScalarOut,
+// If fill-aware=true, we only perform the combine operation if either
+//   a) CM is Replace
+//   b) the new value is NOT fill_value
+// In other words, with fill_aware=true we IGNORE new values that are equal to fill_value,
+// unless we are replacing the content.
+// NOTE: the default 'void' for the scalar types is obviously never used, since the
+//       type is deduced from the inputs. The reason for the default is to allow to
+//       give a default to fill_aware.
+template<CombineMode CM, bool fill_aware = false, typename ScalarIn = void, typename ScalarOut = void,
          typename CoeffType = typename ekat::ScalarTraits<ScalarIn>::scalar_type>
 KOKKOS_FORCEINLINE_FUNCTION
 std::enable_if_t<not ekat::ScalarTraits<ScalarIn>::is_simd and
                  not ekat::ScalarTraits<ScalarOut>::is_simd>
-fill_aware_combine (const ScalarIn& newVal, ScalarOut& result,
-                    const typename ekat::ScalarTraits<ScalarIn>::scalar_type fill_val,
-                    const CoeffType alpha, const CoeffType beta)
+combine (const ScalarIn& newVal, ScalarOut& result,
+         const CoeffType alpha, const CoeffType beta)
 {
+  // Replace is simple, and does not care about fill_aware
   if constexpr (CM==CombineMode::Replace) {
-    return combine<CM>(newVal,result,alpha,beta);
+    result = newVal;
+    return;
   }
 
-  if (newVal!=fill_val) {
-    combine<CM>(newVal,result,alpha,beta);
+  if constexpr (fill_aware) {
+    if (newVal!=constants::fill_value<ScalarIn>) {
+      combine<CM,false>(newVal,result,alpha,beta);
+    }
+  } else {
+    // Not a fill-aware combine
+    using ekat::impl::max;
+    using ekat::impl::min;
+    switch (CM) {
+      case CombineMode::Update:
+        result *= beta;
+        result += alpha*newVal;
+        break;
+      case CombineMode::Multiply:
+        result *= (alpha*beta)*newVal;
+        break;
+      case CombineMode::Divide:
+        result /= (alpha/beta) * newVal;
+        break;
+      case CombineMode::Max:
+        result  = max(beta*result,static_cast<const ScalarOut&>(alpha*newVal));
+        break;
+      case CombineMode::Min:
+        result  = min(beta*result,static_cast<const ScalarOut&>(alpha*newVal));
+        break;
+      default:
+        EKAT_KERNEL_ASSERT ("Unsupported/unexpected combine mode.\n");
+    }
+  }
+}
+
+// Special version of combine for pack types
+template<CombineMode CM, bool fill_aware = false, typename ScalarIn = void, typename ScalarOut = void,
+         typename CoeffType = typename ekat::ScalarTraits<ScalarIn>::scalar_type>
+KOKKOS_FORCEINLINE_FUNCTION
+std::enable_if_t<ekat::ScalarTraits<ScalarIn>::is_simd or
+                 ekat::ScalarTraits<ScalarOut>::is_simd>
+combine (const ScalarIn& newVal, ScalarOut& result,
+         const CoeffType alpha, const CoeffType beta)
+{
+  if constexpr (CM==CombineMode::Replace) {
+    result = newVal;
+    return;
+  }
+  if constexpr (fill_aware) {
+    auto where = ekat::where(newVal!=constants::fill_value<ScalarIn>,result);
+
+    if (where.any()) {
+      auto tmp = result;
+      combine<CM,false>(newVal,tmp,alpha,beta);
+      where = tmp;
+    }
   }
 }
 

--- a/components/eamxx/src/share/util/eamxx_data_interpolation.cpp
+++ b/components/eamxx/src/share/util/eamxx_data_interpolation.cpp
@@ -539,10 +539,6 @@ create_vert_remapper (const VertRemapData& data)
     vremap->set_extrapolation_type(s2et(data.extrap_top),VerticalRemapper::Top);
     vremap->set_extrapolation_type(s2et(data.extrap_bot),VerticalRemapper::Bot);
 
-    // Set the mask value only if needed. RemapData has a default that is invalid for VerticalRemapper
-    if (data.extrap_bot=="Mask" or data.extrap_top=="Mask") {
-      vremap->set_mask_value(data.mask_value);
-    }
     m_vert_remapper = vremap;
   }
 

--- a/components/eamxx/src/share/util/eamxx_data_interpolation.hpp
+++ b/components/eamxx/src/share/util/eamxx_data_interpolation.hpp
@@ -34,7 +34,6 @@ public:
     VRemapType vr_type = None;
     std::string extrap_top = "P0";
     std::string extrap_bot = "P0";
-    Real mask_value = std::numeric_limits<Real>::quiet_NaN(); // Unused for P0 extrapolation
     std::string pname; // What we need to load from nc file
     Field pmid, pint;  // The model pmid/pint
     std::shared_ptr<AbstractRemapper> custom_remapper; // Use this custom remapper

--- a/components/eamxx/src/share/util/eamxx_time_interpolation.cpp
+++ b/components/eamxx/src/share/util/eamxx_time_interpolation.cpp
@@ -164,47 +164,7 @@ void TimeInterpolation::initialize_data_from_files()
   input_params.set("filename",triplet_curr.filename);
   m_file_data_atm_input = std::make_shared<AtmosphereInput>(input_params,m_fm_time1);
   m_file_data_atm_input->set_logger(m_logger);
-  // Assign the mask value gathered from the FillValue found in the source file.
-  // TODO: Should we make it possible to check if FillValue is in the metadata and only assign mask_value if it is?
-  for (auto& name : m_field_names) {
-    auto& field0 = m_fm_time0->get_field(name);
-    auto& field1 = m_fm_time1->get_field(name);
-    auto& field_out = m_interp_fields.at(name);
 
-    auto set_fill_value = [&](const auto var_fill_value) {
-      const auto dt = field_out.data_type();
-      if (dt==DataType::FloatType) {
-        field0.get_header().set_extra_data("mask_value",static_cast<float>(var_fill_value));
-        field1.get_header().set_extra_data("mask_value",static_cast<float>(var_fill_value));
-        field_out.get_header().set_extra_data("mask_value",static_cast<float>(var_fill_value));
-      } else if (dt==DataType::DoubleType) {
-        field0.get_header().set_extra_data("mask_value",static_cast<double>(var_fill_value));
-        field1.get_header().set_extra_data("mask_value",static_cast<double>(var_fill_value));
-        field_out.get_header().set_extra_data("mask_value",static_cast<double>(var_fill_value));
-      } else {
-        EKAT_ERROR_MSG (
-            "[TimeInterpolation] Unexpected/unsupported field data type.\n"
-            " - field name: " + field_out.name() + "\n"
-            " - data type : " + e2str(dt) + "\n");
-      }
-    };
-
-    const auto& pio_var = scorpio::get_var(triplet_curr.filename,name);
-    if (scorpio::refine_dtype(pio_var.nc_dtype)=="float") {
-      auto var_fill_value = scorpio::get_attribute<float>(triplet_curr.filename,name,"_FillValue");
-      set_fill_value(var_fill_value);
-    } else if (scorpio::refine_dtype(pio_var.nc_dtype)=="double") {
-      auto var_fill_value = scorpio::get_attribute<double>(triplet_curr.filename,name,"_FillValue");
-      set_fill_value(var_fill_value);
-    } else {
-      EKAT_ERROR_MSG (
-          "Unrecognized/unsupported data type\n"
-          " - filename: " + triplet_curr.filename + "\n"
-          " - varname : " + name + "\n"
-          " - dtype   : " + pio_var.dtype + "\n");
-    }
-
-  }
   // Read first snap of data and shift to time0
   read_data();
   shift_data();
@@ -351,24 +311,6 @@ void TimeInterpolation::read_data()
     input_params.set("filename",triplet_curr.filename);
     m_file_data_atm_input = std::make_shared<AtmosphereInput>(input_params,m_fm_time1);
     m_file_data_atm_input->set_logger(m_logger);
-    // Also determine the FillValue, if used
-    // TODO: Should we make it possible to check if FillValue is in the metadata and only assign mask_value if it is?
-    for (auto& name : m_field_names) {
-      auto& field = m_fm_time1->get_field(name);
-      const auto dt = field.data_type();
-      if (dt==DataType::FloatType) {
-        auto var_fill_value = scorpio::get_attribute<float>(triplet_curr.filename,name,"_FillValue");
-        field.get_header().set_extra_data("mask_value",var_fill_value);
-      } else if (dt==DataType::DoubleType) {
-        auto var_fill_value = scorpio::get_attribute<double>(triplet_curr.filename,name,"_FillValue");
-        field.get_header().set_extra_data("mask_value",var_fill_value);
-      } else {
-        EKAT_ERROR_MSG (
-            "[TimeInterpolation] Unexpected/unsupported field data type.\n"
-            " - field name: " + field.name() + "\n"
-            " - data type : " + e2str(dt) + "\n");
-      }
-    }
   }
 
   if (m_logger) {

--- a/components/eamxx/tests/single-process/surface_coupling/output.yaml
+++ b/components/eamxx/tests/single-process/surface_coupling/output.yaml
@@ -2,7 +2,6 @@
 ---
 filename_prefix: surface_coupling_output
 averaging_type: instant
-fill_value: -99999.0
 field_names:
   # IMPORTER
   - sfc_alb_dir_vis


### PR DESCRIPTION
The user will no longer be able to specify the value for fillValue in the output yaml files.
This enables a cascade of simplifications, since we no longer need to pass the value
around, as the code is now capable of retrieving fill_value from a central place.

Also, add a special extra meta-data interface to FieldHeader to simplify querying
whether a field may contain fill value entries.

[BFB]

---

Hopefully simplifies the path toward addressing #6803. The next step will be to move the creation of mask fields into the diagnostics classes, and have IO simply query whether a field has a `mask_field` metadata set or not (or maybe just query `may_be_filled`), without assuming anything regarding the origin of the field. This will _assume_ that the provider(s) of the field will set the `may_be_filled` metadata during init (rather than at runtime), so that IO can figure out whether it needs to enable tracking fill value or not.

Note: I need to verify that all the mask logic is correctly transfered during remap ops in IO. I will manually run an ne30 eamxx-prod test to verify things work as expected.
