### PR TITLE
EAMxx: fix bug in buildnml routine

### DIFF
--- a/components/eamxx/cime_config/eamxx_buildnml.py
+++ b/components/eamxx/cime_config/eamxx_buildnml.py
@@ -996,11 +996,7 @@ def get_file_parameters(caseroot):
         result.extend(refine_type(item.text, force_type="array(file)"))
 
     # Remove duplicates. Not sure if an error would be warranted if dupes exist
-    result_no_dups = []
-    for item in result:
-        if item not in result:
-            result_no_dups.append(item)
-    return result_no_dups
+    return list(dict.fromkeys(result))
 
 ###############################################################################
 def create_input_data_list_file(case,caseroot):


### PR DESCRIPTION
Fix an issue causing eamxx input data list to be always empty.

[BFB]

---

I thought `fromkeys()` was just a method of `OrderedDict`, so I replaced it with a (buggy) manual removal of duplicates. Since `dict` also has that method, I'm reverting back to that.

@meng630 FYI