### PR TITLE
Updates MAM4xx long runtime test cases to use MPASSI

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -842,8 +842,8 @@ _TESTS = {
         "time"  : "03:00:00",
         "tests" : (
             "SMS_D_Lm2.ne4pg2_oQU480.F2010-EAMxx-MAM4xx-MPASSI",
-            "ERS_Ld80.ne4pg2_ne4pg2.F2010-EAMxx-MAM4xx",
-            "SMS_Ly1.ne4pg2_oQU480.F2010-EAMxx-MAM4xx"
+            "ERS_Ld80.ne4pg2_oQU480.F2010-EAMxx-MAM4xx-MPASSI",
+            "SMS_Ly1.ne4pg2_oQU480.F2010-EAMxx-MAM4xx-MPASSI"
         )
     },
 


### PR DESCRIPTION
It is a known issue that Compy's Intel compiler would trap on an FPE when run in 
the debug mode using the CICE model. Now, the CICE cases are not even running in the
non-debug mode. They blow up with the following error with both the SCREAMv1
and MAM4xx compsets. The model runs fine with the MPASSI. The model started 
failing at master hash `8dade22601322b35`. All the MAM4xx tests on Compy are 
now using MPASSI.
```
Error! Failed post-condition property check (cannot be repaired).
 0:   - Atmosphere process name: p3
 0:   - Property check name: NaN check for field T_mid
 0:   - Atmosphere process MPI Rank: 0
 0:   - Message: FieldNaNCheck failed.
 0:   - field id: T_mid[physics_pg2] <double:ncol,lev>(12,72) [K]
 0:   - indices (w/ global column index): (51,71)
 0:   - lat/lon: (32.585029, 320.270895)
 0:   - additional data (w/ local column index):
```