### PR TITLE
DRAFT - Update NARRM configurations for the v3 release version

### DIFF
--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -3399,7 +3399,7 @@
     <domain name="r025">
       <nx>1440</nx>
       <ny>720</ny>
-      <file grid="atm|lnd" mask="IcoswISC30E3r5">$DIN_LOC_ROOT/share/domains/domain.lnd.r025_IcoswISC30E3r5.240129.nc</file>
+      <file grid="atm|lnd" mask="IcoswISC30E3r5">$DIN_LOC_ROOT/share/domains/domain.lnd.r025_IcoswISC30E3r5.250923.nc</file>
       <file grid="atm|lnd" mask="RRSwISC6to18E3r5">$DIN_LOC_ROOT/share/domains/domain.lnd.r025_RRSwISC6to18E3r5.240402.nc</file>
       <desc>r025 is 1/4 degree river routing grid:</desc>
     </domain>

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -390,7 +390,7 @@ _TESTS = {
             "SMS_Ld1.ne30pg2_r05_IcoswISC30E3r5.WCYCL1850.allactive-wcprod_1850",
             "SMS_Ld1.ne30pg2_r05_IcoswISC30E3r5.WCYCLSSP370.allactive-wcprodssp",
             "SMS_Ld1.ne30pg2_r05_IcoswISC30E3r5.WCYCLSSP585.allactive-wcprodssp",
-            "SMS_Ld1_PS.northamericax4v1pg2_WC14to60E2r3.WCYCL1850.allactive-wcprodrrm_1850",
+            "SMS_Ld1_P256.northamericax4v1pg2_r025_IcoswISC30E3r5.WCYCL1850.allactive-wcprodrrm_1850",
             "SMS_D_Ld1.ne30pg2_r05_IcoswISC30E3r5.CRYO1850",
             )
         },

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -390,7 +390,7 @@ _TESTS = {
             "SMS_Ld1.ne30pg2_r05_IcoswISC30E3r5.WCYCL1850.allactive-wcprod_1850",
             "SMS_Ld1.ne30pg2_r05_IcoswISC30E3r5.WCYCLSSP370.allactive-wcprodssp",
             "SMS_Ld1.ne30pg2_r05_IcoswISC30E3r5.WCYCLSSP585.allactive-wcprodssp",
-            "SMS_Ld1_P256.northamericax4v1pg2_r025_IcoswISC30E3r5.WCYCL1850.allactive-wcprodrrm_1850",
+            "SMS_Ld1_P512.northamericax4v1pg2_r025_IcoswISC30E3r5.WCYCL1850.allactive-wcprodrrm_1850",
             "SMS_D_Ld1.ne30pg2_r05_IcoswISC30E3r5.CRYO1850",
             )
         },

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -152,7 +152,7 @@
 <bnd_topo hgrid="ne0np4_conus_x4v1_lowcon"        >atm/cam/topo/USGS_conusx4v1-tensor12x_consistentSGH_c150924.nc</bnd_topo>
 <bnd_topo hgrid="ne0np4_conus_x4v1_lowcon" npg="2">atm/cam/topo/USGS_conusx4v1pg2_12x_consistentSGH_20200609.nc</bnd_topo>
 <bnd_topo hgrid="ne0np4_northamericax4v1"  >atm/cam/topo/USGS_northamericax4v1_12xdel2_consistentSGH_191023.nc</bnd_topo>
-<bnd_topo hgrid="ne0np4_northamericax4v1" npg="2">atm/cam/topo/USGS_northamericax4v1pg2_12xdel2_consistentSGH_20020209.nc</bnd_topo>
+<bnd_topo hgrid="ne0np4_northamericax4v1" npg="2">atm/cam/topo/USGS-gtopo30_northamericax4v1np4pg2_oroshp_x6t.c20250813.nc</bnd_topo>
 <bnd_topo hgrid="ne0np4_antarcticax4v1"  >atm/cam/topo/USGS-gtopo30_antarcticax4v1_12xdel2_consistentSGH_191120.nc</bnd_topo>
 <bnd_topo hgrid="ne0np4_antarcticax4v1"  npg="2">atm/cam/topo/USGS_gtopo30_antarcticax4v1pg2_12xdel2_consistentSGH_20200925.nc</bnd_topo>
 <bnd_topo hgrid="ne0np4_arcticx4v1"      npg="2">atm/cam/topo/USGS-gtopo30_arcticx4v1pg2_12xdel2_20210527.nc</bnd_topo>

--- a/components/eam/bld/namelist_files/namelist_defaults_eam.xml
+++ b/components/eam/bld/namelist_files/namelist_defaults_eam.xml
@@ -111,9 +111,11 @@
 <ncdata dyn="se" hgrid="ne30np4x8arm"                     nlev="26" ocn="aquaplanet">atm/cam/inic/homme/cami_0003-01-01_arm30x8_L26_ape_c000000.nc</ncdata>
 <ncdata dyn="se" hgrid="ne0np4_arm_x8v3_lowcon"           nlev="30"                 >atm/cam/inic/homme/cami-mam3_0000-01-01_arm_x8v3_lowcon_np4_L30_c000000.nc</ncdata>
 <ncdata dyn="se" hgrid="ne0np4_arm_x8v3_lowcon"           nlev="26" ocn="aquaplanet">atm/cam/inic/homme/cami_0003-01-01_arm_x8v3_lowcon_np4_L26_ape_c000000.nc</ncdata>
+<ncdata dyn="se" hgrid="ne0np4_conus_x4v1_lowcon"         nlev="80"                 >atm/cam/inic/homme/v3.LR_mapped_conusx4v1np4-topoadj.eam.i.2010-01-01.nc</ncdata>
 <ncdata dyn="se" hgrid="ne0np4_conus_x4v1_lowcon"         nlev="72"                 >atm/cam/inic/homme/cami_0002-01-01-00000_conusx4v1np4_L72_c160719.nc</ncdata>
 <ncdata dyn="se" hgrid="ne0np4_conus_x4v1_lowcon"         nlev="30"                 >atm/cam/inic/homme/cami-mam3_0000-01-01_conusx4v1np4_L30_c141106.nc</ncdata>
 <ncdata dyn="se" hgrid="ne0np4_conus_x4v1_lowcon"         nlev="30" ocn="aquaplanet">atm/cam/inic/homme/cami_0003-01-01_conusx4v1np4_L30_ape_c000000.nc</ncdata>
+<ncdata dyn="se" hgrid="ne0np4_northamericax4v1"          nlev="80"                 >atm/cam/inic/homme/v3.LR_mapped_northamericax4v1np4-topoadj.eam.i.2010-01-01.nc</ncdata>
 <ncdata dyn="se" hgrid="ne0np4_northamericax4v1"          nlev="72"                 >atm/cam/inic/homme/cami_0001-01-01_northamericax4v1_c190709.nc</ncdata>
 <ncdata dyn="se" hgrid="ne0np4_antarcticax4v1"            nlev="72"                 >atm/cam/inic/homme/cami_mam3_Linoz_0000-01-antarcticax4v1_L72_topoadj_c20200507.nc</ncdata>
 <ncdata dyn="se" hgrid="ne0np4_arcticx4v1"                nlev="72"                 >atm/cam/inic/homme/eam_i_mam4_Linoz_0011-01-arcticx4v1np4_L72_c20220127.nc</ncdata>

--- a/components/eam/cime_config/config_component.xml
+++ b/components/eam/cime_config/config_component.xml
@@ -55,9 +55,6 @@
       <value compset="_ELM%[^_]*BC"            >-bc_dep_to_snow_updates</value>
       <value compset="_EAM.*_BGC%*"            >-co2_cycle</value>
 
-      <!-- Temporarily override the default v3 vertical grid (L80) and use L72 to maintain RRM test coverage -->
-      <value grid="a%ne0">-nlev 72</value>
-
       <!-- Single column model (SCM) -->
       <value compset="_EAM%SCM_"       >&eamv3_phys_defaults; &eamv3_chem_defaults; -scam</value>
 


### PR DESCRIPTION
This PR updates the North American Regionally Refine Model (NARRM) configurations for the v3 release. Main changes are

- The r025 land domain file generated with `--fminval 1.0e-08`
- The topography file with coarser smoothing
- Add https://github.com/E3SM-Project/E3SM/pull/6698

The following diffs of `*_in` among RRM, LR, and HR needs to be confirmed by relevant groups.

NARRM: `/lcrc/group/e3sm2/ac.qtang/E3SMv3_dev/20250927.v3.narrm.L80_newTopo_r025.F20TR.chrysalis/tests/custom-20-_1x3_ndays`
LR: `/lcrc/group/e3sm2/ac.wlin/E3SMv3/AMIP/v3.LR.amip_0101`
HR: `/lcrc/group/e3sm2/ac.xzheng/E3SMv3_dev/20250906.wcycl1850.ne120pg2_r025_RRSwISC6to18E3r5.test6.1.chrysalis`

**atm_in**:
**diff LR RRM**
```
220c220
<  hypervis_subcycle		=  1 
---
>  hypervis_subcycle		=  2 
222c222
<  hypervis_subcycle_tom		=  1 
---
>  hypervis_subcycle_tom		=  3 
230c230
<  nu_top		=  2.5e5 
---
>  nu_top		=  1e5 
442,444d441
< /
< &spmd_dyn_inparm
<  dyn_npes		= 5400
```
**diff HR RRM**
```
230c220
<  hypervis_subcycle		=  1 
---
>  hypervis_subcycle		=  2 
232c222
<  hypervis_subcycle_tom		=  1 
---
>  hypervis_subcycle_tom		=  3 
468,470d442
< &spmd_dyn_inparm
<  dyn_npes		= 86400
< /
```
**lnd_in**:
**diff LR RRM**
```
57a58
>  tw_irr = .false.
59a61
>  use_atm_downscaling_to_topunit = .false.
64a67
>  use_hydrstress = .false.
```