### PR TITLE
Fix access to empty vector in Pacer

### DIFF
--- a/share/pacer/Pacer.cpp
+++ b/share/pacer/Pacer.cpp
@@ -241,6 +241,11 @@ bool addParentPrefix()
 {
     PACER_CHECK_INIT();
 
+    // return early if there is no enclosing timer
+    if (OpenTimers.empty()) {
+      return true;
+    }
+
     const std::string NewPrefix = CurrentPrefix + OpenTimers.back() + ":";
     
     PACER_CHECK_ERROR(GPTLprefix_set(NewPrefix.c_str()));
@@ -254,6 +259,11 @@ bool addParentPrefix()
 bool removeParentPrefix()
 {
     PACER_CHECK_INIT();
+    
+    // return early if there is no enclosing timer
+    if (OpenTimers.empty()) {
+      return true;
+    }
     
     std::string NewPrefix = CurrentPrefix;
     const int NCharsToErase = OpenTimers.back().length() + 1;


### PR DESCRIPTION
This PR fixes a bug in Pacer (accessing an empty vector) exposed when integrating https://github.com/E3SM-Project/Omega/pull/271 into Omega.

I checked that this commit fixes the Omega issue on Frontier. 

[BFB]