### PR TITLE
Add 1850-2023 to ELM sim_year_range for F20TR-CMIP7

### DIFF
--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -1586,7 +1586,7 @@ CLM datasets exist for years: 1000 (for testing), 1850, and 2000
 
 <entry id="sim_year_range" type="char*9" category="default_settings"
        group="default_settings" valid_values=
-"constant,1000-1002,1000-1004,850-1100,1100-1350,1350-1600,1600-1850,1850-2000,1850-2015,1850-2100,2000-2100,2015-2100">
+"constant,1000-1002,1000-1004,850-1100,1100-1350,1350-1600,1600-1850,1850-2000,1850-2015,1850-2023,1850-2100,2000-2100,2015-2100">
 Range of years to simulate transitory datasets for (such as dynamic: land-use datasets, aerosol-deposition, Nitrogen deposition rates etc.)
 Constant means simulation will be held at a constant year given in sim_year.
 A sim_year_range of 1000-1002 or 1000-1004 corresponds to data used for testing only, NOT corresponding to any real datasets.


### PR DESCRIPTION
This is to register the 1850-2023 sim_year_range  specified in the
ELM 20thC_CMIP7_transient use_case file to be recognized as a valid range.

[BFB] No other working configurations are affected.