### PR TITLE
Fix an issue in EAMxx with incorrect metadata in rhist file

### DIFF
--- a/components/eamxx/src/share/io/eamxx_output_manager.cpp
+++ b/components/eamxx/src/share/io/eamxx_output_manager.cpp
@@ -513,7 +513,6 @@ void OutputManager::run(const util::TimeStamp& timestamp)
             scorpio::set_attribute (filespecs.filename,"GLOBAL","last_output_file_num_snaps",m_output_file_specs.storage.num_snapshots_in_file);
             scorpio::set_attribute (filespecs.filename,"GLOBAL","last_output_filename",m_output_file_specs.filename);
           } else {
-            scorpio::set_attribute (filespecs.filename,"GLOBAL","last_output_file_num_snaps", std::numeric_limits<int>::max());
             scorpio::set_attribute (filespecs.filename,"GLOBAL","last_output_filename","");
           }
         }


### PR DESCRIPTION
This commit fixes an issue during restarts that occurs with averaged type output.  The restart history file (rhist) metadata was incorrectly setup which could lead EAMxx to reopen files that already had the max number of snaps in them and continue to fill them at the restart step.

Revised from #6846 which was closed due to unit tests failing.

Fixes #6795