### PR TITLE
implement cice moab driver 

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -885,6 +885,7 @@ _TESTS = {
             "ERS_Vmoab_Ld3.T62_oQU240wLI.GMPAS-IAF",
             "ERS_Vmoab_Ld3.T62_oQU120.CMPASO-NYF",
             "ERS_Vmoab_Ld3.r05_r05.RMOSGPCC",
+            "ERS_Vmoab_Ld3.ne4pg2_ne4pg2.F2010-SCREAMv1",
         )
     },
 
@@ -899,6 +900,7 @@ _TESTS = {
             "PEM_Vmoab_Ld3.T62_oQU240wLI.GMPAS-IAF",
             "PEM_Vmoab_Ld3.T62_oQU120.CMPASO-NYF",
             "PEM_Vmoab_Ld3.r05_r05.RMOSGPCC",
+            "PEM_Vmoab_Ld3.ne4pg2_ne4pg2.F2010-SCREAMv1",
         )
     },
 
@@ -913,6 +915,7 @@ _TESTS = {
             "SMS_Vmoab_Ld1.T62_oQU240wLI.GMPAS-IAF",
             "SMS_Vmoab_Ld1.T62_oQU120.CMPASO-NYF",
             "SMS_Vmoab_Ld1.r05_r05.RMOSGPCC",
+            "SMS_Vmoab_Ld1.ne4pg2_ne4pg2.F2010-SCREAMv1",
             "SMS_Ld1.ne4pg2_r05_oQU480.WCYCL1850NS",
             "SMS_Ld1.ne4pg2_oQU480.WCYCL1850NS",
             "SMS_Ld1.ne4pg2_oQU480.F1850",
@@ -921,6 +924,7 @@ _TESTS = {
             "SMS_Ld1.T62_oQU240wLI.GMPAS-IAF",
             "SMS_Ld1.T62_oQU120.CMPASO-NYF",
             "SMS_Ld1.r05_r05.RMOSGPCC",
+            "SMS_Ld1.ne4pg2_ne4pg2.F2010-SCREAMv1",
         )
     },
 

--- a/components/cice/src/drivers/cpl/ice_comp_mct.F90
+++ b/components/cice/src/drivers/cpl/ice_comp_mct.F90
@@ -404,10 +404,11 @@ contains
     nsend = mct_avect_nRattr(i2x_i)
     totalmbls = mblsize * nsend ! size of the double array
     allocate (i2x_im(lsize, nsend) )
-
+    i2x_im = 0.
     nrecv = mct_avect_nRattr(x2i_i) ! number of fields retrived from MOAB tags, based on names from seq_flds_x2l_fields
     totalmblsimp = mblsize * nrecv ! size of the double array to fill with data from MOAB
     allocate (x2i_im(lsize, nrecv) )
+    x2i_im = 0.
     if (my_task == master_task) then
       write(nu_diag,*) SubName, ' mblsize= ',mblsize,' nsend, nrecv for moab:', nsend, nrecv
     end if
@@ -589,8 +590,6 @@ contains
     else
        call ice_import( x2i_i%rattr )
 #ifdef HAVE_MOAB
-       call ice_import_moab( x2i_im, EClock, totalmblsimp )
-
 #ifdef MOABCOMP
        ! loop over all fields in seq_flds_x2l_fields
        call mct_list_init(temp_list ,seq_flds_x2i_fields)
@@ -607,7 +606,10 @@ contains
        call mct_list_clean(temp_list)
    
 #endif
-#endif
+       call ice_import_moab( x2i_im, EClock, totalmblsimp )
+#endif 
+       
+
     endif
     call ice_timer_stop(timer_cplrecv)
     call t_stopf ('cice_run_import')

--- a/components/cice/src/drivers/cpl/ice_import_export.F90
+++ b/components/cice/src/drivers/cpl/ice_import_export.F90
@@ -26,6 +26,15 @@ module ice_import_export
   use ice_prescribed_mod
   use ice_cpl_indices
   use perf_mod        , only: t_startf, t_stopf, t_barrierf
+#ifdef HAVE_MOAB
+  use iMOAB,            only: iMOAB_SetDoubleTagStorage, iMOAB_GetDoubleTagStorage, iMOAB_WriteMesh
+  use seq_timemgr_mod , only: seq_timemgr_EClockGetData
+  use esmf            , only: ESMF_clock
+  use seq_comm_mct,     only: MPSIID! id of moab sea ice app
+  use shr_kind_mod     , only : CXX => SHR_KIND_CXX
+  use seq_flds_mod     , only : seq_flds_x2i_fields, seq_flds_i2x_fields
+  use iso_c_binding
+#endif
   implicit none
   public
 
@@ -484,5 +493,508 @@ contains
     enddo        !iblk
 
   end subroutine ice_export
+
+#ifdef HAVE_MOAB
+   subroutine  ice_export_moab(i2x_im, EClock, totalmbls) ! 
+   !-----------------------------------------------------
+    !
+    ! Arguments
+      real(r8), allocatable, intent(inout) :: i2x_im(:,:)
+      type(ESMF_Clock)         , intent(inout) :: EClock
+      integer, intent(in)   :: totalmbls
+      !
+      ! Local Variables
+      integer :: i, j, iblk, n, ij 
+      integer :: ilo, ihi, jlo, jhi !beginning and end of physical domain
+      integer (kind=int_kind)                                :: icells ! number of ocean/ice cells
+      integer (kind=int_kind), dimension (nx_block*ny_block) :: indxi  ! compressed indices in i
+      integer (kind=int_kind), dimension (nx_block*ny_block) :: indxj  ! compressed indices in i
+  
+      real (kind=dbl_kind), dimension(nx_block,ny_block,max_blocks) :: &
+           Tsrf  &      ! surface temperature
+           ,  tauxa &      ! atmo/ice stress
+           ,  tauya &
+           ,  tauxo &      ! ice/ocean stress
+           ,  tauyo &
+           ,  ailohi       ! fractional ice area
+  
+      real (kind=dbl_kind) :: &
+           workx, worky           ! tmps for converting grid
+  
+      type(block)        :: this_block                           ! block information for current block
+      logical :: flag
+      integer :: ierr, cur_lnd_stepno
+      character(CXX) ::  tagname ! hold all fields names
+      integer        :: ent_type  ! for setting/getting data 
+#ifdef MOABDEBUG
+      character*100 outfile, wopts, lnum
+#endif
+      character(len=32), parameter :: subname = 'ice_export_moab'
+      !-----------------------------------------------------
+  
+      flag=.false.
+  
+      !calculate ice thickness from aice and vice. Also
+      !create Tsrf from the first tracer (trcr) in ice_state.F
+  
+      !$OMP PARALLEL DO PRIVATE(iblk,i,j,workx,worky)
+      do iblk = 1, nblocks
+         do j = 1, ny_block
+            do i = 1, nx_block
+  
+               ! ice fraction
+               ailohi(i,j,iblk) = min(aice(i,j,iblk), c1)
+  
+               ! surface temperature
+               Tsrf(i,j,iblk)  = Tffresh + trcr(i,j,1,iblk)             !Kelvin (original ???)
+  
+               ! wind stress  (on POP T-grid:  convert to lat-lon)
+               workx = strairxT(i,j,iblk)                             ! N/m^2
+               worky = strairyT(i,j,iblk)                             ! N/m^2
+               tauxa(i,j,iblk) = workx*cos(ANGLET(i,j,iblk)) &
+                               - worky*sin(ANGLET(i,j,iblk))
+               tauya(i,j,iblk) = worky*cos(ANGLET(i,j,iblk)) &
+                               + workx*sin(ANGLET(i,j,iblk))
+  
+               ! ice/ocean stress (on POP T-grid:  convert to lat-lon)
+               workx = -strocnxT(i,j,iblk)                            ! N/m^2
+               worky = -strocnyT(i,j,iblk)                            ! N/m^2
+               tauxo(i,j,iblk) = workx*cos(ANGLET(i,j,iblk)) &
+                               - worky*sin(ANGLET(i,j,iblk))
+               tauyo(i,j,iblk) = worky*cos(ANGLET(i,j,iblk)) &
+                               + workx*sin(ANGLET(i,j,iblk))
+  
+            enddo
+         enddo
+      enddo
+      !$OMP END PARALLEL DO
+  
+      do iblk = 1, nblocks
+         do j = 1, ny_block
+            do i = 1, nx_block
+               if (tmask(i,j,iblk) .and. ailohi(i,j,iblk) < c0 ) then
+                  flag = .true.
+               endif
+            end do
+         end do
+      end do
+      if (flag) then
+         do iblk = 1, nblocks
+            do j = 1, ny_block
+               do i = 1, nx_block
+                  if (tmask(i,j,iblk) .and. ailohi(i,j,iblk) < c0 ) then
+                     write(nu_diag,*) &
+                          ' (ice) send: ERROR ailohi < 0.0 ',i,j,ailohi(i,j,iblk)
+                     call shr_sys_flush(nu_diag)
+                  endif
+               end do
+            end do
+         end do
+      endif
+  
+      ! Fill export state i2x_i
+  
+      i2x_im(:,:) = spval_dbl
+  
+      n=0
+      do iblk = 1, nblocks
+         this_block = get_block(blocks_ice(iblk),iblk)         
+         ilo = this_block%ilo
+         ihi = this_block%ihi
+         jlo = this_block%jlo
+         jhi = this_block%jhi
+  
+         do j = jlo, jhi
+            do i = ilo, ihi
+  
+               n = n+1
+  
+               !-------states-------------------- 
+               i2x_im(n, index_i2x_Si_ifrac)    = ailohi(i,j,iblk)   
+  
+               if ( tmask(i,j,iblk) .and. ailohi(i,j,iblk) > c0 ) then
+                  !-------states-------------------- 
+                  i2x_im(n, index_i2x_Si_t    )    = Tsrf(i,j,iblk)
+                  i2x_im(n, index_i2x_Si_avsdr)    = alvdr(i,j,iblk)
+                  i2x_im(n, index_i2x_Si_anidr)    = alidr(i,j,iblk)
+                  i2x_im(n, index_i2x_Si_avsdf)    = alvdf(i,j,iblk)
+                  i2x_im(n, index_i2x_Si_anidf)    = alidf(i,j,iblk)
+                  i2x_im(n, index_i2x_Si_u10 )     = Uref(i,j,iblk)
+                  i2x_im(n, index_i2x_Si_tref )    = Tref(i,j,iblk)
+                  i2x_im(n, index_i2x_Si_qref )    = Qref(i,j,iblk)
+                  i2x_im(n, index_i2x_Si_snowh)    = vsno(i,j,iblk) &
+                       / ailohi(i,j,iblk)
+  
+                  !--- a/i fluxes computed by ice
+                  i2x_im(n, index_i2x_Faii_taux)   = tauxa(i,j,iblk)    
+                  i2x_im(n, index_i2x_Faii_tauy)   = tauya(i,j,iblk)    
+                  i2x_im(n, index_i2x_Faii_lat )   = flat(i,j,iblk)     
+                  i2x_im(n, index_i2x_Faii_sen )   = fsens(i,j,iblk)    
+                  i2x_im(n, index_i2x_Faii_lwup)   = flwout(i,j,iblk)   
+                  i2x_im(n, index_i2x_Faii_evap)   = evap(i,j,iblk)     
+                  i2x_im(n, index_i2x_Faii_swnet)  = fswabs(i,j,iblk)
+  
+                  !--- i/o fluxes computed by ice
+                  i2x_im(n, index_i2x_Fioi_melth)   = fhocn(i,j,iblk)
+                  i2x_im(n, index_i2x_Fioi_swpen)   = fswthru(i,j,iblk) ! hf from melting          
+                  i2x_im(n, index_i2x_Fioi_meltw)   = fresh(i,j,iblk)   ! h2o flux from melting    ???
+                  i2x_im(n, index_i2x_Fioi_salt)   = fsalt(i,j,iblk)   ! salt flux from melting   ???
+                  i2x_im(n, index_i2x_Fioi_taux)   = tauxo(i,j,iblk)   ! stress : i/o zonal       ???
+                  i2x_im(n, index_i2x_Fioi_tauy)   = tauyo(i,j,iblk)   ! stress : i/o meridional  ???
+               end if
+            enddo    !i
+         enddo    !j
+      enddo        !iblk
+
+      tagname=trim(seq_flds_i2x_fields)//C_NULL_CHAR
+      ent_type = 0 ! vertices only, from now on
+      ierr = iMOAB_SetDoubleTagStorage (MPSIID, tagname, totalmbls , ent_type, i2x_im(1,1) )
+      if (ierr > 0 )  then
+         call shr_sys_abort( subname//' Error: fail to set moab i2x '// trim(seq_flds_i2x_fields) )
+      endif
+      call seq_timemgr_EClockGetData( EClock, stepno=cur_lnd_stepno )
+#ifdef MOABDEBUG
+      write(lnum,"(I0.2)")cur_lnd_stepno
+      outfile = 'ice_export_'//trim(lnum)//'.h5m'//C_NULL_CHAR
+      wopts   = 'PARALLEL=WRITE_PART'//C_NULL_CHAR
+      ierr = iMOAB_WriteMesh(MPSIID, outfile, wopts)
+      if (ierr > 0 )  then
+         call shr_sys_abort( subname//' fail to write the cice mesh file with data')
+      endif
+#endif
+
+   end subroutine ice_export_moab
+
+   subroutine ice_import_moab(x2i_im, EClock, totalmblsimp)
+
+      !-----------------------------------------------------
+      ! Arguments
+      real(r8), allocatable, intent(inout) :: x2i_im(:,:)
+      type(ESMF_Clock)         , intent(inout) :: EClock
+      integer, intent(in) :: totalmblsimp
+      !
+      ! Local variables
+      integer     :: i, j, iblk, n
+      integer     :: ilo, ihi, jlo, jhi !beginning and end of physical domain
+      type(block) :: this_block         ! block information for current block
+      integer,parameter                :: nflds=18,nfldv=6
+      real (kind=dbl_kind),allocatable :: aflds(:,:,:,:)
+      real (kind=dbl_kind)             :: workx, worky
+      logical (kind=log_kind)          :: first_call = .true.
+      character(CXX) ::  tagname ! hold all fields names
+      integer        :: ent_type  ! for setting/getting data 
+      integer :: ierr, cur_lnd_stepno
+      character(len=32), parameter :: subname = 'ice_import_moab'
+#ifdef MOABDEBUG
+      character*100 outfile, wopts, lnum
+#endif
+      !-----------------------------------------------------
+  
+      ! Note that the precipitation fluxes received  from the coupler
+      ! are in units of kg/s/m^2 which is what CICE requires.
+      ! Note also that the read in below includes only values needed
+      ! by the thermodynamic component of CICE.  Variables uocn, vocn,
+      ! ss_tltx, and ss_tlty are excluded. Also, because the SOM and
+      ! DOM don't  compute SSS.   SSS is not read in and is left at
+      ! the initilized value (see ice_flux.F init_coupler_flux) of
+      ! 34 ppt
+  
+      ! Use aflds to gather the halo updates of multiple fields
+      ! Need to separate the scalar from the vector halo updates
+  
+      allocate(aflds(nx_block,ny_block,nflds,nblocks))
+      aflds = c0
+  
+      n=0
+      do iblk = 1, nblocks
+         this_block = get_block(blocks_ice(iblk),iblk)         
+         ilo = this_block%ilo
+         ihi = this_block%ihi
+         jlo = this_block%jlo
+         jhi = this_block%jhi
+  
+         do j = jlo, jhi
+            do i = ilo, ihi
+  
+               n = n+1
+               aflds(i,j, 1,iblk)   = x2i_im(n, index_x2i_So_t)
+               aflds(i,j, 2,iblk)   = x2i_im(n, index_x2i_So_s)
+               aflds(i,j, 3,iblk)   = x2i_im(n, index_x2i_Sa_z)
+               aflds(i,j, 4,iblk)   = x2i_im(n, index_x2i_Sa_ptem)
+               aflds(i,j, 5,iblk)   = x2i_im(n, index_x2i_Sa_tbot)
+               aflds(i,j, 6,iblk)   = x2i_im(n, index_x2i_Sa_shum)
+               aflds(i,j, 7,iblk)   = x2i_im(n, index_x2i_Sa_dens)
+               aflds(i,j, 8,iblk)   = x2i_im(n, index_x2i_Fioo_q)
+               aflds(i,j, 9,iblk)   = x2i_im(n, index_x2i_Faxa_swvdr)
+               aflds(i,j,10,iblk)   = x2i_im(n, index_x2i_Faxa_swndr)
+               aflds(i,j,11,iblk)   = x2i_im(n, index_x2i_Faxa_swvdf)
+               aflds(i,j,12,iblk)   = x2i_im(n, index_x2i_Faxa_swndf)
+               aflds(i,j,13,iblk)   = x2i_im(n, index_x2i_Faxa_lwdn)
+               aflds(i,j,14,iblk)   = x2i_im(n, index_x2i_Faxa_rain)
+               aflds(i,j,15,iblk)   = x2i_im(n, index_x2i_Faxa_snow)
+               if (index_x2i_Sa_wsresp == 0) then
+                  aflds(i,j,16,iblk) = 0._dbl_kind
+               else
+                  aflds(i,j,16,iblk) = x2i_im(n, index_x2i_Sa_wsresp)
+               end if
+               if (index_x2i_Sa_tau_est == 0) then
+                  aflds(i,j,17,iblk) = 0._dbl_kind
+               else
+                  aflds(i,j,17,iblk) = x2i_im(n, index_x2i_Sa_tau_est)
+               end if
+               if (index_x2i_Sa_ugust == 0) then
+                  aflds(i,j,18,iblk) = 0._dbl_kind
+               else
+                  aflds(i,j,18,iblk) = x2i_im(n, index_x2i_Sa_ugust)
+               end if
+            enddo    !i
+         enddo    !j
+  
+      enddo        !iblk
+  
+      if (.not.prescribed_ice) then
+         call t_startf ('cice_imp_halo')
+         call ice_HaloUpdate(aflds, halo_info, field_loc_center, &
+              field_type_scalar)
+         call t_stopf ('cice_imp_halo')
+      endif
+  
+      !$OMP PARALLEL DO PRIVATE(iblk,i,j)
+      do iblk = 1, nblocks
+         do j = 1,ny_block
+            do i = 1,nx_block
+               sst  (i,j,iblk)   = aflds(i,j, 1,iblk)
+               sss  (i,j,iblk)   = aflds(i,j, 2,iblk)
+               zlvl (i,j,iblk)   = aflds(i,j, 3,iblk)
+               potT (i,j,iblk)   = aflds(i,j, 4,iblk)
+               Tair (i,j,iblk)   = aflds(i,j, 5,iblk)
+               Qa   (i,j,iblk)   = aflds(i,j, 6,iblk)
+               rhoa (i,j,iblk)   = aflds(i,j, 7,iblk)
+               frzmlt (i,j,iblk) = aflds(i,j, 8,iblk)
+               swvdr(i,j,iblk)   = aflds(i,j, 9,iblk)
+               swidr(i,j,iblk)   = aflds(i,j,10,iblk)
+               swvdf(i,j,iblk)   = aflds(i,j,11,iblk)
+               swidf(i,j,iblk)   = aflds(i,j,12,iblk)
+               flw  (i,j,iblk)   = aflds(i,j,13,iblk)
+               frain(i,j,iblk)   = aflds(i,j,14,iblk)
+               fsnow(i,j,iblk)   = aflds(i,j,15,iblk)
+            enddo    !i
+         enddo    !j
+      enddo        !iblk
+      !$OMP END PARALLEL DO
+  
+      deallocate(aflds)
+      allocate(aflds(nx_block,ny_block,nfldv,nblocks))
+      aflds = c0
+  
+      n=0
+      do iblk = 1, nblocks
+         this_block = get_block(blocks_ice(iblk),iblk)
+         ilo = this_block%ilo
+         ihi = this_block%ihi
+         jlo = this_block%jlo
+         jhi = this_block%jhi
+  
+         do j = jlo, jhi
+            do i = ilo, ihi
+               n = n+1
+               aflds(i,j, 1,iblk)   = x2i_im(n, index_x2i_So_u)
+               aflds(i,j, 2,iblk)   = x2i_im(n, index_x2i_So_v)
+               aflds(i,j, 3,iblk)   = x2i_im(n, index_x2i_Sa_u)
+               aflds(i,j, 4,iblk)   = x2i_im(n, index_x2i_Sa_v)
+               aflds(i,j, 5,iblk)   = x2i_im(n, index_x2i_So_dhdx)
+               aflds(i,j, 6,iblk)   = x2i_im(n, index_x2i_So_dhdy)
+            enddo
+         enddo
+      enddo
+  
+      if (.not.prescribed_ice) then
+         call t_startf ('cice_imp_halo')
+         call ice_HaloUpdate(aflds, halo_info, field_loc_center, &
+              field_type_vector)
+         call t_stopf ('cice_imp_halo')
+      endif
+  
+      !$OMP PARALLEL DO PRIVATE(iblk,i,j)
+      do iblk = 1, nblocks
+         do j = 1,ny_block
+            do i = 1,nx_block
+               uocn (i,j,iblk)   = aflds(i,j, 1,iblk)
+               vocn (i,j,iblk)   = aflds(i,j, 2,iblk)
+               uatm (i,j,iblk)   = aflds(i,j, 3,iblk)
+               vatm (i,j,iblk)   = aflds(i,j, 4,iblk)
+               ss_tltx(i,j,iblk) = aflds(i,j, 5,iblk)
+               ss_tlty(i,j,iblk) = aflds(i,j, 6,iblk)
+            enddo    !i
+         enddo    !j
+      enddo        !iblk
+      !$OMP END PARALLEL DO
+  
+      deallocate(aflds)
+  
+      !-------------------------------------------------------
+      ! Set aerosols from coupler 
+      !-------------------------------------------------------
+  
+      n=0
+      do iblk = 1, nblocks
+         this_block = get_block(blocks_ice(iblk),iblk)         
+         ilo = this_block%ilo
+         ihi = this_block%ihi
+         jlo = this_block%jlo
+         jhi = this_block%jhi
+  
+         do j = jlo, jhi
+            do i = ilo, ihi
+  
+               n = n+1
+  
+#ifdef MODAL_AER
+              !HW++ modal treatment
+  
+              ! BC species 1 (=intersitial/external BC)
+              faero(i,j,1,iblk) = x2i_im(n, index_x2i_Faxa_bcphodry) &
+                                + x2i_im(n, index_x2i_Faxa_bcphidry)
+  
+              ! BC species 2 (=cloud_water/within-ice BC)
+              faero(i,j,2,iblk) = x2i_im(n, index_x2i_Faxa_bcphiwet)
+  
+              ! Combine all of the dust into one category
+              faero(i,j,3,iblk) = x2i_im(n, index_x2i_Faxa_dstwet1) &
+                                + x2i_im(n, index_x2i_Faxa_dstdry1) &
+                                + x2i_im(n, index_x2i_Faxa_dstwet2) &
+                                + x2i_im(n, index_x2i_Faxa_dstdry2) &
+                                + x2i_im(n, index_x2i_Faxa_dstwet3) &
+                                + x2i_im(n, index_x2i_Faxa_dstdry3) &
+                                + x2i_im(n, index_x2i_Faxa_dstwet4) &
+                                + x2i_im(n, index_x2i_Faxa_dstdry4)
+              !mgf--
+#else
+              ! bulk treatment
+  
+               faero(i,j,1,iblk) = x2i_im(n, index_x2i_Faxa_bcphodry)
+  
+               faero(i,j,2,iblk) = x2i_im(n, index_x2i_Faxa_bcphidry) &
+                    + x2i_im(n, index_x2i_Faxa_bcphiwet)
+               ! Combine all of the dust into one category
+               faero(i,j,3,iblk) = x2i_im(n, index_x2i_Faxa_dstwet1) &
+                    + x2i_im(n, index_x2i_Faxa_dstdry1) &
+                    + x2i_im(n, index_x2i_Faxa_dstwet2) &
+                    + x2i_im(n, index_x2i_Faxa_dstdry2) &
+                    + x2i_im(n, index_x2i_Faxa_dstwet3) &
+                    + x2i_im(n, index_x2i_Faxa_dstdry3) &
+                    + x2i_im(n, index_x2i_Faxa_dstwet4) &
+                    + x2i_im(n, index_x2i_Faxa_dstdry4)
+  
+#endif
+  !HW +++
+            enddo    !i
+         enddo    !j
+  
+      enddo        !iblk
+  
+  
+      !-----------------------------------------------------------------
+      ! rotate zonal/meridional vectors to local coordinates
+      ! compute data derived quantities
+      !-----------------------------------------------------------------
+  
+      ! Vector fields come in on T grid, but are oriented geographically
+      ! need to rotate to pop-grid FIRST using ANGLET
+      ! then interpolate to the U-cell centers  (otherwise we
+      ! interpolate across the pole)
+      ! use ANGLET which is on the T grid !
+  
+      call t_startf ('cice_imp_ocn')
+      !$OMP PARALLEL DO PRIVATE(iblk,i,j,workx,worky)
+      do iblk = 1, nblocks
+  
+         do j = 1,ny_block
+            do i = 1,nx_block
+  
+               ! ocean
+               workx      = uocn  (i,j,iblk) ! currents, m/s 
+               worky      = vocn  (i,j,iblk)
+               uocn(i,j,iblk) = workx*cos(ANGLET(i,j,iblk)) & ! convert to POP grid 
+                    + worky*sin(ANGLET(i,j,iblk))
+               vocn(i,j,iblk) = worky*cos(ANGLET(i,j,iblk)) &
+                    - workx*sin(ANGLET(i,j,iblk))
+  
+               workx      = ss_tltx  (i,j,iblk)           ! sea sfc tilt, m/m
+               worky      = ss_tlty  (i,j,iblk)
+               ss_tltx(i,j,iblk) = workx*cos(ANGLET(i,j,iblk)) & ! convert to POP grid 
+                    + worky*sin(ANGLET(i,j,iblk))
+               ss_tlty(i,j,iblk) = worky*cos(ANGLET(i,j,iblk)) &
+                    - workx*sin(ANGLET(i,j,iblk))
+  
+               sst(i,j,iblk) = sst(i,j,iblk) - Tffresh       ! sea sfc temp (C)
+               Tf (i,j,iblk) = -1.8_dbl_kind                 ! hardwired for NCOM
+               !         Tf (i,j,iblk) = -depressT*sss(i,j,iblk)       ! freezing temp (C)
+               !         Tf (i,j,iblk) = -depressT*max(sss(i,j,iblk),ice_ref_salinity)
+  
+            enddo
+         enddo
+      enddo
+      !$OMP END PARALLEL DO
+      call t_stopf ('cice_imp_ocn')
+  
+      ! Interpolate ocean dynamics variables from T-cell centers to 
+      ! U-cell centers.
+  
+      if (.not.prescribed_ice) then
+         call t_startf ('cice_imp_t2u')
+         call t2ugrid_vector(uocn)
+         call t2ugrid_vector(vocn)
+         call t2ugrid_vector(ss_tltx)
+         call t2ugrid_vector(ss_tlty)
+         call t_stopf ('cice_imp_t2u')
+      end if
+  
+      ! Atmosphere variables are needed in T cell centers in
+      ! subroutine stability and are interpolated to the U grid
+      ! later as necessary.
+  
+      call t_startf ('cice_imp_atm')
+      !$OMP PARALLEL DO PRIVATE(iblk,i,j,workx,worky)
+      do iblk = 1, nblocks
+         do j = 1, ny_block
+            do i = 1, nx_block
+  
+               ! atmosphere
+               workx      = uatm(i,j,iblk) ! wind velocity, m/s
+               worky      = vatm(i,j,iblk) 
+               uatm (i,j,iblk) = workx*cos(ANGLET(i,j,iblk)) & ! convert to POP grid
+                               + worky*sin(ANGLET(i,j,iblk))   ! note uatm, vatm, wind
+               vatm (i,j,iblk) = worky*cos(ANGLET(i,j,iblk)) & ! are on the T-grid here
+                    - workx*sin(ANGLET(i,j,iblk))
+  
+               wind (i,j,iblk) = sqrt(uatm(i,j,iblk)**2 + vatm(i,j,iblk)**2)
+               fsw  (i,j,iblk) = swvdr(i,j,iblk) + swvdf(i,j,iblk) &
+                               + swidr(i,j,iblk) + swidf(i,j,iblk)
+            enddo
+         enddo
+      enddo
+      !$OMP END PARALLEL DO
+      call t_stopf ('cice_imp_atm')  
+
+      call seq_timemgr_EClockGetData( EClock, stepno=cur_lnd_stepno )
+#ifdef MOABDEBUG
+      write(lnum,"(I0.2)")cur_lnd_stepno
+      outfile = 'ice_import_'//trim(lnum)//'.h5m'//C_NULL_CHAR
+      wopts   = 'PARALLEL=WRITE_PART'//C_NULL_CHAR
+      ierr = iMOAB_WriteMesh(MPSIID, outfile, wopts)
+      if (ierr > 0 )  then
+         call shr_sys_abort( subname//' Error: fail to the moab ice mesh before import ') 
+      endif
+        
+#endif
+      tagname=trim(seq_flds_x2i_fields)//C_NULL_CHAR
+      ent_type = 0 ! vertices 
+      ierr = iMOAB_GetDoubleTagStorage ( MPSIID, tagname, totalmblsimp , ent_type, x2i_im(1,1) )
+      if (ierr > 0 )  then
+         call shr_sys_abort( subname//' Error: fail to get seq_flds_x2i_fields for ice moab instance on component ') 
+      endif
+   end subroutine ice_import_moab
+#endif
 
 end module ice_import_export

--- a/components/cice/src/drivers/cpl/ice_import_export.F90
+++ b/components/cice/src/drivers/cpl/ice_import_export.F90
@@ -690,6 +690,14 @@ contains
 #endif
       !-----------------------------------------------------
   
+      ! retrieve data from moab tags
+      tagname=trim(seq_flds_x2i_fields)//C_NULL_CHAR
+      ent_type = 0 ! vertices 
+      ierr = iMOAB_GetDoubleTagStorage ( MPSIID, tagname, totalmblsimp , ent_type, x2i_im(1,1) )
+      if (ierr > 0 )  then
+         call shr_sys_abort( subname//' Error: fail to get seq_flds_x2i_fields for ice moab instance on component ') 
+      endif
+
       ! Note that the precipitation fluxes received  from the coupler
       ! are in units of kg/s/m^2 which is what CICE requires.
       ! Note also that the read in below includes only values needed
@@ -700,8 +708,7 @@ contains
       ! 34 ppt
   
       ! Use aflds to gather the halo updates of multiple fields
-      ! Need to separate the scalar from the vector halo updates
-  
+      ! Need to separate the scalar from the vector halo updates  
       allocate(aflds(nx_block,ny_block,nflds,nblocks))
       aflds = c0
   
@@ -988,12 +995,6 @@ contains
       endif
         
 #endif
-      tagname=trim(seq_flds_x2i_fields)//C_NULL_CHAR
-      ent_type = 0 ! vertices 
-      ierr = iMOAB_GetDoubleTagStorage ( MPSIID, tagname, totalmblsimp , ent_type, x2i_im(1,1) )
-      if (ierr > 0 )  then
-         call shr_sys_abort( subname//' Error: fail to get seq_flds_x2i_fields for ice moab instance on component ') 
-      endif
    end subroutine ice_import_moab
 #endif
 

--- a/components/elm/src/cpl/lnd_comp_mct.F90
+++ b/components/elm/src/cpl/lnd_comp_mct.F90
@@ -149,10 +149,8 @@ contains
     character(len=*),  parameter :: format = "('("//trim(sub)//") :',A)"
 
 #ifdef HAVE_MOAB
-    character*100 outfile, wopts, localmeshfile
+    character*100 outfile, wopts
     integer :: ierr, nsend,n
-    character(len=SHR_KIND_CL) :: atm_gnam          ! atm grid
-    character(len=SHR_KIND_CL) :: lnd_gnam          ! lnd grid
 #endif
     !-----------------------------------------------------------------------
 
@@ -867,11 +865,9 @@ contains
     real(r8)   :: latv, lonv
     integer   dims, i, iv, ilat, ilon, igdx, ierr, tagindex
     integer tagtype, numco, ent_type, mbtype, block_ID
-    character*100 outfile, wopts, localmeshfile
+    character*100 outfile, wopts
     character(CXX) ::  tagname ! hold all fields
     character*32  appname
-
-    integer, allocatable :: moabconn(:) ! will have the connectivity in terms of local index in verts
 
     ! define a MOAB app for ELM
     appname="LNDMB"//C_NULL_CHAR

--- a/components/elm/src/cpl/lnd_comp_mct.F90
+++ b/components/elm/src/cpl/lnd_comp_mct.F90
@@ -545,9 +545,6 @@ contains
     call lnd_import( bounds, x2l_l%rattr, atm2lnd_vars, glc2lnd_vars, lnd2atm_vars)
     
 #ifdef HAVE_MOAB
-! calling MOAB's import last means this is what the model will use.
-    call lnd_import_moab( EClock, bounds, atm2lnd_vars, glc2lnd_vars)
-
 #ifdef MOABCOMP
     ! loop over all fields in seq_flds_x2l_fields
     call mct_list_init(temp_list ,seq_flds_x2l_fields)
@@ -562,8 +559,10 @@ contains
       call seq_comm_compare_mb_mct(modelStr, mpicom_lnd_moab, x2l_l, mct_field,  mlnid, tagname, ent_type, difference)
     enddo
     call mct_list_clean(temp_list)
-
 #endif
+! calling MOAB's import last means this is what the model will use.
+! also, call after comparisons are made, so we can see the eventual differences
+    call lnd_import_moab( EClock, bounds, atm2lnd_vars, glc2lnd_vars)
 #endif
 
     call t_stopf ('lc_lnd_import')

--- a/driver-moab/main/cplcomp_exchange_mod.F90
+++ b/driver-moab/main/cplcomp_exchange_mod.F90
@@ -1652,6 +1652,7 @@ subroutine  copy_aream_from_area(mbappid)
                   call shr_sys_abort(subname//' ERROR in sending sea ice mesh to coupler ')
                endif
             else
+               ! we could be using cice model 
                comp%mbGridType = 0 ! 0 or 1, pc or cells
                comp%mblsize = nvert(1) ! vertices
             endif
@@ -1668,6 +1669,7 @@ subroutine  copy_aream_from_area(mbappid)
                endif
             else
                ! we need to read the mesh ice (domain file) 
+               ! we could be using cice model or data sea ice; in both cases ice_domain should be non-empty
                ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;NO_CULLING;REPARTITION'//C_NULL_CHAR
                infile = trim(ice_domain)//C_NULL_CHAR
                if (seq_comm_iamroot(CPLID)) then

--- a/driver-moab/main/prep_atm_mod.F90
+++ b/driver-moab/main/prep_atm_mod.F90
@@ -281,19 +281,15 @@ contains
 
             ! Since we are projecting fields from OCN to ATM-PHY grid, we need to define
             ! OCN o2x fields to ATM-PHY grid (or ATM-DYN (spectral) ) on coupler side
-            if (atm_pg_active) then
-               tagname = trim(seq_flds_o2x_fields)//C_NULL_CHAR
-               tagtype = 1 ! dense
-               numco = 1 !
-               ierr = iMOAB_DefineTagStorage(mbaxid, tagname, tagtype, numco,  tagindex )
-               if (ierr .ne. 0) then
-                  write(logunit,*) subname,' error in defining tags for seq_flds_o2x_fields'
-                  call shr_sys_abort(subname//' ERROR in coin defining tags for seq_flds_o2x_fields')
-               endif
-            else ! spectral case, fix later TODO
-               !numco = np*np !
-               numco = 16
-            endif !
+            tagname = trim(seq_flds_o2x_fields)//C_NULL_CHAR
+            tagtype = 1 ! dense
+            numco = 1 !
+            ierr = iMOAB_DefineTagStorage(mbaxid, tagname, tagtype, numco,  tagindex )
+            if (ierr .ne. 0) then
+               write(logunit,*) subname,' error in defining tags for seq_flds_o2x_fields'
+               call shr_sys_abort(subname//' ERROR in coin defining tags for seq_flds_o2x_fields')
+            endif
+           
 
             if (.not. samegrid_ao) then ! most cases
 
@@ -541,17 +537,13 @@ contains
 
 ! because we will project fields from ocean to atm phys grid, we need to define
       ! ice i2x fields to atm phys grid (or atm spectral ext ) on coupler side
-      if (atm_pg_active) then
-         tagname = trim(seq_flds_i2x_fields)//C_NULL_CHAR
-         tagtype = 1 ! dense
-         numco = 1 !
-         ierr = iMOAB_DefineTagStorage(mbaxid, tagname, tagtype, numco,  tagindex )
-         if (ierr .ne. 0) then
-            write(logunit,*) subname,' error in defining tags for seq_flds_i2x_fields'
-            call shr_sys_abort(subname//' ERROR in coin defining tags for seq_flds_i2x_fields')
-         endif
-      else ! spectral case, TODO
-         tagtype = 1 ! dense
+      tagname = trim(seq_flds_i2x_fields)//C_NULL_CHAR
+      tagtype = 1 ! dense
+      numco = 1 !
+      ierr = iMOAB_DefineTagStorage(mbaxid, tagname, tagtype, numco,  tagindex )
+      if (ierr .ne. 0) then
+         write(logunit,*) subname,' error in defining tags for seq_flds_i2x_fields'
+         call shr_sys_abort(subname//' ERROR in coin defining tags for seq_flds_i2x_fields')
       endif
 
       if (ice_c2_atm) then
@@ -707,80 +699,76 @@ contains
 
          ! now take care of the mapper for MOAB.  Need to always do if ice_present
          if (iamroot_CPLID) then
-              write(logunit,*) ' '
-              write(logunit,F00) 'Initializing MOAB mapper_Fi2a'
+            write(logunit,*) ' '
+            write(logunit,F00) 'Initializing MOAB mapper_Fi2a'
+         endif
+
+         if (.not. compute_maps_online_i2a  .and.  .not. samegrid_ao ) then
+         !!!!!!!!!!!!!!!!!!!!!!!
+         !  read  Fi2a map
+         !!!!!!!!!!!!!!!!!!!!!!!
+            type1 = 3 ! this is type of grid
+            arearead = 0 ! no need for areas
+            call moab_map_init_rcfile( mbixid, mbaxid, mbintxia, type1, &
+                  'seq_maps.rc', 'ice2atm_fmapname:', 'ice2atm_fmaptype:', samegrid_ao, &
+                  arearead, wgtIdFi2a, 'mapper_Fi2a MOAB init', esmf_map_flag )
+
+            ! need to call migrate map mesh, which will compute the right covering mesh
+            context_id = idintx ! intx id
+            ierr = iMOAB_MigrateMapMesh( mbixid, mbintxia, mpicom_CPLID, mpigrp_CPLID, &
+                                       mpigrp_CPLID, type1, ice(1)%cplcompid, context_id)
+            if (ierr .ne. 0) then
+               write(logunit,*) subname,' error in migrating ocn mesh for map ocn c2 atm '
+               call shr_sys_abort(subname//' ERROR in migrating ocn mesh for map ocn c2 atm  ')
             endif
 
-            if (.not. compute_maps_online_i2a  .and.  .not. samegrid_ao ) then
-            !!!!!!!!!!!!!!!!!!!!!!!
-            !  read  Fi2a map
-            !!!!!!!!!!!!!!!!!!!!!!!
-               type1 = 3 ! this is type of grid
-               arearead = 0 ! no need for areas
-               call moab_map_init_rcfile( mbixid, mbaxid, mbintxia, type1, &
-                     'seq_maps.rc', 'ice2atm_fmapname:', 'ice2atm_fmaptype:', samegrid_ao, &
-                     arearead, wgtIdFi2a, 'mapper_Fi2a MOAB init', esmf_map_flag )
-
-               ! need to call migrate map mesh, which will compute the right covering mesh
-               context_id = idintx ! intx id
-               ierr = iMOAB_MigrateMapMesh( mbixid, mbintxia, mpicom_CPLID, mpigrp_CPLID, &
-                                          mpigrp_CPLID, type1, ice(1)%cplcompid, context_id)
-               if (ierr .ne. 0) then
-                  write(logunit,*) subname,' error in migrating ocn mesh for map ocn c2 atm '
-                  call shr_sys_abort(subname//' ERROR in migrating ocn mesh for map ocn c2 atm  ')
-               endif
-
-               ! we also need to compute the comm graph for the second hop, from the ocn on coupler to the
-               ! seaice for the intx seaice-atm context (coverage)
-               type1 = 3; !  fv for ice and atm; fv-cgll does not work anyway
-               type2 = 3;
-               ierr = iMOAB_ComputeCommGraph( mbixid, mbintxia, mpicom_CPLID, mpigrp_CPLID, mpigrp_CPLID, type1, type2, &
-                                          ice(1)%cplcompid, idintx)
-               if (ierr .ne. 0) then
-                  write(logunit,*) subname,' error in computing comm graph for second hop, ice-atm'
-                  call shr_sys_abort(subname//' ERROR in computing comm graph for second hop, ice-atm')
-               endif
-            !!!!!!!!!!!!!!!!!!!!!!!
-            !  compute  Fi2a map
-            !!!!!!!!!!!!!!!!!!!!!!!
-            else
-               wgtIdFi2a = wgtIdSi2a ! we use the same weights as for Si2a
-            end if
-
-            mapper_Fi2a%src_mbid = mbixid
-            mapper_Fi2a%tgt_mbid = mbaxid
-            mapper_Fi2a%intx_mbid = mbintxia
-            mapper_Fi2a%src_context = ice(1)%cplcompid
-            mapper_Fi2a%intx_context = idintx
-            mapper_Fi2a%weight_identifier = wgtIdFi2a
-            mapper_Fi2a%mbname = 'mapper_Fi2a'
-            if ( samegrid_ao ) then ! this case can appear in cice case
-               type1 = 3; !  fv for ice and atm;
-               type2 = 3;
-               ierr = iMOAB_ComputeCommGraph( mbixid, mbaxid, mpicom_CPLID, mpigrp_CPLID, mpigrp_CPLID, type1, type2, &
-                                          ice(1)%cplcompid, atm(1)%cplcompid )
-               if (ierr .ne. 0) then
-                  write(logunit,*) subname,' error in computing comm graph for ice-atm'
-                  call shr_sys_abort(subname//' ERROR in computing comm graph for ice-atm')
-               endif
-               mapper_Fi2a%intx_context = atm(1)%cplcompid
+            ! we also need to compute the comm graph for the second hop, from the ocn on coupler to the
+            ! seaice for the intx seaice-atm context (coverage)
+            type1 = 3; !  fv for ice and atm; fv-cgll does not work anyway
+            type2 = 3;
+            ierr = iMOAB_ComputeCommGraph( mbixid, mbintxia, mpicom_CPLID, mpigrp_CPLID, mpigrp_CPLID, type1, type2, &
+                                       ice(1)%cplcompid, idintx)
+            if (ierr .ne. 0) then
+               write(logunit,*) subname,' error in computing comm graph for second hop, ice-atm'
+               call shr_sys_abort(subname//' ERROR in computing comm graph for second hop, ice-atm')
             endif
+         !!!!!!!!!!!!!!!!!!!!!!!
+         !  compute  Fi2a map
+         !!!!!!!!!!!!!!!!!!!!!!!
+         else
+            wgtIdFi2a = wgtIdSi2a ! we use the same weights as for Si2a
+         end if
+
+         mapper_Fi2a%src_mbid = mbixid
+         mapper_Fi2a%tgt_mbid = mbaxid
+         mapper_Fi2a%intx_mbid = mbintxia
+         mapper_Fi2a%src_context = ice(1)%cplcompid
+         mapper_Fi2a%intx_context = idintx
+         mapper_Fi2a%weight_identifier = wgtIdFi2a
+         mapper_Fi2a%mbname = 'mapper_Fi2a'
+         if ( samegrid_ao ) then ! this case can appear in cice case
+            type1 = 3; !  fv for ice and atm;
+            type2 = 3;
+            ierr = iMOAB_ComputeCommGraph( mbixid, mbaxid, mpicom_CPLID, mpigrp_CPLID, mpigrp_CPLID, type1, type2, &
+                                       ice(1)%cplcompid, atm(1)%cplcompid )
+            if (ierr .ne. 0) then
+               write(logunit,*) subname,' error in computing comm graph for ice-atm'
+               call shr_sys_abort(subname//' ERROR in computing comm graph for ice-atm')
+            endif
+            mapper_Fi2a%intx_context = atm(1)%cplcompid
+         endif
       endif !  if (ice_present) then
       call shr_sys_flush(logunit)
 
       if (mbaxid > 0) then
           ! we still need to define seq_flds_l2x_fields on atm cpl mesh
-         if (atm_pg_active) then
-            tagname = trim(seq_flds_l2x_fields)//C_NULL_CHAR
-            tagtype = 1 ! dense
-            numco = 1 !
-            ierr = iMOAB_DefineTagStorage(mbaxid, tagname, tagtype, numco,  tagindex )
-            if (ierr .ne. 0) then
-               write(logunit,*) subname,' error in defining tags for seq_flds_l2x_fields'
-               call shr_sys_abort(subname//' ERROR in coin defining tags for seq_flds_l2x_fields')
-            endif
-         else ! spectral case, TODO
-            tagtype = 1 ! dense
+         tagname = trim(seq_flds_l2x_fields)//C_NULL_CHAR
+         tagtype = 1 ! dense
+         numco = 1 !
+         ierr = iMOAB_DefineTagStorage(mbaxid, tagname, tagtype, numco,  tagindex )
+         if (ierr .ne. 0) then
+            write(logunit,*) subname,' error in defining tags for seq_flds_l2x_fields'
+            call shr_sys_abort(subname//' ERROR in coin defining tags for seq_flds_l2x_fields')
          endif
       endif
 

--- a/driver-moab/main/prep_atm_mod.F90
+++ b/driver-moab/main/prep_atm_mod.F90
@@ -681,8 +681,9 @@ contains
                endif
               endif
             endif
-
-
+            if (samegrid_ao) then
+               mapper_Si2a%intx_context = atm(1)%cplcompid
+            endif
          endif ! if ((mbaxid .ge. 0) .and.  (mbixid .ge. 0)) then
 
       endif ! if (ice_present) for mapper_Si2a

--- a/driver-moab/main/prep_lnd_mod.F90
+++ b/driver-moab/main/prep_lnd_mod.F90
@@ -426,14 +426,14 @@ contains
           end if
           call seq_map_init_rcfile(mapper_Sa2l, atm(1), lnd(1), &
                'seq_maps.rc','atm2lnd_smapname:','atm2lnd_smaptype:',samegrid_al, &
-               'mapper_Sa2l initialization',esmf_map_flag)
+               'mapper_Sa2l initialization',esmf_map_flag, no_match=.true.)
           if (iamroot_CPLID) then
              write(logunit,*) ' '
              write(logunit,F00) 'Initializing mapper_Fa2l'
           end if
           call seq_map_init_rcfile(mapper_Fa2l, atm(1), lnd(1), &
                'seq_maps.rc','atm2lnd_fmapname:','atm2lnd_fmaptype:',samegrid_al, &
-               'mapper_Fa2l initialization',esmf_map_flag)
+               'mapper_Fa2l initialization',esmf_map_flag, no_match=.true.)
 ! similar to prep_atm_init, lnd and atm reversed
           ! important change: do not compute intx at all between atm and land when we have samegrid_al
           ! we will use just a comm graph to send data from atm to land on coupler

--- a/driver-moab/main/prep_lnd_mod.F90
+++ b/driver-moab/main/prep_lnd_mod.F90
@@ -304,17 +304,6 @@ contains
                     endif
                   endif
 #endif
-                 ! we also need to compute the comm graph for the second hop, from the rof on coupler to the
-                 ! rof for the intx rof-lnd context (coverage)
-
-                  type1 = 3 ! land is FV now on coupler side
-                  type2 = 3;
-                  ierr = iMOAB_ComputeCommGraph( mbrxid, mbintxrl, mpicom_CPLID, mpigrp_CPLID, mpigrp_CPLID, type1, type2, &
-                                              rof(1)%cplcompid, idintx)
-                  if (ierr .ne. 0) then
-                    write(logunit,*) subname,' error in computing comm graph for second hop, lnd-rof'
-                    call shr_sys_abort(subname//' ERROR in computing comm graph for second hop, lnd-rof')
-                  endif
               endif ! (compute_maps_online_r2l)
 
               ! now take care of the mapper
@@ -379,6 +368,17 @@ contains
                      call shr_sys_abort(subname//' ERROR in migrating rof mesh for map rof c2 lnd')
                   endif
               endif ! compute or read mape
+              ! we also need to compute the comm graph for the second hop, from the rof on coupler to the
+                 ! rof for the intx rof-lnd context (coverage)
+
+              type1 = 3 ! land is FV now on coupler side
+              type2 = 3;
+              ierr = iMOAB_ComputeCommGraph( mbrxid, mbintxrl, mpicom_CPLID, mpigrp_CPLID, mpigrp_CPLID, type1, type2, &
+                                          rof(1)%cplcompid, idintx)
+              if (ierr .ne. 0) then
+                write(logunit,*) subname,' error in computing comm graph for second hop, lnd-rof'
+                call shr_sys_abort(subname//' ERROR in computing comm graph for second hop, lnd-rof')
+              endif
 
             endif ! samegrid_lr or not
 

--- a/driver-moab/main/prep_ocn_mod.F90
+++ b/driver-moab/main/prep_ocn_mod.F90
@@ -447,7 +447,16 @@ contains
             ! we also need to compute the comm graph for the second hop, from the atm on coupler to the
             ! atm for the intx atm-ocn context (coverage)
             call seq_comm_getinfo(CPLID, mpigrp=mpigrp_CPLID)
-
+            ! To project fields from ATM to OCN grid, we need to define
+            ! ATM a2x fields to OCN grid on coupler side
+            tagname = trim(seq_flds_a2x_fields)//C_NULL_CHAR
+            tagtype = 1 ! dense
+            numco = 1 !
+            ierr = iMOAB_DefineTagStorage(mboxid, tagname, tagtype, numco, tagindex )
+            if (ierr .ne. 0) then
+               write(logunit,*) subname,' error in defining tags for seq_flds_a2x_fields on OCN cpl'
+               call shr_sys_abort(subname//' ERROR in coin defining tags for seq_flds_a2x_fields on OCN cpl')
+            endif
             ! next, let us compute the ATM and OCN data transfer
             if (.not. samegrid_ao) then ! not a data OCN model
 
@@ -499,17 +508,6 @@ contains
                   endif
 #endif
                end if
-
-               ! To project fields from ATM to OCN grid, we need to define
-               ! ATM a2x fields to OCN grid on coupler side
-               tagname = trim(seq_flds_a2x_fields)//C_NULL_CHAR
-               tagtype = 1 ! dense
-               numco = 1 !
-               ierr = iMOAB_DefineTagStorage(mboxid, tagname, tagtype, numco, tagindex )
-               if (ierr .ne. 0) then
-                  write(logunit,*) subname,' error in defining tags for seq_flds_a2x_fields on OCN cpl'
-                  call shr_sys_abort(subname//' ERROR in coin defining tags for seq_flds_a2x_fields on OCN cpl')
-               endif
 
                if (compute_maps_online_a2o) then
                   volumetric = 0 ! can be 1 only for FV->DGLL or FV->CGLL;

--- a/driver-moab/main/prep_ocn_mod.F90
+++ b/driver-moab/main/prep_ocn_mod.F90
@@ -655,7 +655,7 @@ contains
             end if
 
             ! If loading map from disk, then load the scalar map as well
-            if (.not. compute_maps_online_a2o) then
+            if (.not. compute_maps_online_a2o .and. .not. samegrid_ao ) then
                type1 = 3 ! this is type of grid
                arearead = 0 ! no need for areas
                call moab_map_init_rcfile( mbaxid, mboxid, mbintxao, type1, &
@@ -669,6 +669,14 @@ contains
                if (ierr .ne. 0) then
                   write(logunit,*) subname,' error in migrating atm mesh for map atm c2 ocn '
                   call shr_sys_abort(subname//' ERROR in migrating atm mesh for map atm c2 ocn ')
+               endif
+
+               type2 = 3;  ! FV mesh on coupler OCN
+               ierr = iMOAB_ComputeCommGraph( mbaxid, mbintxao, mpicom_CPLID, mpigrp_CPLID, mpigrp_CPLID, type1, type2, &
+                                             atm(1)%cplcompid, idintx)
+               if (ierr .ne. 0) then
+                  write(logunit,*) subname,' error in computing comm graph atm c2 ocn '
+                  call shr_sys_abort(subname//' ERROR in computing comm graph atm c2 ocn ')
                endif
             else ! if (.not. compute_maps_online_a2o)
                wgtIdVa2o = wgtIdFa2o ! use the same map as Sa2o
@@ -767,7 +775,7 @@ contains
           end if
 
           ! If loading map from disk, then load the R2O_liq map
-          if (.not. compute_maps_online_r2o) then
+          if (.not. compute_maps_online_r2o .and. .not. samegrid_ro) then
             type_grid = 3 ! this is type of grid
             arearead = 1 ! read area_a for river model
             call moab_map_init_rcfile( mbrxid, mboxid, mbintxro, type_grid, &
@@ -849,7 +857,7 @@ contains
          end if
 
          ! If loading map from disk, then load the R2O_ice map
-         if (.not. compute_maps_online_r2o) then
+         if (.not. compute_maps_online_r2o  .and. .not. samegrid_ro) then
             type_grid = 3 ! this is type of grid
             arearead = 0 ! no need for areas
             call moab_map_init_rcfile( mbrxid, mboxid, mbintxro, type_grid, &
@@ -878,7 +886,7 @@ contains
                write(logunit,F00) 'Initializing MOAB mapper_Fr2o'
             end if
             ! If loading map from disk, then load the scalar map as well
-            if (.not. compute_maps_online_r2o) then
+            if (.not. compute_maps_online_r2o .and. .not. samegrid_ro) then
                type_grid = 3 ! this is type of grid
                arearead = 0 ! no need for areas
                call moab_map_init_rcfile( mbrxid, mboxid, mbintxro, type_grid, &
@@ -896,7 +904,7 @@ contains
 
          context_id = rmapid ! ocn(1)%cplcompid*100+rof(1)%cplcompid
          type_grid = 3 ! this is type of grid
-         if (.not. compute_maps_online_r2o) then
+         if (.not. compute_maps_online_r2o .and. .not. samegrid_ro) then
             ierr = iMOAB_MigrateMapMesh ( mbrxid, mbintxro, mpicom_CPLID, mpigrp_CPLID, &
                                           mpigrp_CPLID, type_grid, rof(1)%cplcompid, context_id )
             if (ierr .ne. 0) then
@@ -904,17 +912,34 @@ contains
                call shr_sys_abort(subname//' ERROR in migrating rof mesh for map rof c2 ocn ')
             endif
          endif
-         ! this creates a parallel communication graph between mbrxid and mbintxro,
-         ! with ids rof(1)%cplcompid, rmapid (rmapid is 100*src+tgt)
-         ! this will be used in send/receive mappers
-         ierr = iMOAB_ComputeCommGraph( mbrxid, mbintxro, mpicom_CPLID, mpigrp_CPLID, mpigrp_CPLID, &
-                                          type_grid, type_grid, rof(1)%cplcompid, rmapid )
-         if (ierr .ne. 0) then
-            write(logunit,*) subname,' error in compute graph ROF - ROF coverage for ocean context'
-            call shr_sys_abort(subname//' ERROR in compute graph ROF - ROF coverage for ocean context ')
+
+         if (samegrid_ro) then
+            ! this creates a parallel communication graph between mbrxid and mboxid,
+            ! with ids rof(1)%cplcompid, ocn(1)%cplcompid
+            ! this will be used in send/receive mappers 
+            ierr = iMOAB_ComputeCommGraph( mbrxid, mboxid, mpicom_CPLID, mpigrp_CPLID, mpigrp_CPLID, &
+                                             type_grid, type_grid, rof(1)%cplcompid, ocn(1)%cplcompid )
+            if (ierr .ne. 0) then
+               write(logunit,*) subname,' error in compute graph ROF -  ocean '
+               call shr_sys_abort(subname//' ERROR in compute graph ROF - ocean  ')
+            endif
+            mapper_Fr2o%intx_context = ocn(1)%cplcompid 
+            mapper_Rr2o_ice%intx_context = ocn(1)%cplcompid
+            mapper_Rr2o_liq%intx_context = ocn(1)%cplcompid
+
+         else
+            ! this creates a parallel communication graph between mbrxid and mbintxro,
+            ! with ids rof(1)%cplcompid, rmapid (rmapid is 100*src+tgt)
+            ! this will be used in send/receive mappers
+            ierr = iMOAB_ComputeCommGraph( mbrxid, mbintxro, mpicom_CPLID, mpigrp_CPLID, mpigrp_CPLID, &
+                                             type_grid, type_grid, rof(1)%cplcompid, rmapid )
+            if (ierr .ne. 0) then
+               write(logunit,*) subname,' error in compute graph ROF - ROF coverage for ocean context'
+               call shr_sys_abort(subname//' ERROR in compute graph ROF - ROF coverage for ocean context ')
+            endif
          endif
 
-       endif
+       endif ! endif for rof_c2_ocn
        call shr_sys_flush(logunit)
 
        if (glc_c2_ocn) then

--- a/driver-moab/main/prep_rof_mod.F90
+++ b/driver-moab/main/prep_rof_mod.F90
@@ -562,33 +562,166 @@ contains
               write(logunit,*) subname,' error in registering ATM-ROF mesh intersection context'
               call shr_sys_abort(subname//' ERROR in registering ATM-ROF mesh intersection context')
             endif
+            tagname = trim(seq_flds_a2x_fields_to_rof)//':norm8wt'//C_NULL_CHAR
+            tagtype = 1 ! dense
+            numco = 1 !
+            ierr = iMOAB_DefineTagStorage(mbrxid, tagname, tagtype, numco,  tagindex )
+            if (ierr .ne. 0) then
+               write(logunit,*) subname,' error in defining tags for seq_flds_a2x_fields_to_rof on ROF cpl'
+               call shr_sys_abort(subname//' ERROR in  defining tags for seq_flds_a2x_fields_to_rof on ROF cpl')
+            endif
+            ! now take care of the mapper
+            if ( mapper_Fa2r%src_mbid .gt. -1 ) then
+               if (iamroot_CPLID) then
+                     write(logunit,F00) 'overwriting '//trim(mapper_Fa2r%mbname) &
+                           //' mapper_Fa2r'
+               endif
+            endif
+            mapper_Fa2r%src_mbid = mbaxid
+            mapper_Fa2r%tgt_mbid = mbrxid
+            mapper_Fa2r%intx_mbid = mbintxar
+            mapper_Fa2r%src_context = atm(1)%cplcompid
+            mapper_Fa2r%intx_context = idintx
+            mapper_Fa2r%weight_identifier = wgtIdFa2r
+            mapper_Fa2r%mbname = 'mapper_Fa2r'
+            ! because we will project fields from atm to rof grid, we need to define
+            ! rof a2x fields to rof grid on coupler side
+
+            
 
             ! if we are not loading maps from disk, compute the intersection mesh between
             ! ATM and ROF meshes
-            if (compute_maps_online_a2r) then
-               ierr =  iMOAB_ComputeMeshIntersectionOnSphere( mbaxid, mbrxid, mbintxar )
+            if (samegrid_ar) then
+               type1 = 3
+               type2 = 3
+               ierr = iMOAB_ComputeCommGraph( mbaxid, mbrxid, mpicom_CPLID, mpigrp_CPLID, mpigrp_CPLID, type1, type2, &
+                                          atm(1)%cplcompid, rof(1)%cplcompid)
                if (ierr .ne. 0) then
-                  write(logunit,*) subname,' error in computing ATM-ROF mesh intersection'
-                  call shr_sys_abort(subname//' ERROR in computing ATM-ROF mesh intersection')
+                  write(logunit,*) subname,' error in computing ATM-ROF comm graph'
+                  call shr_sys_abort(subname//' ERROR in computing ATM-ROF comm graph')
                endif
-               if (iamroot_CPLID) then
-                  write(logunit,*) 'iMOAB mesh intersection between ATM and ROF with id:', idintx
-               end if
-#ifdef MOABDEBUG
-               wopts = C_NULL_CHAR
-               call shr_mpi_commrank( mpicom_CPLID, rank )
-               if (rank .lt. 3) then
-                  write(lnum,"(I0.2)")rank !
-                  outfile = 'intx_ar_'//trim(lnum)// '.h5m' // C_NULL_CHAR
-                  ierr = iMOAB_WriteMesh(mbintxar, outfile, wopts) ! write local intx file
+               mapper_Fa2r%intx_context = rof(1)%cplcompid
+            else
+               if (compute_maps_online_a2r) then
+                  ierr =  iMOAB_ComputeMeshIntersectionOnSphere( mbaxid, mbrxid, mbintxar )
                   if (ierr .ne. 0) then
-                     write(logunit,*) subname,' error in writing ATM-ROF intersection mesh file '
-                     call shr_sys_abort(subname//' ERROR in writing ATM-ROF intersection mesh file ')
+                     write(logunit,*) subname,' error in computing ATM-ROF mesh intersection'
+                     call shr_sys_abort(subname//' ERROR in computing ATM-ROF mesh intersection')
                   endif
-               endif
+                  if (iamroot_CPLID) then
+                     write(logunit,*) 'iMOAB mesh intersection between ATM and ROF with id:', idintx
+                  end if
+#ifdef MOABDEBUG
+                  wopts = C_NULL_CHAR
+                  call shr_mpi_commrank( mpicom_CPLID, rank )
+                  if (rank .lt. 3) then
+                     write(lnum,"(I0.2)")rank !
+                     outfile = 'intx_ar_'//trim(lnum)// '.h5m' // C_NULL_CHAR
+                     ierr = iMOAB_WriteMesh(mbintxar, outfile, wopts) ! write local intx file
+                     if (ierr .ne. 0) then
+                        write(logunit,*) subname,' error in writing ATM-ROF intersection mesh file '
+                        call shr_sys_abort(subname//' ERROR in writing ATM-ROF intersection mesh file ')
+                     endif
+                  endif
 #endif
-               ! we also need to compute the comm graph for the second hop, from the atm on coupler to the
-               ! atm for the intersection of ATM-ROF context (coverage)
+                  volumetric = 0 ! can be 1 only for FV->DGLL or FV->CGLL;
+                  if (atm_pg_active) then
+                     dm1 = "fv"//C_NULL_CHAR
+                     dofnameS="GLOBAL_ID"//C_NULL_CHAR
+                     orderS = 1 !  fv-fv
+                  else ! this part does not work, anyway
+                     dm1 = "cgll"//C_NULL_CHAR
+                     dofnameS="GLOBAL_DOFS"//C_NULL_CHAR
+                     orderS = 4 ! np !  it should be 4
+                  endif
+                  dm2 = "fv"//C_NULL_CHAR
+                  dofnameT="GLOBAL_ID"//C_NULL_CHAR
+                  orderT = 1  !  not much arguing
+                  fNoBubble = 1
+                  monotonicity = 0 !
+                  noConserve = 0
+                  validate = 0 ! less verbose
+                  fInverseDistanceMap = 0
+                  if (iamroot_CPLID) then
+                     write(logunit,*) subname, 'launch iMOAB weights with args ', 'mbintxar=', mbintxar, ' wgtIdef=', wgtIdFa2r, &
+                        'dm1=', trim(dm1), ' orderS=',  orderS, 'dm2=', trim(dm2), ' orderT=', orderT, &
+                                                   fNoBubble, monotonicity, volumetric, fInverseDistanceMap, &
+                                                   noConserve, validate, &
+                                                   trim(dofnameS), trim(dofnameT)
+                  endif
+                  ierr = iMOAB_ComputeScalarProjectionWeights ( mbintxar, wgtIdFa2r, &
+                                                   trim(dm1), orderS, trim(dm2), orderT, ''//C_NULL_CHAR, &
+                                                   fNoBubble, monotonicity, volumetric, fInverseDistanceMap, &
+                                                   noConserve, validate, &
+                                                   trim(dofnameS), trim(dofnameT) )
+                  if (ierr .ne. 0) then
+                     write(logunit,*) subname,' error in computing ATM-ROF weights '
+                     call shr_sys_abort(subname//' ERROR in computing ATM-ROF weights ')
+                  endif
+
+               else
+                  type1 = 3 ! this is type of grid, maybe should be saved on imoab app ?
+                  arearead = 0 ! no need for areas
+                  call moab_map_init_rcfile( mbaxid, mbrxid, mbintxar, type1, &
+                        'seq_maps.rc', 'atm2rof_fmapname:', 'atm2rof_fmaptype:',samegrid_ar, &
+                        arearead, wgtIdFa2r, 'mapper_Fa2r MOAB initialization', esmf_map_flag)
+               end if
+            endif ! samegrid_ar
+          endif ! if ((mbrxid .ge. 0) .and.  (mbaxid .ge. 0))
+! endif HAVE_MOAB
+#endif
+
+          if (iamroot_CPLID) then
+             write(logunit,*) ' '
+             write(logunit,F00) 'Initializing mapper_Sa2r'
+          end if
+          call seq_map_init_rcfile(mapper_Sa2r, atm(1), rof(1), &
+               'seq_maps.rc','atm2rof_smapname:','atm2rof_smaptype:',samegrid_ar, &
+               string='mapper_Sa2r initialization', esmf_map=esmf_map_flag, no_match=no_match )
+#ifdef HAVE_MOAB
+          if ((mbaxid .ge. 0) .and.  (mbrxid .ge. 0) ) then
+            ! now take care of the mapper, use the same one as before
+            if (iamroot_CPLID) then
+               write(logunit,*) ' '
+               write(logunit,F00) 'Initializing MOAB mapper_Sa2r'
+            end if
+            if ( mapper_Sa2r%src_mbid .gt. -1 ) then
+                if (iamroot_CPLID) then
+                     write(logunit,F00) 'overwriting '//trim(mapper_Sa2r%mbname) &
+                             //' mapper_Sa2r'
+                endif
+            endif
+            mapper_Sa2r%src_mbid = mbaxid
+            mapper_Sa2r%tgt_mbid = mbrxid
+            mapper_Sa2r%intx_mbid = mbintxar
+            mapper_Sa2r%src_context = atm(1)%cplcompid
+            mapper_Sa2r%intx_context = idintx
+            mapper_Sa2r%weight_identifier = wgtIdSa2r
+            mapper_Sa2r%mbname = 'mapper_Sa2r'
+
+            if (samegrid_ar) then
+               ! graph was already computed earlier 
+               mapper_Sa2r%intx_context = rof(1)%cplcompid
+            else
+               ! If loading map from disk, then load the scalar map as well
+               if (.not. compute_maps_online_a2r) then
+                  type1 = 3 ! this is type of grid
+                  arearead = 0 ! no need for areas
+                  call moab_map_init_rcfile( mbaxid, mbrxid, mbintxar, type1, &
+                        'seq_maps.rc', 'atm2rof_smapname:', 'atm2rof_smaptype:', samegrid_ar, &
+                        arearead, wgtIdSa2r, 'mapper_Sa2r MOAB initialization', esmf_map_flag )
+
+                  ! this creates a par comm graph between mblxid and mbintxlr, with ids lnd(1)%cplcompid
+                  ierr = iMOAB_MigrateMapMesh (mbaxid, mbintxar, mpicom_CPLID, mpigrp_CPLID, &
+                        mpigrp_CPLID, type1, atm(1)%cplcompid, idintx)
+                  if (ierr .ne. 0) then
+                     write(logunit,*) subname,' error in migrating ATM mesh based on ATM-ROF map'
+                     call shr_sys_abort(subname//' ERROR in migrating ATM mesh based on ATM-ROF map')
+                  endif
+               end if
+               
+                              ! we also need to compute the comm graph for the second hop, from the atm on coupler to the
+                     ! atm for the intersection of ATM-ROF context (coverage)
                call seq_comm_getData(CPLID ,mpigrp=mpigrp_CPLID)
                if (atm_pg_active) then
                   type1 = 3; !  FV for both rof and atm; FV-CGLL does not work anyway
@@ -725,7 +858,7 @@ contains
 
        call shr_sys_flush(logunit)
 
-    end if
+    end if  ! rof_present .and. atm_present
 
     if (rof_present .and. ocn_present) then
 

--- a/driver-moab/main/prep_rof_mod.F90
+++ b/driver-moab/main/prep_rof_mod.F90
@@ -301,7 +301,6 @@ contains
        allocate(l2x_lm2(lsize_lm, nfields_sh_lr)) ! this will be obtained from land instance
        l2racc_lm(:,:) = 0.
        l2racc_lm_cnt = 0
-
        allocate(l2r_rx(num_inst_rof))
        do eri = 1,num_inst_rof
           call mct_avect_init(l2r_rx(eri), rList=seq_flds_l2x_fluxes_to_rof, lsize=lsize_r)
@@ -474,7 +473,6 @@ contains
 
             end if ! if ((mblxid .ge. 0) .and.  (mbrxid .ge. 0))
          endif ! samegrid_lr
-
           ! We'll map irrigation specially, so exclude this from the list of l2r fields
           ! that are mapped "normally".
           !
@@ -504,7 +502,6 @@ contains
           call mct_aVect_zero(a2racc_ax(eai))
        end do
        a2racc_ax_cnt = 0
-
        ! this a2racc_am will be over atm size
        sharedFieldsAtmRof=''
        nfields_sh_ar = mct_aVect_nRAttr(a2racc_ax(1))
@@ -668,8 +665,6 @@ contains
                end if
             endif ! samegrid_ar
           endif ! if ((mbrxid .ge. 0) .and.  (mbaxid .ge. 0))
-! endif HAVE_MOAB
-#endif
 
           if (iamroot_CPLID) then
              write(logunit,*) ' '
@@ -678,7 +673,6 @@ contains
           call seq_map_init_rcfile(mapper_Sa2r, atm(1), rof(1), &
                'seq_maps.rc','atm2rof_smapname:','atm2rof_smaptype:',samegrid_ar, &
                string='mapper_Sa2r initialization', esmf_map=esmf_map_flag, no_match=no_match )
-#ifdef HAVE_MOAB
           if ((mbaxid .ge. 0) .and.  (mbrxid .ge. 0) ) then
             ! now take care of the mapper, use the same one as before
             if (iamroot_CPLID) then
@@ -735,126 +729,9 @@ contains
                   write(logunit,*) subname,' error in computing comm graph for second hop, ATM-ROF'
                   call shr_sys_abort(subname//' ERROR in computing comm graph for second hop, ATM-ROF')
                endif
-            end if
-            ! now take care of the mapper
-            if ( mapper_Fa2r%src_mbid .gt. -1 ) then
-                if (iamroot_CPLID) then
-                     write(logunit,F00) 'overwriting '//trim(mapper_Fa2r%mbname) &
-                             //' mapper_Fa2r'
-                endif
-            endif
-            mapper_Fa2r%src_mbid = mbaxid
-            mapper_Fa2r%tgt_mbid = mbrxid
-            mapper_Fa2r%intx_mbid = mbintxar
-            mapper_Fa2r%src_context = atm(1)%cplcompid
-            mapper_Fa2r%intx_context = idintx
-            mapper_Fa2r%weight_identifier = wgtIdFa2r
-            mapper_Fa2r%mbname = 'mapper_Fa2r'
-            ! because we will project fields from atm to rof grid, we need to define
-            ! rof a2x fields to rof grid on coupler side
-
-            tagname = trim(seq_flds_a2x_fields_to_rof)//':norm8wt'//C_NULL_CHAR
-            tagtype = 1 ! dense
-            numco = 1 !
-            ierr = iMOAB_DefineTagStorage(mbrxid, tagname, tagtype, numco,  tagindex )
-            if (ierr .ne. 0) then
-               write(logunit,*) subname,' error in defining tags for seq_flds_a2x_fields_to_rof on ROF cpl'
-               call shr_sys_abort(subname//' ERROR in  defining tags for seq_flds_a2x_fields_to_rof on ROF cpl')
-            endif
-
-            if (compute_maps_online_a2r) then
-
-               volumetric = 0 ! can be 1 only for FV->DGLL or FV->CGLL;
-               if (atm_pg_active) then
-                  dm1 = "fv"//C_NULL_CHAR
-                  dofnameS="GLOBAL_ID"//C_NULL_CHAR
-                  orderS = 1 !  fv-fv
-               else ! this part does not work, anyway
-                  dm1 = "cgll"//C_NULL_CHAR
-                  dofnameS="GLOBAL_DOFS"//C_NULL_CHAR
-                  orderS = 4 ! np !  it should be 4
-               endif
-               dm2 = "fv"//C_NULL_CHAR
-               dofnameT="GLOBAL_ID"//C_NULL_CHAR
-               orderT = 1  !  not much arguing
-               fNoBubble = 1
-               monotonicity = 0 !
-               noConserve = 0
-               validate = 0 ! less verbose
-               fInverseDistanceMap = 0
-               if (iamroot_CPLID) then
-                  write(logunit,*) subname, 'launch iMOAB weights with args ', 'mbintxar=', mbintxar, ' wgtIdef=', wgtIdFa2r, &
-                     'dm1=', trim(dm1), ' orderS=',  orderS, 'dm2=', trim(dm2), ' orderT=', orderT, &
-                                                fNoBubble, monotonicity, volumetric, fInverseDistanceMap, &
-                                                noConserve, validate, &
-                                                trim(dofnameS), trim(dofnameT)
-               endif
-               ierr = iMOAB_ComputeScalarProjectionWeights ( mbintxar, wgtIdFa2r, &
-                                                trim(dm1), orderS, trim(dm2), orderT, ''//C_NULL_CHAR, &
-                                                fNoBubble, monotonicity, volumetric, fInverseDistanceMap, &
-                                                noConserve, validate, &
-                                                trim(dofnameS), trim(dofnameT) )
-               if (ierr .ne. 0) then
-                  write(logunit,*) subname,' error in computing ATM-ROF weights '
-                  call shr_sys_abort(subname//' ERROR in computing ATM-ROF weights ')
-               endif
-
-            else
-               type1 = 3 ! this is type of grid, maybe should be saved on imoab app ?
-               arearead = 0 ! no need for areas
-               call moab_map_init_rcfile( mbaxid, mbrxid, mbintxar, type1, &
-                     'seq_maps.rc', 'atm2rof_fmapname:', 'atm2rof_fmaptype:',samegrid_ar, &
-                     arearead, wgtIdFa2r, 'mapper_Fa2r MOAB initialization', esmf_map_flag)
-            end if
-
-         end if ! if ((mbrxid .ge. 0) .and.  (mbaxid .ge. 0))
-
-          if (iamroot_CPLID) then
-             write(logunit,*) ' '
-             write(logunit,F00) 'Initializing mapper_Sa2r'
-          end if
-          call seq_map_init_rcfile(mapper_Sa2r, atm(1), rof(1), &
-               'seq_maps.rc','atm2rof_smapname:','atm2rof_smaptype:',samegrid_ar, &
-               string='mapper_Sa2r initialization', esmf_map=esmf_map_flag, no_match=no_match )
-
-          if ((mbaxid .ge. 0) .and.  (mbrxid .ge. 0)) then
-            ! now take care of the mapper, use the same one as before
-            if (iamroot_CPLID) then
-               write(logunit,*) ' '
-               write(logunit,F00) 'Initializing MOAB mapper_Sa2r'
-            end if
-            if ( mapper_Sa2r%src_mbid .gt. -1 ) then
-                if (iamroot_CPLID) then
-                     write(logunit,F00) 'overwriting '//trim(mapper_Sa2r%mbname) &
-                             //' mapper_Sa2r'
-                endif
-            endif
-
-            ! If loading map from disk, then load the scalar map as well
-            if (.not. compute_maps_online_a2r) then
-               type1 = 3 ! this is type of grid
-               arearead = 0 ! no need for areas
-               call moab_map_init_rcfile( mbaxid, mbrxid, mbintxar, type1, &
-                     'seq_maps.rc', 'atm2rof_smapname:', 'atm2rof_smaptype:', samegrid_ar, &
-                     arearead, wgtIdSa2r, 'mapper_Sa2r MOAB initialization', esmf_map_flag )
-
-               ! this creates a par comm graph between mblxid and mbintxlr, with ids lnd(1)%cplcompid
-               ierr = iMOAB_MigrateMapMesh (mbaxid, mbintxar, mpicom_CPLID, mpigrp_CPLID, &
-                     mpigrp_CPLID, type1, atm(1)%cplcompid, idintx)
-               if (ierr .ne. 0) then
-                  write(logunit,*) subname,' error in migrating ATM mesh based on ATM-ROF map'
-                  call shr_sys_abort(subname//' ERROR in migrating ATM mesh based on ATM-ROF map')
-               endif
-            end if
-            mapper_Sa2r%src_mbid = mbaxid
-            mapper_Sa2r%tgt_mbid = mbrxid
-            mapper_Sa2r%intx_mbid = mbintxar
-            mapper_Sa2r%src_context = atm(1)%cplcompid
-            mapper_Sa2r%intx_context = idintx
-            mapper_Sa2r%weight_identifier = wgtIdSa2r
-            mapper_Sa2r%mbname = 'mapper_Sa2r'
-          end if ! if ((mbaxid .ge. 0) .and.  (mbrxid .ge. 0))
-       endif
+            endif ! samegrid_ar
+          end if ! if ((mbaxid .ge. 0) .and.  (mbrxid .ge. 0)) and not same grid ar
+       endif ! if atm_c2_rof
 
        call shr_sys_flush(logunit)
 
@@ -902,7 +779,6 @@ contains
       endif
       o2racc_om(:,:) = 0.
       o2racc_om_cnt = 0
-
        allocate(o2r_rx(num_inst_rof))
        do eri = 1,num_inst_rof
           call mct_avect_init(o2r_rx(eri), rList=seq_flds_o2x_fields_to_rof, lsize=lsize_r)
@@ -1709,7 +1585,6 @@ use iMOAB , only :  iMOAB_GetDoubleTagStorage
     first_time = .false.
 
   end subroutine prep_rof_merge
-
   subroutine prep_rof_mrg_moab  (infodata, cime_model)
    use iMOAB , only : iMOAB_GetMeshInfo, iMOAB_GetDoubleTagStorage, &
      iMOAB_SetDoubleTagStorage, iMOAB_WriteMesh
@@ -2092,7 +1967,6 @@ use iMOAB , only :  iMOAB_GetDoubleTagStorage
 #endif
 
   end subroutine prep_rof_mrg_moab
-
   !================================================================================================
 
   subroutine prep_rof_calc_l2r_rx(fractions_lx, timer)


### PR DESCRIPTION
Add driver-moab hooks to CICE.  For use in SCREAM F-cases.

Also correct some issues for "samegrid" logical in prep_init methods for atm, lnd, ice, ocn, rof.
The SCREAM F-cases with CICE have "samegrid" true for all components pairs.

add ne4pg2_ne4pg2.F2010-SCREAMv1 to the suite of moab tests
case when gridcpl_file != 'unknown_gridcpl_file' is not implemented yet (need an example first)

[BFB] for mct-driver

----

need more standardization, and eventual refactoring 
 should be :
 ```
 create intx app
 define moab tags
 if (samegrid)  then
      compute comm graph for rearrange
 else 
      if (compute map ) then
         compute intx
         compute weights
      else
         read map
         migrate map mesh
      endif
      compute commgraph for coverage mesh 
 endif
```
         
  Tested also higher res cases with CICE and SCREAM, like` --res ne1024pg2_ne1024pg2 --compset F2010-SCREAMv1`
  integration suite was tested with moab driver, 109 tests out of 147 passed; most of the failures were related to spectral atmosphere, land ice and ERP tests 
 