### PR TITLE
Eamxx: clean up GW Cmake

### DIFF
--- a/components/eamxx/src/physics/gw/CMakeLists.txt
+++ b/components/eamxx/src/physics/gw/CMakeLists.txt
@@ -1,13 +1,5 @@
-set(PATH_TO_LEGACY_GW ${SCREAM_BASE_DIR}/../eam/src/physics/cam/gw)
 set(GW_SRCS
-  ${PATH_TO_LEGACY_GW}/gw_utils.F90
-  ${PATH_TO_LEGACY_GW}/gw_common.F90
-  ${PATH_TO_LEGACY_GW}/gw_convect.F90
-  ${PATH_TO_LEGACY_GW}/gw_diffusion.F90
-  ${PATH_TO_LEGACY_GW}/gw_front.F90
-  ${PATH_TO_LEGACY_GW}/gw_oro.F90
-  ${PATH_TO_LEGACY_GW}/../vdiff_lu_solver.F90
-  ${CMAKE_CURRENT_SOURCE_DIR}/tests/infra/gw_iso_c.f90
+  eamxx_gw_process_interface.cpp
 )
 
 # Add ETI source files if not on CUDA/HIP
@@ -38,16 +30,10 @@ if (NOT EAMXX_ENABLE_GPU OR Kokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE OR Kokkos
 endif()
 
 add_library(gw ${GW_SRCS})
-set_target_properties(gw PROPERTIES
-  Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/modules
-)
 
 target_include_directories(gw PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}
-  ${CMAKE_CURRENT_BINARY_DIR}/modules
   ${CMAKE_CURRENT_SOURCE_DIR}/impl
-  ${PATH_TO_LEGACY_GW}
-  ${PATH_TO_LEGACY_GW}/..
 )
 target_link_libraries(gw physics_share scream_share)
 

--- a/components/eamxx/src/physics/gw/eamxx_gw_process_interface.cpp
+++ b/components/eamxx/src/physics/gw/eamxx_gw_process_interface.cpp
@@ -1,0 +1,26 @@
+#include "gw_functions.hpp"
+#include "eamxx_gw_process_interface.hpp"
+
+#include <ekat_assert.hpp>
+#include <ekat_units.hpp>
+
+#include <array>
+
+namespace scream
+{
+
+// =========================================================================================
+GWMicrophysics::GWMicrophysics(const ekat::Comm& comm, const ekat::ParameterList& params)
+  : AtmosphereProcess(comm, params)
+{
+  // Nothing to do here
+}
+
+// =========================================================================================
+void GWMicrophysics::set_grids(const std::shared_ptr<const GridsManager> grids_manager)
+{
+  m_grid = grids_manager->get_grid("physics");
+}
+
+// =========================================================================================
+} // namespace scream

--- a/components/eamxx/src/physics/gw/eamxx_gw_process_interface.hpp
+++ b/components/eamxx/src/physics/gw/eamxx_gw_process_interface.hpp
@@ -1,0 +1,44 @@
+#ifndef SCREAM_GW_MICROPHYSICS_HPP
+#define SCREAM_GW_MICROPHYSICS_HPP
+
+#include "share/atm_process/atmosphere_process.hpp"
+#include "physics/gw/gw_functions.hpp"
+#include "share/physics/eamxx_common_physics_functions.hpp"
+
+#include <ekat_parameter_list.hpp>
+
+#include <string>
+
+namespace scream
+{
+/*
+ * The class responsible to handle the gravity wave physics
+ *
+ * The AD should store exactly ONE instance of this class stored
+ * in its list of subcomponents (the AD should make sure of this).
+ *
+ * This is currently just a placeholder
+*/
+
+class GWMicrophysics : public AtmosphereProcess
+{
+ public:
+  // Constructors
+  GWMicrophysics (const ekat::Comm& comm, const ekat::ParameterList& params);
+
+  // The type of subcomponent
+  AtmosphereProcessType type () const { return AtmosphereProcessType::Physics; }
+
+  // The name of the subcomponent
+  std::string name () const { return "gw"; }
+
+  // Set the grid
+  void set_grids (const std::shared_ptr<const GridsManager> grids_manager);
+
+ protected:
+  std::shared_ptr<const AbstractGrid> m_grid;
+}; // class GWMicrophysics
+
+} // namespace scream
+
+#endif // SCREAM_GW_MICROPHYSICS_HPP

--- a/components/eamxx/src/physics/gw/tests/infra/CMakeLists.txt
+++ b/components/eamxx/src/physics/gw/tests/infra/CMakeLists.txt
@@ -1,8 +1,25 @@
+set(PATH_TO_LEGACY_GW ${SCREAM_BASE_DIR}/../eam/src/physics/cam/gw)
 set(INFRA_SRCS
   gw_test_data.cpp
   gw_iso_c.f90
+  ${PATH_TO_LEGACY_GW}/gw_utils.F90
+  ${PATH_TO_LEGACY_GW}/gw_common.F90
+  ${PATH_TO_LEGACY_GW}/gw_convect.F90
+  ${PATH_TO_LEGACY_GW}/gw_diffusion.F90
+  ${PATH_TO_LEGACY_GW}/gw_front.F90
+  ${PATH_TO_LEGACY_GW}/gw_oro.F90
+  ${PATH_TO_LEGACY_GW}/../vdiff_lu_solver.F90
+)
+
+set_target_properties(gw PROPERTIES
+  Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/modules
 )
 
 add_library(gw_test_infra ${INFRA_SRCS})
 target_link_libraries(gw_test_infra PUBLIC gw scream_test_support)
-target_include_directories(gw_test_infra PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(gw_test_infra PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CMAKE_CURRENT_BINARY_DIR}/modules
+  ${PATH_TO_LEGACY_GW}
+  ${PATH_TO_LEGACY_GW}/..
+)


### PR DESCRIPTION
There is no reason to build the f90 bridge stuff in the top-level GW. It's only needed for testing.

Also, add a placeholder gw_process so that there is at least one source file in the library when ETI is off.

[BFB]