### PR TITLE
EAMxx: change namelist specs for the overall eamxx atm group

### DIFF
--- a/components/eamxx/cime_config/eamxx_buildnml.py
+++ b/components/eamxx/cime_config/eamxx_buildnml.py
@@ -461,7 +461,6 @@ def _create_raw_xml_file_impl(case, xml, filepath=None):
     ...     <selectors/>
     ...     <generated_files/>
     ...     <atmosphere_processes_defaults>
-    ...         <atm_procs_list type="array(string)">P1,P2</atm_procs_list>
     ...         <atm_proc_base>
     ...             <prop1>zero</prop1>
     ...         </atm_proc_base>
@@ -469,6 +468,9 @@ def _create_raw_xml_file_impl(case, xml, filepath=None):
     ...             <atm_procs_list>NONE</atm_procs_list>
     ...             <prop2>one</prop2>
     ...         </atm_proc_group>
+    ...         <eamxx inherit="atm_proc_group">
+    ...             <atm_procs_list>P1,P2</atm_procs_list>
+    ...         </eamxx>
     ...         <P1 inherit="atm_proc_base">
     ...             <prop1>two</prop1>
     ...         </P1>
@@ -480,7 +482,7 @@ def _create_raw_xml_file_impl(case, xml, filepath=None):
     >>> import xml.etree.ElementTree as ET
     >>> defaults = ET.fromstring(xml)
     >>> generated = _create_raw_xml_file_impl(case,defaults)
-    >>> d = convert_to_dict(get_child(generated,'atmosphere_processes'))
+    >>> d = convert_to_dict(get_child(generated,'eamxx'))
     >>> import pprint
     >>> pp = pprint.PrettyPrinter(indent=4)
     >>> pp.pprint(d)
@@ -494,11 +496,10 @@ def _create_raw_xml_file_impl(case, xml, filepath=None):
     >>> xml = '''
     ... <namelist_defaults>
     ...     <selectors>
-    ...       <selector name="grid" case_env="ATM_GRID"/>
+    ...         <selector name="grid" case_env="ATM_GRID"/>
     ...     </selectors>
     ...     <generated_files/>
     ...     <atmosphere_processes_defaults>
-    ...         <atm_procs_list type="array(string)">P1,P2</atm_procs_list>
     ...         <atm_proc_base>
     ...             <prop1>zero</prop1>
     ...         </atm_proc_base>
@@ -506,6 +507,9 @@ def _create_raw_xml_file_impl(case, xml, filepath=None):
     ...             <atm_procs_list>NONE</atm_procs_list>
     ...             <prop2>one</prop2>
     ...         </atm_proc_group>
+    ...         <eamxx inherit="atm_proc_group">
+    ...             <atm_procs_list>P1,P2</atm_procs_list>
+    ...         </eamxx>
     ...         <P1 inherit="atm_proc_base">
     ...             <prop1>two</prop1>
     ...             <prop1 grid='ne4ne4'>two_selected</prop1>
@@ -518,7 +522,7 @@ def _create_raw_xml_file_impl(case, xml, filepath=None):
     >>> import xml.etree.ElementTree as ET
     >>> defaults = ET.fromstring(xml)
     >>> generated = _create_raw_xml_file_impl(case,defaults)
-    >>> d = convert_to_dict(get_child(generated,'atmosphere_processes'))
+    >>> d = convert_to_dict(get_child(generated,'eamxx'))
     >>> import pprint
     >>> pp = pprint.PrettyPrinter(indent=4)
     >>> pp.pprint(d)
@@ -536,12 +540,14 @@ def _create_raw_xml_file_impl(case, xml, filepath=None):
     ...     </selectors>
     ...     <generated_files/>
     ...     <atmosphere_processes_defaults>
-    ...       <atm_procs_list type="array(string)">P1,P2</atm_procs_list>
     ...       <atm_proc_base>
     ...         <number_of_subcycles constraints='gt 0'>1</number_of_subcycles>
     ...         <enable_precondition_checks type='logical'>true</enable_precondition_checks>
     ...         <enable_postcondition_checks type='logical'>true</enable_postcondition_checks>
     ...       </atm_proc_base>
+    ...       <eamxx inherit="atm_proc_group">
+    ...         <atm_procs_list>P1,P2</atm_procs_list>
+    ...       </eamxx>
     ...       <physics_proc_base inherit='atm_proc_base'>
     ...         <Grid>physics_gll</Grid>
     ...         <Grid grid='ne4ne4'>physics_pg2</Grid>
@@ -562,7 +568,7 @@ def _create_raw_xml_file_impl(case, xml, filepath=None):
     >>> import xml.etree.ElementTree as ET
     >>> defaults = ET.fromstring(xml)
     >>> generated = _create_raw_xml_file_impl(case,defaults)
-    >>> d = convert_to_dict(get_child(generated,'atmosphere_processes'))
+    >>> d = convert_to_dict(get_child(generated,'eamxx'))
     >>> import pprint
     >>> pp = pprint.PrettyPrinter(indent=4)
     >>> pp.pprint(d)
@@ -605,15 +611,16 @@ def _create_raw_xml_file_impl(case, xml, filepath=None):
         # 4. Expand any CIME var that appears inside XML nodes text
         expand_cime_vars(xml,case)
 
-        # 5. Grab the atmosphere_processes macro list, with all the defaults
+        # 5. Grab the atmosphere_processes_defaults node, with all the procs defaults
         atm_procs_defaults = get_child(xml,"atmosphere_processes_defaults",remove=True)
 
-        # 6. Get atm procs list
-        atm_procs_list = get_child(atm_procs_defaults,"atm_procs_list",remove=True)
+        # 6. Get eamxx atm procs list
+        eamxx_group = get_child(atm_procs_defaults,"eamxx",remove=True)
+        atm_procs_list = get_child(eamxx_group,"atm_procs_list",remove=True)
 
         # 7. Form the nested list of atm procs needed, append to atmosphere_driver section
         atm_procs = gen_atm_proc_group(atm_procs_list.text, atm_procs_defaults)
-        atm_procs.tag = "atmosphere_processes"
+        atm_procs.tag = "eamxx"
         xml.append(atm_procs)
 
         # 8. Apply all changes in the SCREAM_ATMCHANGE_BUFFER that do not alter

--- a/components/eamxx/cime_config/eamxx_buildnml_impl.py
+++ b/components/eamxx/cime_config/eamxx_buildnml_impl.py
@@ -502,7 +502,9 @@ def resolve_inheritance(root, elem):
                         for child in elem:
                             if child.tag==entry.tag:
                                 expect (att not in child.attrib.keys(),
-                                        f"Do not set '{att}' attribute when parent node already specifies it.")
+                                        f"Do not set '{att}' attribute when parent node already specifies it."
+                                        f" parent node: {parent.tag}\n"
+                                        f" child node : {entry.tag}")
                                 child.attrib[att] = parent_type
 
     for child in elem:

--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -50,7 +50,7 @@ be lost if SCREAM_HACK_XML is not enabled.
       <sections>ctl_nl</sections>
     </file>
     <file name="data/scream_input.yaml" format="yaml">
-      <sections>driver_debug_options,driver_options,iop_options,atmosphere_processes,grids_manager,initial_conditions,scorpio,e3sm_parameters</sections>
+      <sections>driver_debug_options,driver_options,iop_options,eamxx,grids_manager,initial_conditions,scorpio,e3sm_parameters</sections>
     </file>
   </generated_files>
 
@@ -138,15 +138,6 @@ be lost if SCREAM_HACK_XML is not enabled.
 
   <atmosphere_processes_defaults>
 
-    <!--
-      List of atm procs. You can form processes groups by using parentheses,
-      or by giving the group a name, and adding a subsection that inherit
-      from atm_proc_group. atm_procs_list itself *must* represent a group,
-      so it must be of the form (a,b,...).
-      NOTE: *CANNOT* be changed.
-    -->
-    <atm_procs_list type="array(string)">sc_import,homme,physics,sc_export</atm_procs_list>
-
     <!-- Basic options for each atm process -->
     <atm_proc_base>
       <number_of_subcycles constraints="gt 0" doc="how many times to subcycle this atm process">1</number_of_subcycles>
@@ -172,6 +163,11 @@ be lost if SCREAM_HACK_XML is not enabled.
       <type>group</type>
       <schedule_type valid_values="sequential">sequential</schedule_type>
     </atm_proc_group>
+
+    <!-- The list of atm processes for the atm as a whole -->
+    <eamxx inherit="atm_proc_group">
+      <atm_procs_list>sc_import,homme,physics,sc_export</atm_procs_list>
+    </eamxx>
 
     <!-- Surface coupling (import and export) -->
     <sc_import inherit="atm_proc_base"/>

--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -234,7 +234,7 @@ void AtmosphereDriver::create_atm_processes()
   // Create the group of processes. This will recursively create the processes
   // tree, storing also the information regarding parallel execution (if needed).
   // See AtmosphereProcessGroup class documentation for more details.
-  auto& atm_proc_params = m_atm_params.sublist("atmosphere_processes");
+  auto& atm_proc_params = m_atm_params.sublist("eamxx");
   atm_proc_params.rename("EAMxx");
   atm_proc_params.set("logger",m_atm_logger);
   m_atm_process_group = std::make_shared<AtmosphereProcessGroup>(m_atm_comm,atm_proc_params);


### PR DESCRIPTION
Allows users to change the list of processes in the "overall eamxx atm process group".

[BFB]

---

@singhbalwinder this should allow you to do

```bash
./atmchange eamxx::atm_procs_list=sc_import,sc_export
```
I manually tested it on a simple F2010-SCREAMv1 compset, and it seems to work. I need to make sure the doctests in our py scripts pass, so this may not be merged right away, but you can try it by cherry-picking the commit on top of your local branch.