### PR TITLE
For pm-cpu/pm-gpu: revert to gnu version 12.3 compiler

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -219,7 +219,7 @@
 
       <modules compiler="gnu">
         <command name="load">PrgEnv-gnu/8.5.0</command>
-        <command name="load">gcc-native/13.2</command>
+        <command name="load">gcc-native/12.3</command>
         <command name="load">cray-libsci/24.07.0</command>
       </modules>
 
@@ -409,7 +409,7 @@
 
       <modules compiler="gnu.*">
         <command name="load">PrgEnv-gnu/8.5.0</command>
-        <command name="load">gcc-native/13.2</command>
+        <command name="load">gcc-native/12.3</command>
       </modules>
 
       <modules compiler="nvidia.*">
@@ -425,7 +425,7 @@
       <modules compiler="nvidiagpu">
         <command name="load">cudatoolkit/12.9</command>
         <command name="load">craype-accel-nvidia80</command>
-        <command name="load">gcc-native-mixed/13.2</command>
+        <command name="load">gcc-native-mixed/12.3</command>
       </modules>
 
       <modules compiler="gnu">


### PR DESCRIPTION
Undo a change in https://github.com/E3SM-Project/E3SM/pull/7740, by changing only the GNU compiler version (from 13.2 to 12.3) for pm-cpu/pm-gpu.
Fixes https://github.com/E3SM-Project/E3SM/issues/7871
Fixes https://github.com/E3SM-Project/E3SM/issues/7843
Fixes https://github.com/E3SM-Project/E3SM/issues/7842

Should be BFB for vanilla E3SM cases, but not for eamxx cases.
