### PR TITLE
Loads gcc-native/12.3 module on Frontier

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1326,7 +1326,8 @@
         <command name="load">Core/25.03</command>
         <command name="load">PrgEnv-gnu</command>
         <command name="load">cpe/24.11</command>
-        <command name="load">libunwind/1.8.1</command>
+        <command name="load">gcc-native/12.3</command>
+        <command name="load">libunwind</command>
         <command name="load">cray-python/3.11.7</command>
         <command name="load">subversion</command>
         <command name="load">git</command>


### PR DESCRIPTION
This PR resolves the issue of running ERP_Ln22.conusx4v1pg2_r05_oECv3.F2010-SCREAMv1-noAero.frontier_craycray-mphipcc.eamxx-bfbhash--eamxx-L72 test case on Frontier.