### PR TITLE
For pm-cpu maint-2.1, adjust environment to allow cases to work after NERSC August 20th maintenance 

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -205,6 +205,7 @@
       <cmd_path lang="csh">module</cmd_path>
 
       <modules>
+        <command name="unload">cpe</command>
         <command name="unload">cray-hdf5-parallel</command>
         <command name="unload">cray-netcdf-hdf5parallel</command>
         <command name="unload">cray-parallel-netcdf</command>
@@ -215,12 +216,15 @@
         <command name="unload">PrgEnv-nvidia</command>
         <command name="unload">PrgEnv-cray</command>
         <command name="unload">PrgEnv-aocc</command>
+        <command name="unload">gcc-native</command>
         <command name="unload">intel</command>
         <command name="unload">intel-oneapi</command>
         <command name="unload">nvidia</command>
         <command name="unload">aocc</command>
         <command name="unload">cudatoolkit</command>
         <command name="unload">climate-utils</command>
+        <command name="unload">cray-libsci</command>
+        <command name="unload">matlab</command>
         <command name="unload">craype-accel-nvidia80</command>
         <command name="unload">craype-accel-host</command>
         <command name="unload">perftools-base</command>
@@ -253,8 +257,8 @@
 
       <modules>
         <command name="load">craype-accel-host</command>
-        <command name="load">craype/2.7.20</command>
-        <command name="load">cray-mpich/8.1.25</command>
+        <command name="load">craype/2.7.30</command>
+        <command name="load">cray-mpich/8.1.27</command>
         <command name="load">cray-hdf5-parallel/1.12.2.3</command>
         <command name="load">cray-netcdf-hdf5parallel/4.9.0.3</command>
         <command name="load">cray-parallel-netcdf/1.12.3.3</command>
@@ -281,7 +285,6 @@
       <env name="NETCDF_PATH">$ENV{CRAY_NETCDF_HDF5PARALLEL_PREFIX}</env>
       <env name="PNETCDF_PATH">$ENV{CRAY_PARALLEL_NETCDF_PREFIX}</env>
       <env name="GATOR_INITIAL_MB">4000MB</env>
-      <env name="LD_LIBRARY_PATH">$ENV{CRAY_LD_LIBRARY_PATH}:$ENV{LD_LIBRARY_PATH}</env> <!-- https://github.com/E3SM-Project/E3SM/issues/7117 -->
       <env name="MPICH_SMP_SINGLE_COPY_MODE">CMA</env> <!-- https://github.com/E3SM-Project/E3SM/issues/7207 -->
     </environment_variables>
     <resource_limits>


### PR DESCRIPTION
After the NERSC Aug20 maintenance, we see that branches using older sets of module versions were causing runtime fails.
One issue is known by NERSC related to newer libfabric version not working well with older modules (and we can't continue using older libfabric).
A change that seems to avoid this issue also uncovered a different issue regarding runtime errors trying to open netcdf4 files. This was corrected by converting certain netcdf files in inputdata from netcdf4 to cdf5, but only to allow cases in e3sm_prod suite to pass.

Fixes https://github.com/E3SM-Project/E3SM/issues/7623

[BFB] (at least in testing with e3sm_prod suite)