### PR TITLE
Reduce run length of a debug EAMxx-MAM4xx test

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -848,7 +848,7 @@ _TESTS = {
     "e3sm_eamxx_mam4xx_long_runtime" : {
         "time"  : "03:00:00",
         "tests" : (
-            "SMS_D_Lm2.ne4pg2_oQU480.F2010-EAMxx-MAM4xx-MPASSI.eamxx-L72",
+            "SMS_D_Ld40.ne4pg2_oQU480.F2010-EAMxx-MAM4xx-MPASSI.eamxx-L72",
             "ERS_Ld80.ne4pg2_oQU480.F2010-EAMxx-MAM4xx-MPASSI.eamxx-L72",
             "SMS_Ly1.ne4pg2_oQU480.F2010-EAMxx-MAM4xx-MPASSI.eamxx-L72"
         )


### PR DESCRIPTION
Reducing the length from 2 months to 40 days. We want to test the monthly boundary, and a 40-day run will help cover that. Since this is a new test, it will require a new baseline.

[BFB]