### PR TITLE
Port gwd_compute_stress_profiles_and_diffusivities

### DIFF
--- a/components/eamxx/src/physics/gw/gw_functions.hpp
+++ b/components/eamxx/src/physics/gw/gw_functions.hpp
@@ -255,6 +255,9 @@ struct Functions
     const uview_1d<const Real>& ti,
     const uview_1d<const Real>& piln,
     // Inputs/Outputs
+    const uview_2d<Real>& ubmc,
+    const uview_2d<Real>& tausat,
+    const uview_2d<Real>& dsat,
     const uview_2d<Real>& tau);
 
   KOKKOS_FUNCTION

--- a/components/eamxx/src/physics/gw/gw_functions.hpp
+++ b/components/eamxx/src/physics/gw/gw_functions.hpp
@@ -246,7 +246,6 @@ struct Functions
     const Int& pver,
     const Int& pgwv,
     const Int& src_level,
-    const Int& max_level,
     const uview_1d<const Real>& ubi,
     const uview_1d<const Real>& c,
     const uview_1d<const Real>& rhoi,

--- a/components/eamxx/src/physics/gw/gw_functions.hpp
+++ b/components/eamxx/src/physics/gw/gw_functions.hpp
@@ -255,9 +255,10 @@ struct Functions
     const uview_1d<const Real>& ti,
     const uview_1d<const Real>& piln,
     // Inputs/Outputs
-    const uview_2d<Real>& ubmc,
     const uview_2d<Real>& tausat,
     const uview_2d<Real>& dsat,
+    const uview_2d<Real>& wrk1,
+    const uview_2d<Real>& wrk2,
     const uview_2d<Real>& tau);
 
   KOKKOS_FUNCTION

--- a/components/eamxx/src/physics/gw/gw_functions.hpp
+++ b/components/eamxx/src/physics/gw/gw_functions.hpp
@@ -196,7 +196,6 @@ struct Functions
     const Real& yv,
     // Inputs/Outputs
     const uview_2d<Real>& tau,
-    const uview_2d<Real>& work,
     // Outputs
     const uview_2d<Real>& gwut,
     const uview_1d<Real>& utgw,
@@ -255,10 +254,6 @@ struct Functions
     const uview_1d<const Real>& ti,
     const uview_1d<const Real>& piln,
     // Inputs/Outputs
-    const uview_2d<Real>& tausat,
-    const uview_2d<Real>& dsat,
-    const uview_2d<Real>& wrk1,
-    const uview_2d<Real>& wrk2,
     const uview_2d<Real>& tau);
 
   KOKKOS_FUNCTION

--- a/components/eamxx/src/physics/gw/gw_functions.hpp
+++ b/components/eamxx/src/physics/gw/gw_functions.hpp
@@ -240,20 +240,23 @@ struct Functions
   KOKKOS_FUNCTION
   static void gwd_compute_stress_profiles_and_diffusivities(
     // Inputs
+    const MemberType& team,
+    const Workspace& workspace,
+    const GwCommonInit& init,
     const Int& pver,
     const Int& pgwv,
-    const Int& ncol,
-    const uview_1d<const Int>& src_level,
-    const uview_1d<const Spack>& ubi,
-    const uview_1d<const Spack>& c,
-    const uview_1d<const Spack>& rhoi,
-    const uview_1d<const Spack>& ni,
-    const uview_1d<const Spack>& kvtt,
-    const uview_1d<const Spack>& t,
-    const uview_1d<const Spack>& ti,
-    const uview_1d<const Spack>& piln,
+    const Int& src_level,
+    const Int& max_level,
+    const uview_1d<const Real>& ubi,
+    const uview_1d<const Real>& c,
+    const uview_1d<const Real>& rhoi,
+    const uview_1d<const Real>& ni,
+    const uview_1d<const Real>& kvtt,
+    const uview_1d<const Real>& t,
+    const uview_1d<const Real>& ti,
+    const uview_1d<const Real>& piln,
     // Inputs/Outputs
-    const uview_1d<Spack>& tau);
+    const uview_2d<Real>& tau);
 
   KOKKOS_FUNCTION
   static void gwd_project_tau(

--- a/components/eamxx/src/physics/gw/impl/gw_gwd_compute_stress_profiles_and_diffusivities_impl.hpp
+++ b/components/eamxx/src/physics/gw/impl/gw_gwd_compute_stress_profiles_and_diffusivities_impl.hpp
@@ -83,9 +83,8 @@ void Functions<S,D>::gwd_compute_stress_profiles_and_diffusivities(
 
   team.team_barrier();
 
-  // This loop is serial, so it may as well only be performed by one thread.
-  // tau(k) depends on tau(k+1), which eliminates parallelism in the vertical
-  // levels.
+  // The outer loop is serial because tau(k) depends on tau(k+1), which eliminates
+  // parallelism in the vertical levels. We can still parallelize over pgwvs though.
   for (Int k = src_level; k >= init.ktop; --k) {
     // Determine the diffusivity for each column.
     Real d = GWC::dback;

--- a/components/eamxx/src/physics/gw/impl/gw_gwd_compute_stress_profiles_and_diffusivities_impl.hpp
+++ b/components/eamxx/src/physics/gw/impl/gw_gwd_compute_stress_profiles_and_diffusivities_impl.hpp
@@ -2,12 +2,10 @@
 #define GW_GWD_COMPUTE_STRESS_PROFILES_AND_DIFFUSIVITIES_IMPL_HPP
 
 #include "gw_functions.hpp" // for ETI only but harmless for GPU
+#include "util/eamxx_utils.hpp"
 
 namespace scream {
 namespace gw {
-
-#define bfb_square(val) ((val)*(val))
-#define bfb_cube(val)   ((val)*(val)*(val))
 
 /*
  * Implementation of gw gwd_compute_stress_profiles_and_diffusivities. Clients should NOT
@@ -33,52 +31,61 @@ void Functions<S,D>::gwd_compute_stress_profiles_and_diffusivities(
   const uview_1d<const Real>& ti,
   const uview_1d<const Real>& piln,
   // Inputs/Outputs
-  const uview_2d<Real>& tausat,
-  const uview_2d<Real>& dsat,
-  const uview_2d<Real>& wrk1,
-  const uview_2d<Real>& wrk2,
   const uview_2d<Real>& tau)
 {
   static const auto ubmc2mn = GWC::ubmc2mn;
 
-  // Loop from bottom to top to get stress profiles.
+  const int num_pgwv = 2*pgwv + 1;
+
+  // Get temporary workspaces and change them to desired dimensions
+  uview_1d<Real> tausat_1d, dsat_1d, wrk1_1d, wrk2_1d;
+  workspace.template take_many_contiguous_unsafe<4>(
+    {"tausat_1d", "dsat_1d", "wrk1_1d", "wrk2_1d"},
+    {&tausat_1d, &dsat_1d, &wrk1_1d, &wrk2_1d});
+  uview_2d<Real>
+    tausat(tausat_1d.data(), pver+1, num_pgwv),
+    dsat(dsat_1d.data(), pver+1, num_pgwv),
+    wrk1(wrk1_1d.data(), pver+1, num_pgwv),
+    wrk2(wrk2_1d.data(), pver+1, num_pgwv);
+
+  // Loop from bottom to top to get stress profiles. Instead of having 2 levels
+  // of parallelism, we collapse all the parallelism into the top level by multiplying
+  // the level by num_pgwv.
   Kokkos::parallel_for(
-    Kokkos::TeamThreadRange(team, init.ktop, src_level+1), [&] (const int k) {
+    Kokkos::TeamThreadRange(team, init.ktop*num_pgwv, (src_level+1)*num_pgwv), [&] (const int k_pgwv) {
+
+    const int k = k_pgwv / num_pgwv;
+    const int l = k_pgwv % num_pgwv;
 
     // Determine the absolute value of the saturation stress.
     // Define critical levels where the sign of (u-c) changes between interfaces.
-    Kokkos::parallel_for(
-      Kokkos::ThreadVectorRange(team, -pgwv, pgwv+1), [&] (const int l) {
+    const Real ubmc = ubi(k) - c(l);
 
-      const int pl_idx = l + pgwv; // 0-based idx for -pgwv:pgwv arrays
-      const Real ubmc = ubi(k) - c(pl_idx);
+    // Test to see if u-c has the same sign here as the level below.
+    if (ubmc * (ubi(k + 1) - c(l)) > 0.0) {
+      tausat(k, l) = std::abs(init.effkwv * rhoi(k) * bfb_cube(ubmc) /
+                                   (2.0 * ni(k)));
+      if (tausat(k, l) <= GWC::taumin) tausat(k, l) = 0.0;
+    }
+    else {
+      tausat(k, l) = 0.0;
+    }
 
-      // Test to see if u-c has the same sign here as the level below.
-      if (ubmc * (ubi(k + 1) - c(pl_idx)) > 0.0) {
-        tausat(k, pl_idx) = std::abs(init.effkwv * rhoi(k) * bfb_cube(ubmc) /
-                                     (2.0 * ni(k)));
-        if (tausat(k, pl_idx) <= GWC::taumin) tausat(k, pl_idx) = 0.0;
-      }
-      else {
-        tausat(k, pl_idx) = 0.0;
-      }
+    if (!init.do_molec_diff) {
+      dsat(k, l) = bfb_square(ubmc / ni(k)) *
+        (init.effkwv * bfb_square(ubmc) /
+         (GWC::rog * ti(k) * ni(k)) - init.alpha(k));
+    }
 
-      if (!init.do_molec_diff) {
-        dsat(k, pl_idx) = bfb_square(ubmc / ni(k)) *
-          (init.effkwv * bfb_square(ubmc) /
-           (GWC::rog * ti(k) * ni(k)) - init.alpha(k));
-      }
-
-      if (k <= init.nbot_molec || !init.do_molec_diff) {
-        const Real ubmc2 = ekat::impl::max(bfb_square(ubmc), ubmc2mn);
-        const Real at = ni(k) / (2.0 * init.kwv * ubmc2);
-        const Real bt = init.alpha(k);
-        const Real ct = bfb_square(ni(k)) / ubmc2;
-        const Real et = -2.0 * GWC::rog * t(k) * (piln(k + 1) - piln(k));
-        wrk1(k, pl_idx) = at*bt*et;
-        wrk2(k, pl_idx) = at*ct*et;
-      }
-    });
+    if (k <= init.nbot_molec || !init.do_molec_diff) {
+      const Real ubmc2 = ekat::impl::max(bfb_square(ubmc), ubmc2mn);
+      const Real at = ni(k) / (2.0 * init.kwv * ubmc2);
+      const Real bt = init.alpha(k);
+      const Real ct = bfb_square(ni(k)) / ubmc2;
+      const Real et = -2.0 * GWC::rog * t(k) * (piln(k + 1) - piln(k));
+      wrk1(k, l) = at*bt*et;
+      wrk2(k, l) = at*ct*et;
+    }
   });
 
   team.team_barrier();
@@ -134,6 +141,10 @@ void Functions<S,D>::gwd_compute_stress_profiles_and_diffusivities(
     }
     team.team_barrier();
   }
+
+  // Release temporary variables from the workspace
+  workspace.template release_many_contiguous<4>(
+    {&tausat_1d, &dsat_1d, &wrk1_1d, &wrk2_1d});
 }
 
 } // namespace gw

--- a/components/eamxx/src/physics/gw/impl/gw_gwd_compute_stress_profiles_and_diffusivities_impl.hpp
+++ b/components/eamxx/src/physics/gw/impl/gw_gwd_compute_stress_profiles_and_diffusivities_impl.hpp
@@ -103,7 +103,7 @@ void Functions<S,D>::gwd_compute_stress_profiles_and_diffusivities(
       Kokkos::parallel_reduce(
         Kokkos::TeamVectorRange(team, -pgwv, pgwv+1), [&] (const int l, Real& lmax) {
         const int pl_idx = l + pgwv; // 0-based idx for -pgwv:pgwv arrays
-        const Real dscal = ekat::impl::min(1.0, tau(pl_idx, k+1) / (tausat(k, pl_idx) + GWC::taumin));
+        const Real dscal = ekat::impl::min((Real)1.0, tau(pl_idx, k+1) / (tausat(k, pl_idx) + GWC::taumin));
         lmax = ekat::impl::max(lmax, dscal * dsat(k, pl_idx));
       }, Kokkos::Max<Real>(d));
     }

--- a/components/eamxx/src/physics/gw/impl/gw_gwd_compute_stress_profiles_and_diffusivities_impl.hpp
+++ b/components/eamxx/src/physics/gw/impl/gw_gwd_compute_stress_profiles_and_diffusivities_impl.hpp
@@ -3,6 +3,7 @@
 
 #include "gw_functions.hpp" // for ETI only but harmless for GPU
 #include "util/eamxx_utils.hpp"
+#include <ekat_math_utils.hpp>
 
 namespace scream {
 namespace gw {

--- a/components/eamxx/src/physics/gw/impl/gw_gwd_compute_stress_profiles_and_diffusivities_impl.hpp
+++ b/components/eamxx/src/physics/gw/impl/gw_gwd_compute_stress_profiles_and_diffusivities_impl.hpp
@@ -24,7 +24,6 @@ void Functions<S,D>::gwd_compute_stress_profiles_and_diffusivities(
   const Int& pver,
   const Int& pgwv,
   const Int& src_level,
-  const Int& max_level,
   const uview_1d<const Real>& ubi,
   const uview_1d<const Real>& c,
   const uview_1d<const Real>& rhoi,
@@ -44,69 +43,67 @@ void Functions<S,D>::gwd_compute_stress_profiles_and_diffusivities(
     {&ubmc, &tausat});
 
   // Loop from bottom to top to get stress profiles.
-  for (Int k = max_level; k >= init.ktop; --k) {
-    if (src_level >= k) {
+  for (Int k = src_level; k >= init.ktop; --k) {
 
-      // Determine the absolute value of the saturation stress.
-      // Define critical levels where the sign of (u-c) changes between interfaces.
+    // Determine the absolute value of the saturation stress.
+    // Define critical levels where the sign of (u-c) changes between interfaces.
+    for (Int l = -pgwv; l <= pgwv; ++l) {
+      int pl_idx = l + pgwv; // 0-based idx for -pgwv:pgwv arrays
+      ubmc(pl_idx) = ubi(k) - c(pl_idx);
+
+      // Test to see if u-c has the same sign here as the level below.
+      if (ubmc(pl_idx) * (ubi(k + 1) - c(pl_idx)) > 0.0) {
+        tausat(pl_idx) = std::abs(init.effkwv * rhoi(k) * bfb_cube(ubmc(pl_idx)) /
+                                  (2.0 * ni(k)));
+        if (tausat(pl_idx) <= GWC::taumin) tausat(pl_idx) = 0.0;
+      }
+      else {
+        tausat(pl_idx) = 0.0;
+      }
+    }
+
+    // Determine the diffusivity for each column.
+    Real d = GWC::dback;
+    if (init.do_molec_diff) {
+      d += kvtt(k);
+    }
+    else {
       for (Int l = -pgwv; l <= pgwv; ++l) {
         int pl_idx = l + pgwv; // 0-based idx for -pgwv:pgwv arrays
-        ubmc(pl_idx) = ubi(k) - c(pl_idx);
+        const Real dsat = bfb_square(ubmc(pl_idx) / ni(k)) *
+          (init.effkwv * bfb_square(ubmc(pl_idx)) /
+           (GWC::rog * ti(k) * ni(k)) - init.alpha(k));
+        const Real dscal = std::min(1.0, tau(pl_idx, k+1) / (tausat(pl_idx) + GWC::taumin));
+        d = std::max(d, dscal * dsat);
+      }
+    }
 
-        // Test to see if u-c has the same sign here as the level below.
-        if (ubmc(pl_idx) * (ubi(k + 1) - c(pl_idx)) > 0.0) {
-          tausat(pl_idx) = std::abs(init.effkwv * rhoi(k) * bfb_cube(ubmc(pl_idx)) /
-                                    (2.0 * ni(k)));
-          if (tausat(pl_idx) <= GWC::taumin) tausat(pl_idx) = 0.0;
+    // Compute stress for each wave. The stress at this level is the min of
+    // the saturation stress and the stress at the level below reduced by
+    // damping. The sign of the stress must be the same as at the level below.
+    //
+    // If molecular diffusion is on, only do this in levels with molecular
+    // diffusion. Otherwise, do it everywhere.
+    if (k <= init.nbot_molec || !init.do_molec_diff) {
+      for (Int l = -pgwv; l <= pgwv; ++l) {
+        int pl_idx = l + pgwv; // 0-based idx for -pgwv:pgwv arrays
+        const Real ubmc2 = std::max(bfb_square(ubmc(pl_idx)), GWC::ubmc2mn);
+        const Real mi = ni(k) / (2.0 * init.kwv * ubmc2) * (init.alpha(k) + bfb_square(ni(k)) / ubmc2 * d);
+        const Real wrk = -2.0 * mi * GWC::rog * t(k) * (piln(k + 1) - piln(k));
+        Real taudmp;
+        if (wrk >= -150.0 || !init.do_molec_diff) {
+          taudmp = tau(pl_idx, k+1) * std::exp(wrk);
+        } else {
+          taudmp = 0.0;
         }
-        else {
-          tausat(pl_idx) = 0.0;
-        }
+        if (taudmp <= GWC::taumin) taudmp = 0.0;
+        tau(pl_idx, k) = std::min(taudmp, tausat(pl_idx));
       }
-
-      // Determine the diffusivity for each column.
-      Real d = GWC::dback;
-      if (init.do_molec_diff) {
-        d += kvtt(k);
-      }
-      else {
-        for (Int l = -pgwv; l <= pgwv; ++l) {
-          int pl_idx = l + pgwv; // 0-based idx for -pgwv:pgwv arrays
-          const Real dsat = bfb_square(ubmc(pl_idx) / ni(k)) *
-            (init.effkwv * bfb_square(ubmc(pl_idx)) /
-             (GWC::rog * ti(k) * ni(k)) - init.alpha(k));
-          const Real dscal = std::min(1.0, tau(pl_idx, k+1) / (tausat(pl_idx) + GWC::taumin));
-          d = std::max(d, dscal * dsat);
-        }
-      }
-
-      // Compute stress for each wave. The stress at this level is the min of
-      // the saturation stress and the stress at the level below reduced by
-      // damping. The sign of the stress must be the same as at the level below.
-      //
-      // If molecular diffusion is on, only do this in levels with molecular
-      // diffusion. Otherwise, do it everywhere.
-      if (k <= init.nbot_molec || !init.do_molec_diff) {
-        for (Int l = -pgwv; l <= pgwv; ++l) {
-          int pl_idx = l + pgwv; // 0-based idx for -pgwv:pgwv arrays
-          const Real ubmc2 = std::max(bfb_square(ubmc(pl_idx)), GWC::ubmc2mn);
-          const Real mi = ni(k) / (2.0 * init.kwv * ubmc2) * (init.alpha(k) + bfb_square(ni(k)) / ubmc2 * d);
-          const Real wrk = -2.0 * mi * GWC::rog * t(k) * (piln(k + 1) - piln(k));
-          Real taudmp;
-          if (wrk >= -150.0 || !init.do_molec_diff) {
-            taudmp = tau(pl_idx, k+1) * std::exp(wrk);
-          } else {
-            taudmp = 0.0;
-          }
-          if (taudmp <= GWC::taumin) taudmp = 0.0;
-          tau(pl_idx, k) = std::min(taudmp, tausat(pl_idx));
-        }
-      }
-      else {
-        for (Int l = -pgwv; l <= pgwv; ++l) {
-          int pl_idx = l + pgwv; // 0-based idx for -pgwv:pgwv arrays
-          tau(pl_idx, k) = std::min(tau(pl_idx, k+1), tausat(pl_idx));
-        }
+    }
+    else {
+      for (Int l = -pgwv; l <= pgwv; ++l) {
+        int pl_idx = l + pgwv; // 0-based idx for -pgwv:pgwv arrays
+        tau(pl_idx, k) = std::min(tau(pl_idx, k+1), tausat(pl_idx));
       }
     }
   }

--- a/components/eamxx/src/physics/gw/impl/gw_gwd_compute_stress_profiles_and_diffusivities_impl.hpp
+++ b/components/eamxx/src/physics/gw/impl/gw_gwd_compute_stress_profiles_and_diffusivities_impl.hpp
@@ -45,11 +45,12 @@ void Functions<S,D>::gwd_compute_stress_profiles_and_diffusivities(
 
   // Loop from bottom to top to get stress profiles.
   for (Int k = max_level; k >= init.ktop; --k) {
-    // Determine the absolute value of the saturation stress.
-    // Define critical levels where the sign of (u-c) changes between interfaces.
-    for (Int l = -pgwv; l <= pgwv; ++l) {
-      int pl_idx = l + pgwv; // 0-based idx for -pgwv:pgwv arrays
-      if (src_level >= k) {
+    if (src_level >= k) {
+
+      // Determine the absolute value of the saturation stress.
+      // Define critical levels where the sign of (u-c) changes between interfaces.
+      for (Int l = -pgwv; l <= pgwv; ++l) {
+        int pl_idx = l + pgwv; // 0-based idx for -pgwv:pgwv arrays
         ubmc(pl_idx) = ubi(k) - c(pl_idx);
 
         // Test to see if u-c has the same sign here as the level below.
@@ -62,17 +63,15 @@ void Functions<S,D>::gwd_compute_stress_profiles_and_diffusivities(
           tausat(pl_idx) = 0.0;
         }
       }
-    }
 
-    // Determine the diffusivity for each column.
-    Real d = GWC::dback;
-    if (init.do_molec_diff) {
-      d += kvtt(k);
-    }
-    else {
-      for (Int l = -pgwv; l <= pgwv; ++l) {
-        int pl_idx = l + pgwv; // 0-based idx for -pgwv:pgwv arrays
-        if (src_level >= k) {
+      // Determine the diffusivity for each column.
+      Real d = GWC::dback;
+      if (init.do_molec_diff) {
+        d += kvtt(k);
+      }
+      else {
+        for (Int l = -pgwv; l <= pgwv; ++l) {
+          int pl_idx = l + pgwv; // 0-based idx for -pgwv:pgwv arrays
           const Real dsat = bfb_square(ubmc(pl_idx) / ni(k)) *
             (init.effkwv * bfb_square(ubmc(pl_idx)) /
              (GWC::rog * ti(k) * ni(k)) - init.alpha(k));
@@ -80,18 +79,16 @@ void Functions<S,D>::gwd_compute_stress_profiles_and_diffusivities(
           d = std::max(d, dscal * dsat);
         }
       }
-    }
 
-    // Compute stress for each wave. The stress at this level is the min of
-    // the saturation stress and the stress at the level below reduced by
-    // damping. The sign of the stress must be the same as at the level below.
-    //
-    // If molecular diffusion is on, only do this in levels with molecular
-    // diffusion. Otherwise, do it everywhere.
-    if (k <= init.nbot_molec || !init.do_molec_diff) {
-      for (Int l = -pgwv; l <= pgwv; ++l) {
-        int pl_idx = l + pgwv; // 0-based idx for -pgwv:pgwv arrays
-        if (src_level >= k) {
+      // Compute stress for each wave. The stress at this level is the min of
+      // the saturation stress and the stress at the level below reduced by
+      // damping. The sign of the stress must be the same as at the level below.
+      //
+      // If molecular diffusion is on, only do this in levels with molecular
+      // diffusion. Otherwise, do it everywhere.
+      if (k <= init.nbot_molec || !init.do_molec_diff) {
+        for (Int l = -pgwv; l <= pgwv; ++l) {
+          int pl_idx = l + pgwv; // 0-based idx for -pgwv:pgwv arrays
           const Real ubmc2 = std::max(bfb_square(ubmc(pl_idx)), GWC::ubmc2mn);
           const Real mi = ni(k) / (2.0 * init.kwv * ubmc2) * (init.alpha(k) + bfb_square(ni(k)) / ubmc2 * d);
           const Real wrk = -2.0 * mi * GWC::rog * t(k) * (piln(k + 1) - piln(k));
@@ -105,10 +102,9 @@ void Functions<S,D>::gwd_compute_stress_profiles_and_diffusivities(
           tau(pl_idx, k) = std::min(taudmp, tausat(pl_idx));
         }
       }
-    } else {
-      for (Int l = -pgwv; l <= pgwv; ++l) {
-        int pl_idx = l + pgwv; // 0-based idx for -pgwv:pgwv arrays
-        if (src_level >= k) {
+      else {
+        for (Int l = -pgwv; l <= pgwv; ++l) {
+          int pl_idx = l + pgwv; // 0-based idx for -pgwv:pgwv arrays
           tau(pl_idx, k) = std::min(tau(pl_idx, k+1), tausat(pl_idx));
         }
       }

--- a/components/eamxx/src/physics/gw/impl/gw_gwd_compute_tendencies_from_stress_divergence_impl.hpp
+++ b/components/eamxx/src/physics/gw/impl/gw_gwd_compute_tendencies_from_stress_divergence_impl.hpp
@@ -4,6 +4,7 @@
 #include "gw_functions.hpp" // for ETI only but harmless for GPU
 #include "util/eamxx_utils.hpp"
 #include <cmath>
+#include <ekat_math_utils.hpp>
 
 namespace scream {
 namespace gw {

--- a/components/eamxx/src/physics/gw/impl/gw_gwd_compute_tendencies_from_stress_divergence_impl.hpp
+++ b/components/eamxx/src/physics/gw/impl/gw_gwd_compute_tendencies_from_stress_divergence_impl.hpp
@@ -50,7 +50,7 @@ void Functions<S,D>::gwd_compute_tendencies_from_stress_divergence(
   Kokkos::parallel_for(
     Kokkos::TeamVectorRange(team, -pgwv, pgwv+1), [&] (const int l) {
     //  Accumulate the mean wind tendency over wavenumber.
-    int pl_idx = l + pgwv; // 0-based idx for -pgwv:pgwv arrays
+    const int pl_idx = l + pgwv; // 0-based idx for -pgwv:pgwv arrays
 
     // Force tau at the top of the model to zero, if requested.
     if (init.tau_0_ubc) {

--- a/components/eamxx/src/physics/gw/tests/gw_gwd_compute_stress_profiles_and_diffusivities_tests.cpp
+++ b/components/eamxx/src/physics/gw/tests/gw_gwd_compute_stress_profiles_and_diffusivities_tests.cpp
@@ -67,6 +67,9 @@ struct UnitWrap::UnitTest<D>::TestGwdComputeStressProfilesAndDiffusivities : pub
       }
     }
 
+    const auto margin = std::numeric_limits<Real>::epsilon() *
+      (ekat::is_single_precision<Real>::value ? 1000 : 1);
+
     // Verify BFB results, all data should be in C layout
     if (SCREAM_BFB_TESTING && this->m_baseline_action == COMPARE) {
       for (Int i = 0; i < num_runs; ++i) {
@@ -74,7 +77,10 @@ struct UnitWrap::UnitTest<D>::TestGwdComputeStressProfilesAndDiffusivities : pub
         GwdComputeStressProfilesAndDiffusivitiesData& d_test = test_data[i];
         REQUIRE(d_baseline.total(d_baseline.tau) == d_test.total(d_test.tau));
         for (Int k = 0; k < d_baseline.total(d_baseline.tau); ++k) {
-          REQUIRE(d_baseline.tau[k] == d_test.tau[k]);
+          // We must add a tolerance here since we are doing the operations
+          // in a different order in order to improve the amount of parallel
+          // computation
+          REQUIRE(d_baseline.tau[k] == Approx(d_test.tau[k]).margin(margin));
         }
 
       }

--- a/components/eamxx/src/physics/gw/tests/gw_gwd_compute_stress_profiles_and_diffusivities_tests.cpp
+++ b/components/eamxx/src/physics/gw/tests/gw_gwd_compute_stress_profiles_and_diffusivities_tests.cpp
@@ -38,7 +38,7 @@ struct UnitWrap::UnitTest<D>::TestGwdComputeStressProfilesAndDiffusivities : pub
     for (Int i = 0; i < num_runs; ++i) {
       auto& d = baseline_data[i];
       // ni must be very small or else we risk a FPE due to a huge exp
-      d.randomize(engine, { {d.ni, {1.E-08, 2.E-08}}, {d.src_level, {init_data[i].ktop+1, init_data[i].kbotbg-1}} });
+      d.randomize(engine, { {d.ni, {1.E-06, 2.E-06}}, {d.src_level, {init_data[i].ktop+1, init_data[i].kbotbg-1}}, {d.ubi, {2.E-04, 3.E-04}}, {d.c, {1.E-04, 2.E-04}} });
     }
 
     // Create copies of data for use by test. Needs to happen before read calls so that

--- a/components/eamxx/src/physics/gw/tests/gw_gwd_compute_stress_profiles_and_diffusivities_tests.cpp
+++ b/components/eamxx/src/physics/gw/tests/gw_gwd_compute_stress_profiles_and_diffusivities_tests.cpp
@@ -79,7 +79,8 @@ struct UnitWrap::UnitTest<D>::TestGwdComputeStressProfilesAndDiffusivities : pub
         for (Int k = 0; k < d_baseline.total(d_baseline.tau); ++k) {
           // We must add a tolerance here since we are doing the operations
           // in a different order in order to improve the amount of parallel
-          // computation
+          // computation. This tol can be removed once we are no longer using
+          // fortran to generate baselines.
           REQUIRE(d_baseline.tau[k] == Approx(d_test.tau[k]).margin(margin));
         }
 

--- a/components/eamxx/src/physics/gw/tests/infra/gw_test_data.cpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_test_data.cpp
@@ -307,6 +307,11 @@ void gwd_compute_stress_profiles_and_diffusivities(GwdComputeStressProfilesAndDi
   WSM wsm(2*d.init.pgwv + 1, 2, policy);
   GWF::GwCommonInit init_cp = GWF::s_common_init;
 
+  view3dr_d ubmc("ubmc",   d.ncol, d.init.pver + 1, 2*d.init.pgwv + 1);
+  view3dr_d tausat("tausat", d.ncol, d.init.pver + 1, 2*d.init.pgwv + 1);
+  view3dr_d dsat("dsat", d.ncol, d.init.pver + 1, 2*d.init.pgwv + 1);
+  view3dr_d wrk("wrk", d.ncol, d.init.pver + 1, 2*d.init.pgwv + 1);
+
   // unpack init because we do not want the lambda to capture it
   const int pver = d.init.pver;
   const int pgwv = d.init.pgwv;
@@ -324,6 +329,10 @@ void gwd_compute_stress_profiles_and_diffusivities(GwdComputeStressProfilesAndDi
     const auto t_c    = ekat::subview(t, col);
     const auto ti_c   = ekat::subview(ti, col);
     const auto piln_c = ekat::subview(piln, col);
+    const auto ubmc_c = ekat::subview(ubmc, col);
+    const auto tausat_c = ekat::subview(tausat, col);
+    const auto dsat_c = ekat::subview(dsat, col);
+    const auto wrk_c = ekat::subview(wrk, col);
     const auto tau_c  = ekat::subview(tau, col);
 
     GWF::gwd_compute_stress_profiles_and_diffusivities(
@@ -340,6 +349,10 @@ void gwd_compute_stress_profiles_and_diffusivities(GwdComputeStressProfilesAndDi
       t_c,
       ti_c,
       piln_c,
+      ubmc_c,
+      tausat_c,
+      dsat_c,
+//      wrk_c,
       tau_c);
   });
 

--- a/components/eamxx/src/physics/gw/tests/infra/gw_test_data.cpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_test_data.cpp
@@ -307,10 +307,10 @@ void gwd_compute_stress_profiles_and_diffusivities(GwdComputeStressProfilesAndDi
   WSM wsm(2*d.init.pgwv + 1, 2, policy);
   GWF::GwCommonInit init_cp = GWF::s_common_init;
 
-  view3dr_d ubmc("ubmc",   d.ncol, d.init.pver + 1, 2*d.init.pgwv + 1);
   view3dr_d tausat("tausat", d.ncol, d.init.pver + 1, 2*d.init.pgwv + 1);
   view3dr_d dsat("dsat", d.ncol, d.init.pver + 1, 2*d.init.pgwv + 1);
-  view3dr_d wrk("wrk", d.ncol, d.init.pver + 1, 2*d.init.pgwv + 1);
+  view3dr_d wrk1("wrk1", d.ncol, d.init.pver + 1, 2*d.init.pgwv + 1);
+  view3dr_d wrk2("wrk2", d.ncol, d.init.pver + 1, 2*d.init.pgwv + 1);
 
   // unpack init because we do not want the lambda to capture it
   const int pver = d.init.pver;
@@ -329,10 +329,10 @@ void gwd_compute_stress_profiles_and_diffusivities(GwdComputeStressProfilesAndDi
     const auto t_c    = ekat::subview(t, col);
     const auto ti_c   = ekat::subview(ti, col);
     const auto piln_c = ekat::subview(piln, col);
-    const auto ubmc_c = ekat::subview(ubmc, col);
     const auto tausat_c = ekat::subview(tausat, col);
     const auto dsat_c = ekat::subview(dsat, col);
-    const auto wrk_c = ekat::subview(wrk, col);
+    const auto wrk1_c = ekat::subview(wrk1, col);
+    const auto wrk2_c = ekat::subview(wrk2, col);
     const auto tau_c  = ekat::subview(tau, col);
 
     GWF::gwd_compute_stress_profiles_and_diffusivities(
@@ -349,10 +349,10 @@ void gwd_compute_stress_profiles_and_diffusivities(GwdComputeStressProfilesAndDi
       t_c,
       ti_c,
       piln_c,
-      ubmc_c,
       tausat_c,
       dsat_c,
-//      wrk_c,
+      wrk1_c,
+      wrk2_c,
       tau_c);
   });
 

--- a/components/eamxx/src/physics/gw/tests/infra/gw_test_data.cpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_test_data.cpp
@@ -112,9 +112,9 @@ void gw_finalize_cxx(GwInit& init)
 void gwd_compute_tendencies_from_stress_divergence_f(GwdComputeTendenciesFromStressDivergenceData& d)
 {
   gw_init(d.init);
-  d.transpose<ekat::TransposeDirection::c2f>();
+  d.transpose<ekat::TransposeDirection::c2f>(); // This will shift array data + 1
   gwd_compute_tendencies_from_stress_divergence_c(d.ncol, d.do_taper, d.dt, d.effgw, d.tend_level, d.lat, d.dpm, d.rdpm, d.c, d.ubm, d.t, d.nm, d.xv, d.yv, d.tau, d.gwut, d.utgw, d.vtgw);
-  d.transpose<ekat::TransposeDirection::f2c>();
+  d.transpose<ekat::TransposeDirection::f2c>(); // This will shift array data - 1
 }
 
 void gwd_compute_tendencies_from_stress_divergence(GwdComputeTendenciesFromStressDivergenceData& d)

--- a/components/eamxx/src/physics/gw/tests/infra/gw_test_data.cpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_test_data.cpp
@@ -302,14 +302,6 @@ void gwd_compute_stress_profiles_and_diffusivities(GwdComputeStressProfilesAndDi
 
   const auto tau        = three_d_reals_in[0];
 
-  // Find max src_level
-  int max_level = 0;
-  Kokkos::parallel_reduce("find max level", d.ncol, KOKKOS_LAMBDA(const int i, int& lmax) {
-    if (src_level(i) > lmax) {
-      lmax = src_level(i);
-    }
-  }, Kokkos::Max<int>(max_level));
-
   auto policy = ekat::TeamPolicyFactory<ExeSpace>::get_default_team_policy(d.ncol, d.init.pver);
 
   WSM wsm(2*d.init.pgwv + 1, 2, policy);
@@ -340,7 +332,6 @@ void gwd_compute_stress_profiles_and_diffusivities(GwdComputeStressProfilesAndDi
       init_cp,
       pver, pgwv,
       src_level(col),
-      max_level,
       ubi_c,
       c_c,
       rhoi_c,

--- a/components/eamxx/src/physics/gw/tests/infra/gw_test_data.hpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_test_data.hpp
@@ -50,9 +50,9 @@ struct GwInit : public PhysicsTestData {
   PTD_STD_DEF(GwInit, 11, pver, pgwv, dc, orographic_only, do_molec_diff, tau_0_ubc, nbot_molec, ktop, kbotbg, fcrit2, kwv);
 
   template <ekat::TransposeDirection::Enum D>
-  void transpose()
+  void transition()
   {
-    PhysicsTestData::transpose<D>();
+    PhysicsTestData::transition<D>();
 
     shift_int_scalar<D>(ktop);
     shift_int_scalar<D>(kbotbg);
@@ -99,11 +99,11 @@ struct GwdComputeTendenciesFromStressDivergenceData : public PhysicsTestData {
   PTD_STD_DEF_INIT(GwdComputeTendenciesFromStressDivergenceData, 4, ncol, do_taper, dt, effgw);
 
   template <ekat::TransposeDirection::Enum D>
-  void transpose()
+  void transition()
   {
-    PhysicsTestData::transpose<D>();
+    PhysicsTestData::transition<D>();
 
-    init.transpose<D>();
+    init.transition<D>();
   }
 
 };
@@ -133,11 +133,11 @@ struct GwProfData : public PhysicsTestData {
   PTD_STD_DEF_INIT(GwProfData, 2, ncol, cpair);
 
   template <ekat::TransposeDirection::Enum D>
-  void transpose()
+  void transition()
   {
-    PhysicsTestData::transpose<D>();
+    PhysicsTestData::transition<D>();
 
-    init.transpose<D>();
+    init.transition<D>();
   }
 
 };
@@ -174,11 +174,11 @@ struct MomentumEnergyConservationData : public PhysicsTestData {
   PTD_STD_DEF_INIT(MomentumEnergyConservationData, 2, ncol, dt);
 
   template <ekat::TransposeDirection::Enum D>
-  void transpose()
+  void transition()
   {
-    PhysicsTestData::transpose<D>();
+    PhysicsTestData::transition<D>();
 
-    init.transpose<D>();
+    init.transition<D>();
   }
 };
 
@@ -215,11 +215,11 @@ struct GwdComputeStressProfilesAndDiffusivitiesData : public PhysicsTestData {
   PTD_STD_DEF_INIT(GwdComputeStressProfilesAndDiffusivitiesData, 1, ncol);
 
   template <ekat::TransposeDirection::Enum D>
-  void transpose()
+  void transition()
   {
-    PhysicsTestData::transpose<D>();
+    PhysicsTestData::transition<D>();
 
-    init.transpose<D>();
+    init.transition<D>();
   }
 };
 
@@ -258,11 +258,11 @@ struct GwdProjectTauData : public PhysicsTestData {
   PTD_STD_DEF_INIT(GwdProjectTauData, 1, ncol);
 
   template <ekat::TransposeDirection::Enum D>
-  void transpose()
+  void transition()
   {
-    PhysicsTestData::transpose<D>();
+    PhysicsTestData::transition<D>();
 
-    init.transpose<D>();
+    init.transition<D>();
   }
 };
 
@@ -302,11 +302,11 @@ struct GwdPrecalcRhoiData : public PhysicsTestData {
   PTD_STD_DEF_INIT(GwdPrecalcRhoiData, 3, pcnst, ncol, dt);
 
   template <ekat::TransposeDirection::Enum D>
-  void transpose()
+  void transition()
   {
-    PhysicsTestData::transpose<D>();
+    PhysicsTestData::transition<D>();
 
-    init.transpose<D>();
+    init.transition<D>();
   }
 };
 
@@ -356,11 +356,11 @@ struct GwDragProfData : public PhysicsTestData {
   PTD_STD_DEF_INIT(GwDragProfData, 5, pcnst, ncol, do_taper, dt, effgw);
 
   template <ekat::TransposeDirection::Enum D>
-  void transpose()
+  void transition()
   {
-    PhysicsTestData::transpose<D>();
+    PhysicsTestData::transition<D>();
 
-    init.transpose<D>();
+    init.transition<D>();
   }
 };
 
@@ -381,11 +381,11 @@ struct GwFrontInitData : public PhysicsTestData{
   PTD_STD_DEF_INIT(GwFrontInitData, 3, taubgnd, frontgfc_in, kfront_in);
 
   template <ekat::TransposeDirection::Enum D>
-  void transpose()
+  void transition()
   {
-    PhysicsTestData::transpose<D>();
+    PhysicsTestData::transition<D>();
 
-    init.transpose<D>();
+    init.transition<D>();
 
     shift_int_scalar<D>(kfront_in);
   }
@@ -417,11 +417,11 @@ struct GwFrontProjectWindsData : public PhysicsTestData {
   PTD_STD_DEF_INIT(GwFrontProjectWindsData, 2, ncol, kbot);
 
   template <ekat::TransposeDirection::Enum D>
-  void transpose()
+  void transition()
   {
-    PhysicsTestData::transpose<D>();
+    PhysicsTestData::transition<D>();
 
-    init.transpose<D>();
+    init.transition<D>();
   }
 };
 
@@ -449,11 +449,11 @@ struct GwFrontGwSourcesData : public PhysicsTestData {
   PTD_STD_DEF_INIT(GwFrontGwSourcesData, 2, ncol, kbot);
 
   template <ekat::TransposeDirection::Enum D>
-  void transpose()
+  void transition()
   {
-    PhysicsTestData::transpose<D>();
+    PhysicsTestData::transition<D>();
 
-    init.transpose<D>();
+    init.transition<D>();
   }
 };
 
@@ -492,11 +492,11 @@ struct GwCmSrcData : public PhysicsTestData {
   PTD_STD_DEF_INIT(GwCmSrcData, 2, ncol, kbot);
 
   template <ekat::TransposeDirection::Enum D>
-  void transpose()
+  void transition()
   {
-    PhysicsTestData::transpose<D>();
+    PhysicsTestData::transition<D>();
 
-    init.transpose<D>();
+    init.transition<D>();
 
     shift_int_scalar<D>(kbot);
   }
@@ -522,11 +522,11 @@ struct GwConvectInitData : public PhysicsTestData{
   PTD_STD_DEF_INIT(GwConvectInitData, 3, maxh, maxuh, plev_src_wind);
 
   template <ekat::TransposeDirection::Enum D>
-  void transpose()
+  void transition()
   {
-    PhysicsTestData::transpose<D>();
+    PhysicsTestData::transition<D>();
 
-    init.transpose<D>();
+    init.transition<D>();
   }
 };
 
@@ -556,11 +556,11 @@ struct GwConvectProjectWindsData : public PhysicsTestData {
   PTD_STD_DEF_INIT(GwConvectProjectWindsData, 1, ncol);
 
   template <ekat::TransposeDirection::Enum D>
-  void transpose()
+  void transition()
   {
-    PhysicsTestData::transpose<D>();
+    PhysicsTestData::transition<D>();
 
-    init.transpose<D>();
+    init.transition<D>();
   }
 };
 
@@ -595,11 +595,11 @@ struct GwHeatingDepthData : public PhysicsTestData {
   PTD_STD_DEF_INIT(GwHeatingDepthData, 4, ncol, maxq0_conversion_factor, hdepth_scaling_factor, use_gw_convect_old);
 
   template <ekat::TransposeDirection::Enum D>
-  void transpose()
+  void transition()
   {
-    PhysicsTestData::transpose<D>();
+    PhysicsTestData::transition<D>();
 
-    init.transpose<D>();
+    init.transition<D>();
   }
 };
 
@@ -634,11 +634,11 @@ struct GwStormSpeedData : public PhysicsTestData {
   PTD_STD_DEF_INIT(GwStormSpeedData, 2, ncol, storm_speed_min);
 
   template <ekat::TransposeDirection::Enum D>
-  void transpose()
+  void transition()
   {
-    PhysicsTestData::transpose<D>();
+    PhysicsTestData::transition<D>();
 
-    init.transpose<D>();
+    init.transition<D>();
   }
 };
 
@@ -674,11 +674,11 @@ struct GwConvectGwSourcesData : public PhysicsTestData {
   PTD_STD_DEF_INIT(GwConvectGwSourcesData, 2, ncol, hdepth_min);
 
   template <ekat::TransposeDirection::Enum D>
-  void transpose()
+  void transition()
   {
-    PhysicsTestData::transpose<D>();
+    PhysicsTestData::transition<D>();
 
-    init.transpose<D>();
+    init.transition<D>();
   }
 };
 
@@ -719,11 +719,11 @@ struct GwBeresSrcData : public PhysicsTestData {
   PTD_STD_DEF_INIT(GwBeresSrcData, 6, ncol, maxq0_conversion_factor, hdepth_scaling_factor, hdepth_min, storm_speed_min, use_gw_convect_old);
 
   template <ekat::TransposeDirection::Enum D>
-  void transpose()
+  void transition()
   {
-    PhysicsTestData::transpose<D>();
+    PhysicsTestData::transition<D>();
 
-    init.transpose<D>();
+    init.transition<D>();
   }
 };
 
@@ -762,11 +762,11 @@ struct GwEdiffData : public PhysicsTestData {
   PTD_STD_DEF_INIT(GwEdiffData, 4, ncol, kbot, ktop, dt);
 
   template <ekat::TransposeDirection::Enum D>
-  void transpose()
+  void transition()
   {
-    PhysicsTestData::transpose<D>();
+    PhysicsTestData::transition<D>();
 
-    init.transpose<D>();
+    init.transition<D>();
 
     shift_int_scalar<D>(kbot);
     shift_int_scalar<D>(ktop);
@@ -797,11 +797,11 @@ struct GwDiffTendData : public PhysicsTestData {
   PTD_STD_DEF_INIT(GwDiffTendData, 4, ncol, kbot, ktop, dt);
 
   template <ekat::TransposeDirection::Enum D>
-  void transpose()
+  void transition()
   {
-    PhysicsTestData::transpose<D>();
+    PhysicsTestData::transition<D>();
 
-    init.transpose<D>();
+    init.transition<D>();
 
     shift_int_scalar<D>(kbot);
     shift_int_scalar<D>(ktop);
@@ -843,11 +843,11 @@ struct GwOroSrcData : public PhysicsTestData {
   PTD_STD_DEF_INIT(GwOroSrcData, 1, ncol);
 
   template <ekat::TransposeDirection::Enum D>
-  void transpose()
+  void transition()
   {
-    PhysicsTestData::transpose<D>();
+    PhysicsTestData::transition<D>();
 
-    init.transpose<D>();
+    init.transition<D>();
   }
 };
 

--- a/components/eamxx/src/physics/gw/tests/infra/gw_test_data.hpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_test_data.hpp
@@ -675,6 +675,7 @@ void gwd_compute_tendencies_from_stress_divergence(GwdComputeTendenciesFromStres
 void gwd_compute_tendencies_from_stress_divergence_f(GwdComputeTendenciesFromStressDivergenceData& d);
 void gw_prof(GwProfData& d);
 void momentum_energy_conservation(MomentumEnergyConservationData& d);
+void gwd_compute_stress_profiles_and_diffusivities_f(GwdComputeStressProfilesAndDiffusivitiesData& d);
 void gwd_compute_stress_profiles_and_diffusivities(GwdComputeStressProfilesAndDiffusivitiesData& d);
 void gwd_project_tau(GwdProjectTauData& d);
 void gwd_precalc_rhoi(GwdPrecalcRhoiData& d);

--- a/components/eamxx/src/physics/gw/tests/infra/gw_test_data.hpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_test_data.hpp
@@ -48,6 +48,15 @@ struct GwInit : public PhysicsTestData {
   }
 
   PTD_STD_DEF(GwInit, 11, pver, pgwv, dc, orographic_only, do_molec_diff, tau_0_ubc, nbot_molec, ktop, kbotbg, fcrit2, kwv);
+
+  template <ekat::TransposeDirection::Enum D>
+  void transpose()
+  {
+    PhysicsTestData::transpose<D>();
+
+    shift_int_scalar<D>(ktop);
+    shift_int_scalar<D>(kbotbg);
+  }
 };
 
 struct GwdComputeTendenciesFromStressDivergenceData : public PhysicsTestData {
@@ -88,6 +97,15 @@ struct GwdComputeTendenciesFromStressDivergenceData : public PhysicsTestData {
   {}
 
   PTD_STD_DEF_INIT(GwdComputeTendenciesFromStressDivergenceData, 4, ncol, do_taper, dt, effgw);
+
+  template <ekat::TransposeDirection::Enum D>
+  void transpose()
+  {
+    PhysicsTestData::transpose<D>();
+
+    init.transpose<D>();
+  }
+
 };
 
 struct GwProfData : public PhysicsTestData {
@@ -113,6 +131,15 @@ struct GwProfData : public PhysicsTestData {
   {}
 
   PTD_STD_DEF_INIT(GwProfData, 2, ncol, cpair);
+
+  template <ekat::TransposeDirection::Enum D>
+  void transpose()
+  {
+    PhysicsTestData::transpose<D>();
+
+    init.transpose<D>();
+  }
+
 };
 
 struct MomentumEnergyConservationData : public PhysicsTestData {
@@ -145,6 +172,14 @@ struct MomentumEnergyConservationData : public PhysicsTestData {
   {}
 
   PTD_STD_DEF_INIT(MomentumEnergyConservationData, 2, ncol, dt);
+
+  template <ekat::TransposeDirection::Enum D>
+  void transpose()
+  {
+    PhysicsTestData::transpose<D>();
+
+    init.transpose<D>();
+  }
 };
 
 struct GwdComputeStressProfilesAndDiffusivitiesData : public PhysicsTestData {
@@ -178,6 +213,14 @@ struct GwdComputeStressProfilesAndDiffusivitiesData : public PhysicsTestData {
   {}
 
   PTD_STD_DEF_INIT(GwdComputeStressProfilesAndDiffusivitiesData, 1, ncol);
+
+  template <ekat::TransposeDirection::Enum D>
+  void transpose()
+  {
+    PhysicsTestData::transpose<D>();
+
+    init.transpose<D>();
+  }
 };
 
 struct GwdProjectTauData : public PhysicsTestData {
@@ -213,6 +256,14 @@ struct GwdProjectTauData : public PhysicsTestData {
   {}
 
   PTD_STD_DEF_INIT(GwdProjectTauData, 1, ncol);
+
+  template <ekat::TransposeDirection::Enum D>
+  void transpose()
+  {
+    PhysicsTestData::transpose<D>();
+
+    init.transpose<D>();
+  }
 };
 
 struct GwdPrecalcRhoiData : public PhysicsTestData {
@@ -249,6 +300,14 @@ struct GwdPrecalcRhoiData : public PhysicsTestData {
   {}
 
   PTD_STD_DEF_INIT(GwdPrecalcRhoiData, 3, pcnst, ncol, dt);
+
+  template <ekat::TransposeDirection::Enum D>
+  void transpose()
+  {
+    PhysicsTestData::transpose<D>();
+
+    init.transpose<D>();
+  }
 };
 
 struct GwDragProfData : public PhysicsTestData {
@@ -295,6 +354,14 @@ struct GwDragProfData : public PhysicsTestData {
   {}
 
   PTD_STD_DEF_INIT(GwDragProfData, 5, pcnst, ncol, do_taper, dt, effgw);
+
+  template <ekat::TransposeDirection::Enum D>
+  void transpose()
+  {
+    PhysicsTestData::transpose<D>();
+
+    init.transpose<D>();
+  }
 };
 
 struct GwFrontInitData : public PhysicsTestData{
@@ -312,6 +379,16 @@ struct GwFrontInitData : public PhysicsTestData{
   {}
 
   PTD_STD_DEF_INIT(GwFrontInitData, 3, taubgnd, frontgfc_in, kfront_in);
+
+  template <ekat::TransposeDirection::Enum D>
+  void transpose()
+  {
+    PhysicsTestData::transpose<D>();
+
+    init.transpose<D>();
+
+    shift_int_scalar<D>(kfront_in);
+  }
 };
 
 struct GwFrontProjectWindsData : public PhysicsTestData {
@@ -338,6 +415,14 @@ struct GwFrontProjectWindsData : public PhysicsTestData {
   {}
 
   PTD_STD_DEF_INIT(GwFrontProjectWindsData, 2, ncol, kbot);
+
+  template <ekat::TransposeDirection::Enum D>
+  void transpose()
+  {
+    PhysicsTestData::transpose<D>();
+
+    init.transpose<D>();
+  }
 };
 
 struct GwFrontGwSourcesData : public PhysicsTestData {
@@ -362,6 +447,14 @@ struct GwFrontGwSourcesData : public PhysicsTestData {
   {}
 
   PTD_STD_DEF_INIT(GwFrontGwSourcesData, 2, ncol, kbot);
+
+  template <ekat::TransposeDirection::Enum D>
+  void transpose()
+  {
+    PhysicsTestData::transpose<D>();
+
+    init.transpose<D>();
+  }
 };
 
 struct GwCmSrcData : public PhysicsTestData {
@@ -397,6 +490,16 @@ struct GwCmSrcData : public PhysicsTestData {
   {}
 
   PTD_STD_DEF_INIT(GwCmSrcData, 2, ncol, kbot);
+
+  template <ekat::TransposeDirection::Enum D>
+  void transpose()
+  {
+    PhysicsTestData::transpose<D>();
+
+    init.transpose<D>();
+
+    shift_int_scalar<D>(kbot);
+  }
 };
 
 struct GwConvectInitData : public PhysicsTestData{
@@ -417,6 +520,14 @@ struct GwConvectInitData : public PhysicsTestData{
   {}
 
   PTD_STD_DEF_INIT(GwConvectInitData, 3, maxh, maxuh, plev_src_wind);
+
+  template <ekat::TransposeDirection::Enum D>
+  void transpose()
+  {
+    PhysicsTestData::transpose<D>();
+
+    init.transpose<D>();
+  }
 };
 
 struct GwConvectProjectWindsData : public PhysicsTestData {
@@ -443,6 +554,14 @@ struct GwConvectProjectWindsData : public PhysicsTestData {
   {}
 
   PTD_STD_DEF_INIT(GwConvectProjectWindsData, 1, ncol);
+
+  template <ekat::TransposeDirection::Enum D>
+  void transpose()
+  {
+    PhysicsTestData::transpose<D>();
+
+    init.transpose<D>();
+  }
 };
 
 struct GwHeatingDepthData : public PhysicsTestData {
@@ -474,6 +593,14 @@ struct GwHeatingDepthData : public PhysicsTestData {
   {}
 
   PTD_STD_DEF_INIT(GwHeatingDepthData, 4, ncol, maxq0_conversion_factor, hdepth_scaling_factor, use_gw_convect_old);
+
+  template <ekat::TransposeDirection::Enum D>
+  void transpose()
+  {
+    PhysicsTestData::transpose<D>();
+
+    init.transpose<D>();
+  }
 };
 
 struct GwStormSpeedData : public PhysicsTestData {
@@ -505,6 +632,14 @@ struct GwStormSpeedData : public PhysicsTestData {
   {}
 
   PTD_STD_DEF_INIT(GwStormSpeedData, 2, ncol, storm_speed_min);
+
+  template <ekat::TransposeDirection::Enum D>
+  void transpose()
+  {
+    PhysicsTestData::transpose<D>();
+
+    init.transpose<D>();
+  }
 };
 
 struct GwConvectGwSourcesData : public PhysicsTestData {
@@ -537,6 +672,14 @@ struct GwConvectGwSourcesData : public PhysicsTestData {
   {}
 
   PTD_STD_DEF_INIT(GwConvectGwSourcesData, 2, ncol, hdepth_min);
+
+  template <ekat::TransposeDirection::Enum D>
+  void transpose()
+  {
+    PhysicsTestData::transpose<D>();
+
+    init.transpose<D>();
+  }
 };
 
 struct GwBeresSrcData : public PhysicsTestData {
@@ -574,6 +717,14 @@ struct GwBeresSrcData : public PhysicsTestData {
   {}
 
   PTD_STD_DEF_INIT(GwBeresSrcData, 6, ncol, maxq0_conversion_factor, hdepth_scaling_factor, hdepth_min, storm_speed_min, use_gw_convect_old);
+
+  template <ekat::TransposeDirection::Enum D>
+  void transpose()
+  {
+    PhysicsTestData::transpose<D>();
+
+    init.transpose<D>();
+  }
 };
 
 struct GwEdiffData : public PhysicsTestData {
@@ -609,6 +760,17 @@ struct GwEdiffData : public PhysicsTestData {
   {}
 
   PTD_STD_DEF_INIT(GwEdiffData, 4, ncol, kbot, ktop, dt);
+
+  template <ekat::TransposeDirection::Enum D>
+  void transpose()
+  {
+    PhysicsTestData::transpose<D>();
+
+    init.transpose<D>();
+
+    shift_int_scalar<D>(kbot);
+    shift_int_scalar<D>(ktop);
+  }
 };
 
 struct GwDiffTendData : public PhysicsTestData {
@@ -633,6 +795,17 @@ struct GwDiffTendData : public PhysicsTestData {
   {}
 
   PTD_STD_DEF_INIT(GwDiffTendData, 4, ncol, kbot, ktop, dt);
+
+  template <ekat::TransposeDirection::Enum D>
+  void transpose()
+  {
+    PhysicsTestData::transpose<D>();
+
+    init.transpose<D>();
+
+    shift_int_scalar<D>(kbot);
+    shift_int_scalar<D>(ktop);
+  }
 };
 
 struct GwOroSrcData : public PhysicsTestData {
@@ -668,6 +841,14 @@ struct GwOroSrcData : public PhysicsTestData {
   {}
 
   PTD_STD_DEF_INIT(GwOroSrcData, 1, ncol);
+
+  template <ekat::TransposeDirection::Enum D>
+  void transpose()
+  {
+    PhysicsTestData::transpose<D>();
+
+    init.transpose<D>();
+  }
 };
 
 // Glue functions to call fortran from from C++ with the Data struct

--- a/components/eamxx/src/physics/gw/tests/infra/gw_unit_tests_common.hpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_unit_tests_common.hpp
@@ -22,11 +22,15 @@ inline auto get_common_init_data(Engine& engine)
   std::array<GwInit, 4> rv = {
     // gw_ediff::vd_lu_decomp breaks if kbot==pver
 
+    // NOTE: All integer data is assumed to be 0-based (C style)! The
+    // unit-test -> F90 GW layer needs to adjust these in transpose if
+    // it represents an index
+
     //     pver, pgwv,   dc, orog_only, molec_diff, tau_0_ubc, nbot_molec, ktop, kbotbg, fcrit2, kwv
     GwInit(  72,   20, 0.75,     false,      false,     false,         16,   8,     66,    .67, 6.28e-5),
     GwInit(  72,   20, 0.75,     true ,      false,     true ,         16,   6,     68,    .67, 6.28e-5),
     GwInit(  72,   20, 0.75,     false,      true ,     true ,         16,   3,     70,    .67, 6.28e-5),
-    GwInit(  72,   20, 0.75,     true ,      true ,     false,         16,   0,     71,    .67, 6.28e-5),
+    GwInit(  72,   20, 0.75,     true ,      true ,     false,         16,   0,     70,    .67, 6.28e-5),
   };
 
   for (auto& d : rv) {

--- a/components/eamxx/src/physics/gw/tests/infra/gw_unit_tests_common.hpp
+++ b/components/eamxx/src/physics/gw/tests/infra/gw_unit_tests_common.hpp
@@ -23,7 +23,7 @@ inline auto get_common_init_data(Engine& engine)
     // gw_ediff::vd_lu_decomp breaks if kbot==pver
 
     // NOTE: All integer data is assumed to be 0-based (C style)! The
-    // unit-test -> F90 GW layer needs to adjust these in transpose if
+    // unit-test -> F90 GW layer needs to adjust these in d.transition if
     // it represents an index
 
     //     pver, pgwv,   dc, orog_only, molec_diff, tau_0_ubc, nbot_molec, ktop, kbotbg, fcrit2, kwv

--- a/components/eamxx/src/physics/share/physics_test_data.hpp
+++ b/components/eamxx/src/physics/share/physics_test_data.hpp
@@ -383,6 +383,17 @@ class PhysicsTestData
     }
   }
 
+  template <ekat::TransposeDirection::Enum D>
+  void shift_int_scalar(int& scalar)
+  {
+    const int shift = (D == ekat::TransposeDirection::c2f ? 1 : -1);
+    scalar += shift;
+
+    // Since f90 allows for negative index ranges (-foo:foo), we may
+    // have to remove this check.
+    EKAT_ASSERT_MSG(scalar >= 0, "Bad index: " << scalar);
+  }
+
   // Since we are also preparing index data, this function is doing more than transposing. It's shifting the
   // format of all data from one language to another
   template <ekat::TransposeDirection::Enum D>
@@ -392,10 +403,10 @@ class PhysicsTestData
     m_ints.transpose<D>();
     m_bools.transpose<D>();
 
-    // Shift the indices. We might not be able to make the assumption that int data represented indices
+    // Shift the indices. We might not be able to make the assumption that int data represented indices.
+    // NOTE! This will not shift scalar integers. It is up the children structs to do that
     for (size_t i = 0; i < m_ints.m_data.size(); ++i) {
-      m_ints.m_data[i] += (D == ekat::TransposeDirection::c2f ? 1 : -1);
-      EKAT_ASSERT_MSG(m_ints.m_data[i] >= 0, "Bad index: " << m_ints.m_data[i]);
+      shift_int_scalar<D>(m_ints.m_data[i]);
     }
   }
 

--- a/components/eamxx/src/physics/share/physics_test_data.hpp
+++ b/components/eamxx/src/physics/share/physics_test_data.hpp
@@ -395,9 +395,14 @@ class PhysicsTestData
   }
 
   // Since we are also preparing index data, this function is doing more than transposing. It's shifting the
-  // format of all data from one language to another
+  // format of all data from one language to another.
+  //
+  // There is currently no way for this struct to know which integer scalars need
+  // to be shifted, so any subclass that has those will need to define their own
+  // transition method which will call this one and then adjust their int scalars
+  // that represent indices.
   template <ekat::TransposeDirection::Enum D>
-  void transpose()
+  void transition()
   {
     m_reals.transpose<D>();
     m_ints.transpose<D>();

--- a/components/eamxx/src/physics/share/tests/physics_test_data_unit_tests.cpp
+++ b/components/eamxx/src/physics/share/tests/physics_test_data_unit_tests.cpp
@@ -183,8 +183,8 @@ struct UnitWrap::UnitTest<D>::TestTestData
         REQUIRE(d1.bools1[i] == d3.bools1[i]);
       }
 
-      // Check transpose
-      d1.transpose<ekat::TransposeDirection::c2f>();
+      // Check transition
+      d1.transition<ekat::TransposeDirection::c2f>();
       for (Int i = 0; i < d1.dim(d1.one123, 0); ++i) {
         for (Int j = 0; j < d1.dim(d1.one123, 1); ++j) {
           const Int cidx = d1.dim2*i + j;
@@ -206,7 +206,7 @@ struct UnitWrap::UnitTest<D>::TestTestData
         }
       }
 
-      d1.transpose<ekat::TransposeDirection::f2c>();
+      d1.transition<ekat::TransposeDirection::f2c>();
       for (Int i = 0; i < d1.total(d1.one123); ++i) {
         REQUIRE(d1.one123[i] == d2.one123[i]);
         REQUIRE(d1.two123[i] == d2.two123[i]);

--- a/components/eamxx/src/physics/zm/tests/infra/zm_test_data.cpp
+++ b/components/eamxx/src/physics/zm/tests/infra/zm_test_data.cpp
@@ -31,7 +31,7 @@ extern "C" {
 } // extern "C" : end _c decls
 
 void zm_find_mse_max(zm_data_find_mse_max& d){
-  d.transpose<ekat::TransposeDirection::c2f>();
+  d.transition<ekat::TransposeDirection::c2f>();
   zm_find_mse_max_c( d.pcols,
                      d.ncol,
                      d.pver,
@@ -43,7 +43,7 @@ void zm_find_mse_max(zm_data_find_mse_max& d){
                      d.sp_humidity,
                      d.msemax_klev,
                      d.mse_max_val );
-  d.transpose<ekat::TransposeDirection::f2c>();
+  d.transition<ekat::TransposeDirection::f2c>();
 }
 
 // end _c impls

--- a/components/eamxx/src/share/util/eamxx_utils.hpp
+++ b/components/eamxx/src/share/util/eamxx_utils.hpp
@@ -15,6 +15,12 @@
 #include <fstream>
 #include <sstream>
 
+// macros for common powers. Using these should result in
+// fast code and bfb results with fortran.
+#define bfb_square(val) ((val)*(val))
+#define bfb_cube(val)   ((val)*(val)*(val))
+#define bfb_quad(val)   (bfb_square(bfb_square(val)))
+
 namespace scream {
 
 enum MemoryUnits {


### PR DESCRIPTION
Main change: ports gwd_compute_stress_profiles_and_diffusivities to C++.

This was quite tricky. I needed to add several temporary views (tausat, dsat, wrk1, wrk2) to store parallelizable computation. The main loop is serial over k due to the dependency on k+1, but we can at least parallelize over pgwvs.

Other Change list:
1) Be more systematic about the state of the host test data. It should be either entirely C++ mode or f90 mode, with the transition being done by the transpose method. If there are integer scalars that need to be adjusted, the struct should provide it's own definition of transpose.
2) Provide an int shift helper in the common unit test infrastructure.
3) Instead of passing work views in, use WSM
4) Move bfb_pow functions to eamxx_utils.hpp
5) Remove inner ThreadVectorRange from compute..diffusitivities. Flatten
   parallelism to 2-layer
6) Rename PTD::transpose to PTD::transition
7) Improve documentation of PTD::transition

[BFB] (expect for standalone GW)