### PR TITLE
Update craygnu-hipcc.cmake to fix EAMxx build issues on Frontier

### DIFF
--- a/cime_config/machines/cmake_macros/craygnu-hipcc.cmake
+++ b/cime_config/machines/cmake_macros/craygnu-hipcc.cmake
@@ -1,5 +1,5 @@
 set(MPICC "cc")
-set(MPICXX "hipcc") # Needs MPICH_CXX to use hipcc
+set(MPICXX "mpicxx") # Needs MPICH_CXX to use hipcc
 set(MPIFC "ftn") # Linker needs to be the Cray wrapper ftn, not mpif90
 set(SCC "cc")
 set(SCXX "hipcc")
@@ -9,7 +9,7 @@ string(APPEND CPPDEFS " -DLINUX -DFORTRANUNDERSCORE -DNO_R16 -DCPRGNU -DCLANGOPT
 if (COMP_NAME STREQUAL gptl)
     string(APPEND CPPDEFS " -DHAVE_NANOTIME -DBIT64 -DHAVE_SLASHPROC -DHAVE_COMM_F2C -DHAVE_TIMES -DHAVE_GETTIMEOFDAY")
 endif()
-string(APPEND CMAKE_Fortran_FLAGS " -fconvert=big-endian -ffree-line-length-none -ffixed-line-length-none -fallow-argument-mismatch")
+string(APPEND CMAKE_Fortran_FLAGS " -fconvert=big-endian -ffree-line-length-none -ffixed-line-length-none -fallow-argument-mismatch -cpp")
 
 string(APPEND CMAKE_C_FLAGS_DEBUG " -O0 -g -Wall -fbacktrace -fcheck=bounds -ffpe-trap=invalid,zero,overflow")
 string(APPEND CMAKE_Fortran_FLAGS_DEBUG " -O0 -g -Wall -fbacktrace -fcheck=bounds -ffpe-trap=zero,overflow")


### PR DESCRIPTION
Fix EAMxx build issues on Frontier in `craygnu-hipcc.cmake`
* Use `mpicxx` instead of `hipcc` for `MPICXX` so `EKAT` can locate correct MPI include and library paths.
* Add `-cpp` compiler flag to enable C preprocessor for CPP-style directives in `gw_iso_c.f90`.

`e3sm_eamxx_v1` test suite: 29/34 passed, 5 failed with similar segmentation faults in
`eamxx_cxx_f90_interface.cpp:69` and `eamxx_homme_process_interface.cpp:526`.

Previously, we need to set SZ_ROOT to a temporary installation path but since PR #7603 is merged to master, we no longer need to do the workaround:


[BFB]