### PR TITLE
EAMxx: archive yaml/nml files in CaseDocs when buildnml runs

### DIFF
--- a/components/eamxx/cime_config/buildnml
+++ b/components/eamxx/cime_config/buildnml
@@ -29,7 +29,7 @@ from CIME.utils import expect, safe_copy, SharedArea, run_cmd_no_fail
 from CIME.buildnml import parse_input
 
 from eamxx_buildnml import create_raw_xml_file, create_input_files, create_input_data_list_file, \
-    do_cime_vars_on_yaml_output_files
+    do_cime_vars_on_yaml_output_files, archive_case_docs
 
 ###############################################################################
 def buildnml(case, caseroot, compname):
@@ -74,6 +74,9 @@ def buildnml(case, caseroot, compname):
     # to ensure are present on the machine (possibly downloading them)
     #
     create_input_data_list_file(case,caseroot)
+
+    # archive yaml/nml files in CaseDocs
+    archive_case_docs(case,caseroot)
 
 ###############################################################################
 def _main_func():

--- a/components/eamxx/cime_config/eamxx_buildnml.py
+++ b/components/eamxx/cime_config/eamxx_buildnml.py
@@ -1175,3 +1175,32 @@ def do_cime_vars_on_yaml_output_files(case, caseroot):
 ################################################################
 """)
         ordered_dump(scream_input, fd)
+
+###############################################################################
+def archive_case_docs(case,caseroot):
+###############################################################################
+    # Copy ALL eamxx input yaml/nml files to CaseDocs, for provenance
+    with SharedArea():
+        # We for sure have scream_input.yaml and namelist.nl
+        files = ['scream_input.yaml', 'namelist.nl']
+
+        # Get the XML configs, and find all output yaml files
+        rundir = case.get_value("RUNDIR")
+        eamxx_xml_file = os.path.join(caseroot, "namelist_scream.xml")
+
+        with open(eamxx_xml_file, "r") as fd:
+            eamxx_xml = ET.parse(fd).getroot()
+
+        scorpio = get_child(eamxx_xml,'scorpio')
+        out_files_xml = get_child(scorpio,"output_yaml_files",must_exist=False)
+        out_files = out_files_xml.text.split(",") if (out_files_xml is not None and out_files_xml.text is not None) else []
+
+        for fn in out_files:
+            # Get full name
+            src_yaml = os.path.expanduser(os.path.join(fn.strip()))
+            files.append(os.path.basename(src_yaml))
+
+        for f in files:
+            src = os.path.join(caseroot,f'run/data/{f}')
+            dst = os.path.join(caseroot,f'CaseDocs/{f}')
+            safe_copy(src,dst)


### PR DESCRIPTION
Archive yaml/namelist files used by EAMxx in CaseDocs when buildnml runs.

[BFB]

---

Fixes #7055