### PR TITLE
toString impls do not need to do allocations

### DIFF
--- a/share/util/shr_strconvert_mod.F90
+++ b/share/util/shr_strconvert_mod.F90
@@ -69,9 +69,10 @@ pure character(len=cs) function i4ToString(input, format_string)
      ! For most compilers, these two statements are equivalent to a format of
      ! '(I0)', but that's not technically in the standard.
      write(i4ToString, '(I11)') input
+     i4ToString = adjustl(i4ToString)
   end if
 
-  i4ToString = trim(adjustl(i4ToString))
+  i4ToString = trim(i4ToString)
 
 end function i4ToString
 
@@ -85,9 +86,10 @@ pure character(len=cs) function i8ToString(input, format_string)
      ! For most compilers, these two statements are equivalent to a format of
      ! '(I0)', but that's not technically in the standard.
      write(i8ToString, '(I20)') input
+     i8ToString = adjustl(i8ToString)
   end if
 
-  i8ToString = trim(adjustl(i8ToString))
+  i8ToString = trim(i8ToString)
 
 end function i8ToString
 
@@ -109,7 +111,7 @@ pure character(len=cs) function r4ToString(input, format_string)
      end if
   end if
 
-  r4ToString = trim(adjustl(r4ToString))
+  r4ToString = trim(r4ToString)
 
 end function r4ToString
 
@@ -131,7 +133,7 @@ pure character(len=cs) function r8ToString(input, format_string)
      end if
   end if
 
-  r8ToString = trim(adjustl(r8ToString))
+  r8ToString = trim(r8ToString)
 
 end function r8ToString
 


### PR DESCRIPTION
This is changing code that is widely used and has been unchanged for a very long time, so I'm adding a lot of reviewers. Feel free to add more.

I stumbled across this code when trying to debug a weird eamxx failure:
https://github.com/E3SM-Project/E3SM/issues/7842

I observed the following symtoms:

If you look at `components/elm/src/main/reweightMod.F90`, you'll see the line `SHR_ASSERT(bounds%level == BOUNDS_LEVEL_CLUMP, errMsg(__FILE__, __LINE__))` which causes this error:
```
1: free(): invalid pointer
...
0: #8  0x4c7e3ab in __shr_log_mod_MOD_shr_log_errmsg
0:      at /pscratch/sd/a/acmetest/E3SM/share/util/shr_log_mod.F90:78
0: #9  0x914149 in __reweightmod_MOD_reweight_wrapup
0:      at /pscratch/sd/a/acmetest/E3SM/components/elm/src/main/reweightMod.F90:48
0: #10  0x17bda7d in __dynsubgriddrivermod_MOD_dynsubgrid_wrapup_weight_changes
0:      at /pscratch/sd/a/acmetest/E3SM/components/elm/src/dyn_subgrid/dynSubgridDriverMod.F90:403
0: #11  0x17bf256 in __dynsubgriddrivermod_MOD_dynsubgrid_init._omp_fn.0
0:      at /pscratch/sd/a/acmetest/E3SM/components/elm/src/dyn_subgrid/dynSubgridDriverMod.F90:150
```

I thought this was because the `SHR_ASSERT `was failing, but that's not the case (both `bounds%level` and `BOUNDS_LEVEL_CLUMP` are always `2`). If I just comment this `SHR_ASSERT` out entirely, the test PASSES!

The lowest line of code that triggers the `free(): invalid pointer` error is:
`shr_log_errMsg = 'ERROR in '//trim(file)//' at line '//toString(line)`

What I think is happening is that there is some memory corruption that is causing the freeing of the allocation done by `toString` to fail. So, this PR kind of sweeps that issue under the rug, but I do think it's better not to do dynamic allocations if you don't have to. The test PASSes with the changes in this PR.

[BFB]