### PR TITLE
Workflows: adjust eamxx-v1 tests folder names

### DIFF
--- a/.github/workflows/eamxx-v1-testing.yml
+++ b/.github/workflows/eamxx-v1-testing.yml
@@ -146,3 +146,4 @@ jobs:
         if: ${{ always() }}
         run: |
           rm -rf /projects/e3sm/scratch/${{ matrix.test.full_name }}${{ env.compgen_suffix }}${{ env.testid }}
+          rm -f /projects/e3sm/scratch/cs.status.${{ env.testid }}


### PR DESCRIPTION
Ensure that, when we clean up at the end, we don't accidentally remove the folder
of another version of the same test, currently running as part of another PR CI testing.

[BFB]

---

As an example, I think these two ran together:

- [this](https://github.com/E3SM-Project/E3SM/actions/runs/16974255810/job/48118900377?pr=7605) test failed the cleanup phase because a folder was misteriously not empty
- [this](https://github.com/E3SM-Project/E3SM/actions/runs/16971712702/attempts/1?pr=7549) test failed b/c of missing files in the test folder

What I think happened is this:
- test 1 started to cleanup ALL folders whose name matched the pattern
- it gathered the list of file to delete, and started deleting them. This list included files in the folder for the second test
- by the time it deleted the files, the 2nd test had created more files in the test folder, so test 1 could not remove the folder, as it was now no longer empty, so it failed
- test 2 found a corrupted test folder with missing files, so it failed.

This PR uses the sha of the tested branch as part of the test id, which allows us to remove only the correct folder in the cleanup phase, since we now know _exactly_ the full folder name (before, `create_test` was appending the id made with the test creation date and a sha of something).