### PR TITLE
For pm-gpu, change the maxwalltime for debug qos to 30 min

### DIFF
--- a/cime_config/machines/config_batch.xml
+++ b/cime_config/machines/config_batch.xml
@@ -435,7 +435,7 @@
       <queue walltimemax="00:45:00" nodemax="1792" strict="true">preempt</queue>
       <queue walltimemax="00:45:00" nodemax="1792" strict="true">shared</queue>
       <queue walltimemax="00:45:00" nodemax="1792" strict="true">overrun</queue>
-      <queue walltimemax="00:15:00" nodemax="8" strict="true">debug</queue>
+      <queue walltimemax="00:30:00" nodemax="8" strict="true">debug</queue>
     </queues>
   </batch_system>
 
@@ -480,7 +480,7 @@
       <queue walltimemax="00:45:00" nodemax="150" strict="true">preempt</queue>
       <queue walltimemax="00:30:00" nodemax="150" strict="true">shared</queue>
       <queue walltimemax="00:30:00" nodemax="150" strict="true">overrun</queue>
-      <queue walltimemax="00:15:00" nodemax="8" strict="true">debug</queue>
+      <queue walltimemax="00:30:00" nodemax="8" strict="true">debug</queue>
     </queues>
   </batch_system>
 
@@ -525,7 +525,7 @@
       <queue walltimemax="00:45:00" nodemax="150" strict="true">preempt</queue>
       <queue walltimemax="00:30:00" nodemax="150" strict="true">shared</queue>
       <queue walltimemax="00:30:00" nodemax="150" strict="true">overrun</queue>
-      <queue walltimemax="00:15:00" nodemax="8" strict="true">debug</queue>
+      <queue walltimemax="00:30:00" nodemax="8" strict="true">debug</queue>
     </queues>
   </batch_system>
 


### PR DESCRIPTION
This change allows using `create_test` with `-q debug --walltime=00:30:00`, where before, with `strict="true"`, it would override the walltime setting and use 15 min.  Still allowed to use less `-q debug --walltime=00:10:00`.

Just to be consistent, also changed this for muller-gpu/alvarez-gpu.

BFB