### PR TITLE
For pm-cpu: additional changes after Aug20 maintenance for GNU compiler

### DIFF
--- a/cime_config/machines/config_batch.xml
+++ b/cime_config/machines/config_batch.xml
@@ -410,9 +410,11 @@
       <directive> -G 0</directive>
     </directives>
     <queues>
-      <queue walltimemax="00:45:00" nodemax="1600" default="true">regular</queue>
-      <queue walltimemax="00:45:00" nodemax="1600" strict="true">preempt</queue>
-      <queue walltimemax="00:15:00" nodemax="4" strict="true">debug</queue>
+      <queue walltimemax="00:45:00" nodemax="1792" default="true">regular</queue>
+      <queue walltimemax="00:45:00" nodemax="1792" strict="true">preempt</queue>
+      <queue walltimemax="00:45:00" nodemax="1792" strict="true">shared</queue>
+      <queue walltimemax="00:45:00" nodemax="1792" strict="true">overrun</queue>
+      <queue walltimemax="00:15:00" nodemax="8" strict="true">debug</queue>
     </queues>
   </batch_system>
 
@@ -422,8 +424,10 @@
     </directives>
     <queues>
       <!-- Note: walltime is not the max walltime, but the default - see NERSC docs for Q limits, https://docs.nersc.gov/jobs/policy/ -->
-      <queue walltimemax="12:00:00" nodemax="3072" default="true">regular</queue>
-      <queue walltimemax="12:00:00" nodemax="3072" strict="true">preempt</queue>
+      <queue walltimemax="00:30:00" nodemax="3072" default="true">regular</queue>
+      <queue walltimemax="00:30:00" nodemax="3072" strict="true">preempt</queue>
+      <queue walltimemax="00:30:00" nodemax="3072" strict="true">shared</queue>
+      <queue walltimemax="00:30:00" nodemax="3072" strict="true">overrun</queue>
       <queue walltimemax="00:30:00" nodemax="8" strict="true">debug</queue>
     </queues>
   </batch_system>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -233,9 +233,9 @@
       </modules>
 
       <modules compiler="gnu">
-        <command name="load">PrgEnv-gnu/8.3.3</command>
-        <command name="load">gcc/11.2.0</command>
-        <command name="load">cray-libsci/23.02.1.1</command>
+        <command name="load">PrgEnv-gnu/8.5.0</command>
+        <command name="load">gcc-native/12.3</command>
+        <command name="load">cray-libsci/23.12.5</command>
       </modules>
 
       <modules compiler="intel">
@@ -245,23 +245,33 @@
 
       <modules compiler="nvidia">
         <command name="load">PrgEnv-nvidia</command>
-        <command name="load">nvidia/22.7</command>
-        <command name="load">cray-libsci/23.02.1.1</command>
+        <command name="load">nvidia/24.5</command>
+        <command name="load">cray-libsci/23.12.5</command>
       </modules>
 
       <modules compiler="amdclang">
         <command name="load">PrgEnv-aocc</command>
-        <command name="load">aocc/4.0.0</command>
-        <command name="load">cray-libsci/23.02.1.1</command>
+        <command name="load">aocc/4.1.0</command>
+        <command name="load">cray-libsci/23.12.5</command>
       </modules>
 
-      <modules>
+      <modules compiler="intel">
         <command name="load">craype-accel-host</command>
-        <command name="load">craype/2.7.30</command>
+        <command name="load">craype/2.7.20</command>
         <command name="load">cray-mpich/8.1.27</command>
         <command name="load">cray-hdf5-parallel/1.12.2.3</command>
         <command name="load">cray-netcdf-hdf5parallel/4.9.0.3</command>
         <command name="load">cray-parallel-netcdf/1.12.3.3</command>
+        <command name="load">cmake/3.24.3</command>
+      </modules>
+
+      <modules compiler="!intel">
+        <command name="load">craype-accel-host</command>
+        <command name="load">craype/2.7.30</command>
+        <command name="load">cray-mpich/8.1.28</command>
+        <command name="load">cray-hdf5-parallel/1.12.2.9</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.9.0.9</command>
+        <command name="load">cray-parallel-netcdf/1.12.3.9</command>
         <command name="load">cmake/3.24.3</command>
       </modules>
     </module_system>


### PR DESCRIPTION
After Aug20 NERSC maintenance, we found some environment changes causes runtime issues.
https://github.com/E3SM-Project/E3SM/pull/7627 was quickly made to address intel (default) builds,
but this PR also allows GNU compiler builds to work.
Updated amd and nvidia, but not tested.
Note also added more qos options for perlmutter.

For maint-2.0, these changes were made in one PR:
https://github.com/E3SM-Project/E3SM/pull/7670

Tested with `e3sm_prod` using intel/gnu.

[BFB] for intel, not may not be BFB for GNU as we are changing the compiler version