### PR TITLE
Split large mpas-si file to prevent ICE with oneapi compiler

### DIFF
--- a/components/mpas-seaice/src/model_forward/Makefile
+++ b/components/mpas-seaice/src/model_forward/Makefile
@@ -1,13 +1,16 @@
 .SUFFIXES: .F .o
 
 OBJS = 	mpas_seaice_core.o \
+	mpas_seaice_core_interface_structs.o \
 	mpas_seaice_core_interface.o
 
 all: $(OBJS)
 
 mpas_seaice_core.o: 
 
-mpas_seaice_core_interface.o: mpas_seaice_core.o
+mpas_seaice_core_interface_structs.o: mpas_seaice_core.o
+
+mpas_seaice_core_interface.o: mpas_seaice_core.o mpas_seaice_core_interface_structs.o
 
 clean:
 	$(RM) *.o *.i *.mod *.f90

--- a/components/mpas-seaice/src/model_forward/mpas_seaice_core_interface.F
+++ b/components/mpas-seaice/src/model_forward/mpas_seaice_core_interface.F
@@ -7,6 +7,7 @@ module seaice_core_interface
    use seaice_core
    use seaice_analysis_driver
    use mpas_log, only: mpas_log_write
+   use seaice_core_interface_structs
 
    implicit none
    public
@@ -874,11 +875,5 @@ module seaice_core_interface
 #include "../inc/block_dimension_routines.inc"
 
 #include "../inc/define_packages.inc"
-
-#include "../inc/structs_and_variables.inc"
-
-#include "../inc/namelist_call.inc"
-
-#include "../inc/namelist_defines.inc"
 
 end module seaice_core_interface

--- a/components/mpas-seaice/src/model_forward/mpas_seaice_core_interface_structs.F
+++ b/components/mpas-seaice/src/model_forward/mpas_seaice_core_interface_structs.F
@@ -1,0 +1,22 @@
+module seaice_core_interface_structs
+
+   use mpas_derived_types
+   use mpas_pool_routines
+   use mpas_dmpar
+   use mpas_io_units
+   use seaice_core
+   use seaice_analysis_driver
+   use mpas_log, only: mpas_log_write
+   
+   implicit none
+   public
+   
+   contains
+
+#include "../inc/structs_and_variables.inc"
+
+#include "../inc/namelist_call.inc"
+
+#include "../inc/namelist_defines.inc"
+
+end module seaice_core_interface_structs

--- a/components/mpas-seaice/src/seaice.cmake
+++ b/components/mpas-seaice/src/seaice.cmake
@@ -104,6 +104,7 @@ list(APPEND RAW_SOURCES
 # model_forward (DISABLE qsmp for these)
 set(SEAICE_MODEL_FORWARD
   core_seaice/model_forward/mpas_seaice_core.F
+  core_seaice/model_forward/mpas_seaice_core_interface_structs.F
   core_seaice/model_forward/mpas_seaice_core_interface.F
 )
 list(APPEND RAW_SOURCES ${SEAICE_MODEL_FORWARD})


### PR DESCRIPTION
Split large mpas-si file to prevent ICE with oneapi compiler.

Fixes E3SM-Project/E3SM#7595

[BFB]