### PR TITLE
Workflows: limit execution of e3sm-gh-ci/e3sm-gh-ci-w workflows

### DIFF
--- a/.github/workflows/e3sm-gh-ci-cime-tests.yml
+++ b/.github/workflows/e3sm-gh-ci-cime-tests.yml
@@ -7,7 +7,6 @@ on:
       - maint-3.0
     paths:
       # first, yes to these
-      - '.github/workflows/e3sm-gh-ci-cime-tests.yml'
       - 'cime_config/**'
       - 'components/eam/**'
       - 'components/eamxx/**'
@@ -15,12 +14,11 @@ on:
       - 'driver-moab/**'
       - 'driver-mct/**'
       # second, no to these
-      - '!components/eam/docs/**'
-      - '!components/eam/mkdocs.yml'
-      - '!components/eamxx/docs/**'
-      - '!components/eamxx/mkdocs.yml'
-      - '!components/elm/docs/**'
-      - '!components/elm/mkdocs.yml'
+      - '!**/docs/**'
+      - '!**/mkdocs.yml'
+      - '!.github/workflows/**'
+      # Third, DO run if THIS workflow file changes
+      - '.github/workflows/e3sm-gh-ci-cime-tests.yml'
 
   workflow_dispatch:
 

--- a/.github/workflows/e3sm-gh-ci-w-cime-tests.yml
+++ b/.github/workflows/e3sm-gh-ci-w-cime-tests.yml
@@ -5,11 +5,12 @@ on:
     branches: 
       - master
       - maint-3.0
-    paths-ignore:
-      - 'mkdocs.yaml'
-      - 'docs/**'
-      - 'components/*/docs/**'
-      - 'components/*/mkdocs.yml'
+    paths:
+      - '!**/docs/**'
+      - '!**/mkdocs.yml'
+      - '!.github/workflows/**'
+      - '.github/workflows/e3sm-gh-ci-w-cime-tests.yml'
+
 
   workflow_dispatch:
 


### PR DESCRIPTION
Do not run these workflows when OTHER workflows are modified

[BFB]

---

@mahf708 I was tempted to use the same paths clause we use for `ci` also for `ci-w`, but I am not sure if the WCYCL compset is more broad than the ones in `ci`. Is that the case? If not, I can use the same paths clause (with the only differnece of the workflow file name at the bottom) to make it easier for who will maintain these.