### PR TITLE
pm-cpu: allow building eamxx cases with nvidia compiler

### DIFF
--- a/cime_config/machines/cmake_macros/nvidia_alvarez-cpu.cmake
+++ b/cime_config/machines/cmake_macros/nvidia_alvarez-cpu.cmake
@@ -6,14 +6,19 @@ string(APPEND CMAKE_C_FLAGS_RELEASE " -O2")
 string(APPEND CMAKE_CXX_FLAGS_RELEASE " -O2")
 string(APPEND CMAKE_Fortran_FLAGS_RELEASE " -g")
 
+set(HOMME_QUAD_PREC FALSE CACHE BOOL "") # nvidia does not seem to support QUAD
+
+# Appears no longer needed after PR
 # currently, there is known issue with nvidia compiler installation (not seeing all relevant include files)
 # and this is temporary work-around github.com/E3SM-Project/E3SM/issues/7003
-string(APPEND CMAKE_CXX_FLAGS_RELEASE " --gcc-toolchain=/usr/bin/gcc")
-string(APPEND CMAKE_CXX_FLAGS_DEBUG " --gcc-toolchain=/usr/bin/gcc")
+#string(APPEND CMAKE_CXX_FLAGS_RELEASE " --gcc-toolchain=/usr/bin/gcc")
+#string(APPEND CMAKE_CXX_FLAGS_DEBUG " --gcc-toolchain=/usr/bin/gcc")
 
-if (compile_threaded)
-  string(APPEND KOKKOS_OPTIONS " -DKokkos_ENABLE_OPENMP=Off") # work-around for nvidia as kokkos is not passing "-mp" for threaded build
-endif()
+# Also appears no longer needed after PR
+#if (compile_threaded)
+#  string(APPEND KOKKOS_OPTIONS " -DKokkos_ENABLE_OPENMP=Off") # work-around for nvidia as kokkos is not passing "-mp" for threaded build
+#endif()
+
 set(MPICC "cc")
 set(MPICXX "CC")
 set(MPIFC "ftn")

--- a/cime_config/machines/cmake_macros/nvidia_alvarez-cpu.cmake
+++ b/cime_config/machines/cmake_macros/nvidia_alvarez-cpu.cmake
@@ -8,13 +8,13 @@ string(APPEND CMAKE_Fortran_FLAGS_RELEASE " -g")
 
 set(HOMME_QUAD_PREC FALSE CACHE BOOL "") # nvidia does not seem to support QUAD
 
-# Appears no longer needed after PR
+# Appears no longer needed after PR7730
 # currently, there is known issue with nvidia compiler installation (not seeing all relevant include files)
 # and this is temporary work-around github.com/E3SM-Project/E3SM/issues/7003
 #string(APPEND CMAKE_CXX_FLAGS_RELEASE " --gcc-toolchain=/usr/bin/gcc")
 #string(APPEND CMAKE_CXX_FLAGS_DEBUG " --gcc-toolchain=/usr/bin/gcc")
 
-# Also appears no longer needed after PR
+# Also appears no longer needed after PR7730
 #if (compile_threaded)
 #  string(APPEND KOKKOS_OPTIONS " -DKokkos_ENABLE_OPENMP=Off") # work-around for nvidia as kokkos is not passing "-mp" for threaded build
 #endif()

--- a/cime_config/machines/cmake_macros/nvidia_muller-cpu.cmake
+++ b/cime_config/machines/cmake_macros/nvidia_muller-cpu.cmake
@@ -6,14 +6,19 @@ string(APPEND CMAKE_C_FLAGS_RELEASE " -O2")
 string(APPEND CMAKE_CXX_FLAGS_RELEASE " -O2")
 string(APPEND CMAKE_Fortran_FLAGS_RELEASE " -g")
 
+set(HOMME_QUAD_PREC FALSE CACHE BOOL "") # nvidia does not seem to support QUAD
+
+# Appears no longer needed after PR
 # currently, there is known issue with nvidia compiler installation (not seeing all relevant include files)
 # and this is temporary work-around github.com/E3SM-Project/E3SM/issues/7003
-string(APPEND CMAKE_CXX_FLAGS_RELEASE " --gcc-toolchain=/usr/bin/gcc")
-string(APPEND CMAKE_CXX_FLAGS_DEBUG " --gcc-toolchain=/usr/bin/gcc")
+#string(APPEND CMAKE_CXX_FLAGS_RELEASE " --gcc-toolchain=/usr/bin/gcc")
+#string(APPEND CMAKE_CXX_FLAGS_DEBUG " --gcc-toolchain=/usr/bin/gcc")
 
-if (compile_threaded)
-  string(APPEND KOKKOS_OPTIONS " -DKokkos_ENABLE_OPENMP=Off") # work-around for nvidia as kokkos is not passing "-mp" for threaded build
-endif()
+# Also appears no longer needed after PR
+#if (compile_threaded)
+#  string(APPEND KOKKOS_OPTIONS " -DKokkos_ENABLE_OPENMP=Off") # work-around for nvidia as kokkos is not passing "-mp" for threaded build
+#endif()
+
 set(MPICC "cc")
 set(MPICXX "CC")
 set(MPIFC "ftn")

--- a/cime_config/machines/cmake_macros/nvidia_muller-cpu.cmake
+++ b/cime_config/machines/cmake_macros/nvidia_muller-cpu.cmake
@@ -8,13 +8,13 @@ string(APPEND CMAKE_Fortran_FLAGS_RELEASE " -g")
 
 set(HOMME_QUAD_PREC FALSE CACHE BOOL "") # nvidia does not seem to support QUAD
 
-# Appears no longer needed after PR
+# Appears no longer needed after PR7730
 # currently, there is known issue with nvidia compiler installation (not seeing all relevant include files)
 # and this is temporary work-around github.com/E3SM-Project/E3SM/issues/7003
 #string(APPEND CMAKE_CXX_FLAGS_RELEASE " --gcc-toolchain=/usr/bin/gcc")
 #string(APPEND CMAKE_CXX_FLAGS_DEBUG " --gcc-toolchain=/usr/bin/gcc")
 
-# Also appears no longer needed after PR
+# Also appears no longer needed after PR7730
 #if (compile_threaded)
 #  string(APPEND KOKKOS_OPTIONS " -DKokkos_ENABLE_OPENMP=Off") # work-around for nvidia as kokkos is not passing "-mp" for threaded build
 #endif()

--- a/cime_config/machines/cmake_macros/nvidia_pm-cpu.cmake
+++ b/cime_config/machines/cmake_macros/nvidia_pm-cpu.cmake
@@ -5,9 +5,8 @@ endif()
 string(APPEND CMAKE_C_FLAGS_RELEASE " -O2")
 string(APPEND CMAKE_CXX_FLAGS_RELEASE " -O2")
 string(APPEND CMAKE_Fortran_FLAGS_RELEASE " -g")
-if (compile_threaded)
-  string(APPEND KOKKOS_OPTIONS " -DKokkos_ENABLE_OPENMP=Off") # work-around for nvidia as kokkos is not passing "-mp" for threaded build
-endif()
+
+set(HOMME_QUAD_PREC FALSE CACHE BOOL "") # nvidia does not seem to support QUAD
 
 set(MPICC "cc")
 set(MPICXX "CC")

--- a/components/eamxx/CMakeLists.txt
+++ b/components/eamxx/CMakeLists.txt
@@ -572,7 +572,11 @@ if (SCREAM_DOUBLE_PRECISION)
     set(SCREAM_Fortran_FLAGS -real-size 64)
   elseif("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "Cray")
     set(SCREAM_Fortran_FLAGS -s default32 -eZ)
-  else()
+  elseif("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "NVHPC")
+    #set(SCREAM_Fortran_FLAGS -real-size=8 -double-size=8) # these are nvidia flags, but dont need, already supports IEEE 754 floating-point standard
+  elseif("${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU")
+    set(SCREAM_Fortran_FLAGS -fdefault-real-8 -fdefault-double-8)
+  else() # default, currently same as GNU
     set(SCREAM_Fortran_FLAGS -fdefault-real-8 -fdefault-double-8)
   endif()
 endif()

--- a/components/eamxx/src/dynamics/homme/interface/homme_grid_mod.F90
+++ b/components/eamxx/src/dynamics/homme/interface/homme_grid_mod.F90
@@ -16,7 +16,7 @@ module homme_grid_mod
   public :: get_num_local_columns_f90, get_num_global_columns_f90
   public :: get_num_local_elems_f90, get_num_global_elems_f90
   public :: get_np_f90, get_nlev_f90
-  public :: is_planar_geometry_f90
+  public :: is_planar_geometry_f90, check_grids_inited
 
 contains
 
@@ -31,7 +31,7 @@ contains
     endif
   end function is_planar_geometry_f90
 
-  subroutine check_grids_inited (expected)
+  subroutine check_grids_inited (expected) bind(c)
     use parallel_mod,      only: abortmp
     use homme_context_mod, only: is_geometry_inited
     !


### PR DESCRIPTION
We already test eam cases with nvidia compiler on pm-cpu, but there were build issues for eamxx.
These changes allow eamxx cases to build with nvidia on pm-cpu.
We disable QUAD precision (in HOMME) for nvidia as it does not support it.
Remove some previous work-arounds for nvidia compiler.
Change the default flags being set for nvidia.

The only change in homme was to add a function to public list and give it a `bind(c)`.

Fixes https://github.com/E3SM-Project/E3SM/issues/7002
 
[bfb]