### PR TITLE
EAMxx: ensure dask library is imported for compatibility

### DIFF
--- a/components/eamxx/cime_config/SystemTests/rcs_stats.py
+++ b/components/eamxx/cime_config/SystemTests/rcs_stats.py
@@ -67,6 +67,7 @@ try:
     from utils import _ensure_pylib_impl
 
     _ensure_pylib_impl("xarray")
+    _ensure_pylib_impl("dask")
     _ensure_pylib_impl("scipy")
     _ensure_pylib_impl("statsmodels", min_version="0.14.0")
 


### PR DESCRIPTION
This pull request makes a small update to the dependency checks in `rcs_stats.py` by ensuring that the `dask` library is available before running the script. This is similar to how other required libraries are handled.

[BFB]