### PR TITLE
erp fixes for moab driver

### DIFF
--- a/components/eam/src/cpl/atm_comp_mct.F90
+++ b/components/eam/src/cpl/atm_comp_mct.F90
@@ -504,14 +504,12 @@ CONTAINS
           call atm_export_moab(Eclock, cam_out)
 #endif
        else ! if (StepNo != 0) then
-
-          
-#ifdef HAVE_MOAB
-          call atm_read_srfrest_moab ( EClock )
-#else
           call t_startf('atm_read_srfrest_mct')
           call atm_read_srfrest_mct( EClock, x2a_a, a2x_a )
           call t_stopf('atm_read_srfrest_mct')
+#ifdef HAVE_MOAB
+          call atm_read_srfrest_moab ( EClock )
+         
 #endif
 
           ! Sent .true. as an optional argument so that restart_init is set to .true.  in atm_import

--- a/components/eam/src/cpl/atm_comp_mct.F90
+++ b/components/eam/src/cpl/atm_comp_mct.F90
@@ -90,13 +90,13 @@ module atm_comp_mct
 
   private :: atm_setgsmap_mct
   private :: atm_domain_mct
-  private :: atm_read_srfrest_mct
-  private :: atm_write_srfrest_mct
 #ifdef HAVE_MOAB
   private :: atm_read_srfrest_moab
   private :: atm_write_srfrest_moab
+#else
+  private :: atm_read_srfrest_mct
+  private :: atm_write_srfrest_mct
 #endif
-
 !--------------------------------------------------------------------------
 ! Private data
 !--------------------------------------------------------------------------
@@ -107,10 +107,7 @@ module atm_comp_mct
   integer, parameter  :: nlen = 256     ! Length of character strings
   character(len=nlen) :: fname_srf_cam  ! surface restart filename
   character(len=nlen) :: pname_srf_cam  ! surface restart full pathname
-#ifdef HAVE_MOAB
-  character(len=nlen) :: moab_fname_srf_cam  ! surface restart filename
-  character(len=nlen) :: moab_pname_srf_cam  ! surface restart full pathname
-#endif
+
   ! Filename specifier for restart surface file
   character(len=cl) :: rsfilename_spec_cam
 
@@ -508,11 +505,13 @@ CONTAINS
 #endif
        else ! if (StepNo != 0) then
 
+          
+#ifdef HAVE_MOAB
+          call atm_read_srfrest_moab ( EClock )
+#else
           call t_startf('atm_read_srfrest_mct')
           call atm_read_srfrest_mct( EClock, x2a_a, a2x_a )
           call t_stopf('atm_read_srfrest_mct')
-#ifdef HAVE_MOAB
-          call atm_read_srfrest_moab ( EClock )
 #endif
 
           ! Sent .true. as an optional argument so that restart_init is set to .true.  in atm_import
@@ -767,13 +766,15 @@ CONTAINS
     ! Write merged surface data restart file if appropriate
 
     if (rstwr_sync) then
+       
+#ifdef HAVE_MOAB
+       call atm_write_srfrest_moab(yr_spec=yr_sync, &
+            mon_spec=mon_sync, day_spec=day_sync, sec_spec=tod_sync)
+#else
        call t_startf('atm_write_srfrest_mct')
        call atm_write_srfrest_mct( x2a_a, a2x_a, &
             yr_spec=yr_sync, mon_spec=mon_sync, day_spec=day_sync, sec_spec=tod_sync)
        call t_stopf('atm_write_srfrest_mct')
-#ifdef HAVE_MOAB
-       call atm_write_srfrest_moab(yr_spec=yr_sync, &
-            mon_spec=mon_sync, day_spec=day_sync, sec_spec=tod_sync)
 #endif
     end if
 
@@ -1011,12 +1012,11 @@ CONTAINS
         curr_day=day_spec, curr_tod=sec_spec )
    fname_srf_cam = interpret_filename_spec( rsfilename_spec_cam, case=get_restcase(), &
         yr_spec=yr_spec, mon_spec=mon_spec, day_spec=day_spec, sec_spec= sec_spec )
-   !moab_fname_srf_cam = 'moab_'//trim(fname_srf_cam)
-   moab_fname_srf_cam = trim(fname_srf_cam)
-   moab_pname_srf_cam = trim(get_restartdir() )//trim(moab_fname_srf_cam)
-   call getfil(moab_pname_srf_cam, moab_fname_srf_cam)
 
-   call cam_pio_openfile(File, moab_fname_srf_cam, 0)
+   pname_srf_cam = trim(get_restartdir() )//trim(fname_srf_cam)
+   call getfil(pname_srf_cam, fname_srf_cam)
+
+   call cam_pio_openfile(File, fname_srf_cam, 0)
 
    call pio_initdecomp(pio_subsystem, pio_double, (/ngcols/), global_ids, iodesc)
 
@@ -1126,14 +1126,12 @@ CONTAINS
 
    ! Determine and open surface restart dataset
 
-      ! Determine and open surface restart dataset
+   fname_srf_cam = interpret_filename_spec( rsfilename_spec_cam, &
+   yr_spec=yr_spec, mon_spec=mon_spec, day_spec=day_spec, sec_spec= sec_spec )
 
-   !moab_fname_srf_cam = 'moab_'//trim(fname_srf_cam)
-   moab_fname_srf_cam = trim(fname_srf_cam)
-
-   call cam_pio_createfile(File, trim(moab_fname_srf_cam))
+   call cam_pio_createfile(File, trim(fname_srf_cam))
    if (masterproc) then
-      write(iulog,*)'create file :', trim(moab_fname_srf_cam)
+      write(iulog,*)'create file :', trim(fname_srf_cam)
    end if
 
    call pio_initdecomp(pio_subsystem, pio_double, (/ngcols/), global_ids, iodesc)
@@ -1318,8 +1316,7 @@ CONTAINS
     fname_srf_cam = interpret_filename_spec( rsfilename_spec_cam, &
          yr_spec=yr_spec, mon_spec=mon_spec, day_spec=day_spec, sec_spec= sec_spec )
 
-    tmp_fname_srf_cam = 'mct_'//trim(fname_srf_cam)
-    call cam_pio_createfile(File, tmp_fname_srf_cam)
+    call cam_pio_createfile(File, fname_srf_cam)
     call pio_initdecomp(pio_subsystem, pio_double, (/ngcols/), dof, iodesc)
 
     nf_x2a = mct_aVect_nRattr(x2a_a)

--- a/components/eam/src/cpl/atm_comp_mct.F90
+++ b/components/eam/src/cpl/atm_comp_mct.F90
@@ -1011,7 +1011,8 @@ CONTAINS
         curr_day=day_spec, curr_tod=sec_spec )
    fname_srf_cam = interpret_filename_spec( rsfilename_spec_cam, case=get_restcase(), &
         yr_spec=yr_spec, mon_spec=mon_spec, day_spec=day_spec, sec_spec= sec_spec )
-   moab_fname_srf_cam = 'moab_'//trim(fname_srf_cam)
+   !moab_fname_srf_cam = 'moab_'//trim(fname_srf_cam)
+   moab_fname_srf_cam = trim(fname_srf_cam)
    moab_pname_srf_cam = trim(get_restartdir() )//trim(moab_fname_srf_cam)
    call getfil(moab_pname_srf_cam, moab_fname_srf_cam)
 
@@ -1127,7 +1128,8 @@ CONTAINS
 
       ! Determine and open surface restart dataset
 
-   moab_fname_srf_cam = 'moab_'//trim(fname_srf_cam)
+   !moab_fname_srf_cam = 'moab_'//trim(fname_srf_cam)
+   moab_fname_srf_cam = trim(fname_srf_cam)
 
    call cam_pio_createfile(File, trim(moab_fname_srf_cam))
    if (masterproc) then
@@ -1239,7 +1241,6 @@ CONTAINS
          yr_spec=yr_spec, mon_spec=mon_spec, day_spec=day_spec, sec_spec= sec_spec )
     pname_srf_cam = trim(get_restartdir() )//fname_srf_cam
     call getfil(pname_srf_cam, fname_srf_cam)
-
     call cam_pio_openfile(File, fname_srf_cam, 0)
     call pio_initdecomp(pio_subsystem, pio_double, (/ngcols/), dof, iodesc)
     allocate(tmp(size(dof)))
@@ -1309,6 +1310,7 @@ CONTAINS
     type(io_desc_t)           :: iodesc
     character(CL)             :: itemc       ! string converted to char
     type(mct_string)          :: mstring     ! mct char type
+    character(len=nlen)       :: tmp_fname_srf_cam 
     !-----------------------------------------------------------------------
 
     ! Determine and open surface restart dataset
@@ -1316,7 +1318,8 @@ CONTAINS
     fname_srf_cam = interpret_filename_spec( rsfilename_spec_cam, &
          yr_spec=yr_spec, mon_spec=mon_spec, day_spec=day_spec, sec_spec= sec_spec )
 
-    call cam_pio_createfile(File, fname_srf_cam)
+    tmp_fname_srf_cam = 'mct_'//trim(fname_srf_cam)
+    call cam_pio_createfile(File, tmp_fname_srf_cam)
     call pio_initdecomp(pio_subsystem, pio_double, (/ngcols/), dof, iodesc)
 
     nf_x2a = mct_aVect_nRattr(x2a_a)

--- a/driver-moab/main/cime_comp_mod.F90
+++ b/driver-moab/main/cime_comp_mod.F90
@@ -2529,17 +2529,17 @@ contains
     call seq_diagBGC_zero_mct(mode='all')
     if (read_restart .and. iamin_CPLID) then
 
-      !  if (iamroot_CPLID) then
-      !     write(logunit,103) subname,' Reading restart file ',trim(rest_file)
-      !     call shr_sys_flush(logunit)
-      !  end if
+       if (iamroot_CPLID) then
+          write(logunit,103) subname,' Reading restart file ',trim(rest_file)
+          call shr_sys_flush(logunit)
+       end if
 
-      !  call t_startf('CPL:seq_rest_read-init')
-      !  call seq_rest_read(rest_file, infodata, &
-      !       atm, lnd, ice, ocn, rof, glc, wav, esp, iac, &
-      !       fractions_ax, fractions_lx, fractions_ix, fractions_ox, &
-      !       fractions_rx, fractions_gx, fractions_wx, fractions_zx)
-      !  call t_stopf('CPL:seq_rest_read-init')
+       call t_startf('CPL:seq_rest_read-init')
+       call seq_rest_read(rest_file, infodata, &
+            atm, lnd, ice, ocn, rof, glc, wav, esp, iac, &
+            fractions_ax, fractions_lx, fractions_ix, fractions_ox, &
+            fractions_rx, fractions_gx, fractions_wx, fractions_zx)
+       call t_stopf('CPL:seq_rest_read-init')
        if (iamroot_CPLID) then
           write(logunit,103) subname,' Reading moab restart file ','moab_'//trim(rest_file)
           call shr_sys_flush(logunit)
@@ -3570,16 +3570,16 @@ contains
              call shr_sys_flush(logunit)
           end if
           if (iamin_CPLID) then
-            !  call cime_comp_barriers(mpicom=mpicom_CPLID, timer='CPL:RESTART_READ_BARRIER')
-            !  call t_drvstartf ('CPL:RESTART_READ',cplrun=.true.,barrier=mpicom_CPLID)
-            !  call t_startf('CPL:seq_rest_read')
-            !  call seq_rest_read(drv_resume_file, infodata,                     &
-            !       atm, lnd, ice, ocn, rof, glc, wav, esp, iac,                 &
-            !       fractions_ax, fractions_lx, fractions_ix, fractions_ox,      &
-            !       fractions_rx, fractions_gx, fractions_wx, fractions_zx)
-            !  call t_stopf('CPL:seq_rest_read')
+             call cime_comp_barriers(mpicom=mpicom_CPLID, timer='CPL:RESTART_READ_BARRIER')
+             call t_drvstartf ('CPL:RESTART_READ',cplrun=.true.,barrier=mpicom_CPLID)
+             call t_startf('CPL:seq_rest_read')
+             call seq_rest_read(drv_resume_file, infodata,                     &
+                  atm, lnd, ice, ocn, rof, glc, wav, esp, iac,                 &
+                  fractions_ax, fractions_lx, fractions_ix, fractions_ox,      &
+                  fractions_rx, fractions_gx, fractions_wx, fractions_zx)
+             call t_stopf('CPL:seq_rest_read')
 
-            !  call t_drvstopf  ('CPL:RESTART_READ',cplrun=.true.)
+             call t_drvstopf  ('CPL:RESTART_READ',cplrun=.true.)
 
              if (iamroot_CPLID) then
                write(logunit,103) subname,' resume by moab restart file ','moab_'//trim(drv_resume_file)

--- a/driver-moab/main/cime_comp_mod.F90
+++ b/driver-moab/main/cime_comp_mod.F90
@@ -2529,17 +2529,17 @@ contains
     call seq_diagBGC_zero_mct(mode='all')
     if (read_restart .and. iamin_CPLID) then
 
-       if (iamroot_CPLID) then
-          write(logunit,103) subname,' Reading restart file ',trim(rest_file)
-          call shr_sys_flush(logunit)
-       end if
+      !  if (iamroot_CPLID) then
+      !     write(logunit,103) subname,' Reading restart file ',trim(rest_file)
+      !     call shr_sys_flush(logunit)
+      !  end if
 
-       call t_startf('CPL:seq_rest_read-init')
-       call seq_rest_read(rest_file, infodata, &
-            atm, lnd, ice, ocn, rof, glc, wav, esp, iac, &
-            fractions_ax, fractions_lx, fractions_ix, fractions_ox, &
-            fractions_rx, fractions_gx, fractions_wx, fractions_zx)
-       call t_stopf('CPL:seq_rest_read-init')
+      !  call t_startf('CPL:seq_rest_read-init')
+      !  call seq_rest_read(rest_file, infodata, &
+      !       atm, lnd, ice, ocn, rof, glc, wav, esp, iac, &
+      !       fractions_ax, fractions_lx, fractions_ix, fractions_ox, &
+      !       fractions_rx, fractions_gx, fractions_wx, fractions_zx)
+      !  call t_stopf('CPL:seq_rest_read-init')
        if (iamroot_CPLID) then
           write(logunit,103) subname,' Reading moab restart file ','moab_'//trim(rest_file)
           call shr_sys_flush(logunit)
@@ -3570,16 +3570,16 @@ contains
              call shr_sys_flush(logunit)
           end if
           if (iamin_CPLID) then
-             call cime_comp_barriers(mpicom=mpicom_CPLID, timer='CPL:RESTART_READ_BARRIER')
-             call t_drvstartf ('CPL:RESTART_READ',cplrun=.true.,barrier=mpicom_CPLID)
-             call t_startf('CPL:seq_rest_read')
-             call seq_rest_read(drv_resume_file, infodata,                     &
-                  atm, lnd, ice, ocn, rof, glc, wav, esp, iac,                 &
-                  fractions_ax, fractions_lx, fractions_ix, fractions_ox,      &
-                  fractions_rx, fractions_gx, fractions_wx, fractions_zx)
-             call t_stopf('CPL:seq_rest_read')
+            !  call cime_comp_barriers(mpicom=mpicom_CPLID, timer='CPL:RESTART_READ_BARRIER')
+            !  call t_drvstartf ('CPL:RESTART_READ',cplrun=.true.,barrier=mpicom_CPLID)
+            !  call t_startf('CPL:seq_rest_read')
+            !  call seq_rest_read(drv_resume_file, infodata,                     &
+            !       atm, lnd, ice, ocn, rof, glc, wav, esp, iac,                 &
+            !       fractions_ax, fractions_lx, fractions_ix, fractions_ox,      &
+            !       fractions_rx, fractions_gx, fractions_wx, fractions_zx)
+            !  call t_stopf('CPL:seq_rest_read')
 
-             call t_drvstopf  ('CPL:RESTART_READ',cplrun=.true.)
+            !  call t_drvstopf  ('CPL:RESTART_READ',cplrun=.true.)
 
              if (iamroot_CPLID) then
                write(logunit,103) subname,' resume by moab restart file ','moab_'//trim(drv_resume_file)
@@ -5376,7 +5376,6 @@ contains
     logical         , intent(in)    :: drv_pause
     logical         , intent(in)    :: write_restart
     character(len=*), intent(inout) :: drv_resume_file ! Driver resets state from restart file
-    character(len=CL) :: drv_moab_resume_file ! use a different file for moab; do not overwrite the regular name
 
 103 format( 5A )
 104 format( A, i10.8, i8)
@@ -5393,13 +5392,13 @@ contains
              call shr_sys_flush(logunit)
           endif
 
-          call t_startf('CPL:seq_rest_write')
-          call seq_rest_write(EClock_d, seq_SyncClock, infodata,       &
-               atm, lnd, ice, ocn, rof, glc, wav, esp, iac,            &
-               fractions_ax, fractions_lx, fractions_ix, fractions_ox, &
-               fractions_rx, fractions_gx, fractions_wx, fractions_zx, &
-               trim(cpl_inst_tag), drv_resume_file)
-          call t_stopf('CPL:seq_rest_write')
+         !  call t_startf('CPL:seq_rest_write')
+         !  call seq_rest_write(EClock_d, seq_SyncClock, infodata,       &
+         !       atm, lnd, ice, ocn, rof, glc, wav, esp, iac,            &
+         !       fractions_ax, fractions_lx, fractions_ix, fractions_ox, &
+         !       fractions_rx, fractions_gx, fractions_wx, fractions_zx, &
+         !       trim(cpl_inst_tag), drv_resume_file)
+         !  call t_stopf('CPL:seq_rest_write')
 
 #ifdef MOABDEBUG
           call write_moab_state( .true. )
@@ -5407,7 +5406,7 @@ contains
           call t_startf('CPL:seq_rest_mb_write')
           call seq_rest_mb_write(EClock_d, seq_SyncClock, infodata,       &
                atm, lnd, ice, ocn, rof, glc, wav, esp, iac,            &
-               trim(cpl_inst_tag), samegrid_al, samegrid_lr, drv_moab_resume_file)
+               trim(cpl_inst_tag), samegrid_al, samegrid_lr, drv_resume_file)
           call t_stopf('CPL:seq_rest_mb_write')
 
           if (iamroot_CPLID) then

--- a/driver-moab/main/cime_comp_mod.F90
+++ b/driver-moab/main/cime_comp_mod.F90
@@ -5392,14 +5392,6 @@ contains
              call shr_sys_flush(logunit)
           endif
 
-         !  call t_startf('CPL:seq_rest_write')
-         !  call seq_rest_write(EClock_d, seq_SyncClock, infodata,       &
-         !       atm, lnd, ice, ocn, rof, glc, wav, esp, iac,            &
-         !       fractions_ax, fractions_lx, fractions_ix, fractions_ox, &
-         !       fractions_rx, fractions_gx, fractions_wx, fractions_zx, &
-         !       trim(cpl_inst_tag), drv_resume_file)
-         !  call t_stopf('CPL:seq_rest_write')
-
 #ifdef MOABDEBUG
           call write_moab_state( .true. )
 #endif

--- a/driver-moab/main/component_mod.F90
+++ b/driver-moab/main/component_mod.F90
@@ -788,7 +788,7 @@ subroutine component_init_areacor_moab (comp, mbccid, mbcxid, seq_flds_c2x_fluxe
          ! get areas
          tagname='area:aream:mask'//C_NULL_CHAR
          arrsize = 3 * lsize
-         ierr = iMOAB_GetDoubleTagStorage ( mbccid, tagname, arrsize , comp(1)%mbGridType, areas )
+         ierr = iMOAB_GetDoubleTagStorage ( mbccid, tagname, arrsize , comp(1)%mbGridType, areas(1,1) )
          if (ierr .ne. 0) then
            call shr_sys_abort(subname//' cannot get areas  ')
          endif
@@ -820,7 +820,7 @@ subroutine component_init_areacor_moab (comp, mbccid, mbcxid, seq_flds_c2x_fluxe
            call shr_sys_abort(subname//' cannot define correction tags')
          endif
          arrsize = 2 * lsize
-         ierr = iMOAB_SetDoubleTagStorage( mbccid, tagname, arrsize , comp(1)%mbGridType, factors)
+         ierr = iMOAB_SetDoubleTagStorage( mbccid, tagname, arrsize , comp(1)%mbGridType, factors(1,1))
          if (ierr .ne. 0) then
            call shr_sys_abort(subname//' cannot set correction area factors  ')
          endif
@@ -854,7 +854,7 @@ subroutine component_init_areacor_moab (comp, mbccid, mbcxid, seq_flds_c2x_fluxe
          allocate(vals(lsize, nfields))
          tagname = trim(seq_flds_c2x_fluxes)//C_NULL_CHAR
          arrsize = lsize * nfields
-         ierr = iMOAB_GetDoubleTagStorage( mbccid, tagname, arrsize, comp(1)%mbGridType, vals )
+         ierr = iMOAB_GetDoubleTagStorage( mbccid, tagname, arrsize, comp(1)%mbGridType, vals(1,1) )
          if (ierr .ne. 0) then
            call shr_sys_abort(subname//' cannot get flux values:  '//tagname)
          endif
@@ -868,7 +868,7 @@ subroutine component_init_areacor_moab (comp, mbccid, mbcxid, seq_flds_c2x_fluxe
                enddo
             endif
          enddo
-         ierr = iMOAB_SetDoubleTagStorage( mbccid, tagname, arrsize, comp(1)%mbGridType, vals)
+         ierr = iMOAB_SetDoubleTagStorage( mbccid, tagname, arrsize, comp(1)%mbGridType, vals(1,1))
          if (ierr .ne. 0) then
             call shr_sys_abort(subname//' cannot set new flux values  ')
          endif
@@ -1267,7 +1267,7 @@ subroutine component_init_areacor_moab (comp, mbccid, mbcxid, seq_flds_c2x_fluxe
       ! get vals, multiply, then reset them again
       tagname = trim(seq_flds_fluxes)//C_NULL_CHAR
       arrsize = comp%mblsize * nfields
-      ierr = iMOAB_GetDoubleTagStorage( comp%mbApCCid, tagname, arrsize , comp%mbGridType, vals)
+      ierr = iMOAB_GetDoubleTagStorage( comp%mbApCCid, tagname, arrsize , comp%mbGridType, vals(1,1))
       if (ierr .ne. 0) then
          call shr_sys_abort(subname//' cannot get fluxes  ' //trim(type))
       endif

--- a/driver-moab/main/seq_rest_mod.F90
+++ b/driver-moab/main/seq_rest_mod.F90
@@ -398,7 +398,8 @@ subroutine seq_rest_mb_read(rest_file, infodata, samegrid_al, samegrid_lr)
     !
     !-------------------------------------------------------------------------------
     ! actual moab name is
-    moab_rest_file = 'moab_'//trim(rest_file)
+    !moab_rest_file = 'moab_'//trim(rest_file)
+    moab_rest_file = trim(rest_file) 
     !----------------------------------------------------------------------------
     ! get required infodata
     !----------------------------------------------------------------------------
@@ -641,7 +642,7 @@ subroutine seq_rest_mb_read(rest_file, infodata, samegrid_al, samegrid_lr)
        atm, lnd, ice, ocn, rof, glc, wav, esp, iac,            &
        fractions_ax, fractions_lx, fractions_ix, fractions_ox, &
        fractions_rx, fractions_gx, fractions_wx, fractions_zx, &
-       tag, rest_file)
+       tag, rest_file_org)
 
     implicit none
 
@@ -666,7 +667,9 @@ subroutine seq_rest_mb_read(rest_file, infodata, samegrid_al, samegrid_lr)
     type(mct_aVect)        , intent(inout) :: fractions_wx(:)   ! Fractions on wav grid/decomp
     type(mct_aVect)        , intent(inout) :: fractions_zx(:)   ! Fractions on iac grid/decomp
     character(len=*)       , intent(in)    :: tag
-    character(len=CL)      , intent(out)   :: rest_file         ! Restart filename
+    character(len=CL)      , intent(out)   :: rest_file_org         ! Restart filename
+
+    character(len=CL)                      :: rest_file   !  pre-pend with mct_
 
     integer(IN)   :: n,n1,n2,n3,fk
     integer(IN)   :: curr_ymd         ! Current date YYYYMMDD
@@ -736,9 +739,13 @@ subroutine seq_rest_mb_read(rest_file, infodata, samegrid_al, samegrid_lr)
     call seq_timemgr_EClockGetData( EClock_d, curr_ymd=curr_ymd, curr_tod=curr_tod)
     call shr_cal_date2ymd(curr_ymd,yy,mm,dd)
     write(year_char,'(i6.4)') yy
-    write(rest_file,"(4a,i2.2,a,i2.2,a,i5.5,a)") &
+    write(rest_file_org,"(4a,i2.2,a,i2.2,a,i5.5,a)") &
          trim(case_name), '.cpl'//trim(tag)//'.r.',trim(adjustl(year_char)),'-',mm,'-',dd,'-',curr_tod,'.nc'
 
+    rest_file = 'mct_'//trim(rest_file_org) ! will actually write here, and return the original name
+    ! moab will write the original one, and read the original one; mct will read the original too
+    ! for the time being, read twice, the same file;; comapre mct_ one with original one to see how different 
+    ! they are ! tehy should be no different
     ! Write driver data to restart file
 
     if (iamin_CPLID) then
@@ -785,7 +792,7 @@ subroutine seq_rest_mb_read(rest_file, infodata, samegrid_al, samegrid_lr)
           if (loglevel > 0) write(logunit,"(3A)") subname," write rpointer file ", &
                trim(cvar)
           open(iun, file=cvar, form='FORMATTED')
-          write(iun,'(a)') rest_file
+          write(iun,'(a)') rest_file_org ! will write to rpointer file the origname, not the one with mct in it
           close(iun)
           call shr_file_freeUnit( iun )
        endif
@@ -1061,7 +1068,8 @@ subroutine seq_rest_mb_read(rest_file, infodata, samegrid_al, samegrid_lr)
     call shr_cal_date2ymd(curr_ymd,yy,mm,dd)
     write(year_char,'(i6.4)') yy
     write(rest_file,"(4a,i2.2,a,i2.2,a,i5.5,a)") &
-         'moab_'//trim(case_name), '.cpl'//trim(tag)//'.r.',trim(adjustl(year_char)),'-',mm,'-',dd,'-',curr_tod,'.nc'
+        trim(case_name), '.cpl'//trim(tag)//'.r.',trim(adjustl(year_char)),'-',mm,'-',dd,'-',curr_tod,'.nc'
+       !  'moab_'//trim(case_name), '.cpl'//trim(tag)//'.r.',trim(adjustl(year_char)),'-',mm,'-',dd,'-',curr_tod,'.nc'
 
     ! Write driver data to restart file
 

--- a/driver-moab/main/seq_rest_mod.F90
+++ b/driver-moab/main/seq_rest_mod.F90
@@ -1111,16 +1111,16 @@ subroutine seq_rest_mb_read(rest_file, infodata, samegrid_al, samegrid_lr)
           enddo
        endif
 
-!       if (cplroot) then
-!          iun = shr_file_getUnit()
-!          call seq_infodata_GetData(infodata,restart_pfile=cvar)
-!          if (loglevel > 0) write(logunit,"(3A)") subname," write rpointer file ", &
-!               trim(cvar)
-!          open(iun, file=cvar, form='FORMATTED')
-!          write(iun,'(a)') rest_file
-!          close(iun)
-!          call shr_file_freeUnit( iun )
-!       endif
+       if (cplroot) then
+         iun = shr_file_getUnit()
+         call seq_infodata_GetData(infodata,restart_pfile=cvar)
+         if (loglevel > 0) write(logunit,"(3A)") subname," write rpointer file ", &
+            trim(cvar)
+         open(iun, file=cvar, form='FORMATTED')
+         write(iun,'(a)') rest_file
+         close(iun)
+         call shr_file_freeUnit( iun )
+       endif
 
        call shr_mpi_bcast(rest_file,mpicom_CPLID)
        call seq_io_wopen(rest_file,clobber=.true., model_doi_url=model_doi_url)


### PR DESCRIPTION
Do not write restart files using mct data; use only moab and remove "moab" from the name.
mct parts of frankencoupler still needs to read the restart file though (written by moab)

[BFB]