### PR TITLE
Add call to preview_namelists after branch/hybrid setup

### DIFF
--- a/run_e3sm.template.sh
+++ b/run_e3sm.template.sh
@@ -545,6 +545,7 @@ runtime_options() {
 	echo '$RUN_REFDIR = '${RUN_REFDIR}
 	echo '$RUN_REFCASE = '${RUN_REFCASE}
 	echo '$RUN_REFDATE = '${START_DATE}
+	./preview_namelists
 
     else
         echo 'ERROR: $MODEL_START_TYPE = '${MODEL_START_TYPE}' is unrecognized. Exiting.'


### PR DESCRIPTION
The current runscript configuration does not always setup mpas components for branch and hybrid runs, especially when the streams files are patched. This happens currently because the streams files with the branch or hybrid settings will not get created and staged until the run is submitted, but if patch streams files are made they will get used instead. This remedies that situation by calling preview_namelists after branch/hybrid settings and before the patch_mpas_streams section. The streams files should then have the hybrid or branch information in them before any patches are applied.

[BFB]