### PR TITLE
Updates to Pacer to support Omega

### DIFF
--- a/share/pacer/Pacer.cpp
+++ b/share/pacer/Pacer.cpp
@@ -51,6 +51,9 @@ static std::vector<std::string> OpenTimers;
 /// Pacer Mode: standalone or within CIME
 static PacerModeType PacerMode;
 
+// Global timing level
+static int TimingLevel = 0;
+
 /// Check if Pacer is initialized
 /// Returns true if initialized
 inline bool isInitialized(void){
@@ -118,9 +121,14 @@ bool initialize(MPI_Comm InComm, PacerModeType InMode /* = PACER_STANDALONE */) 
     return true;
 }
 
-/// Start the time named TimerName
-bool start(const std::string &TimerName)
+/// Start the timer named TimerName active when TimingLevel >= Level 
+bool start(const std::string &TimerName, int Level)
 {
+    // Return immediately if this timer level is above the global timing level
+    if (Level > TimingLevel) {
+       return true;
+    }
+
     PACER_CHECK_INIT();
 
     PACER_CHECK_ERROR(GPTLstart(TimerName.c_str()));
@@ -131,10 +139,15 @@ bool start(const std::string &TimerName)
     return true;
 }
 
-/// Stop the time named TimerName
+/// Stop the timer named TimerName active when TimingLevel >= Level 
 /// Issues warning if timer hasn't been started yet
-bool stop(const std::string &TimerName)
+bool stop(const std::string &TimerName, int Level)
 {
+    // Return immediately if this timer level is above the global timing level
+    if (Level > TimingLevel) {
+       return true;
+    }
+
     PACER_CHECK_INIT();
 
     auto it = std::find(OpenTimers.begin(), OpenTimers.end(), TimerName);
@@ -173,6 +186,11 @@ bool unsetPrefix()
     PACER_CHECK_ERROR(GPTLprefix_unset());
 
     return true;
+}
+
+void setTimingLevel(int Level)
+{
+    TimingLevel = Level;
 }
 
 /// Prints timing statistics and global summary files

--- a/share/pacer/Pacer.cpp
+++ b/share/pacer/Pacer.cpp
@@ -55,8 +55,11 @@ static std::string CurrentPrefix = "";
 /// Pacer Mode: standalone or within CIME
 static PacerModeType PacerMode;
 
-// Global timing level
+/// Global timing level
 static int TimingLevel = 0;
+
+/// Flag to determine if timing barriers are enabled
+static bool TimingBarriersEnabled = false;
 
 /// Check if Pacer is initialized
 /// Returns true if initialized
@@ -243,6 +246,27 @@ bool enableTiming()
     PACER_CHECK_ERROR(GPTLenable());
     
     return true;
+}
+
+void enableTimingBarriers()
+{
+    TimingBarriersEnabled = true;
+}
+
+void disableTimingBarriers()
+{
+    TimingBarriersEnabled = false;
+}
+
+bool timingBarrier(const std::string &TimerName, int Level, MPI_Comm Comm)
+{
+    bool Ok = true;
+    if (TimingBarriersEnabled && Level <= TimingLevel) {
+      Ok = Ok && start(TimerName, Level);
+      MPI_Barrier(Comm);
+      Ok = Ok && stop(TimerName, Level);
+    }
+    return Ok;
 }
 
 /// Prints timing statistics and global summary files

--- a/share/pacer/Pacer.cpp
+++ b/share/pacer/Pacer.cpp
@@ -193,6 +193,20 @@ void setTimingLevel(int Level)
     TimingLevel = Level;
 }
 
+bool disableTiming()
+{
+    PACER_CHECK_ERROR(GPTLdisable());
+    
+    return true;
+}
+
+bool enableTiming()
+{
+    PACER_CHECK_ERROR(GPTLenable());
+    
+    return true;
+}
+
 /// Prints timing statistics and global summary files
 /// Output Files: TimerFilePrefix.timing.<MyRank>
 /// TimerFilePrefix.summary

--- a/share/pacer/Pacer.cpp
+++ b/share/pacer/Pacer.cpp
@@ -54,11 +54,11 @@ static MPI_Comm InternalComm;
 /// MPI rank of process
 static int MyRank;
 
-// Vector-based stack of open timers
+/// Vector-based stack of open timers
 static std::vector<std::string> OpenTimers;
 
-// GPTL doesn't seem to provide a function to obtain the current prefix
-// so we track it ourselves
+/// GPTL doesn't seem to provide a function to obtain the current prefix
+/// so we track it ourselves
 static std::string CurrentPrefix = "";
 
 /// Pacer Mode: standalone or within CIME
@@ -70,12 +70,12 @@ static int TimingLevel = 0;
 /// Flag to determine if timing barriers are enabled
 static bool TimingBarriersEnabled = false;
 
-// Flag to determine if automatic Kokkos fences are enabled
+/// Flag to determine if automatic Kokkos fences are enabled
 static bool AutoFenceEnabled = false;
 
 /// Check if Pacer is initialized
 /// Returns true if initialized
-inline bool isInitialized(void){
+inline bool isInitialized(){
     if (!IsInitialized) {
         std::cerr << "[ERROR] Pacer: Not initialized." << std::endl;
         return false;
@@ -145,12 +145,12 @@ bool start(const std::string &TimerName, int Level)
 {
     // Return immediately if this timer level is above the global timing level
     if (Level > TimingLevel) {
-       return true;
+        return true;
     }
 
 #ifdef PACER_HAVE_KOKKOS
     if (AutoFenceEnabled) {
-       Kokkos::fence();
+        Kokkos::fence();
     }
 
     // If CUDA is enabled start an NVTX range
@@ -176,7 +176,7 @@ bool stop(const std::string &TimerName, int Level)
 {
     // Return immediately if this timer level is above the global timing level
     if (Level > TimingLevel) {
-       return true;
+        return true;
     }
 
     PACER_CHECK_INIT();
@@ -193,7 +193,7 @@ bool stop(const std::string &TimerName, int Level)
 #endif
 
         if (AutoFenceEnabled) {
-           Kokkos::fence();
+            Kokkos::fence();
         }
 #endif
 
@@ -310,9 +310,9 @@ bool timingBarrier(const std::string &TimerName, int Level, MPI_Comm Comm)
     bool Ok = true;
     if (TimingBarriersEnabled && Level <= TimingLevel) {
 
-      Ok = Ok && start(TimerName, Level);
-      MPI_Barrier(Comm);
-      Ok = Ok && stop(TimerName, Level);
+        Ok = Ok && start(TimerName, Level);
+        MPI_Barrier(Comm);
+        Ok = Ok && stop(TimerName, Level);
     }
     return Ok;
 }

--- a/share/pacer/Pacer.cpp
+++ b/share/pacer/Pacer.cpp
@@ -15,6 +15,11 @@
 
 #ifdef PACER_HAVE_KOKKOS
 #include <Kokkos_Core.hpp>
+
+#if defined(PACER_ADD_RANGES) && defined(KOKKOS_ENABLE_CUDA)
+#include <nvtx3/nvToolsExt.h>
+#endif
+
 #endif
 
 #define PACER_CHECK_INIT() {\
@@ -147,6 +152,12 @@ bool start(const std::string &TimerName, int Level)
     if (AutoFenceEnabled) {
        Kokkos::fence();
     }
+
+    // If CUDA is enabled start an NVTX range
+#if defined(PACER_ADD_RANGES) && defined(KOKKOS_ENABLE_CUDA)
+    nvtxRangePush(TimerName.c_str());
+#endif
+
 #endif
 
     PACER_CHECK_INIT();
@@ -175,6 +186,12 @@ bool stop(const std::string &TimerName, int Level)
     if (it != OpenTimers.end() ) {
 
 #ifdef PACER_HAVE_KOKKOS
+
+        // If CUDA is enabled end the NVTX range
+#if defined(PACER_ADD_RANGES) && defined(KOKKOS_ENABLE_CUDA)
+        nvtxRangePop();
+#endif
+
         if (AutoFenceEnabled) {
            Kokkos::fence();
         }

--- a/share/pacer/Pacer.h
+++ b/share/pacer/Pacer.h
@@ -43,6 +43,12 @@ namespace Pacer {
     /// Unsets prefix for all subsequent timers
     bool unsetPrefix();
     
+    /// Adds the current enclosing timer name to the prefix for all subsequent timers
+    bool addParentPrefix();
+
+    /// Removes the current enclosing timer name from the prefix for all subsequent timers
+    bool removeParentPrefix();
+    
     /// Sets timing level for all subsequent timers
     void setTimingLevel(int Level);
     

--- a/share/pacer/Pacer.h
+++ b/share/pacer/Pacer.h
@@ -60,6 +60,12 @@ namespace Pacer {
 
     /// Enables timing
     bool enableTiming();
+
+    /// Enables automatic Kokkos fences
+    void enableAutoFence();
+
+    /// Disables automatic Kokkos fences
+    void disableAutoFence();
    
     /// Enables timing barriers
     void enableTimingBarriers();

--- a/share/pacer/Pacer.h
+++ b/share/pacer/Pacer.h
@@ -49,6 +49,9 @@ namespace Pacer {
     /// Removes the current enclosing timer name from the prefix for all subsequent timers
     bool removeParentPrefix();
     
+    /// Call and time MPI barrier if timing barriers are turned on
+    bool timingBarrier(const std::string &TimerName, int Level, MPI_Comm comm);
+    
     /// Sets timing level for all subsequent timers
     void setTimingLevel(int Level);
     
@@ -57,6 +60,12 @@ namespace Pacer {
 
     /// Enables timing
     bool enableTiming();
+   
+    /// Enables timing barriers
+    void enableTimingBarriers();
+
+    /// Disables timing barriers
+    void disableTimingBarriers();
 
     /// Prints timing statistics and global summary files
     /// Output Files: TimerFilePrefix.timing.<MyRank>

--- a/share/pacer/Pacer.h
+++ b/share/pacer/Pacer.h
@@ -12,28 +12,11 @@
 #define PACER_H
 
 #include <mpi.h>
-#include <gptl.h>
-#include <unordered_map>
 #include <string>
 
 namespace Pacer {
 
-    /// Flag to determine if the timing infrastructure is initialized
-    static bool IsInitialized = false;
-
-    /// MPI communicator used within Pacer
-    static MPI_Comm InternalComm;
-
-    /// MPI rank of process
-    static int MyRank;
-
-    /// hash table of open timers with count (for multiple parents)
-    static std::unordered_map<std::string,int> OpenTimers;
-
     enum PacerModeType { PACER_STANDALONE, PACER_INTEGRATED };
-
-    /// Pacer Mode: standalone or within CIME
-    static PacerModeType PacerMode;
 
     /// Initialize Pacer timing
     /// InComm: overall MPI communicator used by application.
@@ -70,6 +53,6 @@ namespace Pacer {
     /// Issues warning if any timers are still open
     bool finalize();
 
-};
+}
 
 #endif

--- a/share/pacer/Pacer.h
+++ b/share/pacer/Pacer.h
@@ -25,7 +25,7 @@ namespace Pacer {
 
     /// Check if Pacer is initialized
     /// Returns true if initialized
-    bool isInitialized(void);
+    bool isInitialized();
 
     /// IntegratedMode: Pacer standalone (default:false) or within CIME (true)
     // bool initialize(MPI_Comm InComm, bool IntegratedMode = false);

--- a/share/pacer/Pacer.h
+++ b/share/pacer/Pacer.h
@@ -30,18 +30,21 @@ namespace Pacer {
     /// IntegratedMode: Pacer standalone (default:false) or within CIME (true)
     // bool initialize(MPI_Comm InComm, bool IntegratedMode = false);
 
-    /// Start the time named TimerName
-    bool start(const std::string &TimerName);
+    /// Start the timer named TimerName active when TimingLevel >= Level 
+    bool start(const std::string &TimerName, int Level);
 
-    /// Stop the time named TimerName
+    /// Stop the timer named TimerName active when TimingLevel >= Level 
     /// Issues warning if timer hasn't been started yet
-    bool stop(const std::string &TimerName);
+    bool stop(const std::string &TimerName, int Level);
 
     /// Sets named prefix for all subsequent timers
     bool setPrefix(const std::string &Prefix);
 
     /// Unsets prefix for all subsequent timers
     bool unsetPrefix();
+    
+    /// Sets timing level for all subsequent timers
+    void setTimingLevel(int Level);
 
     /// Prints timing statistics and global summary files
     /// Output Files: TimerFilePrefix.timing.<MyRank>

--- a/share/pacer/Pacer.h
+++ b/share/pacer/Pacer.h
@@ -45,6 +45,12 @@ namespace Pacer {
     
     /// Sets timing level for all subsequent timers
     void setTimingLevel(int Level);
+    
+    /// Disables timing
+    bool disableTiming();
+
+    /// Enables timing
+    bool enableTiming();
 
     /// Prints timing statistics and global summary files
     /// Output Files: TimerFilePrefix.timing.<MyRank>

--- a/share/pacer/TestPacer.cpp
+++ b/share/pacer/TestPacer.cpp
@@ -43,8 +43,17 @@ int main(int argc, char **argv){
 
     Pacer::stop("run_loop", 1);
     
-    Pacer::start("should_not_appear", 2);
-    Pacer::stop("should_not_appear", 2);
+    Pacer::start("should_not_appear_1", 2);
+    Pacer::stop("should_not_appear_1", 2);
+    
+    Pacer::disableTiming();
+      Pacer::start("should_not_appear_2", 0);
+
+      Pacer::start("should_not_appear_3", 0);
+      Pacer::stop("should_not_appear_3", 0);
+
+      Pacer::stop("should_not_appear_2", 0);
+    Pacer::enableTiming();
 
     Pacer::unsetPrefix();
 

--- a/share/pacer/TestPacer.cpp
+++ b/share/pacer/TestPacer.cpp
@@ -54,6 +54,22 @@ int main(int argc, char **argv){
 
       Pacer::stop("should_not_appear_2", 0);
     Pacer::enableTiming();
+    
+    Pacer::start("parent", 1);
+    Pacer::addParentPrefix();
+    
+    Pacer::start("child1", 1);
+    Pacer::stop("child1", 1);
+    
+    Pacer::start("child2", 0);
+      Pacer::addParentPrefix();
+      Pacer::start("grandchild1", 1);
+      Pacer::stop("grandchild1", 1);
+      Pacer::removeParentPrefix();
+    Pacer::stop("child2", 0);
+
+    Pacer::removeParentPrefix();
+    Pacer::stop("parent", 1);
 
     Pacer::unsetPrefix();
 

--- a/share/pacer/TestPacer.cpp
+++ b/share/pacer/TestPacer.cpp
@@ -31,8 +31,9 @@ int main(int argc, char **argv){
     // Pacer::initialize(MPI_COMM_WORLD, Pacer::PACER_STANDALONE);
 
     Pacer::setPrefix("Omega:");
+    Pacer::setTimingLevel(1);
 
-    Pacer::start("run_loop");
+    Pacer::start("run_loop", 1);
 
     float tmp = 1;
 
@@ -40,23 +41,26 @@ int main(int argc, char **argv){
         tmp *= i;
     }
 
-    Pacer::stop("run_loop");
+    Pacer::stop("run_loop", 1);
+    
+    Pacer::start("should_not_appear", 2);
+    Pacer::stop("should_not_appear", 2);
 
     Pacer::unsetPrefix();
 
     // illustrating situation where attempt to stop timer before starting
     // will print a warning
-    Pacer::stop("final");
+    Pacer::stop("final", 0);
 
     // as well as dangling timer which is never stopped explicitly
     // will print a warning at the end during finalize
-    Pacer::start("final");
+    Pacer::start("final", 0);
 
 
     // print: First argument is the prefix used for timing output file names
     // Second argument (optional) controls if timing output should be from all ranks
     // default is false, only rank 0 writes timing output
-    Pacer::print("test");
+    Pacer::print("pacer_test");
     // Pacer::print("test", true);
 
     Pacer::finalize();

--- a/share/pacer/TestPacer.cpp
+++ b/share/pacer/TestPacer.cpp
@@ -71,6 +71,12 @@ int main(int argc, char **argv){
     Pacer::removeParentPrefix();
     Pacer::stop("parent", 1);
 
+    Pacer::timingBarrier("barrier_should_not_appear_1", 0, MPI_COMM_WORLD);
+    Pacer::enableTimingBarriers();
+    Pacer::timingBarrier("barrier_should_not_appear_2", 2, MPI_COMM_WORLD);
+    Pacer::timingBarrier("timing_barrier", 0, MPI_COMM_WORLD);
+
+
     Pacer::unsetPrefix();
 
     // illustrating situation where attempt to stop timer before starting


### PR DESCRIPTION
Adds the following capabilities to the Pacer library for use in Omega:
- timing levels
- conditional MPI barriers for timing
- automatic Kokkos fences
- (optional) NVTX ranges
- functions to disable timing in a region
- functions to adding a prefix based on the parent timer

See https://github.com/E3SM-Project/Omega/pull/271 for more context.

[BFB]