### PR TITLE
EAMxx: workaround for aodvis type conversions

### DIFF
--- a/components/eamxx/src/diagnostics/aodvis.cpp
+++ b/components/eamxx/src/diagnostics/aodvis.cpp
@@ -47,7 +47,7 @@ void AODVis::initialize_impl(const RunType /*run_type*/) {
   auto nondim = ekat::units::Units::nondimensional();
   const auto &grid_name =
       m_diagnostic_output.get_header().get_identifier().get_grid_name();
-  const auto var_fill_value = constants::DefaultFillValue<Real>().value;
+  const auto var_fill_value = Real(constants::DefaultFillValue<float>::value);
 
   m_mask_val = m_params.get<double>("mask_value", var_fill_value);
 

--- a/components/eamxx/src/diagnostics/tests/aodvis_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/aodvis_test.cpp
@@ -31,7 +31,7 @@ TEST_CASE("aodvis") {
   using namespace ShortFieldTagsNames;
   using namespace ekat::units;
 
-  Real var_fill_value = constants::DefaultFillValue<Real>().value;
+  Real var_fill_value = Real(constants::DefaultFillValue<float>::value);
 
   Real some_limit = 0.0025;
 


### PR DESCRIPTION
Fixes #7548 for aodvis and follows logic in field_at_pressure

--

this intentional conversion likely loses precision (idk) but it is what's happening in the fill-value treatment in field ops, so it is the correct course of action here. In the future, maybe we need to be careful in the field ops about these issues. I didn't check other fields, but I suspect this may have been impacting other fields of interest (other than aodvis). Or we may need to define DefaultFillValue to account for double precision.

--

[BFB] because aodvis diag isn't tested