### PR TITLE
Use depth-integrated velocity solver with all MALI meshes

### DIFF
--- a/components/mpas-albany-landice/bld/namelist_files/albany_input.ais20km.yaml
+++ b/components/mpas-albany-landice/bld/namelist_files/albany_input.ais20km.yaml
@@ -2,6 +2,9 @@
 ---
 ANONYMOUS:
 
+  Problem:
+    Depth Integrated Model: true
+
 # Discretization Description
   Discretization:
     #Exodus Output File Name: albany_output.exo

--- a/components/mpas-albany-landice/bld/namelist_files/albany_input.ais_4to20km.yaml
+++ b/components/mpas-albany-landice/bld/namelist_files/albany_input.ais_4to20km.yaml
@@ -2,6 +2,7 @@
 ---
 ANONYMOUS:
   Problem:
+    Depth Integrated Model: true
     Basal Cubature Degree: 4
     LandIce Field Norm:
       sliding_velocity_basalside:

--- a/components/mpas-albany-landice/bld/namelist_files/albany_input.ais_8to30km.yaml
+++ b/components/mpas-albany-landice/bld/namelist_files/albany_input.ais_8to30km.yaml
@@ -2,6 +2,7 @@
 ---
 ANONYMOUS:
   Problem:
+    Depth Integrated Model: true
     Basal Cubature Degree: 4
     LandIce Field Norm:
       sliding_velocity_basalside:

--- a/components/mpas-albany-landice/bld/namelist_files/albany_input.aisgis20km.yaml
+++ b/components/mpas-albany-landice/bld/namelist_files/albany_input.aisgis20km.yaml
@@ -2,6 +2,9 @@
 ---
 ANONYMOUS:
 
+  Problem:
+    Depth Integrated Model: true
+
 # Discretization Description
   Discretization:
     #Exodus Output File Name: albany_output.exo

--- a/components/mpas-albany-landice/bld/namelist_files/albany_input.gis_20km_r01.yaml
+++ b/components/mpas-albany-landice/bld/namelist_files/albany_input.gis_20km_r01.yaml
@@ -2,6 +2,9 @@
 ---
 ANONYMOUS:
 
+  Problem:
+    Depth Integrated Model: true
+
 # Discretization Description
   Discretization:
     #Exodus Output File Name: albany_output.exo


### PR DESCRIPTION
It is about 3x faster with minimal loss of accuracy.  This branch switches to the depth-integrated velocity solver for all meshes - previously it was only being used in E3SM for the more recent Greenland meshes.

[non-BFB] for active MALI runs using one of the changed meshes