### PR TITLE
Allow retreat of ice-sheet calving front in MALI

### DIFF
--- a/components/mpas-albany-landice/bld/namelist_files/namelist_defaults_mali.xml
+++ b/components/mpas-albany-landice/bld/namelist_files/namelist_defaults_mali.xml
@@ -44,7 +44,7 @@
 <config_data_calving>.false.</config_data_calving>
 <config_calving_timescale>0.0</config_calving_timescale>
 <config_restore_calving_front>.true.</config_restore_calving_front>
-<config_restore_calving_front_prevent_retreat>.true.</config_restore_calving_front_prevent_retreat>
+<config_restore_calving_front_prevent_retreat>.false.</config_restore_calving_front_prevent_retreat>
 <config_remove_icebergs>.true.</config_remove_icebergs>
 <config_remove_small_islands>.true.</config_remove_small_islands>
 <config_calving_speed_limit>100.0</config_calving_speed_limit>


### PR DESCRIPTION
This PR changes the value of MALI's namelist option config_restore_calving_front_prevent_retreat from true to false in E3SM.  When true, this option forces MALI to insert a thin layer of ice anywhere that ice shelves retreat to keep the spatial extent of ice shelves unchanged.  This was implemented a long time ago to enforce consistency of the MALI active ice extent with the coupler's current assumption that ice-shelf spatial extent cannot change.  However, it has become clear that by restoring ice where it has been removed by the model evolution creates a fictitious source of mass that is substantial.  In a recent v3.LR G-case with MALI active, this feature was causing a cycle of removing and restoring ice on every time step, and this led to a mass flux integrated over the ice sheet of ~700 Gt/yr - nearly as much as ice-shelf basal melting and entirely fictitious.  At the same time, even though the MCT coupler does not support changing component domain masks, there is not a requirement that the ice sheet's internal active domain needs to match that of the coupler - that is a lesser evil than violating mass conservation so flagrantly.