### PR TITLE
Update module paths on ALCF Crux for maint-3.0

### DIFF
--- a/cime_config/allactive/config_pesall.xml
+++ b/cime_config/allactive/config_pesall.xml
@@ -2171,6 +2171,24 @@
       </pes>
     </mach>
   </grid>
+  <grid name="a%ne0np4_northamericax4v1.pg2_l%.+_oi%IcoswISC30E3r5">
+    <mach name="improv|crux">
+      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+SGLC.+SWAV.+" pesize="S">
+        <comment>improv|crux+allactive: RRM-WCYCL on 10 nodes</comment>
+        <ntasks>
+          <ntasks_atm>-8</ntasks_atm>
+          <ntasks_cpl>-8</ntasks_cpl>
+          <ntasks_lnd>-8</ntasks_lnd>
+          <ntasks_rof>-8</ntasks_rof>
+          <ntasks_ice>-8</ntasks_ice>
+          <ntasks_ocn>-2</ntasks_ocn>
+        </ntasks>
+        <rootpe>
+          <rootpe_ocn>-8</rootpe_ocn>
+        </rootpe>
+      </pes>
+    </mach>
+  </grid>
   <grid name="a%ne30np4_l%.+oi%oEC60to30.+w%wQU225EC60to30">
     <mach name="anvil|chrysalis">
       <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+SGLC.+WW3" pesize="any">

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -3759,10 +3759,10 @@ commented out until "*** No rule to make target '.../libadios2pio-nm-lib.a'" iss
        </arguments>
     </mpirun>
     <module_system type="module" allow_error="true">
-      <init_path lang="python">/usr/share/lmod/lmod/init/python</init_path>
-      <init_path lang="sh">/usr/share/lmod/lmod/init/sh</init_path>
-      <init_path lang="csh">/usr/share/lmod/lmod/init/csh</init_path>
-      <cmd_path lang="python">/usr/share/lmod/lmod/libexec/lmod python</cmd_path>
+      <init_path lang="python">/opt/cray/pe/lmod/lmod/init/env_modules_python.py</init_path>
+      <init_path lang="sh">/opt/cray/pe/lmod/lmod/init/sh</init_path>
+      <init_path lang="csh">/opt/cray/pe/lmod/lmod/init/csh</init_path>
+      <cmd_path lang="python">/opt/cray/pe/lmod/lmod/libexec/lmod python</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
@@ -3785,6 +3785,7 @@ commented out until "*** No rule to make target '.../libadios2pio-nm-lib.a'" iss
       <env name="PERL5LIB">/grand/E3SMinput/soft/perl5/lib/perl5</env>
       <env name="NETCDF_PATH">$ENV{CRAY_NETCDF_HDF5PARALLEL_PREFIX}</env>
       <env name="PNETCDF_PATH">$ENV{CRAY_PARALLEL_NETCDF_PREFIX}</env>
+      <env name="LD_LIBRARY_PATH">$ENV{CRAY_LD_LIBRARY_PATH}:$ENV{LD_LIBRARY_PATH}</env>
       <env name="FI_CXI_RX_MATCH_MODE">hybrid</env>
     </environment_variables>
     <environment_variables BUILD_THREADED="TRUE">


### PR DESCRIPTION
Update module paths on ALCF Crux
1. change lmod paths
2. load correct versions of hdf5 libs with CRAY_LD_LIBRARY_PATH
3. increase pes 6->10 nodes for new rrm-wcycl case

[BFB]