### PR TITLE
Restrict compsets that can use TL319 trigrids

### DIFF
--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -536,7 +536,7 @@
       <mask>WC14to60E2r3</mask>
     </model_grid>
 
-    <model_grid alias="TL319_r05_WC14to60E2r3" compset="(DATM|XATM|SATM)">
+    <model_grid alias="TL319_r05_WC14to60E2r3" compset="(DATM|XATM|SATM).+(DROF%CPLHIST|MOSART)">
       <grid name="atm">TL319</grid>
       <grid name="lnd">r05</grid>
       <grid name="ocnice">WC14to60E2r3</grid>
@@ -546,7 +546,7 @@
       <mask>WC14to60E2r3</mask>
     </model_grid>
 
-    <model_grid alias="TL319_r05_EC30to60E2r2" compset="(DATM|XATM|SATM)">
+    <model_grid alias="TL319_r05_EC30to60E2r2" compset="(DATM|XATM|SATM).+(DROF%CPLHIST|MOSART)">
       <grid name="atm">TL319</grid>
       <grid name="lnd">r05</grid>
       <grid name="ocnice">EC30to60E2r2</grid>
@@ -556,7 +556,7 @@
       <mask>EC30to60E2r2</mask>
     </model_grid>
 
-    <model_grid alias="TL319_r05_ARRM10to60E2r1" compset="(DATM|XATM|SATM)">
+    <model_grid alias="TL319_r05_ARRM10to60E2r1" compset="(DATM|XATM|SATM).+(DROF%CPLHIST|MOSART)">
       <grid name="atm">TL319</grid>
       <grid name="lnd">r05</grid>
       <grid name="ocnice">ARRM10to60E2r1</grid>
@@ -566,7 +566,7 @@
       <mask>ARRM10to60E2r1</mask>
     </model_grid>
 
-    <model_grid alias="TL319_r05_IcoswISC30E3r5" compset="(DATM|XATM|SATM)">
+    <model_grid alias="TL319_r05_IcoswISC30E3r5" compset="(DATM|XATM|SATM).+(DROF%CPLHIST|MOSART)">
       <grid name="atm">TL319</grid>
       <grid name="lnd">r05</grid>
       <grid name="ocnice">IcoswISC30E3r5</grid>
@@ -651,16 +651,6 @@
       <grid name="lnd">TL319</grid>
       <grid name="ocnice">IcoswISC30E3r5</grid>
       <grid name="rof">JRA025</grid>
-      <grid name="glc">null</grid>
-      <grid name="wav">null</grid>
-      <mask>IcoswISC30E3r5</mask>
-    </model_grid>
-
-    <model_grid alias="TL319_r05_IcoswISC30E3r5" compset="(DATM|XATM|SATM)">
-      <grid name="atm">TL319</grid>
-      <grid name="lnd">r05</grid>
-      <grid name="ocnice">IcoswISC30E3r5</grid>
-      <grid name="rof">r05</grid>
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
       <mask>IcoswISC30E3r5</mask>


### PR DESCRIPTION
We had added trigrid mesh aliases with the TL319 atm grid for users running GP-cases, which have all components except atm active. However, some other users have tried using those mesh aliases for G-cases where the drof model is expecting to run on the JRA025 grid, and had confusing runtime errors. This PR adds restrictions on the compsets these mesh aliases are valid for, to require either active ROF or drof in its cplhist mode. Now G-cases will fail in the create step with an error like:
       ERROR: grid alias TL319_r05_WC14to60E2r3 not valid for compset 2000_DATM%JRA-1p5_SLND_MPASSI_MPASO%DATMFORCED_DROF%JRA-1p5_SGLC_SWAV_SIAC_SESP

[BFB]