### PR TITLE
Update OPENACC ifdefs after enddo to match beginning of loop.

### DIFF
--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_si.F
@@ -1437,8 +1437,10 @@ module ocn_time_integration_si
                ! Use of sshNew to save the lagged SSH
                sshNew(iCell) = sshSubcycleNew(iCell)
             end do
+#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
+#endif
    
 #ifdef MPAS_OPENACC
             !$acc parallel loop async &
@@ -1676,8 +1678,10 @@ module ocn_time_integration_si
                SIvec_s0(iCell)  = 0.0_RKIND
                SIvec_z0(iCell)  = 0.0_RKIND
             end do ! iCell
+#ifndef MPAS_OPENACC
             !$omp end do
             !$omp end parallel
+#endif
    
             ! Preconditioning --------------------------------------------!
 
@@ -2555,10 +2559,8 @@ module ocn_time_integration_si
                         layerThicknessNew(k,iCell)
                      end do
                      end do
-#ifndef MPAS_OPENACC
                      !$omp end do
                      !$omp end parallel
-#endif
 
                      ! limit salinity in separate loop
                      if (trim(groupItr%memberName) == &
@@ -2572,10 +2574,8 @@ module ocn_time_integration_si
                            tracersGroupNew(indexSalinity,k,iCell))
                         end do
                         end do
-#ifndef MPAS_OPENACC
                         !$omp end do
                         !$omp end parallel
-#endif
                      end if
 
                      ! Reset debugTracers to fixed value at the surface
@@ -2627,10 +2627,8 @@ module ocn_time_integration_si
                               end do
                            end if
                         end do ! cells
-#ifndef MPAS_OPENACC
                         !$omp end do
                         !$omp end parallel
-#endif
                      end if ! debug tracers
                   end if ! use tracer group
                end if ! tracer

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split.F
@@ -2193,10 +2193,8 @@ module ocn_time_integration_split
                         layerThicknessNew(k,iCell)
                      end do
                      end do
-#ifndef MPAS_OPENACC
                      !$omp end do
                      !$omp end parallel
-#endif
 
                      ! limit salinity in separate loop
                      if (trim(groupItr%memberName) == &
@@ -2210,10 +2208,8 @@ module ocn_time_integration_split
                            tracersGroupNew(indexSalinity,k,iCell))
                         end do
                         end do
-#ifndef MPAS_OPENACC
                         !$omp end do
                         !$omp end parallel
-#endif
                      end if
 
                      ! Reset debugTracers to fixed value at the surface
@@ -2265,10 +2261,8 @@ module ocn_time_integration_split
                               end do
                            end if
                         end do ! cells
-#ifndef MPAS_OPENACC
                         !$omp end do
                         !$omp end parallel
-#endif
                      end if ! debug tracers
                   end if ! use tracer group
                end if ! tracer

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split_ab2.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_time_integration_split_ab2.F
@@ -2366,10 +2366,8 @@ module ocn_time_integration_split_ab2
                         layerThicknessNew(k,iCell)
                      end do
                      end do
-#ifndef MPAS_OPENACC
                      !$omp end do
                      !$omp end parallel
-#endif
 
                      ! limit salinity in separate loop
                      if (trim(groupItr%memberName) == &
@@ -2383,10 +2381,8 @@ module ocn_time_integration_split_ab2
                            tracersGroupNew(indexSalinity,k,iCell))
                         end do
                         end do
-#ifndef MPAS_OPENACC
                         !$omp end do
                         !$omp end parallel
-#endif
                      end if
 
                      ! Reset debugTracers to fixed value at the surface
@@ -2438,10 +2434,8 @@ module ocn_time_integration_split_ab2
                               end do
                            end if
                         end do ! cells
-#ifndef MPAS_OPENACC
                         !$omp end do
                         !$omp end parallel
-#endif
                      end if ! debug tracers
                   end if ! use tracer group
                end if ! tracer


### PR DESCRIPTION
There are several mismatching loops in the timestepping code that cause compile errors if both OpenACC and OpenMP are true. For example, on perlmutter using
```
source load_dev_polaris_0.9.0-alpha.2_pm-cpu_gnu_mpich.sh
cd components/mpas-ocean
make gnu-cray USE_PIO2=true OPENACC=true OPENMP=true DEBUG=true
```
the changes in this PR are required for a successful build. Looking at each loop, you can see that when `MPAS_OPENACC = TRUE` the OpenMP statements do not have matching statements before and after the loop.

[BFB]