### PR TITLE
Fix a minor documentation issue in mpaso Registry.xml

### DIFF
--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -1283,7 +1283,7 @@ Default: Defined in namelist_defaults.xml
 	category="precip_scaling" group="precip_scaling">
 Initial guess scaling factor on precipitation fluxes in FOSI runs when config_precip_scaling_mode = 'time-dependent'.
 
-Valid values: Non-negative number between 0 and 1.0. Default value of 1.0 means no scaling.
+Valid values: Non-negative number. A default value of 1.0 indicates no scaling, but values greater than 1.0 can be used to scale up precipitation fluxes in order to achieve freshwater balance in FOSI runs.
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -1291,7 +1291,7 @@ Default: Defined in namelist_defaults.xml
 	category="precip_scaling" group="precip_scaling">
 Prescribed constant scaling factor on precipitation fluxes in FOSI runs when config_precip_scaling_mode = 'constant'.
 
-Valid values: Non-negative number between 0 and 1.0. Default value of 1.0 means no scaling.
+Valid values: Non-negative number between 0 and 1.0. Default value of 1.0 means no scaling, but values greater than 1.0 can be used to scale up precipitation fluxes in order to achieve freshwater balance in FOSI runs.
 Default: Defined in namelist_defaults.xml
 </entry>
 
@@ -1697,11 +1697,11 @@ Default: Defined in namelist_defaults.xml
 
 <!-- land_ice -->
 
-<entry id="config_land_ice_draft_mode" type="character"
+<entry id="config_land_ice_draft_mode" type="char*1024"
 	category="land_ice" group="land_ice">
 Selects the mode in which land-ice draft is computed.
 
-Valid values= 'data,'pressure-dependent'
+Valid values: 'data', 'pressure-dependent'
 Default: Defined in namelist_defaults.xml
 </entry>
 

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -1079,7 +1079,7 @@
 	<nml_record name="land_ice" mode="init;forward">
 		<nml_option name="config_land_ice_draft_mode" type="character" default_value="pressure-dependent"
 					description="Selects the mode in which land-ice draft is computed."
-					possible_values="'data,'pressure-dependent'"
+					possible_values="'data', 'pressure-dependent'"
 		/>
 		<nml_option name="config_land_ice_rho_ocean" type="real" default_value="1028.0" units="kg m^-3"
 					description="ocean density used to calculate landIceDraft at floatation (assumed constant and uniform). Should be consistent with MALI's config_ocean_density when used to determine grounding line location. This is an alternative to the coupler variable effectiveDensityInLandIce which is not currently used."


### PR DESCRIPTION
In the mpaso Registry file, the possible_values for config_land_ice_draft_mode had a missing single quote:
   possible_values="'data,'pressure-dependent'"
This fixes that and updates the bld files to be consistent. Those updates also pick up changes that must have been missed in PR #7361.

[BFB]