### PR TITLE
Adds a small threshold for checking the sum of percentages of special landunits

### DIFF
--- a/components/elm/tools/mksurfdata_map/src/mkpftMod.F90
+++ b/components/elm/tools/mksurfdata_map/src/mkpftMod.F90
@@ -664,7 +664,7 @@ subroutine mkpft_normalize( pctpft_full, pctspecial, pctnatveg, pctcrop, pctnatp
   ! Error checking
   ! -----------------------------------------------------------------
 
-  if (pctspecial > 100._r8) then
+  if (pctspecial > 100._r8 + 1.e-10) then
      write(6,*) subname//' ERROR: pctspecial > 100: ', pctspecial
      call abort()
   end if


### PR DESCRIPTION
To avoid the tool from crashing when the percentage is slightly above 100.0,
a threshold of 1.e-10 has been added. ELM internally uses a threshold of 1.e-4.

[BFB]