### PR TITLE
Restrict nlmaps_atm2srf_conserve=.true. to v3HR grid

### DIFF
--- a/driver-mct/cime_config/config_component_e3sm.xml
+++ b/driver-mct/cime_config/config_component_e3sm.xml
@@ -245,7 +245,7 @@
     <valid_values>.true.,.false.</valid_values>
     <default_value>.false.</default_value>
     <values match="last">
-      <value grid="a%ne120np4.+oi%RRSwISC6to18E3r5" compset="_EAM.+MPASO">.true.</value>
+      <value grid="a%ne120np4.+oi%RRSwISC6to18E3r5">.true.</value>
     </values>
     <group>seq_infodata_inparm</group>
     <file>env_run.xml</file>


### PR DESCRIPTION
Previously it was set to true for all configurations that use ne120 grid for atm.
This would affect EAM and EAMxx F-cases that use ne120. This change limits its 
use to cases that use v3HR grid (`ne120pg2` for atm and `RRSwISC6to18E3r5` for ocean/ice). 
It applies to both coupled and uncoupled configurations.

[BFB] No impact except for cases using ne120 atm grid with other ocean masks

----------------------------------------------------------------
Verified no impact for v3.HR.piControl-CMIP7 spin-up that uses ne120pg2_r025_RRSwISCE3r5,
previously also tested that nlmaps_atm2srf_conserve=.false. for F1850-CMIP7 that uses the same grid
when the use was restricted to coupled cases. This requirement is now dropped (removing the compset attribute) 