### PR TITLE
Use PIO_ENABLE_NCZARR for NCZarr support detection in buildlib.spio

### DIFF
--- a/share/build/buildlib.spio
+++ b/share/build/buildlib.spio
@@ -209,7 +209,7 @@ def buildlib(bldroot, installpath, case):
         pnetcdf_string = "WITH_PNETCDF:BOOL=ON"
         netcdf4_string = "NetCDF_C_HAS_PARALLEL:BOOL=TRUE"
 
-    netcdf4_nczarr_string = "NetCDF_C_HAS_NCZARR:BOOL=TRUE"
+    netcdf4_nczarr_string = "PIO_ENABLE_NCZARR:BOOL=ON"
     adios_string = "WITH_ADIOS2:BOOL=ON"
     hdf5_string = "WITH_HDF5:BOOL=ON"
     expect_string_found = False


### PR DESCRIPTION
NCZarr support in SCORPIO is still experimental and disabled by default.

This PR updates buildlib.spio to use PIO_ENABLE_NCZARR instead of
NetCDF_C_HAS_NCZARR when detecting NCZarr support.

Fixes #7446

[BFB]