### PR TITLE
HOMME: fix some basic warnings in Fortran code

### DIFF
--- a/components/homme/src/repro_sum_mod.F90
+++ b/components/homme/src/repro_sum_mod.F90
@@ -1087,8 +1087,6 @@ module repro_sum_mod
 !
 ! Local workspace
 !
-      integer :: old_cw                  ! for x86 processors, save
-                                         !  current arithmetic mode
       integer :: ifld, isum              ! loop variables
       integer :: ierr                    ! MPI error return
 
@@ -1104,7 +1102,6 @@ module repro_sum_mod
 !
 !-----------------------------------------------------------------------
 !
-!     call x86_fix_start (old_cw)
 
       if (first_time) then
 #if ( defined SPMD )
@@ -1143,10 +1140,6 @@ module repro_sum_mod
          arr_gsum(ifld) = real(arr_lsum_dd(ifld))
       enddo
 #endif
-
-!     call x86_fix_end (old_cw)
-
-      return
 
    end subroutine repro_sum_ddpdd
 !

--- a/components/homme/src/share/cg_mod.F90
+++ b/components/homme/src/share/cg_mod.F90
@@ -82,8 +82,8 @@ contains
     type (hybrid_t)  , intent(in)     :: hybrid
     integer, optional, intent(in)     :: debug_level
     real(kind=real_kind), optional, intent(in) :: wts(len,nblks)
-    real(kind=real_kind) :: psum
     integer :: err, i
+
     cg%len         = len
     cg%ninst       = ninst
     cg%nblks       = nblks
@@ -171,7 +171,6 @@ contains
     integer kptr
 
     real (kind=real_kind), dimension(cg%ninst)    :: eps
-    real (kind=real_kind), dimension(3*cg%ninst)  :: redp
 
     real (kind=real_kind) :: gamma
     real (kind=real_kind) :: delta
@@ -374,8 +373,6 @@ contains
        return               
 
     end if
-
-10  format("cg:iter:",i4," residual=",e22.14," instance=",i4)
 
   end function congrad0
 

--- a/components/homme/src/share/compose_test_mod.F90
+++ b/components/homme/src/share/compose_test_mod.F90
@@ -83,7 +83,10 @@ contains
     use parallel_mod, only: parallel_t
     use domain_mod, only: domain1d_t
     use element_mod, only: element_t
-    use thread_mod, only: hthreads, vthreads, omp_set_num_threads, omp_get_thread_num
+    use thread_mod, only: hthreads, omp_get_thread_num
+#if defined (HORIZ_OPENMP)
+    use thread_mod, only: vthreads, omp_set_num_threads
+#endif
     use hybrid_mod, only: hybrid_t, hybrid_create
     use derivative_mod, only: derivative_t, derivinit
     use hybvcoord_mod, only: hvcoord_t
@@ -179,7 +182,6 @@ contains
     use element_mod, only: element_t
     use time_mod, only: timelevel_t, timelevel_init_default, timelevel_qdp
     use kinds, only: real_kind
-    use thread_mod, only: hthreads, vthreads, omp_set_num_threads, omp_get_thread_num
     use derivative_mod, only: derivative_t, derivinit
     use dimensions_mod, only: ne, np, nlev, qsize, qsize_d, nelemd
     use coordinate_systems_mod, only: spherical_polar_t
@@ -206,7 +208,7 @@ contains
     real (kind=real_kind), parameter :: twelve_days = 3600.d0 * 24 * 12
 
     type (timelevel_t) :: tl
-    integer :: nsteps, n0_qdp, np1_qdp, ie, i, j, geometry_type, nerr
+    integer :: nsteps, n0_qdp, np1_qdp, ie, i, geometry_type, nerr
     real (kind=real_kind) :: dt, tprev, t, unused((nlev+1)*qsize)
 
     nerr = 0

--- a/components/homme/src/share/control_mod.F90
+++ b/components/homme/src/share/control_mod.F90
@@ -231,7 +231,7 @@ module control_mod
   ! kmass = level index with density.  other levels contain test tracers
   integer, public  :: kmass  = -1
   integer, public  :: toy_chemistry = 0            !  1 = toy chemestry is turned on in 2D advection code
-  real (kind=real_kind), public :: g_sw_output            	   = 9.80616D0          ! m s^-2
+  real (kind=real_kind), public :: g_sw_output = 9.80616D0          ! m s^-2
 
   ! parameters for dcmip12 test 2-0: steady state atmosphere with orography
   real(real_kind), public :: dcmip2_0_h0      = 2000.d0        ! height of mountain range        (meters)
@@ -292,7 +292,6 @@ contains
     !   If you want a value to be computed, set it to <0 on input.
 
     use parallel_mod, only: abortmp, parallel_t
-    use kinds, only: iulog
 
     type (parallel_t), intent(in) :: par
     integer, intent(inout) :: &

--- a/components/homme/src/share/coordinate_systems_mod.F90
+++ b/components/homme/src/share/coordinate_systems_mod.F90
@@ -351,7 +351,6 @@ contains
  
     type (spherical_polar_t)             :: sphere
 
-    integer i,j
     real(kind=real_kind) :: r!, l_inf
 
 ! MNL: removing check that points are on the unit cube because we allow
@@ -447,7 +446,6 @@ contains
  
     type (spherical_polar_t)             :: sphere
 
-    integer i,j
     real(kind=real_kind) :: r!, l_inf
 
 ! MNL: removing check that points are on the unit cube because we allow

--- a/components/homme/src/share/cube_mod.F90
+++ b/components/homme/src/share/cube_mod.F90
@@ -148,10 +148,7 @@ contains
     type (element_t) :: elem
     real (kind=longdouble_kind)      :: gll_points(np)
 
-
-    real (kind=real_kind)      :: area1,area2
-    type (cartesian3d_t) :: quad(4)
-    integer face_no,i,j
+    integer :: face_no,i,j
 
     face_no = elem%vertex%face_number
     ! compute the corners in Cartesian coordinates
@@ -224,21 +221,16 @@ contains
     real(kind=real_kind) :: alpha
     real (kind=longdouble_kind)      :: gll_points(np)
     ! Local variables
-    integer ii
-    integer i,j,nn
-    integer iptr
+    integer :: i,j
 
-    real (kind=real_kind) :: r         ! distance from origin for point on cube tangent to unit sphere
-
-    real (kind=real_kind) :: const, norm
+    real (kind=real_kind) :: norm
     real (kind=real_kind) :: detD      ! determinant of vector field mapping matrix.  
 
     real (kind=real_kind) :: x1        ! 1st cube face coordinate
     real (kind=real_kind) :: x2        ! 2nd cube face coordinate
-    real (kind=real_kind) :: tmpD(2,2)
-    real (kind=real_kind) :: M(2,2),E(2,2),eig(2),DE(2,2),DEL(2,2),V(2,2), nu1, nu2, lamStar1, lamStar2
+    real (kind=real_kind) :: M(2,2),E(2,2),eig(2),DE(2,2),DEL(2,2),V(2,2), lamStar1, lamStar2
     integer :: imaxM(2)
-    real (kind=real_kind) :: l1, l2, sc,min_svd,max_svd,max_normDinv
+    real (kind=real_kind) :: l1, l2, min_svd,max_svd,max_normDinv
 
     
     ! ==============================================
@@ -803,8 +795,11 @@ contains
     type (element_t) :: elem 
 
     ! Local variables
-    integer  i,ie,je,face_no,nn
+    integer :: ie,je,face_no
     real (kind=real_kind)  :: dx,dy, startx, starty
+#if 0
+    integer :: i
+#endif
 
     if (0==ne) call abortmp('Error in set_corner_coordinates: ne is zero')
 
@@ -1857,11 +1852,8 @@ contains
     use control_mod, only : north, south, east, west, neast, seast, swest, nwest
     type (GridEdge_t),target           :: Edge
 
-    integer                            :: np0,sFace,dFace
+    integer                            :: sFace,dFace
     logical                            :: reverse
-    integer,allocatable                :: forwardV(:), forwardP(:)
-    integer,allocatable                :: backwardV(:), backwardP(:)
-    integer                            :: i,ii
 
     sFace = Edge%tail_face
     dFace = Edge%head_face

--- a/components/homme/src/share/derivative_mod_base.F90
+++ b/components/homme/src/share/derivative_mod_base.F90
@@ -102,12 +102,8 @@ contains
     ! Local variables
     type (quadrature_t) :: gp   ! Quadrature points and weights on pressure grid
     
-    real (kind=longdouble_kind) :: dmat(np,np)
-    real (kind=longdouble_kind) :: dpv(np,np)
     real (kind=longdouble_kind) :: dvv(np,np)
-    real (kind=longdouble_kind) :: dvv_diag(np,np)
     real (kind=longdouble_kind) :: v2v(np,np)
-    real (kind=longdouble_kind) :: xnorm
     integer i,j
 
     ! ============================================
@@ -342,8 +338,8 @@ contains
     integer i
     integer j
     integer l
-    real(kind=real_kind) ::  dsdx00,dsdx01
-    real(kind=real_kind) ::  dsdy00,dsdy01
+    real(kind=real_kind) ::  dsdx00
+    real(kind=real_kind) ::  dsdy00
 #ifdef DEBUG
     print *, "gradient_str_nonstag"
 !   write(17) np,s,deriv
@@ -381,8 +377,7 @@ contains
     integer j
     integer l
     
-    real(kind=real_kind) ::  dvdx00,dvdx01
-    real(kind=real_kind) ::  dudy00,dudy01
+    real(kind=real_kind) ::  dvdx00,dudy00
 
     real(kind=real_kind)  :: vvtemp(np,np)
     do j=1,np
@@ -492,7 +487,7 @@ contains
 
     real(kind=real_kind) :: ds(np,np,2)
 
-    integer i,j,l,m,n
+    integer i,j,m,n
     real(kind=real_kind) ::  dscontra(np,np,2)
 
     dscontra=0
@@ -553,7 +548,7 @@ contains
 
     real(kind=real_kind) :: ds(np,np,2)
 
-    integer i,j,l,m,n
+    integer i,j,m,n
     real(kind=real_kind) ::  dscontra(np,np,2)
 
 
@@ -609,14 +604,17 @@ contains
 
     real(kind=real_kind) :: ds(np,np,2)
 
-    integer i,j,l,m,n
+    integer j,m,n
     real(kind=real_kind) ::  dscov(np,np,2)
 
     ! debug: 
+#if 0
+    ! To use for debugging below
     real(kind=real_kind) ::  vcontra(np,np,2)
     real(kind=real_kind) ::  v(np,np,2)
     real(kind=real_kind) ::  div(np,np)
-
+    integer :: i
+#endif
 
 
     dscov=0
@@ -749,9 +747,7 @@ contains
 
     real(kind=real_kind) :: ds(np,np,2)
 
-    integer i
-    integer j
-    integer l
+    integer :: i,j,l
 
     real(kind=real_kind) ::  dsdx00
     real(kind=real_kind) ::  dsdy00
@@ -806,10 +802,13 @@ contains
     integer i,j,m,n
 
     real(kind=real_kind) ::  vtemp(np,np,2)
+#if 0
+    ! Used below only for debugging
     real(kind=real_kind) ::  ggtemp(np,np,2)
     real(kind=real_kind) ::  gtemp(np,np,2)
-    real(kind=real_kind) ::  psi(np,np)
     real(kind=real_kind) :: xtmp
+    real(kind=real_kind) ::  psi(np,np)
+#endif
 
     ! latlon- > contra
     do j=1,np
@@ -985,8 +984,6 @@ contains
       real(kind=real_kind) :: dvdx00,dudy00
       real(kind=real_kind) :: vco(np,np,2)
       real(kind=real_kind) :: vtemp(np,np)
-      real(kind=real_kind) :: rdx
-      real(kind=real_kind) :: rdy
 
       ! convert to covariant form
                                                                     
@@ -1083,8 +1080,7 @@ contains
     type (derivative_t), intent(in) :: deriv
     type (element_t), intent(in) :: elem
     real(kind=real_kind)             :: laplace(np,np)
-    real(kind=real_kind)             :: laplace2(np,np)
-    integer i,j
+    integer :: i,j
 
     ! Local
     real(kind=real_kind) :: grads(np,np,2), oldgrads(np,np,2)
@@ -1216,9 +1212,8 @@ contains
     real(kind=real_kind), optional :: nu_ratio
     ! Local
 
-    integer i,j,l,m,n
+    integer m,n
     real(kind=real_kind) :: vor(np,np),div(np,np)
-    real(kind=real_kind) :: v1,v2,div1,div2,vor1,vor2,phi_x,phi_y
 
     div=divergence_sphere(v,deriv,elem)
     vor=vorticity_sphere(v,deriv,elem)
@@ -1414,8 +1409,6 @@ contains
     real (kind=real_kind)              :: flux_r(n,n)
     real (kind=real_kind)              :: flux_b(n,n)
     real (kind=real_kind)              :: flux_t(n,n)
-    
-    integer i,j
 
     if (.not.ALLOCATED(integration_matrix)      .or. &
         SIZE(integration_matrix,1).ne.n .or. &
@@ -1519,8 +1512,6 @@ contains
     real (kind=real_kind)              :: val(np,np)
     real (kind=real_kind)              :: values(intervals,intervals)
 
-    integer i,j
-
     if (.not.ALLOCATED(integration_matrix)      .or. &
         SIZE(integration_matrix,1).ne.intervals .or. &
         SIZE(integration_matrix,2).ne.np) then
@@ -1555,9 +1546,8 @@ contains
     
     implicit none
 
-    integer              , intent(in)  :: np
-    integer              , intent(in)  :: intervals
-    real (kind=real_kind)              :: values(intervals,intervals)
+    integer, intent(in)  :: np
+    integer, intent(in)  :: intervals
 
 
     real(kind=real_kind), parameter :: zero = 0.0D0, one=1.0D0, two=2.0D0
@@ -1570,7 +1560,6 @@ contains
 
     real (kind=real_kind) :: legrange_div(np)
     real (kind=real_kind) :: a,b,x,y, x_j, x_i 
-    real (kind=real_kind) :: r(1) 
     integer i,j,n,m
 
     if (ALLOCATED(integration_matrix)) deallocate(integration_matrix)
@@ -1676,7 +1665,7 @@ contains
     real (kind=real_kind), dimension(np*np,nlev), intent(in), optional  :: dpmass
     real (kind=real_kind), dimension(np*np), intent(in)   :: sphweights
 
-    integer  k1, k, iter, weightsnum
+    integer  k1, k, iter
     real (kind=real_kind) :: addmass, weightssum, mass, sumc, minpk, maxpk
     real (kind=real_kind) :: x(np*np),c(np*np)
     real (kind=real_kind) :: tol_limiter = 5e-14

--- a/components/homme/src/share/dof_mod.F90
+++ b/components/homme/src/share/dof_mod.F90
@@ -72,16 +72,9 @@ contains
 
     type (LongEdgeBuffer_t)    :: edge
 
-    real(kind=real_kind)  da                     ! area element
-
-    type (quadrature_t) :: gp
-
     integer (kind=int_kind) :: ldofP(np,np,nelemd)
 
-    integer ii
-    integer i,j,ig,ie
-    integer kptr
-    integer iptr
+    integer :: ig,ie,kptr
 
     ! ===================
     ! begin code
@@ -96,7 +89,7 @@ contains
     do ie=1,nelemd
        ig = elem(ie)%vertex%number
        call genLocalDOF(ig,np,ldofP(:,:,ie))
-	 
+
        kptr=0
        call LongEdgeVpack(edge,ldofP(:,:,ie),1,kptr,elem(ie)%desc)
     end do
@@ -362,7 +355,6 @@ contains
     type (index_t), pointer  :: idx 
     type (LongEdgeBuffer_t)    :: edge
     integer :: i, j, ii, ie, base
-    integer(kind=long_kind), pointer :: gdof(:,:)
     integer :: fdofp_local(np,np,nelemd)
 
     call initLongEdgeBuffer(edge,1)
@@ -426,7 +418,6 @@ contains
          write(6,*) (elem(ie)%gdofP(i,j), i=1,np)
       enddo
    enddo
- 10 format('I5')
 
  end subroutine PrintDofP
 

--- a/components/homme/src/share/edge_mod_base.F90
+++ b/components/homme/src/share/edge_mod_base.F90
@@ -163,17 +163,13 @@ contains
     !
     ! 
     ! Local variables
-    integer :: nbuf,ith
+    integer :: nbuf
     integer :: nSendCycles, nRecvCycles
-    integer :: icycle, ierr
     integer :: iam,ie, i 
-    integer :: edgeid,elemid
     integer :: ptr,llen,moveLength, mLen, tlen 
     integer :: numthreads
-    type (Cycle_t), pointer :: pCycle
     type (Schedule_t), pointer :: pSchedule
-    integer :: dest, source, length, tag, iptr
-    integer :: nlen, ithr
+    integer :: iptr, nlen
 
 !    call t_adj_detailf(+3)
 !    call t_startf('initedgebuffer')
@@ -512,9 +508,7 @@ endif
     integer,              intent(in)   :: nlyr_tot
     type (EdgeDescriptor_t)            :: desc        ! =>elem(ie)%desc
     ! Local variables
-    integer :: i,k,ir,ll,llval,iptr
-
-
+    integer :: i,k,ll,llval,iptr
     integer :: is,ie,in,iw
 
     if (edge%nlyr_max < (kptr+vlyr) ) then
@@ -648,10 +642,9 @@ endif
 !    type (EdgeDescriptor_t),intent(in) :: desc
 
     ! Local variables
-    integer :: i,k,ir,ll,llval,iptr
+    integer :: k,ll,llval
     type (EdgeDescriptor_t), pointer  :: desc
     integer :: is,ie,in,iw
-    real (kind=real_kind) :: tmp
 
     if (edge%nlyr_max < (kptr+vlyr) ) then
        call abortmp('edgeSpack: Buffer overflow: edge%nlyr_max too small')
@@ -741,7 +734,7 @@ endif
     type (EdgeDescriptor_t),intent(in) :: desc
 
     ! Local variables
-    integer :: i,k,ir,l
+    integer :: i,k,l
     integer :: is,ie,in,iw
 
     if(.not. threadsafe) then
@@ -852,7 +845,7 @@ endif
   end subroutine LongEdgeVpack
 
   subroutine edgeVunpack(edge,v,vlyr,kptr,ielem)
-    use dimensions_mod, only : np, max_corner_elem
+    use dimensions_mod, only : np
     use control_mod, only : north, south, east, west, neast, nwest, seast, swest
     type (EdgeBuffer_t),         intent(in)  :: edge
 
@@ -882,7 +875,6 @@ endif
     ! Local
     integer :: i,k,ll,iptr
     integer :: is,ie,in,iw
-    integer :: ks,ke,kblock
     integer :: getmapL
 
     ! for nlyr_tot, dont use edge%nlyr, since some threads may be ahead of this thread
@@ -963,7 +955,7 @@ endif
 
     ! Local
     logical, parameter :: UseUnroll = .TRUE.
-    integer :: i,k,l, nce
+    integer :: i,l, nce
     integer :: is,ie,in,iw,ine,inw,isw,ise,nlyr_tot
     type (EdgeDescriptor_t), pointer   :: desc
 
@@ -1201,7 +1193,7 @@ endif
   ! ========================================
 
   subroutine edgeDGVunpack(edge,v,vlyr,kptr,ielem)
-    use dimensions_mod, only : np, max_corner_elem
+    use dimensions_mod, only : np
     use control_mod, only : north, south, east, west, neast, nwest, seast, swest
 
     type (EdgeBuffer_t),         intent(in)  :: edge
@@ -1211,7 +1203,7 @@ endif
     integer,               intent(in)  :: ielem
 
     ! Local
-    integer :: i,k,iptr,nce
+    integer :: i,k,iptr
     integer :: is,ie,in,iw, nlyr_tot
     type (EdgeDescriptor_t), pointer   :: desc
 
@@ -1336,7 +1328,7 @@ endif
     integer,               intent(in)  :: ielem
 
     ! Local
-    integer :: i,k,l,iptr
+    integer :: k,l,iptr
     integer :: is,ie,in,iw
     integer :: getmapL
     type (EdgeDescriptor_t), pointer   :: desc
@@ -1426,7 +1418,7 @@ endif
 
     ! Local
 
-    integer :: i,k,l,iptr
+    integer :: k,l,iptr
     integer :: is,ie,in,iw
     integer :: getmapL
     type (EdgeDescriptor_t), pointer   :: desc
@@ -2115,7 +2107,7 @@ endif
 
     ! Local variables
 
-    integer :: nbuf,nhc,i
+    integer :: nbuf,nhc
 
     ! sanity check for threading
     if (omp_get_num_threads()>1) then
@@ -2175,7 +2167,7 @@ endif
     integer                               :: nhc, np
 
     ! Local variables
-    integer :: i,j,k,ir,l,e
+    integer :: i,j,k,ir,l
 
     integer :: is,ie,in,iw
 

--- a/components/homme/src/share/gllfvremap_mod.F90
+++ b/components/homme/src/share/gllfvremap_mod.F90
@@ -184,7 +184,7 @@ contains
     use dimensions_mod, only: nlev
     use parallel_mod, only: parallel_t, abortmp
     use quadrature_mod, only: gausslobatto, quadrature_t
-    use control_mod, only: geometry, cubed_sphere_map
+    use control_mod, only: geometry
 
     type (parallel_t), intent(in) :: par
     type (element_t), intent(in) :: elem(:)
@@ -319,10 +319,8 @@ contains
 
     real(kind=real_kind), dimension(np,np,nlev) :: wg1, dp, p
     real(kind=real_kind), dimension(np*np,nlev) :: wf1, dp_fv, p_fv
-    real(kind=real_kind) :: qmin, qmax, ones(np,np)
-    integer :: ie, nf, nf2, qi, qsize, k, nerr
+    integer :: ie, nf, nf2, qi, qsize, nerr
 
-    ones = one
     nf = gfr%nphys
     nf2 = nf*nf
 
@@ -415,8 +413,7 @@ contains
     real(kind=real_kind), intent(in) :: T(:,:,:), uv(:,:,:,:), q(:,:,:,:)
 
     real(kind=real_kind), dimension(np,np,nlev) :: dp, wg1, p
-    real(kind=real_kind), dimension(np*np,nlev) :: wf1, wf2, dp_fv, p_fv
-    real(kind=real_kind) :: qmin, qmax
+    real(kind=real_kind), dimension(np*np,nlev) :: wf1, dp_fv, p_fv
     integer :: ie, nf, nf2, k, qsize, qi, nerr
 
     nf = gfr%nphys
@@ -765,7 +762,6 @@ contains
     real(kind=real_kind), intent(out) :: phis(:,:)
 
     type (hybrid_t) :: hybrid
-    integer :: nets, nete
 
     if (.not. par%dynproc) return
     hybrid = hybrid_create(par, 0, 1)
@@ -810,7 +806,6 @@ contains
     real(kind=real_kind), intent(in) :: phis(:,:)
 
     type (hybrid_t) :: hybrid
-    integer :: nets, nete
 
     if (.not. par%dynproc) return
     hybrid = hybrid_create(par, 0, 1)
@@ -981,7 +976,7 @@ contains
     real(kind=real_kind), intent(out) :: R(:,:), tau(:)
 
     real(kind=real_kind) :: wrk(np*np*nphys*nphys), v
-    integer :: gi, gj, fi, fj, npsq, info
+    integer :: gi, gj, fi, fj, info
 
     do fj = 1,nphys
        do fi = 1,nphys
@@ -1038,7 +1033,7 @@ contains
     type (GllFvRemap_t), intent(inout) :: gfr
     real(kind=real_kind), intent(in) :: R(:,:), tau(:)
 
-    integer :: nf, fi, fj, gi, gj
+    integer :: nf, fi, fj
     real(kind=real_kind) :: f(np,np), g(np,np)
 
     gfr%f2g_remapd = zero
@@ -1065,7 +1060,7 @@ contains
     real(kind=real_kind), intent(out) :: g(:,:)
 
     integer :: nf, nf2, npi, np2, gi, gj, fi, fj, info
-    real(kind=real_kind) :: accum, wrk(gfr%nphys,gfr%nphys), x(np,np), wr(np*np)
+    real(kind=real_kind) :: wrk(gfr%nphys,gfr%nphys), x(np,np), wr(np*np)
 
     nf = gfr%nphys
     nf2 = nf*nf
@@ -1118,7 +1113,6 @@ contains
   end subroutine gfr_f2g_remapd_op
 
   subroutine gfr_init_geometry(elem, gfr)
-    use kinds, only: iulog
     use control_mod, only: cubed_sphere_map
     use coordinate_systems_mod, only: cartesian3D_t, spherical_polar_t, &
          sphere_tri_area, change_coordinates
@@ -1346,7 +1340,7 @@ contains
     real(kind=real_kind), intent(in) :: gll_metdet(:,:), fv_metdet(:), g(:,:)
     real(kind=real_kind), intent(out) :: f(:)
 
-    integer :: nf, nf2, gi, gj, k
+    integer :: nf, nf2, k
     real(kind=real_kind) :: gw(np,np)
 
     nf = gfr%nphys
@@ -1428,7 +1422,7 @@ contains
     real(kind=real_kind), intent(out) :: q_f(:,:)
 
     real(kind=real_kind) :: qmin, qmax, wg(np,np), wf1(np*np), wf2(np*np)
-    integer :: q, k, nf, nf2, nlev
+    integer :: k, nf, nf2, nlev
 
     nf = gfr%nphys
     nf2 = nf*nf
@@ -1618,7 +1612,7 @@ contains
     real(kind=real_kind), intent(in) :: gll_metdet(:,:), fv_metdet(:), f(:)
     real(kind=real_kind), intent(out) :: g(:,:)
 
-    integer :: nf, nf2, gi, gj, fi, fj
+    integer :: nf, nf2, gi, gj
     real(kind=real_kind) :: wrk(np*np)
 
     nf = gfr%nphys
@@ -1640,8 +1634,8 @@ contains
 
     type (GllFvRemap_t), intent(inout) :: gfr
 
-    real(kind=real_kind) :: Mnp2(np*np,4), wr(np*np)
-    integer :: i, j, k, info, n
+    real(kind=real_kind) :: Mnp2(np*np,4)
+    integer :: i, info, n
 
     if (gfr%nphys /= 1) return
 
@@ -1771,7 +1765,7 @@ contains
     integer, intent(in) :: nets, nete
 
     real(kind=real_kind) :: wr(np,np,2), ones(np,np,1)
-    integer :: ie, nf, nerr
+    integer :: ie, nerr
 
     if (gfr%nphys /= 1 .or. .not. gfr%boost_pg1) return
 
@@ -1824,7 +1818,6 @@ contains
     integer, intent(in) :: nets, nete
 
     real(kind=real_kind), dimension(np,np,nlev) :: dp, p, wr1
-    real(kind=real_kind) :: qmin, qmax
     integer :: ie, k, qi, nerr
 
     if (gfr%nphys /= 1 .or. .not. gfr%boost_pg1) return
@@ -2021,7 +2014,7 @@ contains
     integer, intent(in) :: np, npi
     real(kind=real_kind), intent(out) :: y(:,:)
 
-    integer :: gi, gj, fi, fj, info
+    integer :: gi, gj, fi, fj
     real(kind=real_kind) :: accum
 
     do fj = 1,np
@@ -2127,8 +2120,6 @@ contains
     integer, intent(in) :: ie, i, j
     type (cartesian3D_t), intent(out) :: p
 
-    real(kind=real_kind) :: r
-
     p = gfr%center_f(i,j,ie)
   end subroutine gfr_f_get_cartesian3d
 
@@ -2166,7 +2157,7 @@ contains
     real (kind=real_kind), intent(in) :: spheremp(n), dp(n)
     real (kind=real_kind), intent(inout) :: qmin, qmax, q(n)
 
-    integer :: n2, k1, i, j
+    integer :: k1
     logical :: modified
     real(kind=real_kind) :: addmass, mass, sumc, den
     real(kind=real_kind) :: x(n), c(n), v(n)
@@ -2452,7 +2443,7 @@ contains
     real(kind=real_kind), intent(in) :: dp(:,:,:), dp_fv(:,:), q_g(:,:,:), q_f(:,:)
 
     real(kind=real_kind) :: qmin_f, qmin_g, qmax_f, qmax_g, mass_f, mass_g, den
-    integer :: q, k, nf, nf2, nerr
+    integer :: k, nf, nf2, nerr
 
     nerr = 0
     nf = gfr%nphys
@@ -2490,9 +2481,8 @@ contains
     type (element_t), intent(in) :: elem(:)
     real(kind=real_kind), intent(in) :: qmin(:), qmax(:), dp(:,:,:), q0_g(:,:,:), q1_g(:,:,:)
 
-    real(kind=real_kind) :: qmin_f, qmin_g, qmax_f, qmax_g, mass_f, mass0, mass1, den, &
-         wr(np,np)
-    integer :: q, k, nerr
+    real(kind=real_kind) :: qmin_f, qmin_g, qmax_f, qmax_g, mass0, mass1, den
+    integer :: k, nerr
 
     nerr = 0
     do k = 1,size(dp,3)
@@ -2629,7 +2619,7 @@ contains
     real(kind=real_kind) :: a, b, rd, x, y, f0(np*np), f1(np*np), g(np,np), &
          wf(np*np), wg(np,np), qmin, qmax, qmin1, qmax1, lat, lon, latext(2), &
          lonext(2), tol
-    integer :: nf, nf2, ie, i, j, k, iremap, info, ilimit, it
+    integer :: nf, nf2, ie, i, j, k, iremap, ilimit, it
     real(kind=real_kind), allocatable :: Qdp_fv(:,:), ps_v_fv(:,:), &
          qmins(:,:,:), qmaxs(:,:,:)
     logical :: limit

--- a/components/homme/src/share/global_norms_mod.F90
+++ b/components/homme/src/share/global_norms_mod.F90
@@ -46,7 +46,7 @@ contains
     use kinds,       only : real_kind
     use hybrid_mod,  only : hybrid_t
     use element_mod, only : element_t
-    use dimensions_mod, only : np, nelemd
+    use dimensions_mod, only : np
     use physical_constants, only : dd_pi, domain_size
     use parallel_mod, only: global_shared_buf, global_shared_sum
 
@@ -57,7 +57,6 @@ contains
 
     real (kind=real_kind) :: I_sphere
 
-    real (kind=real_kind) :: I_priv
     real (kind=real_kind) :: I_shared
     common /gblintcom/I_shared
 
@@ -109,7 +108,7 @@ contains
     use kinds,       only : real_kind
     use hybrid_mod,  only : hybrid_t
     use element_mod, only : element_t
-    use dimensions_mod, only : np,ne, nelem, nelemd
+    use dimensions_mod, only : np,ne, nelem
     use mesh_mod,     only : MeshUseMeshFile          
 
     use reduction_mod, only : ParallelMin,ParallelMax
@@ -133,7 +132,7 @@ contains
     real (kind=real_kind) :: min_min_dx, max_min_dx, avg_min_dx
     real (kind=real_kind) :: min_normDinv, max_normDinv
     real (kind=real_kind) :: min_len
-    integer :: ie,corner, i, j,nlon
+    integer :: ie
 
 
     h(:,:,nets:nete)=1.0D0
@@ -196,7 +195,6 @@ contains
     min_area = min_area*scale_factor*scale_factor/1000000_real_kind
     max_area = max_area*scale_factor*scale_factor/1000000_real_kind
     avg_area = avg_area*scale_factor*scale_factor/1000000_real_kind
-
 
     ! for an equation du/dt = i c u, leapfrog is stable for |c u dt| < 1
     ! Consider a gravity wave at the equator, c=340m/s  
@@ -265,7 +263,7 @@ contains
     type (hybrid_t)      , intent(in) :: hybrid
 
     ! Element statisics
-    real (kind=real_kind) :: min_max_dx,max_unif_dx   ! used for normalizing scalar HV
+    real (kind=real_kind) :: min_max_dx ! used for normalizing scalar HV
     real (kind=real_kind) :: max_normDinv  ! used for CFL
     real (kind=real_kind) :: normDinv_hypervis
     real (kind=real_kind) :: lambda_max, lambda_vis, min_gw, lambda, nu_div_actual, nu_top_actual

--- a/components/homme/src/share/gridgraph_mod.F90
+++ b/components/homme/src/share/gridgraph_mod.F90
@@ -149,7 +149,7 @@ contains
     type (GridVertex_t), intent(out)   :: vertex2
     type (GridVertex_t), intent(in)    :: vertex1
 
-    integer                            :: i,j,n
+    integer                            :: i,n
    
      n = SIZE(vertex1%nbrs)
 
@@ -208,7 +208,7 @@ contains
 
      implicit none
      type (GridVertex_t)           :: Vertex(:)
-     integer                       :: i,nelem
+     integer                       :: nelem
 
      nelem = SIZE(Vertex)
 
@@ -465,10 +465,8 @@ contains
     implicit none 
     type (GridVertex_t), intent(in),target :: Vertex(:)
   
-    integer        :: i,nvert
-    integer ::n_west, n_east, n_south, n_north, n_swest, n_seast, n_nwest, n_neast
-    integer ::w_west, w_east, w_south, w_north, w_swest, w_seast, w_nwest, w_neast
-    integer ::n, print_buf(90), nbr(8), j, k, start, cnt, nbrs_cnt(8)
+    integer :: i,nvert
+    integer :: n, print_buf(90), nbr(8), j, k, start, cnt, nbrs_cnt(8)
 
     nbr = (/ west, east, south, north, swest, seast, nwest, neast/)
 
@@ -544,7 +542,7 @@ contains
   type (GridEdge_t), intent(inout)       :: GridEdge(:)
   type (GridVertex_t), intent(in),target :: GridVertex(:)
 
-  integer                                :: i,j,k,iptr,m,n,wgtV,wgtP
+  integer                                :: i,j,k,iptr,m,n
   integer                                :: nelem,nelem_edge,inbr
   logical                                :: Verbose=.FALSE.
   integer                                :: mynbr_cnt, cnt, mystart, start

--- a/components/homme/src/share/ll_mod.F90
+++ b/components/homme/src/share/ll_mod.F90
@@ -60,12 +60,9 @@ contains
   end subroutine PrintEdgeList
 
   subroutine LLFree(List)
-
     implicit none
     type(root_t) :: List
     type(node_t), pointer :: temp_node
-    integer :: nlist,i
-
 
     temp_node => List%first
     ! Find the end of the list

--- a/components/homme/src/share/mass_matrix_mod.F90
+++ b/components/homme/src/share/mass_matrix_mod.F90
@@ -32,14 +32,11 @@ contains
 
     type (EdgeBuffer_t)    :: edge
 
-    real(kind=real_kind)  da                     ! area element
-
     type (quadrature_t) :: gp
 
-    integer ii
-    integer i,j
-    integer kptr
-    integer iptr
+    integer :: ii
+    integer :: i,j
+    integer :: kptr
 
     ! ===================
     ! begin code

--- a/components/homme/src/share/metagraph_mod.F90
+++ b/components/homme/src/share/metagraph_mod.F90
@@ -255,12 +255,11 @@ contains
     integer                          :: nelem,nelem_edge, nedges  
     integer,allocatable              :: icount(:)
     integer                          :: ic,i,j,ii
-    integer                          :: npart
     integer                          :: head_processor_number
     integer                          :: tail_processor_number
-    integer :: nedge_active,enum
+    integer :: enum
     logical :: found
-    integer iTail, iHead, wgtP,wgtS
+    integer :: wgtP,wgtS
 
     type (root_t) :: mEdgeList ! root_t = C++ std::set<std::pair<int,int> >
 
@@ -474,9 +473,6 @@ contains
     endif
 
     call LLFree(mEdgeList)
-
-90  format('EDGE #',I2,2x,'TYPE ',I1,2x,'Processor Numbers ',I2,' ---> ',I2)
-100 format(10x,I2,1x,'(',I1,') ---> ',I2,1x,'(',I1,')')
 
   end subroutine initMetaGraph
 

--- a/components/homme/src/share/metis_mod.F90
+++ b/components/homme/src/share/metis_mod.F90
@@ -25,7 +25,7 @@ contains
     use dimensions_mod , only : nmpi_per_node, npart, nnodes, nelem
     use control_mod, only:  partmethod
     use params_mod, only : wrecursive
-    
+
     implicit none
 
     type (GridVertex_t), intent(inout) :: GridVertex(:)
@@ -44,18 +44,12 @@ contains
 
     integer(kind=int_kind), allocatable          :: part(:)
     integer, allocatable          :: part_nl(:),local2global_nl(:)
-    integer, allocatable          :: part_fl(:),local2global_fl(:)
-
-
-    integer, allocatable          :: cnt(:),newnum(:),oldnum(:)
 
     integer                       :: nelem_edge,numflag,edgecut,wgtflag
-    integer                       :: head_part,tail_part
     integer                       :: options(5)
-    integer                       :: i,j,ii,ig,in,ip,if
-    integer                       :: nelem_nl,nelem_fl,newPartition
+    integer                       :: i,ig,in,ip
+    integer                       :: nelem_nl,newPartition
     integer                       :: partitionmethod,numpartitions
-    integer                       :: nodes_per_frame
     logical , parameter           :: Debug = .true.
     real (kind=4)                 :: dummy(1) 
     nelem_edge = SIZE(GridEdge) 
@@ -353,7 +347,7 @@ contains
     type (GridVertex_t), intent(in) :: GridVertex(:)
     integer,intent(out)           :: xadj(:),adjncy(:),adjwgt(:)
 
-    integer                         :: i,j,k,ii,jj
+    integer                         :: i,j,k,ii
     integer                         :: degree,nelem
     !integer(kind=int_kind),allocatable  :: neigh_list(:),sort_indices(:)
     !real(kind=REAL_KIND),allocatable    :: neigh_wgt(:)

--- a/components/homme/src/share/namelist_mod.F90
+++ b/components/homme/src/share/namelist_mod.F90
@@ -215,8 +215,11 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
     character(len=MAX_FILE_LEN) :: mesh_file
     integer :: se_ftype, se_limiter_option
     integer :: se_nsplit
-    integer :: interp_nlat, interp_nlon, interp_gridtype, interp_type
-    integer :: i, ii, j
+    integer :: interp_nlat, interp_nlon, interp_gridtype
+    integer :: i, ii
+#if !defined(CAM) && !defined(SCREAM) && !defined(HOMME_WITHOUT_PIOLIBRARY)
+    integer :: j, interp_type
+#endif
     integer  :: ierr
     character(len=80) :: errstr, arg
     real(kind=real_kind) :: dt_max, se_tstep

--- a/components/homme/src/share/physical_constants.F90
+++ b/components/homme/src/share/physical_constants.F90
@@ -68,7 +68,7 @@ module physical_constants
   real (kind=real_kind), public, parameter :: Rwater_vapor = 461.50D0
   real (kind=real_kind), public, parameter :: Cpwater_vapor= 1870.0D0
   real (kind=real_kind), public, parameter :: kappa        = Rgas/Cp
-  real (kind=real_kind), public, parameter :: Rd_on_Rv     = Rgas/Rwater_vapor	
+  real (kind=real_kind), public, parameter :: Rd_on_Rv     = Rgas/Rwater_vapor
   real (kind=real_kind), public, parameter :: Cpd_on_Cpv   = Cp/Cpwater_vapor
   real (kind=real_kind), public, parameter :: rrearth0     = 1.0_real_kind/rearth0
   real (kind=real_kind), public            :: rrearth      = rrearth0

--- a/components/homme/src/share/prim_si_mod.F90
+++ b/components/homme/src/share/prim_si_mod.F90
@@ -105,7 +105,10 @@ contains
     ! Local Variables
     ! ========================
 
-    integer :: k,nf
+    integer :: k
+#if (defined COLUMN_OPENMP)
+    integer :: nf
+#endif
     real (kind=real_kind) :: facp(np,np), facm(np,np)
 
     ! ===========================================================

--- a/components/homme/src/share/reduction_mod.F90
+++ b/components/homme/src/share/reduction_mod.F90
@@ -376,7 +376,7 @@ contains
     type (hybrid_t),       intent(in)    :: hybrid  ! parallel handle
 
     ! Local variables
-    integer ierr, k
+    integer ierr
 
     !$OMP BARRIER
     ! the first and fastest thread performs initializing copy
@@ -421,7 +421,7 @@ contains
     type (hybrid_t),       intent(in)    :: hybrid  ! parallel handle
 
     ! Local variables
-    integer ierr, k
+    integer ierr
 
     !$OMP BARRIER
     ! the first and fastest thread performs initializing copy
@@ -556,10 +556,10 @@ contains
   ! =======================================
   subroutine ElementSum_1d(res,variable,type,hybrid)
     use hybrid_mod, only : hybrid_t
-    use dimensions_mod, only : nelem
 #ifdef _MPI
   use parallel_mod, only : ORDERED, mpireal_t, mpi_min, mpi_max, mpi_sum, mpi_success
 #else
+  use dimensions_mod, only : nelem
   use parallel_mod, only : ORDERED
 #endif
     implicit none

--- a/components/homme/src/share/scalable_grid_init_mod.F90
+++ b/components/homme/src/share/scalable_grid_init_mod.F90
@@ -463,7 +463,7 @@ contains
 
     type (GridManager_t), intent(inout) :: gm
     type (GridVertex_t), pointer :: gv
-    integer :: id, ne2, nelem, sfc, i, j, k, id_nbr, n_owned_or_used, o
+    integer :: id, ne2, nelem, sfc, i, j, k, n_owned_or_used, o
     logical :: owned
     integer :: idxs, idxe, face_current, face, nface, sfcidx(7), max_pos
     integer, allocatable :: positions(:,:), id_sfc_pairs(:,:)
@@ -586,7 +586,7 @@ contains
     use cube_mod, only: CubeSetupEdgeIndex
 
     type (GridManager_t), intent(inout) :: gm
-    integer :: igv, ngv, i, j, k, id_nbr, ll, loc
+    integer :: igv, ngv, i, ll, loc
     type (GridVertex_t), pointer :: gv
     type (GridVertex_t) :: gv_tmp
 
@@ -834,7 +834,7 @@ contains
 
     type (GridManager_t), intent(inout) :: gm
 
-    integer :: i,j,k,iptr,m,n,wgtV,wgtP,gid,igv
+    integer :: i,j,k,iptr,m,n,gid,igv
     integer :: nelem,nelem_edge,inbr,igvnbr
     integer :: mynbr_cnt, cnt, mystart, start
     logical :: owned_or_used
@@ -947,7 +947,7 @@ contains
 
   function find_next_factorable(n_in, direction) result(n)
     integer, intent(in) :: n_in, direction
-    integer :: n, dir, f
+    integer :: n, dir
 
     n = n_in
     if (direction > 0) then
@@ -1034,21 +1034,21 @@ contains
     end do
   end subroutine sgi_check
 
-  subroutine print_array(rank, name, a)
-    integer, intent(in) :: rank, a(:)
-    character(*), intent(in) :: name
-    character(128) :: filename
-    integer :: i
+  ! subroutine print_array(rank, name, a)
+  !   integer, intent(in) :: rank, a(:)
+  !   character(*), intent(in) :: name
+  !   character(128) :: filename
+  !   integer :: i
 
-    write(filename, '(a,i1)') name,rank
-    open(unit=42, file=filename)
-    write (42, fmt='(a,a,a)', advance='no')  '(sv b.',filename(1:5),'(sort ['
-    do i = 1, size(a)
-       write (42, fmt='(i4)', advance='no') a(i)
-    end do
-    write (42, fmt='(a)', advance='yes') ']))'
-    close(42)
-  end subroutine print_array
+  !   write(filename, '(a,i1)') name,rank
+  !   open(unit=42, file=filename)
+  !   write (42, fmt='(a,a,a)', advance='no')  '(sv b.',filename(1:5),'(sort ['
+  !   do i = 1, size(a)
+  !      write (42, fmt='(i4)', advance='no') a(i)
+  !   end do
+  !   write (42, fmt='(a)', advance='yes') ']))'
+  !   close(42)
+  ! end subroutine print_array
   
   ! Compare MetaVertex created the scalable way against the one created the
   ! original, unscalable way.

--- a/components/homme/src/share/schedule_mod.F90
+++ b/components/homme/src/share/schedule_mod.F90
@@ -56,7 +56,6 @@ contains
     integer                       :: i,j,is,ir,ncycle
     integer                       :: il,ie,ig
     integer                       :: nelemd0
-    integer                       :: jmd
     integer                       :: inbr
     integer                       :: nSched
     integer,allocatable           :: tmpP(:,:)
@@ -67,7 +66,6 @@ contains
     integer			  :: iSched
     logical, parameter            :: VerbosePrint=.FALSE.
     logical, parameter            :: Debug=.FALSE.
-    integer :: ierr
     integer :: l1,l2,l1id,l2id
 
 
@@ -297,7 +295,6 @@ contains
        endif
     enddo
 100 format('CheckSchedule: ERR IAM:',I3,' SIZEOF(SendBuffer):',I10,' != SIZEOF(RecvBuffer) :',I10)
-110 format('CheckSchedule: ERR IAM:',I3,' LENGTH(SendBuffer):',I10,' != LENGTH(RecvBuffer) :',I10)
 
   end subroutine CheckSchedule
   subroutine PrintSchedule(Schedule)
@@ -337,10 +334,6 @@ contains
        call PrintGridEdge(pCycle%edge%members)
     enddo
 90  format('NODE # ',I2,2x,'NCYCLES ',I2)
-97  format(10x,'EDGE #',I2,2x,'TYPE ',I1,2x,'G.EDGES',I4,2x,'WORDS ',I5,2x, &
-         'SRC ',I3,2x,'DEST ',I3,2x,'PTR ',I4)
-100 format(15x,I4,5x,I3,1x,'(',I1,') --',I1,'--> ',I3,1x,'(',I1,')')
-
 
   end subroutine PrintSchedule
 
@@ -454,7 +447,7 @@ contains
     do i=1,n
        if( tmp(1,i) == inbr) then 
           ptr = tmp(2,i)
-          return	
+          return
        endif
        if( tmp(1,i) == -1 ) then  
           tmp(1,i) = inbr

--- a/components/homme/src/share/spacecurve_mod.F90
+++ b/components/homme/src/share/spacecurve_mod.F90
@@ -1206,8 +1206,7 @@ contains
        type (GridEdge_t),   intent(inout) :: GridEdge(:)
 
        integer               :: nelem,nelem_edge,nelemd
-       integer               :: head_part,tail_part
-       integer               :: j,k,tmp1,id,s1,extra
+       integer               :: k,tmp1,id,s1,extra
 
        nelem      = SIZE(GridVertex(:))
        nelem_edge = SIZE(GridEdge(:))
@@ -1261,7 +1260,7 @@ contains
   function sfcmap_init(ne, sfcmap) result(ierr)
     integer, intent(in) :: ne
     type (sfcmap_t), intent(out) :: sfcmap
-    integer :: i, ierr, f
+    integer :: ierr
 
     sfcmap%n = ne
     sfcmap%fact = factor(ne)
@@ -1308,7 +1307,7 @@ contains
     type (sfcmap_t), intent(inout) :: s
     integer, intent(in) :: idxs, idxe
     integer, target, intent(inout) :: pos(:,:)
-    integer :: index, status
+    integer :: status
     
     s%pos2i = .false.
     s%idxs = idxs
@@ -1639,7 +1638,7 @@ contains
        ma, md, ja, jd) result(o)
     type (sfcmap_t), intent(inout) :: s
     integer, intent(in) :: k, k_n, region_min, ma, md, ja, jd
-    integer :: km1, km1_n, km1_n2, ima, region, o
+    integer :: km1, km1_n, ima, region, o
 
     if (k == 0) then ! base case
        s%index = s%index + 1
@@ -1835,8 +1834,6 @@ contains
   end subroutine GilbertCurve
 
   recursive subroutine gilbert(Mesh, ix, iy, iax, iay, ibx, iby, global_index_ctr)
-
-    use dimensions_mod, only : ne_x, ne_y
 
     implicit none
 

--- a/components/homme/src/share/viscosity_base.F90
+++ b/components/homme/src/share/viscosity_base.F90
@@ -64,11 +64,7 @@ public :: compute_zeta_C0_contra    ! for older versions of sweq which carry
 public :: compute_div_C0_contra     ! velocity around in contra-coordinates
 public :: compute_eta_C0_contra
 
-type (EdgeBuffer_t)          :: edge1
-
 contains
-
-
 
 #ifdef _PRIM
 

--- a/components/homme/src/theta-l/share/model_init_mod.F90
+++ b/components/homme/src/theta-l/share/model_init_mod.F90
@@ -15,7 +15,7 @@ module model_init_mod
 
   use element_mod,        only: element_t
   use derivative_mod,     only: derivative_t,gradient_sphere, laplace_sphere_wk
-  use hybvcoord_mod, 	  only: hvcoord_t
+  use hybvcoord_mod,      only: hvcoord_t
   use hybrid_mod,         only: hybrid_t
   use dimensions_mod,     only: np,nlev,nlevp
   use element_ops,        only: initialize_reference_states

--- a/components/homme/src/theta-l/share/prim_advance_mod.F90
+++ b/components/homme/src/theta-l/share/prim_advance_mod.F90
@@ -71,8 +71,6 @@ contains
     type (parallel_t) :: par
     type (element_t), intent(inout), target   :: elem(:)
     character(len=*)    , intent(in) :: integration
-    integer :: i
-    integer :: ie
 
 
   end subroutine prim_advance_init1
@@ -100,13 +98,13 @@ contains
     integer              , intent(in)            :: nete
     logical,               intent(in)            :: compute_diagnostics
 
-    real (kind=real_kind) :: dt2, time, dt_vis, x, eta_ave_w
-    real (kind=real_kind) :: itertol,a1,a2,a3,a4,a5,a6,ahat1,ahat2
-    real (kind=real_kind) :: ahat3,ahat4,ahat5,ahat6,dhat1,dhat2,dhat3,dhat4
-    real (kind=real_kind) ::  gamma,delta,ap,aphat,dhat5,offcenter
+    real (kind=real_kind) :: dt2, dt_vis, eta_ave_w
+    real (kind=real_kind) :: itertol,a1,a2,a3
+    real (kind=real_kind) :: dhat3
+    real (kind=real_kind) :: aphat,offcenter
 
-    integer :: ie,nm1,n0,np1,nstep,qsplit_stage,k
-    integer :: n,i,j,maxiter
+    integer :: ie,nm1,n0,np1,nstep
+    integer :: maxiter
 
 #ifdef ARKODE 
     type(parameter_list)    :: arkode_parameters
@@ -566,7 +564,7 @@ contains
 
   ! local
   real (kind=real_kind) :: eta_ave_w  ! weighting for mean flux terms
-  integer :: k2,k,kptr,i,j,ie,ic,nt,nlyr_tot,nlyr_tom,ssize
+  integer :: k,kptr,ie,ic,nt,nlyr_tot,nlyr_tom,ssize
   real (kind=real_kind), dimension(np,np,2,nlev,nets:nete)      :: vtens
   real (kind=real_kind), dimension(np,np,nlev,4,nets:nete)      :: stens  ! dp3d,theta,w,phi
 
@@ -580,14 +578,16 @@ contains
   real (kind=real_kind), dimension(np,np,4) :: lap_s  ! dp3d,theta,w,phi
   real (kind=real_kind), dimension(np,np,2) :: lap_v
   real (kind=real_kind) :: exner0(nlev)
-  real (kind=real_kind) :: heating(np,np,nlev)
+#if 0
   real (kind=real_kind) :: exner(np,np,nlev)
-  real (kind=real_kind) :: pnh(np,np,nlevp)    
   real (kind=real_kind) :: temp(np,np,nlev)    
+  real (kind=real_kind) :: pnh(np,np,nlevp)    
   real (kind=real_kind) :: temp_i(np,np,nlevp)    
+  real (kind=real_kind) :: heating(np,np,nlev)
+  integer :: k2
+#endif
   real (kind=real_kind) :: dt,xfac
 
-  integer :: l1p,l2p,l1n,l2n,l
   call t_startf('advance_hypervis')
 
 #ifdef HOMMEXX_BFB_TESTING
@@ -1070,7 +1070,6 @@ contains
 
   real (kind=real_kind) :: gradw_i(np,np,2,nlevp)
   real (kind=real_kind) :: v_gradw_i(np,np,nlevp)     
-  real (kind=real_kind) :: v_gradtheta(np,np,nlev)     
   real (kind=real_kind) :: v_theta(np,np,2,nlev)
   real (kind=real_kind) :: div_v_theta(np,np,nlev)
   real (kind=real_kind) :: v_gradphinh_i(np,np,nlevp) ! v*gradphi at interfaces
@@ -1083,8 +1082,6 @@ contains
 
   real (kind=real_kind) :: vtens1(np,np,nlev)
   real (kind=real_kind) :: vtens2(np,np,nlev)
-  real (kind=real_kind) :: stens(np,np,nlev,3) ! tendencies w,phi,theta
-                                               ! w,phi tendencies not computed at nlevp
   real (kind=real_kind) :: w_tens(np,np,nlevp)  ! need to update w at surface as well
   real (kind=real_kind) :: theta_tens(np,np,nlev)
   real (kind=real_kind) :: phi_tens(np,np,nlevp)
@@ -1097,7 +1094,11 @@ contains
   real (kind=real_kind) ::  temp(np,np,nlev)
   real (kind=real_kind) ::  vtemp(np,np,2,nlev)       ! generic gradient storage
   real (kind=real_kind), dimension(np,np) :: sdot_sum ! temporary field
-  real (kind=real_kind) ::  v1,v2,w,d_eta_dot_dpdn_dn, T0
+  real (kind=real_kind) ::  v1,v2, T0
+
+#ifdef ENERGY_DIAGNOSTICS
+  real (kind=real_kind) ::  d_eta_dot_dpdn_dn
+#endif
   integer :: i,j,k,kptr,ie, nlyr_tot
 
   call t_startf('compute_andor_apply_rhs')

--- a/components/homme/src/theta-l/share/prim_state_mod.F90
+++ b/components/homme/src/theta-l/share/prim_state_mod.F90
@@ -116,11 +116,9 @@ contains
                              fusum_local(nets:nete), fvsum_local(nets:nete), ftsum_local(nets:nete), fqsum_local(nets:nete), &
                              wsum_local(nets:nete), phisum_local(nets:nete), dpsum_local(nets:nete)
 
-    real (kind=real_kind) :: umin_p, vmin_p, tmin_p, qvmin_p(qsize_d),&
-         psmin_p, dpmin_p, TSmin_p
+    real (kind=real_kind) :: qvmin_p(qsize_d), psmin_p, dpmin_p, TSmin_p
 
-    real (kind=real_kind) :: umax_p, vmax_p, tmax_p, qvmax_p(qsize_d),&
-         psmax_p, dpmax_p, TSmax_p
+    real (kind=real_kind) :: qvmax_p(qsize_d), psmax_p, dpmax_p, TSmax_p
 
     real (kind=real_kind) :: usum_p, vsum_p, tsum_p, qvsum_p(qsize_d),&
          pssum_p, dpsum_p, thetasum_p, wsum_p
@@ -140,7 +138,6 @@ contains
     character(len=3)      :: which
  
     real(kind=real_kind) :: relvort
-    real(kind=real_kind) :: v1, v2, vco(np,np,2,nlev)
 
     real (kind=real_kind) :: time, time2,time1, scale, dt, dt_f
     real (kind=real_kind) :: IEvert1,IEvert2,PEvert1,PEvert2

--- a/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
+++ b/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
@@ -101,7 +101,6 @@ contains
     !
     ! Local(s)
     !
-    integer :: ie
     real (kind=real_kind), target :: dvv (np,np), elem_mp(np,np)
     type (c_ptr) :: hybrid_am_ptr, hybrid_ai_ptr, hybrid_bm_ptr, hybrid_bi_ptr
     character(len=MAX_STRING_LEN), target :: test_name
@@ -170,7 +169,7 @@ contains
     ! Local(s)
     !
     real (kind=real_kind), target, dimension(np,np,2,2)     :: elem_D, elem_Dinv, elem_metinv, elem_tensorvisc
-    real (kind=real_kind), target, dimension(np,np)         :: elem_mp, elem_fcor, elem_spheremp
+    real (kind=real_kind), target, dimension(np,np)         :: elem_fcor, elem_spheremp
     real (kind=real_kind), target, dimension(np,np)         :: elem_rspheremp, elem_metdet
     real (kind=real_kind), target, dimension(np,np,3,2)     :: elem_vec_sph2cart
 
@@ -428,7 +427,7 @@ contains
     type (c_ptr) :: elem_state_dp3d_ptr, elem_state_Qdp_ptr, elem_state_Q_ptr, elem_state_ps_v_ptr
     type (c_ptr) :: elem_derived_omega_p_ptr
     integer :: n0_qdp, np1_qdp
-    real(kind=real_kind) :: dt_remap, dt_q, eta_ave_w
+    real(kind=real_kind) :: dt_remap, dt_q
     logical :: compute_forcing_and_push_to_c, push_to_f
 
     if (nsplit<1) then
@@ -562,8 +561,13 @@ contains
   function is_push_to_f_required(tl,statefreq,nextOutputStep,compute_diagnostics,nsplit_iter) &
        result(push_to_f)
 
+#if !defined(HOMMEXX_BENCHMARK_NOFORCING) && !defined(SCREAM) && !defined(CAM)
     use control_mod, only : test_with_forcing, prescribed_wind
-    use time_mod,    only : timelevel_t, nsplit
+#endif
+    use time_mod,    only : timelevel_t
+#ifdef CAM
+    use time_mod,    only : nsplit
+#endif
 
     type (TimeLevel_t),   intent(in) :: tl
     integer,              intent(in) :: statefreq, nextOutputStep, nsplit_iter


### PR DESCRIPTION
Mostly unused local variables plus some tab-related ones

[BFB]

---

I had some spare time last weekend. These are only _some_ of the warnings. In particular, there are quite a few more related to unused dummy args, but those require either a fcn signature change, or some programming trick to make the compiler think we're using the arg (I'd rather we did the first). But unused local vars make up for a significant portion of the code, and were easy to remove, so it's a start.