### PR TITLE
add a machine, cades-baseline, a cluster in ORNL.

### DIFF
--- a/cime_config/machines/cmake_macros/gnu_cades-baseline.cmake
+++ b/cime_config/machines/cmake_macros/gnu_cades-baseline.cmake
@@ -1,0 +1,3 @@
+set(SUPPORTS_CXX "TRUE")
+set(PIO_FILESYSTEM_HINTS "gpfs")
+string(APPEND CMAKE_Fortran_FLAGS " -fallow-argument-mismatch")

--- a/cime_config/machines/config_batch.xml
+++ b/cime_config/machines/config_batch.xml
@@ -736,6 +736,20 @@
          </queues>
    </batch_system>
 
+
+   <batch_system MACH="cades-baseline" type="slurm" >
+         <submit_args>
+           <arg flag="-A CLI185"/>
+           <arg flag="--mem=0G"/>
+           <arg flag="--ntasks-per-node 128"/>
+         </submit_args>
+         <queues>
+            <queue walltimemax="24:00" default="true">batch_ccsi</queue>
+            <!-- note: if above limited by computing resources, can use the following -->
+            <!-- <queue walltimemax="24:00" default="true">batch</queue> -->
+         </queues>
+   </batch_system>
+
    <batch_system MACH="itasca" type="pbs">
      <queues>
        <queue walltimemax="24:00" default="true">batch</queue>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -4196,6 +4196,124 @@
 
   </machine>
 
+  <machine MACH="cades-baseline">
+    <DESC>OCSS, ornl-css, CADES-baseline, os is Linux, 128 pes/node, batch system is slurm</DESC>
+    <NODENAME_REGEX>.*baseline.*</NODENAME_REGEX>
+    <OS>LINUX</OS>
+    <COMPILERS>gnu</COMPILERS>
+    <MPILIBS>openmpi,openmpi-amanzitpls,mpi-serial</MPILIBS>
+    <CIME_OUTPUT_ROOT>/gpfs/wolf2/cades/cli185/scratch/$USER</CIME_OUTPUT_ROOT>
+    <DIN_LOC_ROOT>/gpfs/wolf2/cades/cli185/world-shared/e3sm/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/gpfs/wolf2/cades/cli185/world-shared/e3sm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>/gpfs/wolf2/cades/cli185/world-shared/e3sm/archive/$USER/$CASE</DOUT_S_ROOT>
+    <BASELINE_ROOT>/gpfs/wolf2/cades/cli185/world-shared/e3sm/baselines/$COMPILER</BASELINE_ROOT>
+    <CCSM_CPRNC>/gpfs/wolf2/cades/cli185/world-shared/e3sm/tools/cprnc.baseline</CCSM_CPRNC>
+    <GMAKE_J>64</GMAKE_J>
+    <TESTS>e3sm_developer</TESTS>
+    <NTEST_PARALLEL_JOBS>128</NTEST_PARALLEL_JOBS>
+    <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
+    <SUPPORTED_BY>yuanf -at- ornl.gov</SUPPORTED_BY>
+    <MAX_TASKS_PER_NODE>128</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>128</MAX_MPITASKS_PER_NODE>
+    <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
+    <mpirun mpilib="openmpi" compiler="gnu">
+      <executable>srun</executable>
+      <arguments>
+        <arg name="num_tasks"> -n {{ total_tasks }}</arg>
+      </arguments>
+    </mpirun>
+    <mpirun mpilib="openmpi-amanzitpls" compiler="gnu">
+      <executable>srun</executable>
+      <arguments>
+        <arg name="num_tasks"> -n {{ total_tasks }}</arg>
+      </arguments>
+    </mpirun>
+    <mpirun mpilib="mpi-serial">
+      <executable> </executable>
+    </mpirun>
+
+    <module_system type="module" allow_error="true">
+      <init_path lang="sh">/sw/baseline/nsp/lmod/8.7.37/init/sh</init_path>
+      <init_path lang="csh">/sw/baseline/nsp/lmod/8.7.37/init/csh</init_path>
+      <init_path lang="python">/sw/baseline/nsp/lmod/8.7.37/init/env_modules_python.py</init_path>
+      <init_path lang="perl">/sw/baseline/nsp/lmod/8.7.37/init/perl</init_path>
+      <cmd_path lang="perl">module</cmd_path>
+      <cmd_path lang="python">/sw/baseline/nsp/lmod/8.7.37/libexec/lmod python</cmd_path>
+      <cmd_path lang="sh">module</cmd_path>
+      <cmd_path lang="csh">module</cmd_path>
+      <modules>
+        <command name="purge"/>
+        <command name="load">miniforge3/24.11.3-0</command>
+	    <command name="load">cmake/3.30.5</command>
+      </modules>
+      
+      <modules compiler="gnu" mpilib="openmpi">
+	    <command name="load">DefApps</command>
+	    <command name="load">gcc/12.4.0</command>
+        <command name="load">openmpi/5.0.5</command>
+	    <command name="load">netlib-lapack/3.11.0</command>
+	    <command name="load">hdf5/1.14.5-mpi</command>
+        <command name="load">netcdf-c/4.9.2-mpi-h5f</command>
+        <command name="load">netcdf-cxx/4.2-mpi</command>
+        <command name="load">netcdf-fortran/4.6.1-mpi-h5f</command>
+        <command name="load">parallel-netcdf/1.12.3-mpi</command>
+      </modules>
+
+      <modules compiler="gnu" mpilib="openmpi-amanzitpls">
+        <command name="load">DefApps</command>
+        <command name="load">gcc/12.4.0</command>
+        <command name="load">openmpi/5.0.5</command>
+        <command name="load">openblas/0.3.28</command>
+        <command name="use">-a /ccsopen/proj/cli185/ats-dev/modulefiles</command>
+        <command name="load">ats/tpls-0.98.12+master/cades-baseline/openblas-0.3.28-openmpi-5.0.5-gcc-12.4.0/opt</command>
+      </modules>
+
+      <modules compiler="gnu" mpilib="mpi-serial">
+        <command name="load">DefApps</command>
+        <command name="load">gcc/12.4.0</command>
+        <command name="unload">openmpi</command>
+        <command name="load">netlib-lapack/3.11.0</command>
+      </modules>
+
+    </module_system>
+
+    <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>
+    <EXEROOT>$CIME_OUTPUT_ROOT/$CASE/bld</EXEROOT>
+    <environment_variables compiler="gnu" mpilib="openmpi">
+      <env name="PETSC_PATH">/ccsopen/proj/cli185/petsc-3.x-noopt/</env>
+      <!--  perl5 lib</env> -->
+      <env name="PATH">/ccsopen/home/zdr/opt/perl/bin:$ENV{PATH}/</env>
+      <!--  either of the following approaches is working very well
+      <env name="HDF5_ROOT">$SHELL{dirname $(dirname $(which h5dump))}</env>
+      <env name="NETCDF_C_PATH">$SHELL{dirname $(dirname $(which nc-config))}</env>
+      <env name="NETCDF_FORTRAN_PATH">$SHELL{dirname $(dirname $(which nf-config))}</env>
+      <env name="PNETCDF_PATH">$SHELL{dirname $(dirname $(which pnetcdf_version))}</env>
+      <env name="BLASLAPACK_LIBDIR">/sw/baseline/spack-envs/base/opt/linux-rhel8-zen3/gcc-12.2.0/netlib-lapack-3.11.0-lpwyqsehj7wuz2i45umfhwa5ymv2dz5b/lib64</env>
+      -->
+      <env name="HDF5_ROOT">$ENV{OLCF_HDF5_ROOT}</env>
+      <env name="NETCDF_C_PATH">$ENV{OLCF_NETCDF_C_ROOT}</env>
+      <env name="NETCDF_FORTRAN_PATH">$ENV{OLCF_NETCDF_FORTRAN_ROOT}</env>
+      <env name="PNETCDF_PATH">$ENV{OLCF_PARALLEL_NETCDF_ROOT}</env>
+      <env name="BLASLAPACK_LIBDIR">$ENV{OLCF_NETLIB_LAPACK_ROOT}/lib64</env>
+    </environment_variables>
+    <environment_variables compiler="gnu" mpilib="openmpi-amanzitpls">
+      <env name="PETSC_PATH">/ccsopen/proj/cli185/ats-dev/amanzi-tpls/install/tpls-0.98.12/cades-baseline/openblas-0.3.28-openmpi-5.0.5-gcc-12.4.0/opt/petsc-3.20/</env>
+      <env name="PATH">/ccsopen/home/zdr/opt/perl/bin:$ENV{PATH}/</env>
+      <env name="HDF5_ROOT">/ccsopen/proj/cli185/ats-dev/amanzi-tpls/install/tpls-0.98.12/cades-baseline/openblas-0.3.28-openmpi-5.0.5-gcc-12.4.0/opt</env>
+      <env name="NETCDF_C_PATH">/ccsopen/proj/cli185/ats-dev/amanzi-tpls/install/tpls-0.98.12/cades-baseline/openblas-0.3.28-openmpi-5.0.5-gcc-12.4.0/opt</env>
+      <env name="NETCDF_FORTRAN_PATH">/ccsopen/proj/cli185/ats-dev/amanzi-tpls/install/tpls-0.98.12/cades-baseline/openblas-0.3.28-openmpi-5.0.5-gcc-12.4.0/opt</env>
+    </environment_variables>
+    <environment_variables compiler="gnu" mpilib="mpi-serial">
+      <env name="PATH">/ccsopen/proj/cli185/netcdf-hdf5_mpi-serial/bin:/ccsopen/home/zdr/opt/perl/bin:$ENV{PATH}/</env>
+      <env name="HDF5_ROOT">/ccsopen/proj/cli185/netcdf-hdf5_mpi-serial/</env>
+      <env name="NETCDF_C_PATH">/ccsopen/proj/cli185/netcdf-hdf5_mpi-serial/</env>
+      <env name="NETCDF_FORTRAN_PATH">/ccsopen/proj/cli185/netcdf-hdf5_mpi-serial/</env>
+      <env name="PNETCDF_PATH"/>
+      <env name="BLASLAPACK_LIBDIR">$ENV{OLCF_NETLIB_LAPACK_ROOT}/lib64</env>
+    </environment_variables>
+
+  </machine>
+
   <machine MACH="chicoma-cpu">
     <DESC>Chicoma CPU-only nodes at LANL IC. Each node has 2 AMD EPYC 7H12 64-Core (Milan) 512GB</DESC>
     <NODENAME_REGEX>ch-fe*</NODENAME_REGEX>

--- a/cime_config/machines/config_pio.xml
+++ b/cime_config/machines/config_pio.xml
@@ -63,6 +63,7 @@
       <value mach="lawrencium-lr6">netcdf</value>
 	  <value mach="eddi">netcdf</value>
       <value mach="cades">netcdf</value>
+      <value mach="cades-baseline">netcdf</value>
       <value mach="chicoma-cpu">netcdf</value>
       <value mach="chicoma-gpu">netcdf</value>
       <value mach="bebop" mpilib="impi" compset=".*CAM5.+MPAS.*">netcdf</value>


### PR DESCRIPTION
A cluster located in ORNL. It's machines for ORNL CCSI group to apply for E3SM land model and maybe ATM model. In addition, two changes may be useful to local group users are added. (1) in one test case, 'DATM' is looking for and trying to download one input data from repository server, but not existed any more. (2) for FATES full stages simulations, 2 compsets (20TR) of ELM are added. 