### PR TITLE
Fix URL for Omega documentation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ research problems and Department of Energy mission needs while efficiently using
 - [MOSART](./MOSART/index.md)
 - [MPAS-Ocean](./MPAS-Ocean/index.md)
 - [MPAS-seaice](./MPAS-seaice/index.md)
-- [Omega](https://docs.e3sm.org/Omega/omega/) — not yet supported.
+- [Omega](https://docs.e3sm.org/Omega/Omega/index.html) — not yet supported.
 - [Data Models](./Data-Models/index.md)
 
 ## Tools


### PR DESCRIPTION
We moved the location where we build the Omega documentation to be consistent with
other E3SM components. The link from E3SM needs to be updated accordingly.