### PR TITLE
Change ghci-snl-cpu machine output root to /tmp

### DIFF
--- a/.github/workflows/eamxx-v1-testing.yml
+++ b/.github/workflows/eamxx-v1-testing.yml
@@ -113,12 +113,9 @@ jobs:
           path: |
             /projects/e3sm/scratch/${{ matrix.test.full_name }}*/TestStatus
             /projects/e3sm/scratch/${{ matrix.test.full_name }}*/TestStatus.log
-            /projects/e3sm/scratch/${{ matrix.test.full_name }}*/bld/*.bldlog.*
-            /projects/e3sm/scratch/${{ matrix.test.full_name }}*/bld/case2bld/*.bldlog.*
-            /projects/e3sm/scratch/${{ matrix.test.full_name }}*/run/*.log.*
-            /projects/e3sm/scratch/${{ matrix.test.full_name }}*/run/case2run/*.log.*
-            /projects/e3sm/scratch/${{ matrix.test.full_name }}*/run/*.cprnc.out
-            /projects/e3sm/scratch/${{ matrix.test.full_name }}*/run/case2run/*.cprnc.out
+            /projects/e3sm/scratch/${{ matrix.test.full_name }}*/bld/**/*.bldlog.*
+            /projects/e3sm/scratch/${{ matrix.test.full_name }}*/run/**/*.log.*
+            /projects/e3sm/scratch/${{ matrix.test.full_name }}*/run/**/*.cprnc.out
           retention-days: 14
         env:
           NODE_EXTRA_CA_CERTS: ${{ env.NODE_EXTRA_CA_CERTS }}
@@ -128,8 +125,7 @@ jobs:
         with:
           name: outputs.${{ matrix.test.short_name }}
           path: |
-            /projects/e3sm/scratch/${{ matrix.test.full_name }}*/run/*.nc*
-            /projects/e3sm/scratch/${{ matrix.test.full_name }}*/run/case2run/*.nc*
+            /projects/e3sm/scratch/${{ matrix.test.full_name }}*/run/**/*.nc*
           retention-days: 14
         env:
           NODE_EXTRA_CA_CERTS: ${{ env.NODE_EXTRA_CA_CERTS }}

--- a/.github/workflows/eamxx-v1-testing.yml
+++ b/.github/workflows/eamxx-v1-testing.yml
@@ -47,8 +47,6 @@ env:
   submit: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch') }}
   # Generate only if user requested via workflow_dispatch
   generate: ${{ github.event_name == 'workflow_dispatch' && inputs.bless }}
-  # Correct case folder suffix for generate/compare, used to find files to upload as artifacts
-  folder_suffix: ${{ github.event_name == 'workflow_dispatch' && inputs.bless && '.G' || '.C' }}
   # Compare/generate flags for create_test
   flags: ${{ github.event_name == 'workflow_dispatch' && inputs.bless && '-o -g -b master' || '-c -b master' }}
 
@@ -74,7 +72,7 @@ jobs:
             short_name: ERS_Ln22.ne4pg2_ne4pg2.F2010-SCREAMv1.eamxx-small_kernels--eamxx-output-preset-5
           - full_name: REP_D_Ln5.ne4pg2_oQU480.F2010-EAMxx-MAM4xx.ghci-snl-cpu_gnu
             short_name: REP_D_Ln5.ne4pg2_oQU480.F2010-EAMxx-MAM4xx
-          - full_name: "ERS.ne4pg2_ne4pg2.F2010-SCREAMv1.ghci-snl-cpu_gnu.eamxx-prod"
+          - full_name: ERS.ne4pg2_ne4pg2.F2010-SCREAMv1.ghci-snl-cpu_gnu.eamxx-prod
             short_name: ERS.ne4pg2_ne4pg2.F2010-SCREAMv1.eamxx-prod
       fail-fast: false
     name: cpu-gcc / ${{ matrix.test.short_name }}
@@ -113,14 +111,14 @@ jobs:
         with:
           name: logs.${{ matrix.test.short_name }}
           path: |
-            /projects/e3sm/scratch/${{ matrix.test.full_name }}${{ env.folder_suffix }}*/TestStatus
-            /projects/e3sm/scratch/${{ matrix.test.full_name }}${{ env.folder_suffix }}*/TestStatus.log
-            /projects/e3sm/scratch/${{ matrix.test.full_name }}${{ env.folder_suffix }}*/bld/*.bldlog.*
-            /projects/e3sm/scratch/${{ matrix.test.full_name }}${{ env.folder_suffix }}*/bld/case2bld/*.bldlog.*
-            /projects/e3sm/scratch/${{ matrix.test.full_name }}${{ env.folder_suffix }}*/run/*.log.*
-            /projects/e3sm/scratch/${{ matrix.test.full_name }}${{ env.folder_suffix }}*/run/case2run/*.log.*
-            /projects/e3sm/scratch/${{ matrix.test.full_name }}${{ env.folder_suffix }}*/run/*.cprnc.out
-            /projects/e3sm/scratch/${{ matrix.test.full_name }}${{ env.folder_suffix }}*/run/case2run/*.cprnc.out
+            /projects/e3sm/scratch/${{ matrix.test.full_name }}*/TestStatus
+            /projects/e3sm/scratch/${{ matrix.test.full_name }}*/TestStatus.log
+            /projects/e3sm/scratch/${{ matrix.test.full_name }}*/bld/*.bldlog.*
+            /projects/e3sm/scratch/${{ matrix.test.full_name }}*/bld/case2bld/*.bldlog.*
+            /projects/e3sm/scratch/${{ matrix.test.full_name }}*/run/*.log.*
+            /projects/e3sm/scratch/${{ matrix.test.full_name }}*/run/case2run/*.log.*
+            /projects/e3sm/scratch/${{ matrix.test.full_name }}*/run/*.cprnc.out
+            /projects/e3sm/scratch/${{ matrix.test.full_name }}*/run/case2run/*.cprnc.out
           retention-days: 14
         env:
           NODE_EXTRA_CA_CERTS: ${{ env.NODE_EXTRA_CA_CERTS }}
@@ -130,12 +128,8 @@ jobs:
         with:
           name: outputs.${{ matrix.test.short_name }}
           path: |
-            /projects/e3sm/scratch/${{ matrix.test.full_name }}${{ env.folder_suffix }}*/run/*.nc*
-            /projects/e3sm/scratch/${{ matrix.test.full_name }}${{ env.folder_suffix }}*/run/case2run/*.nc*
+            /projects/e3sm/scratch/${{ matrix.test.full_name }}*/run/*.nc*
+            /projects/e3sm/scratch/${{ matrix.test.full_name }}*/run/case2run/*.nc*
           retention-days: 14
         env:
           NODE_EXTRA_CA_CERTS: ${{ env.NODE_EXTRA_CA_CERTS }}
-      - name: Clean up
-        if: ${{ always() }}
-        run: |
-          rm -rf /projects/e3sm/scratch/${{ matrix.test.full_name }}*

--- a/.github/workflows/eamxx-v1-testing.yml
+++ b/.github/workflows/eamxx-v1-testing.yml
@@ -111,11 +111,11 @@ jobs:
         with:
           name: logs.${{ matrix.test.short_name }}
           path: |
-            /projects/e3sm/scratch/${{ matrix.test.full_name }}*/TestStatus
-            /projects/e3sm/scratch/${{ matrix.test.full_name }}*/TestStatus.log
-            /projects/e3sm/scratch/${{ matrix.test.full_name }}*/bld/**/*.bldlog.*
-            /projects/e3sm/scratch/${{ matrix.test.full_name }}*/run/**/*.log.*
-            /projects/e3sm/scratch/${{ matrix.test.full_name }}*/run/**/*.cprnc.out
+            /tmp/${{ matrix.test.full_name }}*/TestStatus
+            /tmp/${{ matrix.test.full_name }}*/TestStatus.log
+            /tmp/${{ matrix.test.full_name }}*/bld/**/*.bldlog.*
+            /tmp/${{ matrix.test.full_name }}*/run/**/*.log.*
+            /tmp/${{ matrix.test.full_name }}*/run/**/*.cprnc.out
           retention-days: 14
         env:
           NODE_EXTRA_CA_CERTS: ${{ env.NODE_EXTRA_CA_CERTS }}
@@ -125,7 +125,7 @@ jobs:
         with:
           name: outputs.${{ matrix.test.short_name }}
           path: |
-            /projects/e3sm/scratch/${{ matrix.test.full_name }}*/run/**/*.nc*
+            /tmp/${{ matrix.test.full_name }}*/run/**/*.nc*
           retention-days: 14
         env:
           NODE_EXTRA_CA_CERTS: ${{ env.NODE_EXTRA_CA_CERTS }}

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1772,7 +1772,7 @@
     <PROXY>proxy.sandia.gov:80</PROXY>
     <COMPILERS>gnu</COMPILERS>
     <MPILIBS>openmpi</MPILIBS>
-    <CIME_OUTPUT_ROOT>/projects/e3sm/scratch</CIME_OUTPUT_ROOT>
+    <CIME_OUTPUT_ROOT>/tmp</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>/projects/e3sm/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>/projects/e3sm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>


### PR DESCRIPTION
Make eamxx-v1 workflow simpler and increase security of CI runs.

[BFB]

---

In particular:

- no need to clean up the test folders (they are automatically deleted when the container is torn down)
- no need to carefully figure out the test case folder to ensure we don't accidentally capture other concurrent tests outputs