### PR TITLE
Make rad_asym_splt true by default for RRTMG

### DIFF
--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -860,6 +860,10 @@ if ($rad_pkg eq 'rrtmgp') {
   add_default($nl,'fixed_total_solar_irradiance');
 }
 
+if ($rad_pkg eq 'rrtmg') {
+  add_default($nl, 'rad_asym_splt')
+}
+
 #
 # Simulated years: sim_year and sim_year_start
 #

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -1377,6 +1377,9 @@
 <fixed_total_solar_irradiance>-1       </fixed_total_solar_irradiance>
 <do_spa_optics> .false.</do_spa_optics>
 
+<!-- Only for use with RRTMG -->
+<rad_asym_splt> .true.</rad_asym_splt>
+
 <!-- ================================================================== -->
 <!-- Defaults for SE                                                    -->
 <!-- ================================================================== -->

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -4499,7 +4499,7 @@ group="radiation_nl" valid_values="" >
 Split surface insolation asymmetrically between VIS/NIR. 
 Coefficient determines fraction of VIS flux (i.e., less than 0.7 um) 
 in RRTMG overlap band that spans 0.625–0.778 um
-Default: FALSE
+Default: TRUE
 </entry>
 
 <entry id="use_rad_dt_cosz" type="logical"  category="radiation"


### PR DESCRIPTION
Makes the rad_asym_splt setting introduced by PR #7488 on by default for RRTMG

[NML]
[non-BFB]