### PR TITLE
EAMxx: change behavior of print_global_state_hash

### DIFF
--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -603,6 +603,14 @@ void AtmosphereDriver::create_fields()
   m_atm_process_group->gather_internal_fields();
   for (const auto& f : m_atm_process_group->get_internal_fields()) {
     m_field_mgr->add_field(f);
+
+    // Internal fields have their group names set by the processes that create them.
+    // Hence, simply add them to all the groups they are marked as part of
+    const auto& ftrack = f.get_header().get_tracking();
+    const auto& fid    = f.get_header().get_identifier();
+    for (const auto& gn : ftrack.get_groups_names()) {
+      m_field_mgr->add_to_group(fid, gn);
+    }
   }
 
   // Now go through the input fields/groups to the atm proc group,
@@ -618,15 +626,6 @@ void AtmosphereDriver::create_fields()
       for (const auto& fn : g.m_info->m_fields_names) {
         m_field_mgr->add_to_group(fn, g.grid_name(), "RESTART");
       }
-    }
-  }
-  // Internal fields have their group names set by the processes that create them.
-  // Hence, simply add them to all the groups they are marked as part of
-  for (const auto& f : m_atm_process_group->get_internal_fields()) {
-    const auto& ftrack = f.get_header().get_tracking();
-    const auto& fid    = f.get_header().get_identifier();
-    for (const auto& gn : ftrack.get_groups_names()) {
-      m_field_mgr->add_to_group(fid, gn);
     }
   }
 

--- a/components/eamxx/src/share/atm_process/atmosphere_process.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process.cpp
@@ -179,8 +179,7 @@ void AtmosphereProcess::run (const double dt) {
     if (m_internal_diagnostics_level > 0)
       // Print hash of INPUTS before run
       print_global_state_hash(name() + "-pre-sc-" + std::to_string(m_subcycle_iter),
-                              m_start_of_step_ts,
-                              true, false, true);
+                              m_start_of_step_ts, true);
 
     // Run derived class implementation
     run_impl(dt_sub);
@@ -188,8 +187,7 @@ void AtmosphereProcess::run (const double dt) {
     if (m_internal_diagnostics_level > 0)
       // Print hash of OUTPUTS/INTERNALS after run
       print_global_state_hash(name() + "-pst-sc-" + std::to_string(m_subcycle_iter),
-                              m_end_of_step_ts,
-                              false, true, true);
+                              m_end_of_step_ts, false);
 
     if (has_energy_fixer()){
       const bool water_thermo_fixer = has_air_sea_surface_water_thermo_fixer();
@@ -630,7 +628,8 @@ void AtmosphereProcess::add_me_as_customer (const Field& f) {
   f.get_header_ptr()->get_tracking().add_customer(weak_from_this());
 }
 
-void AtmosphereProcess::add_internal_field (const Field& f, const std::vector<std::string>& groups) {
+void AtmosphereProcess::
+add_internal_field (const Field& f, const std::vector<std::string>& groups) {
   auto& fi = m_internal_fields.emplace_back(f);
   for (const auto& gn : groups) {
     fi.get_header().get_tracking().add_group(gn);

--- a/components/eamxx/src/share/atm_process/atmosphere_process.hpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process.hpp
@@ -286,7 +286,7 @@ public:
   // Note: (mem, nmem) describe an arbitrary device array. If mem!=nullptr,
   // the array will be hashed and reported as an additional entry
   void print_global_state_hash(const std::string& label, const TimeStamp& t,
-                               const bool in = true, const bool out = true, const bool internal = true,
+                               const bool pre_run,
                                const Real* mem = nullptr, const int nmem = 0) const;
 
   // For BFB tracking in production simulations.


### PR DESCRIPTION
When hashing internal fields before the run_impl call, only hash a field if it's part of the RESTART group.

[BFB]

---

More in detail:

- the routine now only requires info on whether it is called before or after the run_impl call;
- if pre-run, hashes input+internal fields, otherwise output+internal;
- in the pre-run call, only hash internal fields that are part of the restart group (the others are assumed to be diagnostic internal fields, and hence they are allowed to have different content before the run_impl call).

Fixes #7885 