### PR TITLE
EAMxx: separate version info from rest of config.h

### DIFF
--- a/components/eamxx/CMakeLists.txt
+++ b/components/eamxx/CMakeLists.txt
@@ -589,11 +589,9 @@ if (NOT DEFINED ENV{SCREAM_FAKE_ONLY})
                  ${CMAKE_CURRENT_BINARY_DIR}/src/eamxx_config.h
                  F90_FILE ${CMAKE_CURRENT_BINARY_DIR}/src/eamxx_config.f)
 
-  # Generate eamxx_config.h and eamxx_config.f
-  include (EkatUtils)
-  EkatConfigFile(${CMAKE_CURRENT_SOURCE_DIR}/src/eamxx_config.h.in
-                 ${CMAKE_CURRENT_BINARY_DIR}/src/eamxx_config.h
-                 F90_FILE ${CMAKE_CURRENT_BINARY_DIR}/src/eamxx_config.f)
+  # Generate eamxx_version.h
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/eamxx_version.h.in
+                 ${CMAKE_CURRENT_BINARY_DIR}/src/eamxx_version.h)
 else()
   # This is a "fake" build of scream, to stress test the testing scripts.
   # We only need to build something in our tests folder

--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -13,6 +13,7 @@
 #include "share/util/eamxx_utils.hpp"
 #include "share/io/eamxx_io_utils.hpp"
 #include "share/property_checks/mass_and_energy_conservation_check.hpp"
+#include "eamxx_version.h"
 
 #include <ekat_assert.hpp>
 #include <ekat_string_utils.hpp>

--- a/components/eamxx/src/eamxx_config.h.in
+++ b/components/eamxx/src/eamxx_config.h.in
@@ -52,10 +52,4 @@
 // Whether or not small kernels are used in SHOC
 #cmakedefine SCREAM_SHOC_SMALL_KERNELS
 
-// The sha of the last commit
-#define EAMXX_GIT_VERSION "${EAMXX_GIT_VERSION}"
-
-// The version of EAMxx
-#define EAMXX_VERSION "${EAMXX_VERSION_MAJOR}.${EAMXX_VERSION_MINOR}.${EAMXX_VERSION_PATCH}"
-
 #endif

--- a/components/eamxx/src/eamxx_version.h.in
+++ b/components/eamxx/src/eamxx_version.h.in
@@ -1,0 +1,10 @@
+#ifndef SCREAM_VERSION_H
+#define SCREAM_VERSION_H
+
+// The sha of the last commit
+#define EAMXX_GIT_VERSION "${EAMXX_GIT_VERSION}"
+
+// The version of EAMxx
+#define EAMXX_VERSION "${EAMXX_VERSION_MAJOR}.${EAMXX_VERSION_MINOR}.${EAMXX_VERSION_PATCH}"
+
+#endif

--- a/components/eamxx/src/share/eamxx_config.cpp
+++ b/components/eamxx/src/share/eamxx_config.cpp
@@ -1,6 +1,7 @@
 #include "eamxx_config.hpp"
 #include "eamxx_session.hpp"
 #include "eamxx_types.hpp"
+#include "eamxx_version.h"
 
 #include <ekat_kokkos_session.hpp>
 #include <ekat_arch.hpp>
@@ -9,12 +10,20 @@
 
 namespace scream {
 
+std::string eamxx_version () {
+  return EAMXX_VERSION;
+}
+
+std::string eamxx_git_version () {
+  return EAMXX_GIT_VERSION;
+}
+
 std::string eamxx_config_string() {
   std::string config = "\n-------- EKAT CONFIGS --------\n\n";
   config += "Active AVX settings: " + ekat::active_avx_string () + "\n";
   config += "Compiler Id: " + ekat::compiler_id_string () + "\n";
   config += ekat::kokkos_config_string();
-  config += "\n-------- SCREAM CONFIGS --------\n\n";
+  config += "\n-------- EAMXX CONFIGS --------\n\n";
   config += " sizeof(Real) = " + std::to_string(sizeof(Real)) + "\n";
   config += " default pack size = " + std::to_string(SCREAM_PACK_SIZE) + "\n";
   config += " default FPE mask: " +

--- a/components/eamxx/src/share/eamxx_config.hpp
+++ b/components/eamxx/src/share/eamxx_config.hpp
@@ -16,6 +16,9 @@
 
 namespace scream {
 
+std::string eamxx_version ();
+std::string eamxx_git_version ();
+
 std::string eamxx_config_string();
 
 // Utils to set/get whether leap year is used or not

--- a/components/eamxx/src/share/io/eamxx_output_manager.cpp
+++ b/components/eamxx/src/share/io/eamxx_output_manager.cpp
@@ -4,7 +4,6 @@
 #include "share/io/eamxx_scorpio_interface.hpp"
 #include "share/util/eamxx_timing.hpp"
 #include "share/eamxx_config.hpp"
-#include "eamxx_version.h"
 
 #include <ekat_parameter_list.hpp>
 #include <ekat_comm.hpp>
@@ -905,8 +904,8 @@ void OutputManager::set_file_header(const IOFileSpecs& file_specs)
 
   set_str_att("case",p.get<std::string>("caseid","NONE"));
   set_str_att("source","E3SM Atmosphere Model (EAMxx)");
-  set_str_att("eamxx_version",EAMXX_VERSION);
-  set_str_att("git_version",p.get<std::string>("git_version",EAMXX_GIT_VERSION));
+  set_str_att("eamxx_version",eamxx_version());
+  set_str_att("git_version",p.get<std::string>("git_version",eamxx_git_version()));
   set_str_att("hostname",p.get<std::string>("hostname","UNKNOWN"));
   set_str_att("username",p.get<std::string>("username","UNKNOWN"));
   set_str_att("atm_initial_conditions_file",p.get<std::string>("initial_conditions_file","NONE"));

--- a/components/eamxx/src/share/io/eamxx_output_manager.cpp
+++ b/components/eamxx/src/share/io/eamxx_output_manager.cpp
@@ -4,6 +4,7 @@
 #include "share/io/eamxx_scorpio_interface.hpp"
 #include "share/util/eamxx_timing.hpp"
 #include "share/eamxx_config.hpp"
+#include "eamxx_version.h"
 
 #include <ekat_parameter_list.hpp>
 #include <ekat_comm.hpp>


### PR DESCRIPTION
Avoid a full rebuild of eamxx when the git sha changes and cmake is triggered by make.

[BFB]

---

Since the last commit sha was in eamxx_config.h, which was included (directly or indirectly) by virtually every eamxx cpp file, doing a commit and touching a file that triggers cmake (like a CMakeLists.txt) would cause a full eamxx rebuild. This is a bit annoying when doing development on a small-ish machine where a full model rebuild takes a long time.

This PR moves the sha commit in a _separate_ header file, which is _only_ included by `eamxx_config.cpp`. So if you, say, add a commit that touches `src/physics/p3/CMakeLists.txt` and re-run make, you only don't rebuild any of the share folder other than `eamxx_config.cpp.o` (which if fast), and then just relink.

Edit: as an example, I added a dummy commit changing some formatting of a CMakeLists.txt file, then ran `make scream_share` which triggered a cmake-rerun. With this branch, only one file got recompiled (eamxx_config.cpp), while in master tens of files were rebuilt.