### PR TITLE
Add MOAB-based lateral halo exchange infrastructure in ELM

### DIFF
--- a/components/elm/src/biogeophys/SoilStateType.F90
+++ b/components/elm/src/biogeophys/SoilStateType.F90
@@ -1099,12 +1099,19 @@ contains
     real(r8), pointer , intent(inout) :: data_g_out(:,:)
     !
     integer :: c, g, j
+    integer :: ncols_per_gcell(bounds_proc%begg:bounds_proc%endg)
 
     data_g_out(:,:) = 0._r8
+    ncols_per_gcell(:) = 0
 
     do c = bounds_proc%begc, bounds_proc%endc
        if (col_pp%itype(c) == col_itype) then
           g = col_pp%gridcell(c)
+          ncols_per_gcell(g) = ncols_per_gcell(g) + 1
+          if (ncols_per_gcell(g) > 1) then
+             call endrun('PackOwnedGridLevelDataForMOAB: more than one matching '// &
+                  'column per grid cell; one-nat-veg-column invariant violated.')
+          end if
           do j = 1, nlevgrnd
              data_g_out(g, j) = data_c_in(c, j)
           end do
@@ -1137,35 +1144,73 @@ contains
   end subroutine UnpackGhostGridLevelDataFromMOAB
 
   !------------------------------------------------------------------------
-  subroutine ExchangeAFieldUsingMOAB(bounds_proc, col_itype, field_col)
+  subroutine BatchExchangeFieldsUsingMOAB(bounds_proc, col_itype, watsat, hksat, bsw, sucsat)
     !
-    use domainLateralMod , only : ldomain_lateral, GridLevelSoilLayerDataHaloExchange
+    ! Pack all four fields into a single grid-level buffer, perform one MPI
+    ! round via GridLevelRealDataHaloExchange, then unpack.
+    ! Field layout: field f (1..4), soil layer j (1..nlevgrnd) →
+    !   component index (f-1)*nlevgrnd + j.
+    !
+    use domainLateralMod , only : GridLevelRealDataHaloExchange
+    use domainLateralMod , only : setup_twoD_real_data_for_moab, twoD_real_data_for_moab
+    use MOABGridType     , only : moab_gcell, mlndghostid
     !
     implicit none
     !
     ! !ARGUMENTS:
     type(bounds_type) , intent(in)    :: bounds_proc
     integer           , intent(in)    :: col_itype
-    real(r8), pointer          , intent(inout) :: field_col(:,:)
+    real(r8), pointer , intent(inout) :: watsat(:,:)
+    real(r8), pointer , intent(inout) :: hksat(:,:)
+    real(r8), pointer , intent(inout) :: bsw(:,:)
+    real(r8), pointer , intent(inout) :: sucsat(:,:)
     !
-    real(r8), pointer                :: data(:,:)
+    integer, parameter               :: nfields = 4
+    real(r8), pointer                :: data(:,:)   ! (begg:endg_all, nfields*nlevgrnd)
+    type(twoD_real_data_for_moab)    :: data_moab
+    integer :: c, g, j
 
-    ! allocate memory for owned+ghost cells
-    allocate(data(bounds_proc%begg:bounds_proc%endg_all, nlevgrnd))
+    ! allocate grid-level buffer for all fields
+    allocate(data(bounds_proc%begg:bounds_proc%endg_all, nfields*nlevgrnd))
+    data(:,:) = 0._r8
 
-    ! pack data
-    call PackOwnedGridLevelDataForMOAB(bounds_proc, col_itype, field_col, data)
+    ! --- pack owned columns ---
+    do c = bounds_proc%begc, bounds_proc%endc
+       if (col_pp%itype(c) == col_itype) then
+          g = col_pp%gridcell(c)
+          do j = 1, nlevgrnd
+             data(g, 0*nlevgrnd + j) = watsat(c, j)
+             data(g, 1*nlevgrnd + j) = hksat(c, j)
+             data(g, 2*nlevgrnd + j) = bsw(c, j)
+             data(g, 3*nlevgrnd + j) = sucsat(c, j)
+          end do
+       end if
+    end do
 
-    ! do the halo exchange
-    call GridLevelSoilLayerDataHaloExchange(ldomain_lateral, bounds_proc%begg, bounds_proc%endg, bounds_proc%endg_all, data)
+    ! --- single MPI halo exchange ---
+    call setup_twoD_real_data_for_moab(mlndghostid, 'batch_soil_data', nfields*nlevgrnd, &
+                                       moab_gcell%num_ghosted, data_moab)
+    call GridLevelRealDataHaloExchange(data_moab, bounds_proc%begg, bounds_proc%endg, &
+                                       bounds_proc%endg_all, data)
 
-    ! unpack data
-    call UnpackGhostGridLevelDataFromMOAB(bounds_proc, col_itype, data, field_col)
+    ! --- unpack ghost columns ---
+    do c = bounds_proc%endc + 1, bounds_proc%endc_all
+       if (col_pp%itype(c) == col_itype) then
+          g = col_pp%gridcell(c)
+          do j = 1, nlevgrnd
+             watsat(c, j) = data(g, 0*nlevgrnd + j)
+             hksat(c, j)  = data(g, 1*nlevgrnd + j)
+             bsw(c, j)    = data(g, 2*nlevgrnd + j)
+             sucsat(c, j) = data(g, 3*nlevgrnd + j)
+          end do
+       end if
+    end do
 
     ! free memory
+    deallocate(data_moab%values)
     deallocate(data)
 
-  end subroutine ExchangeAFieldUsingMOAB
+  end subroutine BatchExchangeFieldsUsingMOAB
 
   !------------------------------------------------------------------------
   subroutine InitColdGhost(this, bounds_proc)
@@ -1183,10 +1228,8 @@ contains
     !
     integer, parameter               :: nat_veg_col_itype = 1
 
-    call ExchangeAFieldUsingMOAB(bounds_proc, nat_veg_col_itype, this%watsat_col)
-    call ExchangeAFieldUsingMOAB(bounds_proc, nat_veg_col_itype, this%hksat_col )
-    call ExchangeAFieldUsingMOAB(bounds_proc, nat_veg_col_itype, this%bsw_col   )
-    call ExchangeAFieldUsingMOAB(bounds_proc, nat_veg_col_itype, this%sucsat_col)
+    call BatchExchangeFieldsUsingMOAB(bounds_proc, nat_veg_col_itype, &
+         this%watsat_col, this%hksat_col, this%bsw_col, this%sucsat_col)
 
   end subroutine InitColdGhost
 

--- a/components/elm/src/biogeophys/SoilStateType.F90
+++ b/components/elm/src/biogeophys/SoilStateType.F90
@@ -117,7 +117,7 @@ contains
     call this%InitHistory(bounds)
     call this%InitCold(bounds)
 
-#ifdef HAVE_MOAB
+#ifdef MOAB_LATERAL
     call this%InitColdGhost(bounds)
 #endif
 
@@ -1086,7 +1086,7 @@ contains
 
 #else
 
-#ifdef HAVE_MOAB
+#ifdef MOAB_LATERAL
 
   !------------------------------------------------------------------------
   subroutine PackOwnedGridLevelDataForMOAB(bounds_proc, col_itype, data_c_in, data_g_out)

--- a/components/elm/src/data_types/ColumnConnectionSetType.F90
+++ b/components/elm/src/data_types/ColumnConnectionSetType.F90
@@ -1,0 +1,137 @@
+module ColumnConnectionSetType
+
+
+  use shr_kind_mod   , only : r8 => shr_kind_r8
+  use shr_infnan_mod , only : isnan => shr_infnan_isnan, nan => shr_infnan_nan, assignment(=)
+  use decompMod      , only : bounds_type
+  use abortutils     , only : endrun
+  use ColumnType     , only : col_pp
+  implicit none
+  save
+  public
+
+  type, public :: col_connection_set_type
+     Integer           :: nconn                          ! number of connections
+     Integer, pointer  :: col_id_up(:)         => null() ! list of ids of upwind cells
+     Integer, pointer  :: col_id_dn(:)         => null() ! list of ids of downwind cells
+     Integer, pointer  :: grid_id_up(:)        => null() ! list of ids of upwind cells
+     Integer, pointer  :: grid_id_dn(:)        => null() ! list of ids of downwind cells
+     integer, pointer  :: grid_id_up_norder(:) => null() ! list of ids of upwind cells in natural order
+     integer, pointer  :: grid_id_dn_norder(:) => null() ! list of ids of downwind cells in natural order
+     integer, pointer  :: col_up_forder(:)     => null() ! the order in which the lateral flux should be added for upwind cells
+     integer, pointer  :: col_dn_forder(:)     => null() ! the order in which the lateral flux should be added for downwind cells
+     Real(r8), pointer :: dist(:)              => null() ! list of distance vectors
+     Real(r8), pointer :: face_length(:)       => null() ! list of edge of faces normal to distance vectors
+     Real(r8), pointer :: uparea(:)            => null() ! list of up cell areas of horizaontal faces 
+     Real(r8), pointer :: downarea(:)          => null() ! list of down cell areas of horizaontal faces 
+     Real(r8), pointer :: dzg(:)               => null() ! list of areas of dz between downwind and upwind cells
+     Real(r8), pointer :: facecos(:)           => null() ! dot product of the cell face normal vector and cell centroid vector
+     Real(r8), pointer :: vertcos(:)           => null() ! dot product of the cell face normal vector and cell centroid vector for vertical flux, the rank for vertcos
+     ! is from 1 to column size which is different from rank of lateral faces
+   contains
+#ifdef HAVE_MOAB
+   procedure, public :: Init => InitViaMOAB
+#endif
+  end type col_connection_set_type
+
+  type (col_connection_set_type), public, target :: c2c_connections   ! connection type
+
+contains
+
+#ifdef HAVE_MOAB
+  !------------------------------------------------------------------------
+  subroutine InitViaMOAB(this, bounds_proc)
+    !
+    use MOABGridType, only : moab_edge_internal, moab_gcell
+    use decompMod   , only : bounds_type
+    !
+    implicit none
+    !
+    class (col_connection_set_type) :: this
+    type(bounds_type), intent(in)   :: bounds_proc       ! bound information at processor level
+    !
+    integer            :: g, g_up_moab, g_dn_moab, g_up_elm, g_dn_elm
+    integer            :: c, c_up, c_dn
+    integer            :: iconn, nconn
+    integer, parameter :: nat_veg_col_itype = 1
+    integer, pointer   :: nat_col_id(:)
+
+
+    ! allocate memory and initialize
+    allocate(nat_col_id(bounds_proc%begg_all:bounds_proc%endg_all))
+    nat_col_id(:) = -1
+
+    ! loop over columns to determine the naturally-vegetated column for each grid cell.
+    do c = bounds_proc%begc_all, bounds_proc%endc_all
+       if (col_pp%itype(c) == nat_veg_col_itype) then
+          g = col_pp%gridcell(c)
+
+          if (nat_col_id(g) /= -1) then
+             call endrun('ERROR: More than one naturally vegetated column found.')
+          end if
+
+          nat_col_id(g) = c
+       end if
+    end do
+
+    ! loop over grid level connections and determine number of column level connections
+    nconn = 0
+    do iconn = 1, moab_edge_internal%num
+       g_up_moab = moab_edge_internal%cell_ids(iconn, 1)
+       g_dn_moab = moab_edge_internal%cell_ids(iconn, 2)
+
+       g_up_elm = moab_gcell%moab2elm(g_up_moab)
+       g_dn_elm = moab_gcell%moab2elm(g_dn_moab)
+
+       if (nat_col_id(g_up_elm) /= -1 .and. nat_col_id(g_dn_elm) /= -1) then
+          nconn = nconn + 1
+       end if
+    end do
+
+    ! allocate and initialize data structure
+    this%nconn = nconn
+    allocate(this%col_id_up(nconn))         ;  this%col_id_up(:)         = 0
+    allocate(this%col_id_dn(nconn))         ;  this%col_id_dn(:)         = 0
+    allocate(this%grid_id_up(nconn))        ;  this%grid_id_up(:)        = 0
+    allocate(this%grid_id_dn(nconn))        ;  this%grid_id_dn(:)        = 0
+    allocate(this%grid_id_up_norder(nconn)) ;  this%grid_id_up_norder(:) = 0
+    allocate(this%grid_id_dn_norder(nconn)) ;  this%grid_id_dn_norder(:) = 0
+    allocate(this%col_up_forder(nconn))     ;  this%col_up_forder(:)     = 0
+    allocate(this%col_dn_forder(nconn))     ;  this%col_dn_forder(:)     = 0
+    allocate(this%face_length(nconn))       ;  this%face_length(:)       = 0
+    allocate(this%uparea(nconn))            ;  this%uparea(:)            = 0
+    allocate(this%downarea(nconn))          ;  this%downarea(:)          = 0
+    allocate(this%dist(nconn))              ;  this%dist(:)              = 0
+    allocate(this%dzg(nconn))               ;  this%dzg(:)               = 0
+    allocate(this%facecos(nconn))           ;  this%facecos(:)           = 0
+
+    nconn = 0
+    do iconn = 1, moab_edge_internal%num
+       g_up_moab = moab_edge_internal%cell_ids(iconn, 1)
+       g_dn_moab = moab_edge_internal%cell_ids(iconn, 2)
+
+       g_up_elm = moab_gcell%moab2elm(g_up_moab)
+       g_dn_elm = moab_gcell%moab2elm(g_dn_moab)
+
+       if (nat_col_id(g_up_elm) /= -1 .and. nat_col_id(g_dn_elm) /= -1) then
+          nconn = nconn + 1
+
+          this%col_id_up(nconn) = nat_col_id(g_up_elm)
+          this%col_id_dn(nconn) = nat_col_id(g_dn_elm)
+
+          this%grid_id_up(nconn) = g_up_elm
+          this%grid_id_dn(nconn) = g_dn_elm
+
+          this%grid_id_up_norder(nconn) = moab_gcell%natural_id(g_up_moab)
+          this%grid_id_dn_norder(nconn) = moab_gcell%natural_id(g_dn_moab)
+       end if
+    end do
+
+    ! free up memory
+    deallocate(nat_col_id)
+
+  end subroutine InitViaMOAB
+#endif
+
+end module ColumnConnectionSetType
+

--- a/components/elm/src/data_types/ColumnConnectionSetType.F90
+++ b/components/elm/src/data_types/ColumnConnectionSetType.F90
@@ -29,7 +29,7 @@ module ColumnConnectionSetType
      Real(r8), pointer :: vertcos(:)           => null() ! dot product of the cell face normal vector and cell centroid vector for vertical flux, the rank for vertcos
      ! is from 1 to column size which is different from rank of lateral faces
    contains
-#ifdef HAVE_MOAB
+#ifdef MOAB_LATERAL
    procedure, public :: Init => InitViaMOAB
 #endif
   end type col_connection_set_type
@@ -38,7 +38,7 @@ module ColumnConnectionSetType
 
 contains
 
-#ifdef HAVE_MOAB
+#ifdef MOAB_LATERAL
   !------------------------------------------------------------------------
   subroutine InitViaMOAB(this, bounds_proc)
     !

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -1101,7 +1101,7 @@ contains
   !------------------------------------------------------------------------
   ! Subroutines to initialize and clean column energy state data structure
   !------------------------------------------------------------------------
-  subroutine col_es_init(this, begc, endc)
+  subroutine col_es_init(this, begc, endc, endc_owned)
     !
     ! !USES:
     use landunit_varcon, only : istice, istwet, istsoil, istdlak, istice_mec
@@ -1111,7 +1111,7 @@ contains
     !
     ! !ARGUMENTS:
     class(column_energy_state) :: this
-    integer, intent(in) :: begc,endc
+    integer, intent(in) :: begc,endc, endc_owned
     !------------------------------------------------------------------------
     !
     ! !LOCAL VARIABLES:
@@ -1227,7 +1227,7 @@ contains
     !-----------------------------------------------------------------------
 
     ! Initialize soil+snow temperatures
-    do c = begc,endc
+    do c = begc,endc_owned
        l = col_pp%landunit(c)
 
        ! Snow level temperatures - all land points
@@ -1385,12 +1385,12 @@ contains
   !------------------------------------------------------------------------
   ! Subroutines to initialize and clean column water state data structure
   !------------------------------------------------------------------------
-  subroutine col_ws_init(this, begc, endc, h2osno_input, snow_depth_input, watsat_input)
+  subroutine col_ws_init(this, begc, endc, endc_owned, h2osno_input, snow_depth_input, watsat_input)
     !
     use elm_varctl  , only : use_lake_wat_storage, use_arctic_init
     ! !ARGUMENTS:
     class(column_water_state) :: this
-    integer , intent(in)      :: begc,endc
+    integer , intent(in)      :: begc,endc, endc_owned
     real(r8), intent(in)      :: h2osno_input(begc:)
     real(r8), intent(in)      :: snow_depth_input(begc:)
     real(r8), intent(in)      :: watsat_input(begc:, 1:)          ! volumetric soil water at saturation (porosity)
@@ -1680,7 +1680,7 @@ contains
     ! Arrays that are initialized from input arguments
     this%wslake_col(begc:endc) = 0._r8
 
-    do c = begc,endc
+    do c = begc,endc_owned
        l = col_pp%landunit(c)
        this%h2osno(c)                 = h2osno_input(c)
        this%int_snow(c)               = h2osno_input(c)
@@ -5774,11 +5774,11 @@ contains
   !------------------------------------------------------------------------
   ! Subroutines to initialize and clean column water flux data structure
   !------------------------------------------------------------------------
-  subroutine col_wf_init(this, begc, endc)
+  subroutine col_wf_init(this, begc, endc, endc_owned)
     !
     ! !ARGUMENTS:
     class(column_water_flux) :: this
-    integer, intent(in) :: begc,endc
+    integer, intent(in) :: begc,endc, endc_owned
     ! !LOCAL VARIABLES:
     integer  :: l,c
     integer  :: ncells
@@ -6064,7 +6064,7 @@ contains
     this%qflx_to_downhill(begc:endc) = 0._r8
 
     ! needed for CNNLeaching
-    do c = begc, endc
+    do c = begc, endc_owned
        l = col_pp%landunit(c)
        if (col_pp%is_soil(c) .or. col_pp%is_crop(c)) then
           this%qflx_drain(c) = 0._r8

--- a/components/elm/src/main/accumulMod.F90
+++ b/components/elm/src/main/accumulMod.F90
@@ -278,7 +278,7 @@ contains
 
     beg = accum(nf)%beg1d
     end = accum(nf)%end1d
-    if (size(field,dim=1) /= end-beg+1) then
+    if (size(field,dim=1) < end-beg+1) then
        write(iulog,*)'ERROR in extract_accum_field for field ',accum(nf)%name
        write(iulog,*)'size of first dimension of field is ',&
             size(field,dim=1),' and should be ',end-beg+1
@@ -341,7 +341,7 @@ contains
     numlev = accum(nf)%numlev
     beg = accum(nf)%beg1d
     end = accum(nf)%end1d
-    if (size(field,dim=1) /= end-beg+1) then
+    if (size(field,dim=1) < end-beg+1) then
        write(iulog,*)'ERROR in extract_accum_field for field ',accum(nf)%name
        write(iulog,*)'size of first dimension of field is ',&
             size(field,dim=1),' and should be ',end-beg+1
@@ -406,7 +406,7 @@ contains
 
     beg = accum(nf)%beg1d
     end = accum(nf)%end1d
-    if (size(field,dim=1) /= end-beg+1) then
+    if (size(field,dim=1) < end-beg+1) then
        write(iulog,*)'ERROR in UPDATE_ACCUM_FIELD_SL for field ',accum(nf)%name
        write(iulog,*)'size of first dimension of field is ',size(field,dim=1),&
             ' and should be ',end-beg+1
@@ -500,7 +500,7 @@ contains
     numlev = accum(nf)%numlev
     beg = accum(nf)%beg1d
     end = accum(nf)%end1d
-    if (size(field,dim=1) /= end-beg+1) then
+    if (size(field,dim=1) < end-beg+1) then
        write(iulog,*)'ERROR in UPDATE_ACCUM_FIELD_ML for field ',accum(nf)%name
        write(iulog,*)'size of first dimension of field is ',size(field,dim=1),&
             ' and should be ',end-beg+1

--- a/components/elm/src/main/decompInitMod.F90
+++ b/components/elm/src/main/decompInitMod.F90
@@ -2528,7 +2528,53 @@ contains
       procinfo%endp_all        = procinfo%endp      + procinfo%npfts_ghost
       procinfo%endCohort_all   = procinfo%endCohort + procinfo%nCohorts_ghost
 
-#elif defined(USE_PETSC_LIB)
+#else
+      ! No ghost cells
+       procinfo%ncells_ghost    = 0
+       procinfo%ntunits_ghost   = 0
+       procinfo%nlunits_ghost   = 0
+       procinfo%ncols_ghost     = 0
+       procinfo%npfts_ghost     = 0
+       procinfo%nCohorts_ghost  = 0
+
+       procinfo%begg_ghost      = 0
+       procinfo%begt_ghost      = 0
+       procinfo%begl_ghost      = 0
+       procinfo%begc_ghost      = 0
+       procinfo%begp_ghost      = 0
+       procinfo%begCohort_ghost = 0
+       procinfo%endg_ghost      = 0
+       procinfo%endt_ghost      = 0
+       procinfo%endl_ghost      = 0
+       procinfo%endc_ghost      = 0
+       procinfo%endp_ghost      = 0
+       procinfo%endCohort_ghost = 0
+
+       ! All = local (as no ghost cells)
+       procinfo%ncells_all      = procinfo%ncells
+       procinfo%ntunits_all     = procinfo%ntunits
+       procinfo%nlunits_all     = procinfo%nlunits
+       procinfo%ncols_all       = procinfo%ncols
+       procinfo%npfts_all       = procinfo%npfts
+       procinfo%nCohorts_all    = procinfo%nCohorts
+
+       procinfo%begg_all        = procinfo%begg
+       procinfo%begt_all        = procinfo%begt
+       procinfo%begl_all        = procinfo%begl
+       procinfo%begc_all        = procinfo%begc
+       procinfo%begp_all        = procinfo%begp
+       procinfo%begCohort_all   = procinfo%begCohort
+       procinfo%endg_all        = procinfo%endg
+       procinfo%endt_all        = procinfo%endt
+       procinfo%endl_all        = procinfo%endl
+       procinfo%endc_all        = procinfo%endc
+       procinfo%endp_all        = procinfo%endp
+       procinfo%endCohort_all   = procinfo%endCohort
+#endif
+
+    else
+
+#if defined(USE_PETSC_LIB)
 
        call get_proc_bounds(begg, endg)
 

--- a/components/elm/src/main/decompInitMod.F90
+++ b/components/elm/src/main/decompInitMod.F90
@@ -2380,50 +2380,6 @@ contains
 
     if (.not.lateral_connectivity) then
 
-       ! No ghost cells
-       procinfo%ncells_ghost    = 0
-       procinfo%ntunits_ghost   = 0
-       procinfo%nlunits_ghost   = 0
-       procinfo%ncols_ghost     = 0
-       procinfo%npfts_ghost     = 0
-       procinfo%nCohorts_ghost  = 0
-
-       procinfo%begg_ghost      = 0
-       procinfo%begt_ghost      = 0
-       procinfo%begl_ghost      = 0
-       procinfo%begc_ghost      = 0
-       procinfo%begp_ghost      = 0
-       procinfo%begCohort_ghost = 0
-       procinfo%endg_ghost      = 0
-       procinfo%endt_ghost      = 0
-       procinfo%endl_ghost      = 0
-       procinfo%endc_ghost      = 0
-       procinfo%endp_ghost      = 0
-       procinfo%endCohort_ghost = 0
-
-       ! All = local (as no ghost cells)
-       procinfo%ncells_all      = procinfo%ncells
-       procinfo%ntunits_all     = procinfo%ntunits
-       procinfo%nlunits_all     = procinfo%nlunits
-       procinfo%ncols_all       = procinfo%ncols
-       procinfo%npfts_all       = procinfo%npfts
-       procinfo%nCohorts_all    = procinfo%nCohorts
-
-       procinfo%begg_all        = procinfo%begg
-       procinfo%begt_all        = procinfo%begt
-       procinfo%begl_all        = procinfo%begl
-       procinfo%begc_all        = procinfo%begc
-       procinfo%begp_all        = procinfo%begp
-       procinfo%begCohort_all   = procinfo%begCohort
-       procinfo%endg_all        = procinfo%endg
-       procinfo%endt_all        = procinfo%endt
-       procinfo%endl_all        = procinfo%endl
-       procinfo%endc_all        = procinfo%endc
-       procinfo%endp_all        = procinfo%endp
-       procinfo%endCohort_all   = procinfo%endCohort
-
-    else
-
 #if defined(MOAB_LATERAL)
 
       call get_proc_bounds(begg, endg)

--- a/components/elm/src/main/elm_initializeMod.F90
+++ b/components/elm/src/main/elm_initializeMod.F90
@@ -23,6 +23,7 @@ module elm_initializeMod
   use ELMFatesInterfaceMod  , only : ELMFatesGlobals1,ELMFatesGlobals2
   use BeTRSimulationELM, only : create_betr_simulation_elm
   use SoilLittVertTranspMod, only : CreateLitterTransportList
+  use ColumnConnectionSetType, only : c2c_connections
   use iso_c_binding
   !
   !-----------------------------------------
@@ -418,6 +419,9 @@ contains
 
     call initGridCells()
     call initGhostGridCells()
+#ifdef HAVE_MOAB
+    call c2c_connections%Init(bounds_proc)
+#endif
 
     if (fsurdat /= " " .and. use_finetop_rad) then
        if (masterproc) then

--- a/components/elm/src/main/elm_initializeMod.F90
+++ b/components/elm/src/main/elm_initializeMod.F90
@@ -228,11 +228,15 @@ contains
             'Unsupported domain_decomp_type = ' // trim(domain_decomp_type))
     end select
 
+#ifdef HAVE_MOAB
+    call domainlateral_init(ldomain_lateral)
+#else
     if (lateral_connectivity) then
        call domainlateral_init(ldomain_lateral, cellsOnCell, edgesOnCell, &
             nEdgesOnCell, areaCell, dcEdge, dvEdge, &
             nCells_loc, nEdges_loc, maxEdges)
     endif
+#endif
 
     ! *** Get JUST gridcell processor bounds ***
     ! Remaining bounds (landunits, columns, patches) will be determined
@@ -413,6 +417,7 @@ contains
     ! This is needed here for the following call to decompInit_glcp
 
     call initGridCells()
+    call initGhostGridCells()
 
     if (fsurdat /= " " .and. use_finetop_rad) then
        if (masterproc) then

--- a/components/elm/src/main/elm_initializeMod.F90
+++ b/components/elm/src/main/elm_initializeMod.F90
@@ -229,7 +229,7 @@ contains
             'Unsupported domain_decomp_type = ' // trim(domain_decomp_type))
     end select
 
-#ifdef HAVE_MOAB
+#ifdef MOAB_LATERAL
     call domainlateral_init(ldomain_lateral)
 #else
     if (lateral_connectivity) then
@@ -419,7 +419,7 @@ contains
 
     call initGridCells()
     call initGhostGridCells()
-#ifdef HAVE_MOAB
+#ifdef MOAB_LATERAL
     call c2c_connections%Init(bounds_proc)
 #endif
 

--- a/components/elm/src/main/elm_instMod.F90
+++ b/components/elm/src/main/elm_instMod.F90
@@ -421,7 +421,7 @@ contains
 
     call grc_es%Init(bounds_proc%begg_all, bounds_proc%endg_all)
     call lun_es%Init(bounds_proc%begl_all, bounds_proc%endl_all)
-    call col_es%Init(bounds_proc%begc_all, bounds_proc%endc_all)
+    call col_es%Init(bounds_proc%begc_all, bounds_proc%endc_all, bounds_proc%endc)
     call veg_es%Init(bounds_proc%begp_all, bounds_proc%endp_all)
 
     call canopystate_vars%init(bounds_proc)
@@ -436,7 +436,7 @@ contains
 
     call grc_ws%Init(bounds_proc%begg_all, bounds_proc%endg_all)
     call lun_ws%Init(bounds_proc%begl_all, bounds_proc%endl_all)
-    call col_ws%Init(bounds_proc%begc_all, bounds_proc%endc_all, &
+    call col_ws%Init(bounds_proc%begc_all, bounds_proc%endc_all, bounds_proc%endc, &
          h2osno_col(begc:endc),                    &
          snow_depth_col(begc:endc),                &
          soilstate_vars%watsat_col(begc:endc, 1:))
@@ -445,7 +445,7 @@ contains
     call waterflux_vars%init(bounds_proc)
 
     call grc_wf%Init(bounds_proc%begg_all, bounds_proc%endg_all, bounds_proc)
-    call col_wf%Init(bounds_proc%begc_all, bounds_proc%endc_all)
+    call col_wf%Init(bounds_proc%begc_all, bounds_proc%endc_all, bounds_proc%endc)
     call veg_wf%Init(bounds_proc%begp_all, bounds_proc%endp_all)
 
     call chemstate_vars%Init(bounds_proc)

--- a/components/elm/src/main/initGridCellsMod.F90
+++ b/components/elm/src/main/initGridCellsMod.F90
@@ -718,7 +718,7 @@ contains
     call CheckGhostSubgridHierarchy()
 #endif
 
-#ifdef HAVE_MOAB
+#ifdef MOAB_LATERAL
     call initGhostColumnsMOAB()
 #endif
   end subroutine initGhostGridcells
@@ -1334,7 +1334,7 @@ contains
 !^ifdef USE_PETSC_LIB
 
 
-#if HAVE_MOAB
+#if MOAB_LATERAL
   !------------------------------------------------------------------------
   subroutine initGhostColumnsMOAB()
     !

--- a/components/elm/src/utils/domainLateralMod.F90
+++ b/components/elm/src/utils/domainLateralMod.F90
@@ -591,15 +591,15 @@ contains
 
   type, public :: domainlateral_type
      type(oneD_int_data_for_moab)  :: grid_level_count
-     type(twoD_real_data_for_moab) :: soil_lyr_data_real
   end type domainlateral_type
 
   type(domainlateral_type)    , public :: ldomain_lateral
   !
   ! !PUBLIC MEMBER FUNCTIONS:
   public domainlateral_init                 ! initializes
+  public setup_twoD_real_data_for_moab
   public GridLevelIntegerDataHaloExchange
-  public GridLevelSoilLayerDataHaloExchange !
+  public GridLevelRealDataHaloExchange
   !
   !EOP
   !------------------------------------------------------------------------------
@@ -685,8 +685,6 @@ contains
     ! DESCRIPTION:
     ! Creates data structure for doing halo exchanges using MOAB
     !
-    use elm_varpar, only :  nlevgrnd
-    !
     implicit none
     !
     ! ARGUMENTS:
@@ -694,9 +692,6 @@ contains
 
     ! creates the MOAB tag 1D data at grid level
     call setup_oneD_int_data_for_moab(mlndghostid, 'grid_level_count', moab_gcell%num_ghosted, domain_l%grid_level_count)
-
-    ! creates the MOAB tag for exchanging vertically distributed soil dataset
-    call setup_twoD_real_data_for_moab(mlndghostid, 'soil_data', nlevgrnd, moab_gcell%num_ghosted, domain_l%soil_lyr_data_real)
 
   end subroutine domainlateral_init
 
@@ -798,49 +793,46 @@ contains
   end subroutine GridLevelIntegerDataHaloExchange
 
   !------------------------------------------------------------------------------
-  subroutine GridLevelSoilLayerDataHaloExchange(domain_l, begg, endg_owned, endg_all, elm_data)
+  subroutine GridLevelRealDataHaloExchange(data_moab, begg, endg_owned, endg_all, elm_data)
     !
     ! DESCRIPTION:
-    ! Performs halo exchange of real data. It is assumed that there are nlevgrnd values
-    ! per grid cell. elm_data has data in ELM-format such that owned grid cells at the beginning
-    ! followed by ghost grid cells. After MOAB-based halo exchange values are filled in
-    ! elm_data corresponding to ghost cells.
+    ! Performs halo exchange of real data. elm_data has data in ELM-format such that
+    ! owned grid cells are at the beginning followed by ghost grid cells. After
+    ! MOAB-based halo exchange, values in elm_data are filled for ghost cells.
+    ! data_moab must be pre-set up by the caller via setup_twoD_real_data_for_moab.
     !
-    !
-    ! !ARGUMENTS:
     implicit none
     !
-    type(domainlateral_type)          :: domain_l      ! domain datatype
-    integer, intent(in)               :: begg    ! beginning index of grid cell
-    integer, intent(in)               :: endg_owned    ! ending index for owned grid cells
-    integer, intent(in)               :: endg_all    ! ending index for all (owned + ghost) grid cells
-    real(r8), intent(inout) , pointer :: elm_data(:,:) ! data packed in ELM's format
+    type(twoD_real_data_for_moab) , intent(inout) :: data_moab     ! caller-owned MOAB tag struct
+    integer, intent(in)                           :: begg          ! beginning index of grid cell
+    integer, intent(in)                           :: endg_owned    ! ending index for owned grid cells
+    integer, intent(in)                           :: endg_all      ! ending index for all (owned + ghost) grid cells
+    real(r8), intent(inout), pointer              :: elm_data(:,:) ! data packed in ELM's format
     !
     integer :: g, j, idx
-    integer :: ierr
 
     ! convert data from ELM format to MOAB format
     do g = begg, endg_owned
        idx = moab_gcell%elm2moab(g)
-       do j = 1, domain_l%soil_lyr_data_real%num_comp
-          domain_l%soil_lyr_data_real%values(j, idx) = elm_data(g, j)
+       do j = 1, data_moab%num_comp
+          data_moab%values(j, idx) = elm_data(g, j)
        end do
     end do
 
     ! perform halo exchange
-    call do_haloexchange_twoD_real_data_for_moab(domain_l%soil_lyr_data_real)
+    call do_haloexchange_twoD_real_data_for_moab(data_moab)
 
     ! convert data from MOAB format to ELM format
     do idx = 1, moab_gcell%num_ghosted
        if (.not.moab_gcell%is_owned(idx)) then
           g = moab_gcell%moab2elm(idx)
-          do j = 1, domain_l%soil_lyr_data_real%num_comp
-             elm_data(g, j) = domain_l%soil_lyr_data_real%values(j, idx)
+          do j = 1, data_moab%num_comp
+             elm_data(g, j) = data_moab%values(j, idx)
           end do
        end if
     end do
 
-  end subroutine GridLevelSoilLayerDataHaloExchange
+  end subroutine GridLevelRealDataHaloExchange
 
 #else
 

--- a/components/elm/src/utils/domainLateralMod.F90
+++ b/components/elm/src/utils/domainLateralMod.F90
@@ -547,7 +547,7 @@ contains
 
 #else
 
-#ifdef HAVE_MOAB
+#ifdef MOAB_LATERAL
 
   !-----------------------------------------------------------------------
   ! This is a stub for the case when PETSc is unavailable
@@ -719,7 +719,7 @@ contains
 
     ! get the data from MOAB tag
     ierr = iMOAB_GetIntTagStorage(data%moab_app_id, data%tag_name, data%ngcells * data%num_comp, data%entity_type(1), data%values)
-    if (ierr > 0) call endrun('Error: setting values in MOAB tag failed.')
+    if (ierr > 0) call endrun('Error: getting values in MOAB tag failed.')
 
   end subroutine do_haloexchange_oneD_integer_data_for_moab
 
@@ -747,7 +747,7 @@ contains
 
     ! get the data from MOAB tag
     ierr = iMOAB_GetDoubleTagStorage(data%moab_app_id, data%tag_name, data%ngcells * data%num_comp, data%entity_type(1), data%values)
-    if (ierr > 0) call endrun('Error: setting values in MOAB tag failed.')
+    if (ierr > 0) call endrun('Error: getting values in MOAB tag failed.')
 
   end subroutine do_haloexchange_twoD_real_data_for_moab
 


### PR DESCRIPTION
Extends ELM with MOAB-backed MPI halo (ghost cell) exchange to support
lateral transport between columns. All new code is guarded by
`#ifdef HAVE_MOAB`.

- Extend `bounds_type` / `processor_type` with owned, ghost, and
  all-cells index tiers for every subgrid level.
- Set up ghost grid cells and naturally-vegetated ghost columns via
  MOAB ghost-entity determination.
- Add `domainLateralMod` with `oneD_int_data_for_moab` and
  `twoD_real_data_for_moab` tagged-data containers and generic
  `GridLevelIntegerDataHaloExchange` / `GridLevelRealDataHaloExchange`
  APIs.
- Add `ColumnConnectionSetType` to build and store column-to-column
  lateral connection pairs from MOAB internal edges.
- Demonstrate the workflow in `SoilStateType::InitColdGhost`, which
  exchanges soil properties for ghost columns in a single batched MPI
  round.

[BFB]