### PR TITLE
Fix for manually-running eamxx autoformatter

### DIFF
--- a/.github/workflows/eamxx-gh-clang-format.yml
+++ b/.github/workflows/eamxx-gh-clang-format.yml
@@ -42,7 +42,7 @@ jobs:
     - name: get version clang-format-18
       run: |
         ver=$(clang-format-18 --version)
-        # Note: "ver" can contain more than the numerical version number
+        # Note: "ver" likely contains more than the numerical version number
         if [[ "${ver}" == *"18.1.3"* ]]; then
           echo "Running clang-format version ${ver}."
         else
@@ -111,8 +111,6 @@ jobs:
         fi
     - name: diff format changes
       run: git diff > "components/eamxx/clang-format-patch.diff"
-    - name: echo status shell
-      run: "echo ${{ env.status_fail }}"
     - name: upload diff patch
       if: ${{ env.status_fail == 'true' }}
       uses: actions/upload-artifact@v4

--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -21,8 +21,6 @@
 #include <ekat_yaml.hpp>
 #include <ekat_std_utils.hpp>
 
-// trigger workflow
-
 // The global variable fvphyshack is used to help the initial pgN implementation
 // work around some current AD constraints. Search the code for "fvphyshack" to
 // find blocks that eventually should be removed in favor of a design that


### PR DESCRIPTION
Manually-triggered workflows were running `clang-format` on an empty list of files. To address this, I separated the autoformatting step into 2 conditional substeps.

- If the trigger is `event.pull_request`, then we use the output from the `changed-files` step as the file list.
- If the trigger is `event.workflow_dispatch` then we generate the file list by globbing into a bash array.