### PR TITLE
Disable MMF2 test and remove PAM submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -70,9 +70,6 @@
 	path = components/ww3/src/WW3
 	url = git@github.com:E3SM-Project/WW3.git
 	branch = e3sm
-[submodule "components/eam/src/physics/crm/pam/external"]
-	path = components/eam/src/physics/crm/pam/external
-	url = git@github.com:E3SM-Project/PAM.git
 [submodule "components/mpas-seaice/src/icepack"]
 	path = components/mpas-seaice/src/icepack
 	url = git@github.com:E3SM-Project/Icepack.git

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -431,7 +431,6 @@ _TESTS = {
             "ERP_Ln9.ne4pg2_oQU480.WCYCL20TRNS-MMF1.allactive-mmf_fixed_subcycle",
             "ERS_Ln9.ne4pg2_ne4pg2.FRCE-MMF1.eam-cosp_nhtfrq9",
             "SMS_Ln5.ne4_ne4.FSCM-ARM97-MMF1",
-            "SMS_Ln3.ne4pg2_oQU480.F2010-MMF2",
             )
         },
 


### PR DESCRIPTION
The future of the MMF2 configuration is bleak, so the time has come to let it hibernate. This involves disabling the integration test and removing the PAM submodule. Any future effort to revive this configuration will need to do it within EAMxx and we will likely want to avoid  using a submodule given how tedious it made the original development.

[BFB]