### PR TITLE
EAMxx: fix includes in gw tests

### DIFF
--- a/components/eamxx/src/physics/gw/tests/gw_vd_lu_decomp_tests.cpp
+++ b/components/eamxx/src/physics/gw/tests/gw_vd_lu_decomp_tests.cpp
@@ -1,8 +1,8 @@
 #include "catch2/catch.hpp"
 
-#include "share/eamxx_types.hpp"
 #include "physics/gw/gw_functions.hpp"
 #include "physics/gw/tests/infra/gw_test_data.hpp"
+#include "share/core/eamxx_types.hpp"
 
 #include "gw_unit_tests_common.hpp"
 

--- a/components/eamxx/src/physics/gw/tests/gw_vd_lu_solve_tests.cpp
+++ b/components/eamxx/src/physics/gw/tests/gw_vd_lu_solve_tests.cpp
@@ -1,8 +1,8 @@
 #include "catch2/catch.hpp"
 
-#include "share/eamxx_types.hpp"
 #include "physics/gw/gw_functions.hpp"
 #include "physics/gw/tests/infra/gw_test_data.hpp"
+#include "share/core/eamxx_types.hpp"
 
 #include "gw_unit_tests_common.hpp"
 


### PR DESCRIPTION
Fixes an eamxx standalone testing build error.

[BFB]

---

The issue was generated by two PRs (#7690 and #7694) being tested both before any of the two got merged. This is a peculiar corner case where our current testing fails. Having a merge queue would prob solve this, but fortunately it happens very rarely.

I canceled the v1 tests (and the gh ci ones) since those files are not built in CIME cases.

Note: since the [baseline-regen workflow](https://github.com/E3SM-Project/E3SM/actions/runs/17655598777) run with a broken master, it failed to regen baselines, so this PR should still diff on the gw tests. 