### PR TITLE
Update pes file to use defined G-case layouts for all SOwISC meshes

### DIFF
--- a/components/mpas-ocean/cime_config/config_pes.xml
+++ b/components/mpas-ocean/cime_config/config_pes.xml
@@ -408,7 +408,7 @@
       </pes>
     </mach>
   </grid>
-  <grid name="oi%SOwISC12to60E2r4">
+  <grid name="oi%SOwISC.">
     <mach name="chrysalis">
       <pes compset="DATM.+MPASO.+SWAV" pesize="any">
         <comment>mpas-ocean+chrysalis: SO RRM, compset=DATM+MPASO, 32 nodes, ~9 SYPD</comment>


### PR DESCRIPTION
The e3sm_hi_res test suite being run on pm-cpu has a test that fails (SMS.T62_SOwISC12to30E3r3.GMPAS-IAF.pm-cpu_intel) after we updated the mesh from SOwISC12to60E2r4. The default layout is not correct, so this updates the config_pes.xml for mpaso to use the already defined layouts for all SOwISC meshes.

[BFB]