### PR TITLE
EAMXX: ERS_P16_Ln22.ne30pg2_ne30pg2.FIOP-SCREAMv1-DP.eamxx-dpxx-arm97 had fails in elm that we don't care about

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -740,7 +740,7 @@ _TESTS = {
         # each test runs with 225 dynamics and 100 physics columns, roughly size of ne2
         "tests" : (
             "ERS_P16_Ln22.ne30pg2_ne30pg2.FIOP-SCREAMv1-DP.eamxx-dpxx-dycomsrf01",
-            "ERS_P16_Ln22.ne30pg2_ne30pg2.FIOP-SCREAMv1-DP.eamxx-dpxx-arm97",
+            "ERS_P16x1_Ln22.ne30pg2_ne30pg2.FIOP-SCREAMv1-DP.eamxx-dpxx-arm97",
             "ERS_P16_Ln22.ne30pg2_ne30pg2.FIOP-SCREAMv1-DP.eamxx-dpxx-comble",
             "ERS_P16_Ln22.ne30pg2_ne30pg2.FRCE-SCREAMv1-DP",
             )


### PR DESCRIPTION
Changing to 1 thrd fixes the elm issue and doesn't really cost us any coverage (the eamxx stuff will run in parallel on GPU).

[BFB]