### PR TITLE
Disable MPI test for DP unit test

### DIFF
--- a/components/eamxx/tests/multi-process/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_pg2_dp/CMakeLists.txt
+++ b/components/eamxx/tests/multi-process/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_pg2_dp/CMakeLists.txt
@@ -81,13 +81,14 @@ endforeach()
 # Compare output files produced by npX tests, to ensure they are bfb
 include (CompareNCFiles)
 
-CompareNCFilesFamilyMpi (
-  TEST_BASE_NAME ${TEST_BASE_NAME}
-  FILE_META_NAME ${TEST_BASE_NAME}_output.INSTANT.nsteps_x${NUM_STEPS}.npMPIRANKS.${RUN_T0}.nc
-  MPI_RANKS ${TEST_RANK_START} ${TEST_RANK_END}
-  LABELS dynamics physics tms shoc cld spa p3 rrtmgp dp pg2
-  META_FIXTURES_REQUIRED ${FIXTURES_BASE_NAME}_npMPIRANKS_omp1
-)
+# TODO: Temporarily disabling failing MPI tests until fix is in
+# CompareNCFilesFamilyMpi (
+#   TEST_BASE_NAME ${TEST_BASE_NAME}
+#   FILE_META_NAME ${TEST_BASE_NAME}_output.INSTANT.nsteps_x${NUM_STEPS}.npMPIRANKS.${RUN_T0}.nc
+#   MPI_RANKS ${TEST_RANK_START} ${TEST_RANK_END}
+#   LABELS dynamics physics tms shoc cld spa p3 rrtmgp dp pg2
+#   META_FIXTURES_REQUIRED ${FIXTURES_BASE_NAME}_npMPIRANKS_omp1
+# )
 
 if (SCREAM_ENABLE_BASELINE_TESTS)
   # Compare one of the output files with the baselines.


### PR DESCRIPTION
Cleans up CI until fix.

[BFB]