### PR TITLE
include ekat_fpe.hpp in ml_correction .cpp

### DIFF
--- a/components/eamxx/src/physics/ml_correction/eamxx_ml_correction_process_interface.cpp
+++ b/components/eamxx/src/physics/ml_correction/eamxx_ml_correction_process_interface.cpp
@@ -7,6 +7,7 @@
 #include <ekat_assert.hpp>
 #include <ekat_units.hpp>
 #include <ekat_team_policy_utils.hpp>
+#include <ekat_fpe.hpp>
 
 namespace scream {
 // =========================================================================================

--- a/components/eamxx/tests/single-process/ml_correction/ml_correction_standalone.cpp
+++ b/components/eamxx/tests/single-process/ml_correction/ml_correction_standalone.cpp
@@ -5,6 +5,7 @@
 #include "share/grid/mesh_free_grids_manager.hpp"
 
 #include <ekat_yaml.hpp>
+#include <ekat_fpe.hpp>
 
 #include <pybind11/embed.h>
 #include <pybind11/numpy.h>


### PR DESCRIPTION
fix issue #7655: add missing `#include <ekat_fpe.hpp>` to ml_correction .cpp files