### PR TITLE
Some updates for C++20 prep

### DIFF
--- a/components/eamxx/CMakeLists.txt
+++ b/components/eamxx/CMakeLists.txt
@@ -51,8 +51,10 @@ if (SCREAM_CIME_BUILD)
     ${CMAKE_CURRENT_SOURCE_DIR}/cmake/cime)
 endif ()
 
-# We want to use C++17 in EAMxx
-set(CMAKE_CXX_STANDARD 17)
+if (NOT CMAKE_CXX_STANDARD)
+  # Default to C++17 in EAMxx
+  set(CMAKE_CXX_STANDARD 17)
+endif()
 
 if (NOT SCREAM_CIME_BUILD)
   project(SCREAM CXX C Fortran)

--- a/components/eamxx/src/physics/p3/p3_functions.hpp
+++ b/components/eamxx/src/physics/p3/p3_functions.hpp
@@ -173,7 +173,6 @@ struct Functions
 
   // This struct stores prognostic variables evolved by P3.
   struct P3PrognosticState {
-    P3PrognosticState() = default;
     // Cloud mass mixing ratio [kg kg-1]
     view_2d<Spack> qc;
     // Cloud number mixing ratio [# kg-1]
@@ -198,7 +197,6 @@ struct Functions
 
   // This struct stores diagnostic variables used by P3.
   struct P3DiagnosticInputs {
-    P3DiagnosticInputs() = default;
     // CCN activated number tendency [kg-1 s-1]
     view_2d<const Spack> nc_nuceat_tend;
     // CCN prescribed number density [kg-1 s-1]
@@ -235,7 +233,6 @@ struct Functions
 
   // This struct stores diagnostic outputs computed by P3.
   struct P3DiagnosticOutputs {
-    P3DiagnosticOutputs() = default;
     // qitend due to deposition/sublimation
     view_2d<Spack> qv2qi_depos_tend;
     // Precipitation rate, liquid [m s-1]
@@ -264,7 +261,6 @@ struct Functions
 
   // This struct stores time stepping and grid-index-related information.
   struct P3Infrastructure {
-    P3Infrastructure() = default;
     // Model time step [s]
     Real dt;
     // Time step counter (1-based)
@@ -288,7 +284,6 @@ struct Functions
   // This struct stores tendencies computed by P3 and used by other
   // parameterizations.
   struct P3HistoryOnly {
-    P3HistoryOnly() = default;
     // Sum of liq-ice phase change tendencies
     view_2d<Spack> liq_ice_exchange;
     // Sum of vap-liq phase change tendencies
@@ -329,7 +324,6 @@ struct Functions
 
 #ifdef SCREAM_P3_SMALL_KERNELS
   struct P3Temporaries {
-    P3Temporaries() = default;
     // shape parameter of rain
     view_2d<Spack> mu_r;
     // temperature at the beginning of the microphysics step [K]

--- a/components/eamxx/src/physics/shoc/shoc_functions.hpp
+++ b/components/eamxx/src/physics/shoc/shoc_functions.hpp
@@ -79,7 +79,6 @@ struct Functions
 
   // This struct stores runtime options for shoc_main
  struct SHOCRuntime {
-   SHOCRuntime() = default;
    // Runtime options for isotropic_ts
    Scalar lambda_low;
    Scalar lambda_high;
@@ -99,8 +98,6 @@ struct Functions
 
   // This struct stores input views for shoc_main.
   struct SHOCInput {
-    SHOCInput() = default;
-
     // Grid spacing of host model in x direction [m]
     view_1d<const Scalar> dx;
     // grid spacing of host model in y direction [m]
@@ -137,8 +134,6 @@ struct Functions
 
   // This struct stores input/outputs views for shoc_main.
   struct SHOCInputOutput {
-    SHOCInputOutput() = default;
-
     // prognostic temp variable of host model
     // dry static energy [J/kg]
     // dse = Cp*T + g*z + phis
@@ -165,8 +160,6 @@ struct Functions
 
   // This struct stores output only views for shoc_main.
   struct SHOCOutput {
-    SHOCOutput() = default;
-
     // planetary boundary layer depth [m]
     view_1d<Scalar> pblh;
     // surface friction velocity [m/s]
@@ -181,8 +174,6 @@ struct Functions
 
   // This struct stores output views for SHOC diagnostics for shoc_main.
   struct SHOCHistoryOutput {
-    SHOCHistoryOutput() = default;
-
     // Turbulent length scale [m]
     view_2d<Spack>  shoc_mix;
     // vertical velocity variance [m2/s2]
@@ -219,8 +210,6 @@ struct Functions
 
 #ifdef SCREAM_SHOC_SMALL_KERNELS
   struct SHOCTemporaries {
-    SHOCTemporaries() = default;
-
     view_1d<Scalar> se_b;
     view_1d<Scalar> ke_b;
     view_1d<Scalar> wv_b;


### PR DESCRIPTION
In C++20 you cannot aggregate initialize a stuct which has a default
constructor defined. We shouldn't need these constructors since views
themselves have default constructors.

Also, allow EAMxx to take a `CMAKE_CXX_STANDARD` option (default to C++17).

Creating this PR so that https://github.com/E3SM-Project/E3SM/pull/7643 won't have to run full CI while I test.

[BFB]