### PR TITLE
EAMxx: histogram diagnostic

### DIFF
--- a/components/eamxx/docs/user/diags/field_contraction.md
+++ b/components/eamxx/docs/user/diags/field_contraction.md
@@ -91,8 +91,8 @@ We currently have a utility to calculate histograms online.
 To select the histogram, you need to suffix a field name `X` with
 `_histogram_` followed by the values specifying the edges of the bins,
 separated by `_`. For example, the histogram specified by
-`T_mid_histogram_250_270_290_310` has 3 bins defined by
-[250, 270), [270, 290), and [290, 310].
+`T_mid_histogram_250_270_290_310` has 5 bins effectively defined by
+[$-\infty$, 250), [250, 270), [270, 290), [290, 310), and [310, $\infty$).
 
 | Reduction | Weight | Description |
 | --------- | ------ | ----------- |

--- a/components/eamxx/docs/user/diags/field_contraction.md
+++ b/components/eamxx/docs/user/diags/field_contraction.md
@@ -3,7 +3,7 @@
 In EAMxx, we can automatically calculate field reductions
 across the horizontal columns and across the model vertical levels.
 We call these horizontal and vertical reductions.
-We can also automatically calculate zonal averages.
+We can also automatically calculate zonal averages and histograms.
 We have *experimental* support for composing diagnostics; below,
 the horizontal and vertical reductions can be composed
 sequentially, but if using dp- or dz-weighted reductions,
@@ -85,6 +85,19 @@ And so on...
 | --------- | ------ | ----------- |
 | `X_zonal_avg_Y_bins` | Area fraction | Average across the zonal direction |
 
+## Histograms
+
+We currently have a utility to calculate histograms online.
+To select the histogram, you need to suffix a field name `X` with
+`_histogram_` followed by the values specifying the edges of the bins,
+separated by `_`. For example, the histogram specified by
+`T_mid_histogram_250_270_290_310` has 3 bins defined by
+[250, 270), [270, 290), and [290, 310].
+
+| Reduction | Weight | Description |
+| --------- | ------ | ----------- |
+| `X_histogram_V0_V1_..._VN` | 1 or 0 | Count of field values within each range |
+
 ## Example
 
 ```yaml
@@ -99,7 +112,7 @@ fields:
       # in this example, we use T_mid in units of K
       - T_mid_horiz_avg  # K
       - T_mid_vert_avg_dp_weighted  # K
-      - T_mid_vert_sum_dp_weighted  # K * Pa * s / (m * m) 
+      - T_mid_vert_sum_dp_weighted  # K * Pa * s / (m * m)
       - T_mid_vert_avg_dz_weighted  # K
       - T_mid_vert_sum_dz_weighted  # K * m
       - T_mid_vert_avg  # K
@@ -110,6 +123,7 @@ fields:
       - T_mid_vert_avg_dp_weighted_horiz_avg  # K
       - T_mid_zonal_avg_180_bins  # K
       - T_mid_zonal_avg_90_bins  # K
+      - T_mid_histogram_250_270_290_310 # count
 output_control:
   frequency: 1
   frequency_units: nmonths

--- a/components/eamxx/src/diagnostics/CMakeLists.txt
+++ b/components/eamxx/src/diagnostics/CMakeLists.txt
@@ -9,6 +9,7 @@ set(DIAGNOSTIC_SRCS
   field_at_height.cpp
   field_at_level.cpp
   field_at_pressure_level.cpp
+  histogram.cpp
   horiz_avg.cpp
   longwave_cloud_forcing.cpp
   number_path.cpp

--- a/components/eamxx/src/diagnostics/histogram.cpp
+++ b/components/eamxx/src/diagnostics/histogram.cpp
@@ -1,6 +1,7 @@
 #include "diagnostics/histogram.hpp"
 
 #include <ekat_team_policy_utils.hpp>
+#include <ekat_string_utils.hpp>
 
 
 namespace scream {
@@ -34,13 +35,8 @@ void HistogramDiag::initialize_impl(const RunType /*run_type*/) {
                        field_layout.to_string() + "\n");
 
   // extract bin values from configuration
-  std::istringstream stream(m_bin_configuration);
-  std::string token;
-  std::vector<Real> bin_values;
-  while (std::getline(stream, token, '_')) {
-    bin_values.push_back(std::stod(token));
-  }
-  const int num_bins = bin_values.size()-1;
+  std::vector<std::string> bin_strings = ekat::split(m_bin_configuration, "_");
+  const int num_bins = bin_strings.size()-1;
 
   // allocate histogram field
   FieldLayout diagnostic_layout({CMP}, {num_bins}, {"bin"});
@@ -60,7 +56,7 @@ void HistogramDiag::initialize_impl(const RunType /*run_type*/) {
   using RangePolicy    = Kokkos::RangePolicy<Field::device_t::execution_space>;
   Kokkos::parallel_for("store_histogram_bin_values_" + field.name(),
       RangePolicy(0, bin_values_layout.dim(0)), [&] (int i) {
-        bin_values_view(i) = bin_values[i];
+        bin_values_view(i) = std::stod(bin_strings[i]);
       });
 }
 

--- a/components/eamxx/src/diagnostics/histogram.cpp
+++ b/components/eamxx/src/diagnostics/histogram.cpp
@@ -1,5 +1,8 @@
 #include "diagnostics/histogram.hpp"
 
+#include <ekat_team_policy_utils.hpp>
+
+
 namespace scream {
 
 HistogramDiag::HistogramDiag(const ekat::Comm &comm, const ekat::ParameterList &params)
@@ -73,13 +76,13 @@ void HistogramDiag::compute_diagnostic_impl() {
   using KT         = ekat::KokkosTypes<DefaultDevice>;
   using TeamPolicy = Kokkos::TeamPolicy<Field::device_t::execution_space>;
   using TeamMember = typename TeamPolicy::member_type;
-  using ESU        = ekat::ExeSpaceUtils<typename KT::ExeSpace>;
+  using TPF        = ekat::TeamPolicyFactory<typename KT::ExeSpace>;
   switch (field_layout.rank())
   {
     case 1: {
       const int d1 = field_layout.dim(0);
       auto field_view = field.get_view<const Real *>();
-      TeamPolicy team_policy = ESU::get_default_team_policy(num_bins, d1);
+      TeamPolicy team_policy = TPF::get_default_team_policy(num_bins, d1);
       Kokkos::parallel_for("compute_histogram_" + field.name(), team_policy,
           KOKKOS_LAMBDA(const TeamMember &tm) {
             const int bin_i = tm.league_rank();
@@ -97,7 +100,7 @@ void HistogramDiag::compute_diagnostic_impl() {
       const int d1 = field_layout.dim(0);
       const int d2 = field_layout.dim(1);
       auto field_view = field.get_view<const Real **>();
-      TeamPolicy team_policy = ESU::get_default_team_policy(num_bins, d1*d2);
+      TeamPolicy team_policy = TPF::get_default_team_policy(num_bins, d1*d2);
       Kokkos::parallel_for("compute_histogram_" + field.name(), team_policy,
           KOKKOS_LAMBDA(const TeamMember &tm) {
             const int bin_i = tm.league_rank();
@@ -119,7 +122,7 @@ void HistogramDiag::compute_diagnostic_impl() {
       const int d2 = field_layout.dim(1);
       const int d3 = field_layout.dim(2);
       auto field_view = field.get_view<const Real ***>();
-      TeamPolicy team_policy = ESU::get_default_team_policy(num_bins, d1*d2*d3);
+      TeamPolicy team_policy = TPF::get_default_team_policy(num_bins, d1*d2*d3);
       Kokkos::parallel_for("compute_histogram_" + field.name(), team_policy,
           KOKKOS_LAMBDA(const TeamMember &tm) {
             const int bin_i = tm.league_rank();

--- a/components/eamxx/src/diagnostics/histogram.cpp
+++ b/components/eamxx/src/diagnostics/histogram.cpp
@@ -38,7 +38,7 @@ void HistogramDiag::initialize_impl(const RunType /*run_type*/) {
   while (std::getline(stream, token, '_')) {
     bin_values.push_back(std::stod(token));
   }
-  int num_bins = bin_values.size()-1;
+  const int num_bins = bin_values.size()-1;
 
   // allocate histogram field
   FieldLayout diagnostic_layout({CMP}, {num_bins}, {"bin"});

--- a/components/eamxx/src/diagnostics/histogram.cpp
+++ b/components/eamxx/src/diagnostics/histogram.cpp
@@ -70,7 +70,6 @@ void HistogramDiag::compute_diagnostic_impl() {
   auto histogram_layout = m_diagnostic_output.get_header().get_identifier().get_layout();
   const int num_bins = histogram_layout.dim(0);
 
-  m_diagnostic_output.deep_copy(sp(0.0));
   auto bin_values_view = m_bin_values.get_view<Real *>();
   auto histogram_view = m_diagnostic_output.get_view<Real *>();
   using KT         = ekat::KokkosTypes<DefaultDevice>;
@@ -106,7 +105,6 @@ void HistogramDiag::compute_diagnostic_impl() {
             const int bin_i = tm.league_rank();
             const Real bin_lower = bin_values_view(bin_i);
             const Real bin_upper = bin_values_view(bin_i+1);
-            histogram_view(bin_i) = 0;
             Kokkos::parallel_reduce(Kokkos::TeamVectorRange(tm, d1*d2),
                 [&](int ind, Real &val) {
                   const int i1 = ind / d2;
@@ -128,7 +126,6 @@ void HistogramDiag::compute_diagnostic_impl() {
             const int bin_i = tm.league_rank();
             const Real bin_lower = bin_values_view(bin_i);
             const Real bin_upper = bin_values_view(bin_i+1);
-            histogram_view(bin_i) = 0;
             Kokkos::parallel_reduce(Kokkos::TeamVectorRange(tm, d1*d2*d3),
                 [&](int ind, Real &val) {
                   const int i1 = ind / (d2*d3);

--- a/components/eamxx/src/diagnostics/histogram.cpp
+++ b/components/eamxx/src/diagnostics/histogram.cpp
@@ -1,0 +1,94 @@
+#include "diagnostics/histogram.hpp"
+
+namespace scream {
+
+
+HistogramDiag::HistogramDiag(const ekat::Comm &comm, const ekat::ParameterList &params)
+    : AtmosphereDiagnostic(comm, params) {
+  const auto &field_name = m_params.get<std::string>("field_name");
+  m_bin_configuration    = params.get<std::string>("bin_configuration");
+  m_diag_name            = field_name + "_histogram_" + m_bin_configuration;
+}
+
+void HistogramDiag::set_grids(const std::shared_ptr<const GridsManager> grids_manager) {
+  const auto &field_name = m_params.get<std::string>("field_name");
+  const auto &grid_name  = m_params.get<std::string>("grid_name");
+  add_field<Required>(field_name, grid_name);
+}
+
+void HistogramDiag::initialize_impl(const RunType /*run_type*/) {
+  using FieldIdentifier = FieldHeader::identifier_type;
+  using FieldLayout     = FieldIdentifier::layout_type;
+  using ShortFieldTagsNames::CMP;
+  const Field &field              = get_fields_in().front();
+  const FieldIdentifier &field_id = field.get_header().get_identifier();
+
+  // extract bin values from configuration
+  std::istringstream stream(m_bin_configuration);
+  std::string token;
+  std::vector<Real> bin_values;
+  while (std::getline(stream, token, '_')) {
+    bin_values.push_back(std::stod(token));
+  }
+  int num_bins = bin_values.size()-1;
+
+  // allocate histogram field
+  FieldLayout diagnostic_layout({CMP}, {num_bins}, {"bin"});
+  FieldIdentifier diagnostic_id(m_diag_name, diagnostic_layout, field_id.get_units(),
+                                field_id.get_grid_name(), DataType::IntType);
+  m_diagnostic_output = Field(diagnostic_id);
+  m_diagnostic_output.allocate_view();
+
+  // allocate field for bin values
+  FieldLayout bin_values_layout({CMP}, {num_bins+1}, {"bin"});
+  FieldIdentifier bin_values_id(m_diag_name + "_bin_values", bin_values_layout,
+                                field_id.get_units(), field_id.get_grid_name());
+  m_bin_values = Field(bin_values_id);
+  m_bin_values.allocate_view();
+  auto bin_values_view = m_bin_values.get_view<Real *>();
+  using RangePolicy    = Kokkos::RangePolicy<Field::device_t::execution_space>;
+  Kokkos::parallel_for("store_histogram_bin_values_" + field.name(),
+      RangePolicy(0, bin_values_layout.dim(0)), [&] (int i) {
+        bin_values_view(i) = bin_values[i];
+      });
+}
+
+void HistogramDiag::compute_diagnostic_impl() {
+  const auto &field = get_fields_in().front();
+  auto field_layout = field.get_header().get_identifier().get_layout();
+  auto histogram_layout = m_diagnostic_output.get_header().get_identifier().get_layout();
+  const int num_bins = histogram_layout.dim(0);
+  const int field_size = field_layout.size();
+
+  auto bin_values_view = m_bin_values.get_view<Real *>();
+  auto histogram_view = m_diagnostic_output.get_view<Int *>();
+  auto field_view = field.get_view<const Real *>();
+  using KT         = ekat::KokkosTypes<DefaultDevice>;
+  using TeamPolicy = Kokkos::TeamPolicy<Field::device_t::execution_space>;
+  using TeamMember = typename TeamPolicy::member_type;
+  using ESU        = ekat::ExeSpaceUtils<typename KT::ExeSpace>;
+  TeamPolicy team_policy = ESU::get_default_team_policy(num_bins, field_size);
+  Kokkos::parallel_for("compute_histogram_" + field.name(), team_policy,
+      KOKKOS_LAMBDA(const TeamMember &tm) {
+        const int bin_i = tm.league_rank();
+        const Real bin_lower = bin_values_view(bin_i);
+        const Real bin_upper = bin_values_view(bin_i+1);
+        Kokkos::parallel_reduce(Kokkos::TeamVectorRange(tm, field_size),
+            [&](int i, Int &val) {
+              if ((bin_lower <= field_view(i)) && (field_view(i) < bin_upper))
+                val++;
+            },
+            histogram_view(bin_i));
+      });
+
+  // TODO: use device-side MPI calls
+  // TODO: the dev ptr causes problems; revisit this later
+  // TODO: doing cuda-aware MPI allreduce would be ~10% faster
+  Kokkos::fence();
+  m_diagnostic_output.sync_to_host();
+  m_comm.all_reduce(m_diagnostic_output.template get_internal_view_data<Int, Host>(),
+                      histogram_layout.size(), MPI_SUM);
+  m_diagnostic_output.sync_to_dev();
+}
+
+} // namespace scream

--- a/components/eamxx/src/diagnostics/histogram.hpp
+++ b/components/eamxx/src/diagnostics/histogram.hpp
@@ -1,0 +1,41 @@
+#ifndef EAMXX_HISTOTGRAM_HPP
+#define EAMXX_HISTOGRAM_HPP
+
+#include "share/atm_process/atmosphere_diagnostic.hpp"
+
+namespace scream {
+/*
+ * This diagnostic will calculate a histogram of a field across all dimensions
+ * producing a one dimensional field, with CMP tag dimension named "bin", that
+ * indicates how many times a field value in the specified range occurred.
+ */
+
+class HistogramDiag : public AtmosphereDiagnostic {
+
+public:
+  // Constructors
+  HistogramDiag(const ekat::Comm &comm, const ekat::ParameterList &params);
+
+  // The name of the diagnostic
+  std::string name() const { return m_diag_name; }
+
+  // Set the grid
+  void set_grids(const std::shared_ptr<const GridsManager> grids_manager);
+
+protected:
+#ifdef KOKKOS_ENABLE_CUDA
+public:
+#endif
+  void initialize_impl(const RunType /*run_type*/);
+  void compute_diagnostic_impl();
+
+protected:
+  std::string m_diag_name;
+  std::string m_bin_configuration;
+
+  Field m_bin_values;
+};
+
+} // namespace scream
+
+#endif // EAMXX_HISTOGRAM_HPP

--- a/components/eamxx/src/diagnostics/histogram.hpp
+++ b/components/eamxx/src/diagnostics/histogram.hpp
@@ -31,8 +31,7 @@ public:
 
 protected:
   std::string m_diag_name;
-  std::string m_bin_configuration;
-
+  std::vector<Real> m_bin_reals;
   Field m_bin_values;
 };
 

--- a/components/eamxx/src/diagnostics/register_diagnostics.hpp
+++ b/components/eamxx/src/diagnostics/register_diagnostics.hpp
@@ -30,6 +30,7 @@
 #include "diagnostics/zonal_avg.hpp"
 #include "diagnostics/conditional_sampling.hpp"
 #include "diagnostics/binary_ops.hpp"
+#include "diagnostics/histogram.hpp"
 
 namespace scream {
 
@@ -63,6 +64,7 @@ inline void register_diagnostics () {
   diag_factory.register_product("ZonalAvgDiag",&create_atmosphere_diagnostic<ZonalAvgDiag>);
   diag_factory.register_product("ConditionalSampling",&create_atmosphere_diagnostic<ConditionalSampling>);
   diag_factory.register_product("BinaryOpsDiag", &create_atmosphere_diagnostic<BinaryOpsDiag>);
+  diag_factory.register_product("HistogramDiag",&create_atmosphere_diagnostic<HistogramDiag>);
 }
 
 } // namespace scream

--- a/components/eamxx/src/diagnostics/tests/CMakeLists.txt
+++ b/components/eamxx/src/diagnostics/tests/CMakeLists.txt
@@ -82,10 +82,13 @@ CreateDiagTest(vert_contract "vert_contract_test.cpp" MPI_RANKS 1 ${SCREAM_TEST_
 CreateDiagTest(vert_derivative "vert_derivative_test.cpp")
 
 # Test zonal averaging
-CreateDiagTest(zonal_avg zonal_avg_test.cpp MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS})
+CreateDiagTest(zonal_avg "zonal_avg_test.cpp" MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS})
 
 # Test conditional sampling
 CreateDiagTest(conditional_sampling "conditional_sampling_test.cpp")
 
 # Test binary ops
 CreateDiagTest(binary_ops "binary_ops_test.cpp")
+
+# Test histogram
+CreateDiagTest(histogram "histogram_test.cpp" MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS})

--- a/components/eamxx/src/diagnostics/tests/histogram_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/histogram_test.cpp
@@ -2,7 +2,7 @@
 #include "diagnostics/register_diagnostics.hpp"
 #include "share/field/field_utils.hpp"
 #include "share/grid/mesh_free_grids_manager.hpp"
-#include "share/util/eamxx_setup_random_test.hpp"
+#include "share/core/eamxx_setup_random_test.hpp"
 #include "share/util/eamxx_universal_constants.hpp"
 
 namespace scream {

--- a/components/eamxx/src/diagnostics/tests/histogram_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/histogram_test.cpp
@@ -46,8 +46,8 @@ TEST_CASE("histogram") {
   auto grid           = gm->get_grid("Physics");
 
   // Specify histogram bins
-  const std::string bin_configuration = "0_50_100_150_200";
-  const std::vector<Real> bin_values = {0.0, 50.0, 100.0, 150.0, 200.0};
+  const std::string bin_configuration = "50_100_150";
+  const std::vector<Real> bin_values = {-100.0, 50.0, 100.0, 150.0, 1000.0};
 
   // Input (randomized) qc
   FieldLayout scalar1d_layout{{COL}, {ncols}};
@@ -97,7 +97,12 @@ TEST_CASE("histogram") {
   REQUIRE_THROWS(diag_factory.create("HistogramDiag", comm,
                                      params)); // Still no bin configuration
 
+  params.set<std::string>("bin_configuration", "100_25");
+  REQUIRE_THROWS(diag_factory.create("HistogramDiag", comm,
+                                     params)); // Non-monotonic bin configuation
+
   params.set<std::string>("bin_configuration", bin_configuration);
+
   // Now we should be good to go...
   auto diag1 = diag_factory.create("HistogramDiag", comm, params);
   auto diag2 = diag_factory.create("HistogramDiag", comm, params);

--- a/components/eamxx/src/diagnostics/tests/histogram_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/histogram_test.cpp
@@ -8,7 +8,6 @@
 namespace scream {
 
 std::shared_ptr<GridsManager> create_gm(const ekat::Comm &comm, const int ngcols, const int nlevs) {
-
   using vos_t = std::vector<std::string>;
   ekat::ParameterList gm_params;
   gm_params.set("grids_names", vos_t{"Point Grid"});
@@ -128,7 +127,8 @@ TEST_CASE("histogram") {
         diag0_view_h(bin_i) += 1;
     }
   }
-  comm.all_reduce(diag0_field.template get_internal_view_data<Int, Host>(), diag0_layout.size(), MPI_SUM);
+  comm.all_reduce(diag0_field.template get_internal_view_data<Int, Host>(),
+    diag0_layout.size(), MPI_SUM);
   diag0_field.sync_to_dev();
 
   // Compare
@@ -177,7 +177,8 @@ TEST_CASE("histogram") {
       }
     }
   }
-  comm.all_reduce(diag3m_field.template get_internal_view_data<Int, Host>(), diag3m_layout.size(), MPI_SUM);
+  comm.all_reduce(diag3m_field.template get_internal_view_data<Int, Host>(),
+    diag3m_layout.size(), MPI_SUM);
   diag3m_field.sync_to_dev();
   diag3->set_required_field(qc3);
   diag3->initialize(t0, RunType::Initial);

--- a/components/eamxx/src/diagnostics/tests/histogram_test.cpp
+++ b/components/eamxx/src/diagnostics/tests/histogram_test.cpp
@@ -1,0 +1,189 @@
+#include "catch2/catch.hpp"
+#include "diagnostics/register_diagnostics.hpp"
+#include "share/field/field_utils.hpp"
+#include "share/grid/mesh_free_grids_manager.hpp"
+#include "share/util/eamxx_setup_random_test.hpp"
+#include "share/util/eamxx_universal_constants.hpp"
+
+namespace scream {
+
+std::shared_ptr<GridsManager> create_gm(const ekat::Comm &comm, const int ncols, const int nlevs) {
+  const int num_global_cols = ncols * comm.size();
+
+  using vos_t = std::vector<std::string>;
+  ekat::ParameterList gm_params;
+  gm_params.set("grids_names", vos_t{"Point Grid"});
+  auto &pl = gm_params.sublist("Point Grid");
+  pl.set<std::string>("type", "point_grid");
+  pl.set("aliases", vos_t{"Physics"});
+  pl.set<int>("number_of_global_columns", num_global_cols);
+  pl.set<int>("number_of_vertical_levels", nlevs);
+
+  auto gm = create_mesh_free_grids_manager(comm, gm_params);
+  gm->build_grids();
+
+  return gm;
+}
+
+TEST_CASE("histogram") {
+  using namespace ShortFieldTagsNames;
+  using namespace ekat::units;
+
+  // A numerical tolerance
+  auto tol = std::numeric_limits<Real>::epsilon() * 100;
+
+  // A world comm
+  ekat::Comm comm(MPI_COMM_WORLD);
+
+  // A time stamp
+  util::TimeStamp t0({2024, 1, 1}, {0, 0, 0});
+
+  // Create a grids manager - single column for these tests
+  constexpr int nlevs = 3;
+  constexpr int dim3  = 4;
+  const int ngcols    = 6 * comm.size();
+
+  auto gm   = create_gm(comm, ngcols, nlevs);
+  auto grid = gm->get_grid("Physics");
+
+  // Specify histogram bins
+  const std::string bin_configuration = "0_50_100_150_200";
+  const std::vector<Real> bin_values = {0.0, 50.0, 100.0, 150.0, 200.0};
+
+  // Input (randomized) qc
+  FieldLayout scalar1d_layout{{COL}, {ngcols}};
+  FieldLayout scalar2d_layout{{COL, LEV}, {ngcols, nlevs}};
+  FieldLayout scalar3d_layout{{COL, CMP, LEV}, {ngcols, dim3, nlevs}};
+
+  FieldIdentifier qc1_id("qc", scalar1d_layout, kg / kg, grid->name());
+  FieldIdentifier qc2_fid("qc", scalar2d_layout, kg / kg, grid->name());
+  FieldIdentifier qc3_fid("qc", scalar3d_layout, kg / kg, grid->name());
+
+  Field qc1(qc1_id);
+  Field qc2(qc2_fid);
+  Field qc3(qc3_fid);
+
+  qc1.allocate_view();
+  qc2.allocate_view();
+  qc3.allocate_view();
+
+  // Construct random number generator stuff
+  using RPDF = std::uniform_real_distribution<Real>;
+  RPDF pdf(sp(0.0), sp(200.0));
+  auto engine = scream::setup_random_test();
+
+  // Set time for qc and randomize its values
+  qc1.get_header().get_tracking().update_time_stamp(t0);
+  qc2.get_header().get_tracking().update_time_stamp(t0);
+  qc3.get_header().get_tracking().update_time_stamp(t0);
+  randomize(qc1, engine, pdf);
+  randomize(qc2, engine, pdf);
+  randomize(qc3, engine, pdf);
+
+  // Construct the Diagnostics
+  std::map<std::string, std::shared_ptr<AtmosphereDiagnostic>> diags;
+  auto &diag_factory = AtmosphereDiagnosticFactory::instance();
+  register_diagnostics();
+
+  // Create and set up the diagnostic
+  ekat::ParameterList params;
+  REQUIRE_THROWS(diag_factory.create("HistogramDiag", comm,
+                                     params)); // Bad construction
+
+  params.set("grid_name", grid->name());
+  REQUIRE_THROWS(diag_factory.create("HistogramDiag", comm,
+                                     params)); // Still no field_name
+
+  params.set<std::string>("field_name", "qc");
+  REQUIRE_THROWS(diag_factory.create("HistogramDiag", comm,
+                                     params)); // Still no bin configuration
+
+  params.set<std::string>("bin_configuration", bin_configuration);
+  // Now we should be good to go...
+  auto diag1 = diag_factory.create("HistogramDiag", comm, params);
+  auto diag2 = diag_factory.create("HistogramDiag", comm, params);
+  auto diag3 = diag_factory.create("HistogramDiag", comm, params);
+  diag1->set_grids(gm);
+  diag2->set_grids(gm);
+  diag3->set_grids(gm);
+
+  // Test the zonal average of qc1
+  diag1->set_required_field(qc1);
+  diag1->initialize(t0, RunType::Initial);
+  diag1->compute_diagnostic();
+  auto diag1_field = diag1->get_diagnostic();
+
+  // Manual calculation
+  const int num_bins = bin_values.size()-1;
+  const std::string bin_dim_name = diag1_field.get_header().get_identifier().get_layout().name(0);
+  FieldLayout diag0_layout({CMP}, {num_bins}, {bin_dim_name});
+  FieldIdentifier diag0_id("qc_histogram_manual", diag0_layout, kg / kg, grid->name(), DataType::IntType);
+  Field diag0_field(diag0_id);
+  diag0_field.allocate_view();
+
+  // calculate the histogram
+  auto qc1_view_h   = qc1.get_view<const Real *, Host>();
+  auto diag0_view_h = diag0_field.get_view<Int *, Host>();
+  for (int bin_i = 0; bin_i < num_bins; bin_i++) {
+    for (int col_i = 0; col_i < ngcols; col_i++) {
+      if (bin_values[bin_i] <= qc1_view_h(col_i) && qc1_view_h(col_i) < bin_values[bin_i+1])
+        diag0_view_h(bin_i) += 1;
+    }
+  }
+  diag0_field.sync_to_dev();
+
+  // Compare
+  REQUIRE(views_are_equal(diag1_field, diag0_field));
+/*
+  // Try other known cases
+  // Set qc1_v to 1.0 to get zonal averages of 1.0/nlats
+  const Real zavg1 = sp(1.0);
+  qc1.deep_copy(zavg1);
+  diag1->compute_diagnostic();
+  auto diag1_view_host = diag1_field.get_view<Real *, Host>();
+  for (int nlat = 0; nlat < nlats; nlat++) {
+    REQUIRE_THAT(diag1_view_host(nlat), Catch::Matchers::WithinRel(zavg1, tol));
+  }
+
+  // other diags
+  // Set qc2_v to 5.0 to get weighted average of 5.0
+  const Real zavg2 = sp(5.0);
+  qc2.deep_copy(zavg2);
+  diag2->set_required_field(qc2);
+  diag2->initialize(t0, RunType::Initial);
+  diag2->compute_diagnostic();
+  auto diag2_field = diag2->get_diagnostic();
+
+  auto diag2_view_host = diag2_field.get_view<Real **, Host>();
+  for (int i = 0; i < nlevs; ++i) {
+    for (int nlat = 0; nlat < nlats; nlat++) {
+      REQUIRE_THAT(diag2_view_host(nlat, i), Catch::Matchers::WithinRel(zavg2, tol));
+    }
+  }
+
+  // Try a random case with qc3
+  FieldLayout diag3m_layout({CMP, CMP, LEV}, {nlats, dim3, nlevs},
+                            {bin_dim_name, e2str(CMP), e2str(LEV)});
+  FieldIdentifier diag3m_id("qc_zonal_avg_manual", diag3m_layout, kg / kg, grid->name());
+  Field diag3m_field(diag3m_id);
+  diag3m_field.allocate_view();
+  auto qc3_view_h    = qc3.get_view<Real ***, Host>();
+  auto diag3m_view_h = diag3m_field.get_view<Real ***, Host>();
+  for (int i = 0; i < ngcols; i++) {
+    const int nlat = i % nlats;
+    for (int j = 0; j < dim3; j++) {
+      for (int k = 0; k < nlevs; k++) {
+        diag3m_view_h(nlat, j, k) += area_view_h(i) / zonal_areas[nlat] * qc3_view_h(i, j, k);
+      }
+    }
+  }
+  diag3m_field.sync_to_dev();
+  diag3->set_required_field(qc3);
+  diag3->initialize(t0, RunType::Initial);
+  diag3->compute_diagnostic();
+  auto diag3_field = diag3->get_diagnostic();
+  REQUIRE(views_are_equal(diag3_field, diag3m_field));
+  */
+}
+
+} // namespace scream

--- a/components/eamxx/src/physics/ml_correction/eamxx_ml_correction_process_interface.cpp
+++ b/components/eamxx/src/physics/ml_correction/eamxx_ml_correction_process_interface.cpp
@@ -5,6 +5,7 @@
 #include "share/field/field_utils.hpp"
 
 #include <ekat_assert.hpp>
+#include <ekat_fpe.hpp>
 #include <ekat_units.hpp>
 #include <ekat_team_policy_utils.hpp>
 #include <ekat_fpe.hpp>

--- a/components/eamxx/src/share/io/eamxx_io_utils.cpp
+++ b/components/eamxx/src/share/io/eamxx_io_utils.cpp
@@ -148,8 +148,8 @@ create_diagnostic (const std::string& diag_field_name,
   std::regex zonal_avg (R"()" + generic_field + R"(_zonal_avg_(\d+)_bins$)");
   std::regex conditional_sampling (R"()" + generic_field + R"(_where_)" + generic_field + R"(_(gt|ge|eq|ne|le|lt)_([+-]?\d+(?:\.\d+)?)$)");
   std::regex binary_ops (generic_field + "_" "(plus|minus|times|over)" + "_" + generic_field + "$");
-  std::regex vert_derivative (generic_field + "_(p|z)vert_derivative$");
   std::regex histogram (R"()" + generic_field + R"(_histogram_(\d+(\.\d+)?(_\d+(\.\d+)?)+)$)");
+  std::regex vert_derivative (generic_field + "_(p|z)vert_derivative$");
 
   std::string diag_name;
   std::smatch matches;

--- a/components/eamxx/src/share/io/eamxx_io_utils.cpp
+++ b/components/eamxx/src/share/io/eamxx_io_utils.cpp
@@ -131,7 +131,7 @@ create_diagnostic (const std::string& diag_field_name,
   // Note: the number for field_at_p/h can match positive integer/floating-point numbers
   // Start with a generic for a field name allowing for all letters, all numbers, dash, dot, plus, minus, product, and division
   // Escaping all the special ones just in case
-  std::string generic_field = "([A-Za-z0-9_.+\\-\\*\\÷]+)"; 
+  std::string generic_field = "([A-Za-z0-9_.+\\-\\*\\÷]+)";
   std::regex field_at_l (R"()" + generic_field + R"(_at_(lev_(\d+)|model_(top|bot))$)");
   std::regex field_at_p (R"()" + generic_field + R"(_at_(\d+(\.\d+)?)(hPa|mb|Pa)$)");
   std::regex field_at_h (R"()" + generic_field + R"(_at_(\d+(\.\d+)?)(m)_above_(sealevel|surface)$)");
@@ -149,6 +149,7 @@ create_diagnostic (const std::string& diag_field_name,
   std::regex conditional_sampling (R"()" + generic_field + R"(_where_)" + generic_field + R"(_(gt|ge|eq|ne|le|lt)_([+-]?\d+(?:\.\d+)?)$)");
   std::regex binary_ops (generic_field + "_" "(plus|minus|times|over)" + "_" + generic_field + "$");
   std::regex vert_derivative (generic_field + "_(p|z)vert_derivative$");
+  std::regex histogram (R"()" + generic_field + R"(_histogram_(\d+(\.\d+)?(_\d+(\.\d+)?)+)$)");
 
   std::string diag_name;
   std::smatch matches;
@@ -246,6 +247,11 @@ create_diagnostic (const std::string& diag_field_name,
     params.set<std::string>("condition_field", matches[2].str());
     params.set<std::string>("condition_operator", matches[3].str());
     params.set<std::string>("condition_value", matches[4].str());
+  else if (std::regex_search(diag_field_name,matches,histogram)) {
+    diag_name = "HistogramDiag";
+    params.set("grid_name", grid->name());
+    params.set<std::string>("field_name", matches[1].str());
+    params.set<std::string>("bin_configuration", matches[2].str());
   }
   else if (std::regex_search(diag_field_name,matches,binary_ops)) {
     diag_name = "BinaryOpsDiag";

--- a/components/eamxx/src/share/io/eamxx_io_utils.cpp
+++ b/components/eamxx/src/share/io/eamxx_io_utils.cpp
@@ -247,11 +247,6 @@ create_diagnostic (const std::string& diag_field_name,
     params.set<std::string>("condition_field", matches[2].str());
     params.set<std::string>("condition_operator", matches[3].str());
     params.set<std::string>("condition_value", matches[4].str());
-  else if (std::regex_search(diag_field_name,matches,histogram)) {
-    diag_name = "HistogramDiag";
-    params.set("grid_name", grid->name());
-    params.set<std::string>("field_name", matches[1].str());
-    params.set<std::string>("bin_configuration", matches[2].str());
   }
   else if (std::regex_search(diag_field_name,matches,binary_ops)) {
     diag_name = "BinaryOpsDiag";
@@ -259,6 +254,12 @@ create_diagnostic (const std::string& diag_field_name,
     params.set<std::string>("field_1", matches[1].str());
     params.set<std::string>("field_2", matches[3].str());
     params.set<std::string>("binary_op", matches[2].str());
+  }
+  else if (std::regex_search(diag_field_name,matches,histogram)) {
+    diag_name = "HistogramDiag";
+    params.set("grid_name", grid->name());
+    params.set<std::string>("field_name", matches[1].str());
+    params.set<std::string>("bin_configuration", matches[2].str());
   }
   else
   {

--- a/components/eamxx/tests/single-process/ml_correction/ml_correction_standalone.cpp
+++ b/components/eamxx/tests/single-process/ml_correction/ml_correction_standalone.cpp
@@ -4,6 +4,7 @@
 #include "physics/register_physics.hpp"
 #include "share/grid/mesh_free_grids_manager.hpp"
 
+#include <ekat_fpe.hpp>
 #include <ekat_yaml.hpp>
 #include <ekat_fpe.hpp>
 


### PR DESCRIPTION
Implementation of online histograms. As added to the documentation...

To select the histogram, you need to suffix a field name `X` with
`_histogram_` followed by the values specifying the edges of the bins,
separated by `_`. For example, the histogram specified by
`T_mid_histogram_250_270_290_310` has 5 bins defined, effectively,  by
($-\infty$, 250), [250, 270), [270, 290), [290, 310), and [310, $\infty$).

The implementation distributes the histogram bins for parallelism (each thread goes over all columns), although an alternative would be to distribute the columns and leverage an atomic for the bin.  I am open to discussion on this.