### PR TITLE
better handle of ntasks in eam/cice

### DIFF
--- a/components/cice/cime_config/buildnml
+++ b/components/cice/cime_config/buildnml
@@ -41,6 +41,7 @@ def buildnml(case, caseroot, compname):
     nthrds_ice         = case.get_value("NTHRDS_ICE")
     ntasks_ice         = case.get_value("NTASKS_ICE")
     ninst_ice          = case.get_value("NINST_ICE")
+    ntasks             = case.get_value("NTASKS_PER_INST_ICE")
     rundir             = case.get_value("RUNDIR")
     testcase           = case.get_value("TESTCASE")
     casebuild          = case.get_value("CASEBUILD")
@@ -61,7 +62,6 @@ def buildnml(case, caseroot, compname):
     # update env_build.xml settings to reflect changes in the configuration
     # this will trigger whether an automatic build is set upon the job resubmission
     if cice_auto_decomp:
-        ntasks = int(ntasks_ice / ninst_ice)
         hgrid  = ice_grid
         if ice_grid == 'ar9v2': hgrid = 'ar9v1'
         if ice_grid == 'ar9v4': hgrid = 'ar9v3'

--- a/components/eam/cime_config/buildnml
+++ b/components/eam/cime_config/buildnml
@@ -46,6 +46,7 @@ def buildnml(case, caseroot, compname):
     ncpl_base_period	= case.get_value("NCPL_BASE_PERIOD")
     nthrds_atm		= case.get_value("NTHRDS_ATM")
     ntasks_atm		= case.get_value("NTASKS_ATM")
+    ntasks          = case.get_value("NTASKS_PER_INST_ATM")
     ninst_atm		= case.get_value("NINST_ATM")
     pts_mode		= case.get_value("PTS_MODE")
     rundir		= case.get_value("RUNDIR")
@@ -181,7 +182,6 @@ def buildnml(case, caseroot, compname):
             logger.warning("WARNING: {} is being used".format(ncpl_base_period))
 
         start_ymd = run_startdate.replace("-", "")
-        ntasks = ntasks_atm / ninst_atm
 
         if atm_flux_method == 'implicit_stress':
             linearize_pbl_winds = True


### PR DESCRIPTION
Improve the handling of task calculations in the EAM and CICE components by using the proper 
NTASKS_PER_INST_* variables instead of manually calculating tasks per instance. This change ensures correct task 
allocation when dealing with multi-instance configurations.

Fixes #7788 

[BFB]