### PR TITLE
Update field_utils.hpp

### DIFF
--- a/components/eamxx/src/share/field/field_utils.cpp
+++ b/components/eamxx/src/share/field/field_utils.cpp
@@ -323,11 +323,12 @@ void print_field_hyperslab (const Field& f,
 
   const int num_indices = indices.size();
   for (int i=0; i<num_indices; ++i) {
-    EKAT_REQUIRE_MSG ( indices[i]>=0 && indices[i]<fl.dim(i),
-      "Error! Requested index is invalid.\n"
+    EKAT_REQUIRE_MSG ( indices[i]>=0 && indices[i]<fl.dim(tags[i],false),
+      "Error! Requested slice index is out of bound.\n"
       "  - field name: " + f.name() + "\n"
       "  - field layout: " + fl.to_string() + "\n"
-      "  - requested indices: (" + ekat::join(indices,",") + ")\n");
+      "  - hyperslab tags: (" + ekat::join(tags2str(tags),",") + ")\n"
+      "  - hyperslab indices: (" + ekat::join(indices,",") + ")\n");
   }
 
   switch (dt) {

--- a/components/eamxx/src/share/field/field_utils.cpp
+++ b/components/eamxx/src/share/field/field_utils.cpp
@@ -313,12 +313,22 @@ void print_field_hyperslab (const Field& f,
 {
   const auto dt = f.data_type();
   const auto rank = f.rank();
+  const auto& fl = f.get_header().get_identifier().get_layout();
 
   EKAT_REQUIRE_MSG (rank>=static_cast<int>(tags.size()),
       "Error! Requested location incompatible with field rank.\n"
       "  - field name: " + f.name() + "\n"
       "  - field rank: " + std::to_string(rank) + "\n"
-      "  - requested indices: (" + ekat::join(indices,",") + "\n");
+      "  - requested indices: (" + ekat::join(indices,",") + ")\n");
+
+  const int num_indices = indices.size();
+  for (int i=0; i<num_indices; ++i) {
+    EKAT_REQUIRE_MSG ( indices[i]>=0 && indices[i]<fl.dim(i),
+      "Error! Requested index is invalid.\n"
+      "  - field name: " + f.name() + "\n"
+      "  - field layout: " + fl.to_string() + "\n"
+      "  - requested indices: (" + ekat::join(indices,",") + ")\n");
+  }
 
   switch (dt) {
     case DataType::IntType:

--- a/components/eamxx/src/share/field/tests/field_header_tests.cpp
+++ b/components/eamxx/src/share/field/tests/field_header_tests.cpp
@@ -29,6 +29,10 @@ TEST_CASE("field_layout", "") {
   REQUIRE (fl5.type()==LayoutType::Vector3D);
   REQUIRE (fl6.type()==LayoutType::Tensor3D);
 
+  REQUIRE (fl3.dim(COL)==1);
+  REQUIRE_THROWS (fl3.dim(CMP));
+  REQUIRE (fl3.dim(CMP,false)==3);
+
   REQUIRE (not fl1.is_vector_layout());
   REQUIRE (    fl2.is_vector_layout());
   REQUIRE (not fl3.is_vector_layout());

--- a/components/eamxx/src/share/field/tests/field_utils.cpp
+++ b/components/eamxx/src/share/field/tests/field_utils.cpp
@@ -773,6 +773,11 @@ TEST_CASE ("print_field_hyperslab") {
       }
 
     REQUIRE (out.str()==expected.str());
+
+    loc_idxs[0] = nel;
+    REQUIRE_THROWS(print_field_hyperslab(f,loc_tags,loc_idxs,out));
+    loc_idxs[0] = -1;
+    REQUIRE_THROWS(print_field_hyperslab(f,loc_tags,loc_idxs,out));
   }
   SECTION ("slice_0234") {
     std::vector<FieldTag> loc_tags = {EL,GP,GP,LEV};


### PR DESCRIPTION
This adds a check to print_field_hyperslab() to aid in debugging an edge case where a postcondition check tries to throw an error but the underlying grid of the current process is incorrectly defined. Hopefully the check is general enough to help debug other edge cases as well.

[BFB]