### PR TITLE
EAMxx: add some logging to DataInterpolation

### DIFF
--- a/components/eamxx/src/share/atm_process/atmosphere_process.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process.cpp
@@ -2,6 +2,7 @@
 #include "share/util/eamxx_timing.hpp"
 #include "share/property_checks/mass_and_energy_conservation_check.hpp"
 #include "share/field/field_utils.hpp"
+#include "share/util/eamxx_utils.hpp"
 
 #ifdef EAMXX_HAS_PYTHON
 #include "share/field/field_pyutils.hpp"
@@ -18,10 +19,6 @@ namespace py = pybind11;
 #include <string>
 #include <sstream>
 #include <iomanip>
-
-
-namespace scream
-{
 
 ekat::logger::LogLevel str2LogLevel (const std::string& s) {
   using namespace ekat::logger;
@@ -41,7 +38,10 @@ ekat::logger::LogLevel str2LogLevel (const std::string& s) {
     EKAT_ERROR_MSG ("Invalid string value for log level: " + s + "\n");
   }
   return log_level;
-}
+};
+
+namespace scream
+{
 
 AtmosphereProcess::
 AtmosphereProcess (const ekat::Comm& comm, const ekat::ParameterList& params)
@@ -52,11 +52,7 @@ AtmosphereProcess (const ekat::Comm& comm, const ekat::ParameterList& params)
     m_atm_logger = m_params.get<std::shared_ptr<logger_t>>("logger");
   } else {
     // Create a console-only logger, that logs all ranks
-    using namespace ekat::logger;
-    using logger_impl_t = Logger<LogNoFile,LogAllRanks>;
-    auto log_level = m_params.get<std::string>("log_level","trace");
-    m_atm_logger = std::make_shared<logger_impl_t>("",str2LogLevel(log_level),m_comm);
-    m_atm_logger->set_no_format();
+    m_atm_logger = console_logger(str2LogLevel(m_params.get<std::string>("log_level","trace")));
   }
 
   if (m_params.isParameter("number_of_subcycles")) {

--- a/components/eamxx/src/share/io/eamxx_output_manager.hpp
+++ b/components/eamxx/src/share/io/eamxx_output_manager.hpp
@@ -10,6 +10,7 @@
 #include "share/field/field_manager.hpp"
 #include "share/grid/grids_manager.hpp"
 #include "share/util/eamxx_time_stamp.hpp"
+#include "share/util/eamxx_utils.hpp"
 
 #include <ekat_logger.hpp>
 #include <ekat_comm.hpp>
@@ -102,9 +103,7 @@ public:
   void setup (const std::shared_ptr<fm_type>& field_mgr,
               const std::set<std::string>& grid_names);
 
-  void set_logger(const std::shared_ptr<ekat::logger::LoggerBase>& atm_logger) {
-      m_atm_logger = atm_logger;
-  }
+  void set_logger(const std::shared_ptr<ekat::logger::LoggerBase>& atm_logger);
   void add_global (const std::string& name, const std::shared_ptr<std::any>& global);
 
   void init_timestep (const util::TimeStamp& start_of_step, const Real dt);
@@ -185,8 +184,7 @@ protected:
   util::TimeStamp   m_case_t0;
   util::TimeStamp   m_run_t0;
 
-  // The logger to be used throughout the ATM to log message
-  std::shared_ptr<ekat::logger::LoggerBase> m_atm_logger;
+  std::shared_ptr<ekat::logger::LoggerBase> m_atm_logger = console_logger(ekat::logger::LogLevel::warn);
 
   // If true, we save grid data in output file
   bool m_save_grid_data;

--- a/components/eamxx/src/share/io/scorpio_input.cpp
+++ b/components/eamxx/src/share/io/scorpio_input.cpp
@@ -73,6 +73,12 @@ AtmosphereInput::
 }
 
 void AtmosphereInput::
+set_logger(const std::shared_ptr<ekat::logger::LoggerBase>& atm_logger) {
+  EKAT_REQUIRE_MSG (atm_logger, "Error! Invalid logger pointer.\n");
+  m_atm_logger = atm_logger;
+}
+
+void AtmosphereInput::
 init (const ekat::ParameterList& params,
       const std::shared_ptr<const fm_type>& field_mgr)
 {
@@ -196,14 +202,13 @@ set_grid (const std::shared_ptr<const AbstractGrid>& grid)
 void AtmosphereInput::read_variables (const int time_index)
 {
   auto func_start = std::chrono::steady_clock::now();
-  if (m_atm_logger) {
-    m_atm_logger->info("[EAMxx::scorpio_input] Reading variables from file");
-    m_atm_logger->info("  file name: " + m_filename);
-    m_atm_logger->info("  var names: " + ekat::join(m_fields_names,", "));
-    if (time_index!=-1) {
-      m_atm_logger->info("  time idx : " + std::to_string(time_index));
-    }
+  m_atm_logger->info("[EAMxx::scorpio_input] Reading variables from file");
+  m_atm_logger->info("  file name: " + m_filename);
+  m_atm_logger->info("  var names: " + ekat::join(m_fields_names,", "));
+  if (time_index!=-1) {
+    m_atm_logger->info("  time idx : " + std::to_string(time_index));
   }
+
   EKAT_REQUIRE_MSG (m_fields_inited and m_scorpio_inited,
       "Error! Internal structures not fully inited yet. Did you forget to call 'init(..)'?\n");
 

--- a/components/eamxx/src/share/io/scorpio_input.hpp
+++ b/components/eamxx/src/share/io/scorpio_input.hpp
@@ -3,6 +3,7 @@
 
 #include "share/field/field_manager.hpp"
 #include "share/grid/abstract_grid.hpp"
+#include "share/util/eamxx_utils.hpp"
 
 #include <ekat_parameter_list.hpp>
 #include <ekat_logger.hpp>
@@ -98,9 +99,7 @@ public:
   void reset_filename (const std::string& filename);
 
   // Option to add a logger
-  void set_logger(const std::shared_ptr<ekat::logger::LoggerBase>& atm_logger) {
-      m_atm_logger = atm_logger;
-  }
+  void set_logger(const std::shared_ptr<ekat::logger::LoggerBase>& atm_logger);
 protected:
 
   void set_grid (const std::shared_ptr<const AbstractGrid>& grid);
@@ -125,8 +124,7 @@ protected:
   bool m_fields_inited  = false;
   bool m_scorpio_inited = false;
 
-  // The logger to be used throughout the ATM to log message
-  std::shared_ptr<ekat::logger::LoggerBase> m_atm_logger;
+  std::shared_ptr<ekat::logger::LoggerBase> m_atm_logger = console_logger(ekat::logger::LogLevel::warn);
 }; // Class AtmosphereInput
 
 } //namespace scream

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -259,6 +259,12 @@ AtmosphereOutput (const ekat::Comm& comm, const ekat::ParameterList& params,
   init ();
 }
 
+void AtmosphereOutput::
+set_logger(const std::shared_ptr<ekat::logger::LoggerBase>& atm_logger) {
+  EKAT_REQUIRE_MSG (atm_logger, "Error! Invalid logger pointer.\n");
+  m_atm_logger = atm_logger;
+}
+
 /* ---------------------------------------------------------- */
 void AtmosphereOutput::restart (const std::string& filename)
 {
@@ -385,10 +391,8 @@ run (const std::string& filename,
   }
   Real duration_write = 0.0;  // Record of time spent writing output
   if (is_write_step) {
-    if (m_atm_logger) {
-      m_atm_logger->info("[EAMxx::scorpio_output] Writing variables to file");
-      m_atm_logger->info("  file name: " + filename);
-    }
+    m_atm_logger->info("[EAMxx::scorpio_output] Writing variables to file");
+    m_atm_logger->info("  file name: " + filename);
   }
 
   // Update all diagnostics, we need to do this before applying the remapper
@@ -551,9 +555,7 @@ run (const std::string& filename,
   }
 
   if (is_write_step) {
-    if (m_atm_logger) {
-      m_atm_logger->info("  Done! Elapsed time: " + std::to_string(duration_write/1000.0) +" seconds");
-    }
+    m_atm_logger->info("  Done! Elapsed time: " + std::to_string(duration_write/1000.0) +" seconds");
   }
 } // run
 

--- a/components/eamxx/src/share/io/scorpio_output.hpp
+++ b/components/eamxx/src/share/io/scorpio_output.hpp
@@ -144,10 +144,7 @@ public:
     return m_io_grid;
   }
 
-  // Option to add a logger
-  void set_logger(const std::shared_ptr<ekat::logger::LoggerBase>& atm_logger) {
-      m_atm_logger = atm_logger;
-  }
+  void set_logger(const std::shared_ptr<ekat::logger::LoggerBase>& atm_logger);
 
 protected:
 
@@ -223,8 +220,7 @@ protected:
   bool m_track_avg_cnt = false;
   std::string m_decomp_dimname = "";
 
-  // The logger to be used throughout the ATM to log message
-  std::shared_ptr<ekat::logger::LoggerBase> m_atm_logger;
+  std::shared_ptr<ekat::logger::LoggerBase> m_atm_logger = console_logger(ekat::logger::LogLevel::warn);
 };
 
 } //namespace scream

--- a/components/eamxx/src/share/io/scorpio_scm_input.cpp
+++ b/components/eamxx/src/share/io/scorpio_scm_input.cpp
@@ -82,6 +82,12 @@ SCMInput::
   scorpio::release_file(m_filename);
 }
 
+void SCMInput::
+set_logger(const std::shared_ptr<ekat::logger::LoggerBase>& atm_logger) {
+  EKAT_REQUIRE_MSG (atm_logger, "Error! Invalid logger pointer.\n");
+  m_atm_logger = atm_logger;
+}
+
 void SCMInput::create_io_grid ()
 {
   EKAT_REQUIRE_MSG (scorpio::has_dim(m_filename,"ncol"),
@@ -137,13 +143,12 @@ void SCMInput::read_variables (const int time_index)
 {
   auto func_start = std::chrono::steady_clock::now();
   auto fname = [](const Field& f) { return f.name(); };
-  if (m_atm_logger) {
-    m_atm_logger->info("[EAMxx::scorpio_scm_input] Reading variables from file");
-    m_atm_logger->info("  file name: " + m_filename);
-    m_atm_logger->info("  var names: " + ekat::join(m_fields,fname,", "));
-    if (time_index!=-1) {
-      m_atm_logger->info("  time idx : " + std::to_string(time_index));
-    }
+
+  m_atm_logger->info("[EAMxx::scorpio_scm_input] Reading variables from file");
+  m_atm_logger->info("  file name: " + m_filename);
+  m_atm_logger->info("  var names: " + ekat::join(m_fields,fname,", "));
+  if (time_index!=-1) {
+    m_atm_logger->info("  time idx : " + std::to_string(time_index));
   }
 
   // MPI rank with closest column index store column data

--- a/components/eamxx/src/share/io/scorpio_scm_input.hpp
+++ b/components/eamxx/src/share/io/scorpio_scm_input.hpp
@@ -31,9 +31,7 @@ public:
   void read_variables (const int time_index = -1);
 
   // Option to add a logger
-  void set_logger(const std::shared_ptr<ekat::logger::LoggerBase>& atm_logger) {
-      m_atm_logger = atm_logger;
-  }
+  void set_logger(const std::shared_ptr<ekat::logger::LoggerBase>& atm_logger);
 
 #ifndef KOKKOS_ENABLE_CUDA
   // Cuda requires methods enclosing __device__ lambda's to be public
@@ -64,8 +62,7 @@ protected:
 
   ClosestColInfo            m_closest_col_info;
 
-  // The logger to be used throughout the ATM to log message
-  std::shared_ptr<ekat::logger::LoggerBase> m_atm_logger;
+  std::shared_ptr<ekat::logger::LoggerBase> m_atm_logger = console_logger(ekat::logger::LogLevel::warn);
 };
 
 } //namespace scream

--- a/components/eamxx/src/share/util/eamxx_data_interpolation.hpp
+++ b/components/eamxx/src/share/util/eamxx_data_interpolation.hpp
@@ -6,6 +6,8 @@
 #include "share/util/eamxx_time_stamp.hpp"
 #include "share/field/field.hpp"
 
+#include <ekat_logger.hpp>
+
 namespace scream
 {
 
@@ -45,7 +47,7 @@ public:
 
   ~DataInterpolation () = default;
 
-  void toggle_debug_output (bool enable_dbg_output) { m_dbg_output = enable_dbg_output; }
+  void set_logger (const std::shared_ptr<ekat::logger::LoggerBase>& logger);
 
   void setup_time_database (const strvec_t& input_files,
                             const util::TimeLine timeline,
@@ -130,7 +132,7 @@ protected:
   bool                  m_time_db_created   = false;
   bool                  m_data_initialized  = false;
 
-  bool m_dbg_output = false;
+  std::shared_ptr<ekat::logger::LoggerBase> m_logger;
 };
 
 } // namespace scream

--- a/components/eamxx/src/share/util/eamxx_time_interpolation.cpp
+++ b/components/eamxx/src/share/util/eamxx_time_interpolation.cpp
@@ -313,10 +313,8 @@ void TimeInterpolation::read_data()
     m_file_data_atm_input->set_logger(m_logger);
   }
 
-  if (m_logger) {
-    m_logger->info(m_header);
-    m_logger->info("[EAMxx:time_interpolation] Reading data at time " + triplet_curr.timestamp.to_string());
-  }
+  m_logger->info(m_header);
+  m_logger->info("[EAMxx:time_interpolation] Reading data at time " + triplet_curr.timestamp.to_string());
   m_file_data_atm_input->read_variables(triplet_curr.time_idx);
   m_time1 = triplet_curr.timestamp;
 }
@@ -371,6 +369,17 @@ void TimeInterpolation::check_and_update_data(const TimeStamp& ts_in)
 
   }
 }
+
+void TimeInterpolation::
+set_logger(const std::shared_ptr<ekat::logger::LoggerBase>& logger,
+           const std::string& header)
+{
+  EKAT_REQUIRE_MSG (logger, "Error! Invalid logger pointer.\n");
+
+  m_logger = logger;
+  m_header = header;
+}
+
 /*-----------------------------------------------------------------------------------------------*/
 
 } // namespace util

--- a/components/eamxx/src/share/util/eamxx_time_interpolation.hpp
+++ b/components/eamxx/src/share/util/eamxx_time_interpolation.hpp
@@ -4,6 +4,7 @@
 #include "share/grid/abstract_grid.hpp"
 
 #include "share/util/eamxx_time_stamp.hpp"
+#include "share/util/eamxx_utils.hpp"
 
 #include "share/field/field.hpp"
 #include "share/field/field_manager.hpp"
@@ -47,10 +48,7 @@ public:
 
   // Option to add a logger
   void set_logger(const std::shared_ptr<ekat::logger::LoggerBase>& logger,
-                  const std::string& header) {
-      m_logger = logger;
-      m_header = header;
-  }
+                  const std::string& header);
 
 protected:
 
@@ -92,7 +90,7 @@ protected:
   std::shared_ptr<AtmosphereInput>           m_file_data_atm_input;
   bool                                       m_is_data_from_file=false;
 
-  std::shared_ptr<ekat::logger::LoggerBase>  m_logger;
+  std::shared_ptr<ekat::logger::LoggerBase>  m_logger = console_logger(ekat::logger::LogLevel::warn);
   std::string                                m_header;
 }; // class TimeInterpolation
 

--- a/components/eamxx/src/share/util/eamxx_utils.cpp
+++ b/components/eamxx/src/share/util/eamxx_utils.cpp
@@ -77,4 +77,15 @@ std::vector<std::string> globloc(const std::string& pattern) {
 std::map<std::string, std::string> DefaultMetadata::name_2_standardname;
 std::map<std::string, std::string> DefaultMetadata::name_2_longname;
 
+std::shared_ptr<ekat::logger::LoggerBase> console_logger (const ekat::logger::LogLevel log_level)
+{
+  using namespace ekat::logger;
+  using logger_impl_t = Logger<ekat::logger::LogNoFile,LogAllRanks>;
+
+  ekat::Comm comm;
+  auto logger = std::make_shared<logger_impl_t>("",log_level,comm);
+  logger->set_no_format();
+  return logger;
+}
+
 } // namespace scream

--- a/components/eamxx/src/share/util/eamxx_utils.hpp
+++ b/components/eamxx/src/share/util/eamxx_utils.hpp
@@ -5,6 +5,7 @@
 
 #include <ekat_assert.hpp>
 #include <ekat_kokkos_types.hpp>
+#include <ekat_logger.hpp>
 #include <ekat_comm.hpp>
 
 #include <iterator>
@@ -448,6 +449,9 @@ struct DefaultMetadata {
     file.close();
   }
 };
+
+// Create an console logger that logs all ranks
+std::shared_ptr<ekat::logger::LoggerBase> console_logger (const ekat::logger::LogLevel log_level = ekat::logger::LogLevel::info);
 
 extern "C"
 void eamxx_repro_sum(const Real* send, Real* recv,


### PR DESCRIPTION
Print info when reading end-of-interval fields.

[BFB]

---

Also, ensure IO classes always store a valid logger (by default, console-only, with warn log level), so we simplify logging calls.

E.g., adding a logger for the data_interpolation test prints stuff like this:
```
[DataInterpolation] Reading end of interval fields.
 - interval: [2010-07-16-00000, 2011-06-16-00000]
 - filename: data_interpolation_1.nc
 - file time idx: 5
[DataInterpolation] Reading end of interval fields.
 - interval: [2011-06-16-00000, 2010-07-16-00000]
 - filename: data_interpolation_0.nc
 - file time idx: 0
[DataInterpolation] Reading end of interval fields.
 - interval: [2010-07-16-00000, 2010-08-16-00000]
 - filename: data_interpolation_0.nc
 - file time idx: 1
 ...
```