### PR TITLE
EAMxx: add support for rank-0 fields in compute_mask

### DIFF
--- a/components/eamxx/src/share/field/tests/compute_mask.cpp
+++ b/components/eamxx/src/share/field/tests/compute_mask.cpp
@@ -86,7 +86,7 @@ TEST_CASE ("compute_mask") {
     compute_mask(x,3,Comparison::LT,m);
     REQUIRE(views_are_equal(m,one));
 
-    // x<2 is flase
+    // x<2 is false
     m.deep_copy(-1);
     compute_mask(x,2,Comparison::LT,m);
     REQUIRE(views_are_equal(m,zero));

--- a/components/eamxx/src/share/field/utils/compute_mask.cpp
+++ b/components/eamxx/src/share/field/utils/compute_mask.cpp
@@ -145,14 +145,14 @@ void compute_mask (const Field& f, const ScalarWrapper value, Comparison CMP, Fi
   // Sanity checks
   EKAT_REQUIRE_MSG (f.is_allocated(),
       "Error! Input field was not yet allocated.\n"
-      " - field name; " + f.name() + "\n");
+      " - field name: " + f.name() + "\n");
   EKAT_REQUIRE_MSG (f.rank()<=6,
       "Error! Input field rank not supported.\n"
-      " - field name; " + f.name() + "\n"
+      " - field name: " + f.name() + "\n"
       " - field rank: " + std::to_string(f.rank()) + "\n");
   EKAT_REQUIRE_MSG (mask.is_allocated(),
       "Error! Mask field was not yet allocated.\n"
-      " - mask field name; " + mask.name() + "\n");
+      " - mask field name: " + mask.name() + "\n");
   EKAT_REQUIRE_MSG (not mask.is_read_only(),
       "Error! Cannot update mask field, as it is read-only.\n"
       " - mask name: " + mask.name() + "\n");


### PR DESCRIPTION
It is needed in IO when outputing 0d fields.

[BFB]

---

Fixes #7912 