### PR TITLE
Fix sign of ice-shelf basal melt flux MALI passes to rofi

### DIFF
--- a/components/mpas-albany-landice/driver/glc_comp_mct.F
+++ b/components/mpas-albany-landice/driver/glc_comp_mct.F
@@ -1561,9 +1561,10 @@ contains
             g2x_g % rAttr(index_g2x_Fogg_rofi,n) = avgCalvingFlux(i) 
             g2x_g % rAttr(index_g2x_Fogg_rofi,n) = g2x_g % rAttr(index_g2x_Fogg_rofi,n) + avgFaceMeltFlux(i)
             if (trim(config_basal_mass_bal_float) == 'ismip6') then
-               ! if MALI is calculating ISMF, add that to rofl
+               ! if MALI is calculating ISMF, add that to rofi
                ! In some configurations, ISMF will be calculated in coupler or MPAS-Ocean
-               g2x_g % rAttr(index_g2x_Fogg_rofi,n) = g2x_g % rAttr(index_g2x_Fogg_rofi,n) + avgFloatingBMBFlux(i)
+               ! Note avgFloatingBMBFlux is + for mass gain to ice sheet, so sign should be flipped for rofi
+               g2x_g % rAttr(index_g2x_Fogg_rofi,n) = g2x_g % rAttr(index_g2x_Fogg_rofi,n) - avgFloatingBMBFlux(i)
             endif
 
             g2x_g % rAttr(index_g2x_Sg_topo, n) = max(0.0, upperSurface(i)) !updated to avoid warning for values below sea level


### PR DESCRIPTION
There is a sign error in the ice-shelf basal melt flux that MALI passes to rofi when using TF coupling.  This corrects that.