### PR TITLE
Adjust new and unused eamxx_large test suite

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -856,7 +856,7 @@ _TESTS = {
         "time"  : "01:00:00",
         "tests" : (
             "SMS.ne120pg2_ne120pg2.F2010-SCREAMv1.eamxx-L128",
-            "PEM_Ld1.ne120pg2_ne120pg2.F2010-SCREAMv1.eamxx-L128",
+            #"PEM_Ld1.ne120pg2_ne120pg2.F2010-SCREAMv1.eamxx-L128", # second test hits OOM, need either P2048 or change def pelayout
             "ERS_Lh6.ne120pg2_ne120pg2.F2010-SCREAMv1.eamxx-L128--eamxx-prod",
             "SMS_D_Lh6.ne120pg2_ne120pg2.F2010-SCREAMv1.eamxx-prod",
             "SMS.ne256pg2_ne256pg2.F2010-SCREAMv1",


### PR DESCRIPTION
Comment out PEM test is e3sm_eamxx_large test suite as the second test will hit OOM.
To re-enable in the future, would need to adjust the default pelayout for ne120 on pm-gpu at least.

[bfb]