### PR TITLE
The bfb math layer is needed for GW

### DIFF
--- a/components/eam/src/physics/cam/bfb_math.inc
+++ b/components/eam/src/physics/cam/bfb_math.inc
@@ -26,8 +26,8 @@
 #  define bfb_exp(val) exp(val)
 #  define bfb_expm1(val) (exp(val) - 1)
 #  define bfb_tanh(val) tanh(val)
+#  define bfb_cos(val) cos(val)
 #  define bfb_sqrt(val) sqrt(val)
-#  define bfb_tanh(val) tanh(val)
 #  define bfb_erf(val) erf(val)
 #else
 #  define bfb_pow(base, exp) scream_pow(base, exp)
@@ -39,6 +39,7 @@
 #  define bfb_exp(val) scream_exp(val)
 #  define bfb_expm1(val) scream_expm1(val)
 #  define bfb_tanh(val) scream_tanh(val)
+#  define bfb_cos(val) scream_cos(val)
 #  define bfb_erf(val) scream_erf(val)
 #endif
 

--- a/components/eam/src/physics/cam/gw/gw_common.F90
+++ b/components/eam/src/physics/cam/gw/gw_common.F90
@@ -1,3 +1,6 @@
+! Include bit-for-bit math macros.
+#include "bfb_math.inc"
+
 module gw_common
 
 !
@@ -5,6 +8,10 @@ module gw_common
 ! parameterizations.
 !
 use gw_utils, only: r8, btype
+
+#ifdef SCREAM_CONFIG_IS_CMAKE
+use physics_share_f2c, only: scream_cos
+#endif
 
 implicit none
 private
@@ -596,7 +603,9 @@ subroutine gwd_compute_tendencies_from_stress_divergence(ncol, ngwv, do_taper, d
   real(r8) :: ptaper(ncol)
 
   if (do_taper) then    ! taper CM only
-     ptaper = cos(lat)
+     do l=1, ncol
+        ptaper(l) = bfb_cos(lat(l))
+     end do
   else                  ! do not taper other cases
      ptaper = 1._r8
   endif

--- a/components/eamxx/src/physics/gw/CMakeLists.txt
+++ b/components/eamxx/src/physics/gw/CMakeLists.txt
@@ -45,6 +45,7 @@ target_include_directories(gw PUBLIC
   ${CMAKE_CURRENT_BINARY_DIR}/modules
   ${CMAKE_CURRENT_SOURCE_DIR}/impl
   ${PATH_TO_LEGACY_GW}
+  ${PATH_TO_LEGACY_GW}/..
 )
 target_link_libraries(gw physics_share scream_share)
 

--- a/components/eamxx/src/physics/share/physics_share.cpp
+++ b/components/eamxx/src/physics/share/physics_share.cpp
@@ -48,6 +48,7 @@ static Scalar wrap_name(Scalar input) {                                       \
   cuda_wrap_single_arg(exp, std::exp)
   cuda_wrap_single_arg(expm1, std::expm1)
   cuda_wrap_single_arg(tanh, std::tanh)
+  cuda_wrap_single_arg(cos, std::cos)
   cuda_wrap_single_arg(erf, std::erf)
 
 #undef cuda_wrap_single_arg
@@ -126,13 +127,22 @@ Real scream_expm1(Real input)
   return std::expm1(input);
 #endif
 }
-  
+
 Real scream_tanh(Real input)
 {
 #ifdef EAMXX_ENABLE_GPU
   return CudaWrap<Real, DefaultDevice>::tanh(input);
 #else
   return std::tanh(input);
+#endif
+}
+
+Real scream_cos(Real input)
+{
+#ifdef EAMXX_ENABLE_GPU
+  return CudaWrap<Real, DefaultDevice>::cos(input);
+#else
+  return std::cos(input);
 #endif
 }
 

--- a/components/eamxx/src/physics/share/physics_share.hpp
+++ b/components/eamxx/src/physics/share/physics_share.hpp
@@ -16,6 +16,7 @@ Real scream_log10(Real input);
 Real scream_exp(Real input);
 Real scream_expm1(Real input);
 Real scream_tanh(Real input);
+Real scream_cos(Real input);
 Real scream_erf(Real input);
 
 }

--- a/components/eamxx/src/physics/share/physics_share_f2c.F90
+++ b/components/eamxx/src/physics/share/physics_share_f2c.F90
@@ -112,6 +112,16 @@ interface
     real(kind=c_real)            :: scream_tanh
   end function scream_tanh
 
+  function scream_cos(input) bind(C)
+    use iso_c_binding
+
+    !arguments:
+    real(kind=c_real), value, intent(in) :: input
+
+    ! return
+    real(kind=c_real)            :: scream_cos
+  end function scream_cos
+
   function scream_erf(input) bind(C)
     use iso_c_binding
 


### PR DESCRIPTION
Otherwise, bfb between f90 and cxx is impossible on CUDA

Adds a `cos` function to the layer.

[BFB] (except for GW standalone tests)