### PR TITLE
Remove redundant sea ice enthalpy flux term

### DIFF
--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -3895,7 +3895,7 @@
 			 description="Heat flux associated with Evaporation at cell centers sent to coupler. Positive into the ocean."
 		/>
 		<var name="seaIceTemperatureFlux" type="real" dimensions="nCells Time" units="C m s^-1"
-			 description="Heat flux associated with sea ice melt water at cell centers sent to coupler. Positive into the ocean."
+			 description="Heat flux associated with sea ice melt water at cell centers sent to coupler. Positive into the ocean. Currently always assigned a value of 0 because it is included in seaIceHeatFlux as assigned by Icepack"
 		/>
 		<var name="icebergTemperatureFlux" type="real" dimensions="nCells Time" units="C m s^-1"
 			 description="Heat flux associated with iceberg melt at cell centers sent to coupler. Positive into the ocean."

--- a/components/mpas-ocean/src/shared/mpas_ocn_surface_bulk_forcing.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_surface_bulk_forcing.F
@@ -763,9 +763,9 @@ contains
 
            ! Accumulate fluxes that use the freezing point
 ! mrp performance note: should call ocn_freezing_temperature just once here
-           seaIceTemperatureFlux(iCell) = seaIceFreshWaterFlux(iCell) * &
-               ocn_freezing_temperature( tracerGroup(index_salinity_flux, minLevelCell(iCell), iCell), pressure=0.0_RKIND, &
-                                         inLandIceCavity=.false.) / rho_sw
+
+           ! Already included in seaIceHeatFlux deriving from Icepack
+           seaIceTemperatureFlux(iCell) = 0.0_RKIND
 
            surfaceTemperatureFluxWithoutRunoff = rainTemperatureFlux(iCell) + evapTemperatureFlux(iCell) + &
                                                  seaIceTemperatureFlux(iCell)


### PR DESCRIPTION
The enthalpy flux associated with `seaIceFreshWaterFlux` is already included in `seaIceHeatFlux` which derives from `fhocn` in Icepack. Thus, it was incorrect to apply both `seaIceHeatFlux` and `seaIceTemperatureFlux` in MPAS-Ocean, as `seaIceTemperatureFlux` provides the thickness of `seaIceFreshWaterFlux` at the freezing point.

Here, we set `seaIceTemperatureFlux` to 0 always. The variable `seaIceTemperatureFlux` could be removed entirely if desired. I retain it here for clarity.

Addresses https://github.com/E3SM-Project/E3SM/issues/8087

[non-BFB][NCC], affects all configurations with active ocean and sea ice components