### PR TITLE
Workflows: run eamxx-v1 nightly

### DIFF
--- a/.github/workflows/eamxx-v1-testing.yml
+++ b/.github/workflows/eamxx-v1-testing.yml
@@ -36,6 +36,10 @@ on:
         required: true
         type: boolean
 
+  # Also run nightly
+  schedule:
+    - cron: '0 7 * * *'  # Runs at 7 AM UTC, which is midnight MT during Standard Time
+
 concurrency:
   # Two runs are in the same group if they are testing the same git ref
   #  - if trigger=pull_request, the ref is refs/pull/<PR_NUMBER>/merge


### PR DESCRIPTION
When a PR has baseline DIFF fails, knowing master's status can help understanding
where the DIFFs are coming from

[BFB]

---

I've seen some v1 fails in some PRs which surprised me. So I manually ran the workflow on master, and saw the same failure. This points to a non-BFB pr that was merged without the integrator triggering the CI baseline regen job (may very well have been me). Since we don't have the gh CI jobs reporting on cdash, this is easy to miss. And after a few days, it may be hard to backtrack where the DIFF came, especially if in the meantime we've had many PR merged with v1 tests failing.

NOTE: this nightly jobs will NOT report to cdash. They are just run to make life easier when we spot a v1 DIFF that we don't expect. Namely, the integrator/pr-owner can just look at the actions tab, open the v1 workflow page, and select "schedule" event, to see what happened in recent nightly runs.