### PR TITLE
EAM: Improves error messages in modal_aer_opt.F90

### DIFF
--- a/components/eam/src/physics/cam/modal_aer_opt.F90
+++ b/components/eam/src/physics/cam/modal_aer_opt.F90
@@ -1172,7 +1172,7 @@ subroutine modal_aero_sw(list_idx, dt, state, pbuf, nnite, idxnite, is_cmip6_vol
 
                   nerr_dopaer = nerr_dopaer + 1
                   if (dopaer(i) < -1.e-10_r8) then
-                     write(error_str, *) 'dopaer(', i, ')=', dopaer(i) ,' which is < -1.e-10_r8 (negative aerosol optical depth) in ',&
+                     write(error_str, *) 'ERROR: dopaer(', i, ')=', dopaer(i) ,' which is < -1.e-10_r8 (negative aerosol optical depth) in ',&
                                           trim(subname),' [',trim(errmsg(__FILE__, __LINE__)),']'
                      call endrun(trim(error_str))
                   end if
@@ -1581,7 +1581,7 @@ subroutine modal_aero_lw(list_idx, dt, state, pbuf, tauxar, clear_rh)
                   nerr_dopaer = nerr_dopaer + 1
                   if (nerr_dopaer >= nerrmax_dopaer .or. dopaer(i) < -1.e-10_r8) then
                      write(error_str,*) &
-                        'Maximum number of aerosol optical depth errors exceeded (nerrmax_dopaer = ', &
+                        'ERROR: Maximum number of aerosol optical depth errors exceeded (nerrmax_dopaer = ', &
                         nerrmax_dopaer, ') - OR - dopaer(', i, ') = ', dopaer(i), ' which is < -1.e-10_r8 in ', &
                         trim(subname), ' [', trim(errmsg(__FILE__, __LINE__)),']'
 


### PR DESCRIPTION
Improves error messages in modal_aer_opt.F90 to provide more detailed diagnostic information when aerosol optical depth errors occur, making it easier to debug crashes.

Key changes:

Replaced generic error messages with detailed messages that include the specific value of dopaer(i) causing the error
Added error_str variable to construct comprehensive error messages with file/line information

Fixes #7877 

[BFB]