### PR TITLE
Updates to FATES zenith angles on the first step of non-continue restarts

### DIFF
--- a/components/elm/src/main/elm_driver.F90
+++ b/components/elm/src/main/elm_driver.F90
@@ -1373,8 +1373,7 @@ contains
        ! On the first step, send the solar zenith angles to FATES on non-continue restarts
        ! for the two-stream radiation scheme.
        if (use_fates .and. .not.doalb .and. get_nstep() == 1 .and. nsrest == nsrStartup) then
-          if ( (trim(finidat) == '') .or. & 
-               (fates_radiation_model=='twostream' .and. .not.use_fates_sp )) then
+          if ( trim(finidat) == '' .or. fates_radiation_model=='twostream') then
              call alm_fates%wrap_canopy_radiation(bounds_clump,surfalb_vars,nextsw_cday,declinp1)
           end if
        end if


### PR DESCRIPTION
These changes ensure that zenith angles are passed to FATES on non-continue restarts on the first step. The legacy FATES radiative transfer scheme (Norman) was not sensitive to this, but the newer two-stream scheme needs this information at this point in the call sequence.

[non-BFB] for FATES tests.