### PR TITLE
For pm-cpu, remove loading evp-patch module

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -248,7 +248,6 @@
         <command name="load">cray-netcdf-hdf5parallel/4.9.0.9</command>
         <command name="load">cray-parallel-netcdf/1.12.3.9</command>
         <command name="load">cmake/3.24.3</command>
-        <command name="load">evp-patch</command>
       </modules>
     </module_system>
 


### PR DESCRIPTION
The evp-patch module was a temporary fix and now NERSC has removed it.
Unfortunately, this causes our pm-cpu builds to immediately fail.
Remove the module load of evp-patch from pm-cpu.

[bfb]
