### PR TITLE
Add free-slip, partial-slip and no-slip momentum BCs

### DIFF
--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -528,6 +528,12 @@ add_default($nl, 'config_dt');
 add_default($nl, 'config_time_integrator');
 add_default($nl, 'config_number_of_time_levels');
 
+#################################
+# Namelist group: lateral_walls #
+#################################
+
+add_default($nl, 'config_wall_slip_factor');
+
 ########################
 # Namelist group: hmix #
 ########################
@@ -1891,6 +1897,7 @@ my @groups = qw(run_modes
                 io
                 decomposition
                 time_integration
+                lateral_walls
                 hmix
                 hmix_del2
                 hmix_del4

--- a/components/mpas-ocean/bld/build-namelist-group-list
+++ b/components/mpas-ocean/bld/build-namelist-group-list
@@ -3,6 +3,7 @@ my @groups = qw(run_modes
                 io
                 decomposition
                 time_integration
+                lateral_walls
                 hmix
                 hmix_del2
                 hmix_del4

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -48,6 +48,12 @@ add_default($nl, 'config_dt');
 add_default($nl, 'config_time_integrator');
 add_default($nl, 'config_number_of_time_levels');
 
+#################################
+# Namelist group: lateral_walls #
+#################################
+
+add_default($nl, 'config_wall_slip_factor');
+
 ########################
 # Namelist group: hmix #
 ########################

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -61,7 +61,7 @@
 <config_number_of_time_levels>2</config_number_of_time_levels>
 
 <!-- lateral_walls -->
-<config_wall_slip_factor>0.0</config_wall_slip_factor>
+<config_wall_slip_factor>1.0</config_wall_slip_factor>
 
 <!-- hmix -->
 <config_hmix_scaleWithMesh ocn_grid="oQU480">.false.</config_hmix_scaleWithMesh>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -60,6 +60,9 @@
 <config_time_integrator>'split_explicit_ab2'</config_time_integrator>
 <config_number_of_time_levels>2</config_number_of_time_levels>
 
+<!-- lateral_walls -->
+<config_wall_slip_factor>0.0</config_wall_slip_factor>
+
 <!-- hmix -->
 <config_hmix_scaleWithMesh ocn_grid="oQU480">.false.</config_hmix_scaleWithMesh>
 <config_hmix_scaleWithMesh ocn_grid="oQU240">.false.</config_hmix_scaleWithMesh>

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -217,6 +217,17 @@ Default: Defined in namelist_defaults.xml
 </entry>
 
 
+<!-- lateral walls -->
+
+<entry id="config_wall_slip_factor" type="real"
+	category="lateral_walls" group="lateral_walls">
+Lateral wall slip boundary condition: no-slip=0.0, free-slip=1.0, with partial-slip lying in-between. This factor multiplies relative vorticity computed at vertices positioned on lateral boundaries.
+
+Valid values: Any real number between 0.0 and 1.0.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+
 <!-- hmix -->
 
 <entry id="config_hmix_scaleWithMesh" type="logical"

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -217,13 +217,13 @@ Default: Defined in namelist_defaults.xml
 </entry>
 
 
-<!-- lateral walls -->
+<!-- lateral_walls -->
 
 <entry id="config_wall_slip_factor" type="real"
 	category="lateral_walls" group="lateral_walls">
 Lateral wall slip boundary condition: no-slip=0.0, free-slip=1.0, with partial-slip lying in-between. This factor multiplies relative vorticity computed at vertices positioned on lateral boundaries.
 
-Valid values: Any real number between 0.0 and 1.0.
+Valid values: Any real number between 0.0 and 1.0
 Default: Defined in namelist_defaults.xml
 </entry>
 

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -222,7 +222,7 @@
 		/>
 	</nml_record>
 	<nml_record name="lateral_walls" mode="forward">
-		<nml_option name="config_wall_slip_factor" type="real" default_value="0.0"
+		<nml_option name="config_wall_slip_factor" type="real" default_value="1.0"
 					description="Lateral wall slip boundary condition: no-slip=1.0, free-slip=0.0, with partial-slip lying in-between. This factor multiplies relative vorticity computed at vertices positioned on lateral boundaries."
 					possible_values="0.0 - 1.0"
 		/>

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -221,6 +221,12 @@
 					possible_values="Any integer greater than or equal to 2."
 		/>
 	</nml_record>
+	<nml_record name="lateral_walls" mode="forward">
+		<nml_option name="config_wall_slip_factor" type="real" default_value="0.0"
+					description="Lateral wall slip boundary condition: no-slip=1.0, free-slip=0.0, with partial-slip lying in-between. This factor multiplies relative vorticity computed at vertices positioned on lateral boundaries."
+					possible_values="0.0 - 1.0"
+		/>
+	</nml_record>
 	<nml_record name="hmix" mode="forward">
 		<nml_option name="config_hmix_scaleWithMesh" type="logical" default_value=".false."
 					description="If false, del2 and del4 coefficients are constant throughout the mesh (equivalent to setting $\rho_m=1$ throughout the mesh).  If true, these coefficients scale as mesh density to the -3/4 power."

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -222,7 +222,7 @@
 		/>
 	</nml_record>
 	<nml_record name="lateral_walls" mode="forward">
-		<nml_option name="config_wall_slip_factor" type="real" default_value="0.0"
+		<nml_option name="config_wall_slip_factor" type="real" default_value="1.0"
 					description="Lateral wall slip boundary condition: no-slip=0.0, free-slip=1.0, with partial-slip lying in-between. This factor multiplies relative vorticity computed at vertices positioned on lateral boundaries."
 					possible_values="Any real number between 0.0 and 1.0"
 		/>

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -222,9 +222,9 @@
 		/>
 	</nml_record>
 	<nml_record name="lateral_walls" mode="forward">
-		<nml_option name="config_wall_slip_factor" type="real" default_value="1.0"
-					description="Lateral wall slip boundary condition: no-slip=1.0, free-slip=0.0, with partial-slip lying in-between. This factor multiplies relative vorticity computed at vertices positioned on lateral boundaries."
-					possible_values="0.0 - 1.0"
+		<nml_option name="config_wall_slip_factor" type="real" default_value="0.0"
+					description="Lateral wall slip boundary condition: no-slip=0.0, free-slip=1.0, with partial-slip lying in-between. This factor multiplies relative vorticity computed at vertices positioned on lateral boundaries."
+					possible_values="Any real number between 0.0 and 1.0"
 		/>
 	</nml_record>
 	<nml_record name="hmix" mode="forward">

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -643,8 +643,7 @@ contains
 
       integer :: iVertex, iEdge, iCell, i, k
 
-      real (kind=RKIND) :: r_tmp, wall_slip_factor
-      real (kind=RKIND), dimension(:), allocatable :: areaDual
+      real (kind=RKIND) :: r_tmp, wall_slip_factor, areaDual
 
       err = 0
 
@@ -668,43 +667,39 @@ contains
       ! free-slip = 0.0
       ! partial-slip in-between
       wall_slip_factor = config_wall_slip_factor
-      
-      allocate(areaDual(nVertLevels))
 
 #ifdef MPAS_OPENACC
       !$acc parallel loop &
-      !$acc          present(circulation, relativeVorticity, areaTriangle, edgesOnVertex, &
+      !$acc          present(circulation, relativeVorticity, edgesOnVertex, &
       !$acc                  maxLevelVertexBot, dcEdge, normalVelocity, edgeSignOnVertex, &
-      !$acc                  minLevelVertexTop) &
+      !$acc                  minLevelVertexTop, kiteAreasOnVertex, cellMask) &
       !$acc          private(areaDual, i, iVertex, iEdge, iCell, k, r_tmp, wall_slip_factor)
 #else
-      !$omp do schedule(runtime) private(areaDual, i, iEdge, iCell, k, r_tmp, wall_slip_factor)
+      !$omp do schedule(runtime) &
+      !$omp          private(areaDual, i, iEdge, iCell, k, r_tmp, wall_slip_factor)
 #endif
       do iVertex = 1, nVerticesAll
-         areaDual(:) = 0.0_RKIND  ! only the unmasked kites
-         do i = 1, vertexDegree
-            iEdge = edgesOnVertex(i, iVertex)
-            iCell = cellsOnVertex(i, iVertex)
-            do k = minLevelVertexTop(iVertex), maxLevelVertexBot(iVertex)
-              r_tmp = edgeSignOnVertex(i, iVertex) * dcEdge(iEdge) * normalVelocity(k, iEdge)
-              circulation(k, iVertex) = circulation(k, iVertex) + r_tmp
-              areaDual(k) = areaDual(k) + cellMask(k, iCell) * kiteAreasOnVertex(i, iVertex)
-            end do
-         end do
          do k = minLevelVertexTop(iVertex), maxLevelVertexBot(iVertex)
-            relativeVorticity(k, iVertex) = circulation(k, iVertex) / areaDual(k)
+            areaDual = 0.0_RKIND
+            do i = 1, vertexDegree
+               iEdge = edgesOnVertex(i, iVertex)
+               iCell = cellsOnVertex(i, iVertex)
+               r_tmp = edgeSignOnVertex(i, iVertex) * &
+                       dcEdge(iEdge) * normalVelocity(k, iEdge)
+               circulation(k, iVertex) = circulation(k, iVertex) + r_tmp
+               areaDual = areaDual + &
+                          cellMask(k, iCell) * kiteAreasOnVertex(i, iVertex)
+            end do
             if (boundaryVertex(k, iVertex) .gt. 0.0_RKIND) then
-              circulation(k, iVertex) = wall_slip_factor * circulation(k, iVertex)
-              relativeVorticity(k, iVertex) = wall_slip_factor * relativeVorticity(k, iVertex)
+               circulation(k, iVertex) = wall_slip_factor * circulation(k, iVertex)
             end if
+            relativeVorticity(k, iVertex) = circulation(k, iVertex) / areaDual
          end do
       end do
 #ifndef MPAS_OPENACC
       !$omp end do
       !$omp end parallel
 #endif
-
-      deallocate(areaDual)
 
    !--------------------------------------------------------------------
 
@@ -1353,12 +1348,11 @@ contains
          cell1, cell2                ! neighbor cell   addresses
 
       real(kind=RKIND) :: &
-         invAreaTri1,          &! 1/triangle area
          invAreaCell1,         &! 1/cell area
          invLength,            &! 1/length
          layerThicknessVertex, &! layer thickness at vertex
          apvm_scale_factor,    &! scale factor for APVM form
-         areaDual
+         areaDual               ! unmaksed dual-cell overlap
 
       ! Local arrays
       ! normalizedPlanetaryVorticityVertex: earth's rotational rate
@@ -1399,7 +1393,7 @@ contains
       !$acc            normalizedPlanetaryVorticityVertex, &
       !$acc            relativeVorticity, fVertex, layerThickness, &
       !$acc            kiteAreasOnVertex, cellsOnVertex, &
-      !$acc            maxLevelVertexBot) &
+      !$acc            minLevelVertexTop, maxLevelVertexBot) &
       !$acc    private(i, k, iCell, areaDual, layerThicknessVertex)
 #else
       !$omp parallel

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -688,9 +688,9 @@ contains
             end do
          end do
          do k = minLevelVertexTop(iVertex), maxLevelVertexBot(iVertex)
-            if (boundaryVertex(k, iVertex)) then
-               circulation(k, iVertex) = wall_slip_factor * circulation(k, iVertex)
-               relativeVorticity(k, iVertex) = wall_slip_factor * relativeVorticity(k, iVertex)
+            if (boundaryVertex(k, iVertex) .gt. 0.0_RKIND) then
+              circulation(k, iVertex) = wall_slip_factor * circulation(k, iVertex)
+              relativeVorticity(k, iVertex) = wall_slip_factor * relativeVorticity(k, iVertex)
             end if
          end do
       end do

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -641,7 +641,7 @@ contains
       !
       !-----------------------------------------------------------------
 
-      integer :: iVertex, iEdge, i, k
+      integer :: iVertex, iEdge, iCell, i, k
 
       real (kind=RKIND) :: r_tmp, wall_slip_factor
       real (kind=RKIND), dimension(:), allocatable :: areaDual
@@ -676,7 +676,7 @@ contains
       !$acc          present(circulation, relativeVorticity, areaTriangle, edgesOnVertex, &
       !$acc                  maxLevelVertexBot, dcEdge, normalVelocity, edgeSignOnVertex, &
       !$acc                  minLevelVertexTop) &
-      !$acc          private(areaDual, iVertex, iEdge, k, r_tmp, wall_slip_factor)
+      !$acc          private(areaDual, i, iVertex, iEdge, iCell, k, r_tmp, wall_slip_factor)
 #else
       !$omp do schedule(runtime) private(areaDual, i, iEdge, iCell, k, r_tmp, wall_slip_factor)
 #endif

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -643,7 +643,7 @@ contains
 
       integer :: iVertex, iEdge, i, k
 
-      real (kind=RKIND) :: invAreaTri1, r_tmp
+      real (kind=RKIND) :: invAreaTri1, r_tmp, wall_slip_factor
 
       err = 0
 
@@ -663,14 +663,19 @@ contains
       !$omp end do
 #endif
 
+      ! no-slip = 1.0
+      ! free-slip = 0.0
+      ! partial-slip in-between
+      wall_slip_factor = config_wall_slip_factor
+
 #ifdef MPAS_OPENACC
       !$acc parallel loop &
       !$acc          present(circulation, relativeVorticity, areaTriangle, edgesOnVertex, &
       !$acc                  maxLevelVertexBot, dcEdge, normalVelocity, edgeSignOnVertex, &
       !$acc                  minLevelVertexTop) &
-      !$acc          private(invAreaTri1, iVertex, iEdge, k, r_tmp)
+      !$acc          private(invAreaTri1, iVertex, iEdge, k, r_tmp, wall_slip_factor)
 #else
-      !$omp do schedule(runtime) private(invAreaTri1, i, iEdge, k, r_tmp)
+      !$omp do schedule(runtime) private(invAreaTri1, i, iEdge, k, r_tmp, wall_slip_factor)
 #endif
       do iVertex = 1, nVerticesAll
          invAreaTri1 = 1.0_RKIND / areaTriangle(iVertex)
@@ -681,6 +686,12 @@ contains
               circulation(k, iVertex) = circulation(k, iVertex) + edgeSignOnVertex(i, iVertex) * r_tmp
               relativeVorticity(k, iVertex) = relativeVorticity(k, iVertex) + edgeSignOnVertex(i, iVertex) * r_tmp * invAreaTri1
             end do
+         end do
+         do k = minLevelVertexTop(iVertex), maxLevelVertexBot(iVertex)
+            if (boundaryVertex(k, iVertex)) then
+               circulation(k, iVertex) = wall_slip_factor * circulation(k, iVertex)
+               relativeVorticity(k, iVertex) = wall_slip_factor * relativeVorticity(k, iVertex)
+            end if
          end do
       end do
 #ifndef MPAS_OPENACC

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -603,7 +603,7 @@ contains
 !  routine ocn_relativeVorticity_circulation
 !
 !> \brief   Computes relative vorticity and circulation
-!> \author  Mark Petersen, Doug Jacobsen, Todd Ringler
+!> \author  Mark Petersen, Doug Jacobsen, Todd Ringler, Darren Engwirda
 !> \date    November 2013
 !> \details
 !>  Computes relative vorticity and circulation
@@ -663,24 +663,25 @@ contains
       !$omp end do
 #endif
 
-      ! no-slip = 1.0
-      ! free-slip = 0.0
+      ! no-slip = 0.0
+      ! free-slip = 1.0
       ! partial-slip in-between
       wall_slip_factor = config_wall_slip_factor
 
 #ifdef MPAS_OPENACC
       !$acc parallel loop &
       !$acc          present(circulation, relativeVorticity, edgesOnVertex, &
-      !$acc                  maxLevelVertexBot, dcEdge, normalVelocity, edgeSignOnVertex, &
-      !$acc                  minLevelVertexTop, kiteAreasOnVertex, cellMask) &
-      !$acc          private(areaDual, i, iVertex, iEdge, iCell, k, r_tmp, wall_slip_factor)
+      !$acc                  maxLevelVertexBot, dcEdge, normalVelocity, &
+      !$acc                  edgeSignOnVertex, cellMask, &
+      !$acc                  minLevelVertexTop, kiteAreasOnVertex) &
+      !$acc          private(areaDual, i, iEdge, iCell, k, r_tmp, wall_slip_factor)
 #else
       !$omp do schedule(runtime) &
       !$omp          private(areaDual, i, iEdge, iCell, k, r_tmp, wall_slip_factor)
 #endif
       do iVertex = 1, nVerticesAll
          do k = minLevelVertexTop(iVertex), maxLevelVertexBot(iVertex)
-            areaDual = 0.0_RKIND
+            areaDual = 0.0_RKIND  ! only unmaksed kites
             do i = 1, vertexDegree
                iEdge = edgesOnVertex(i, iVertex)
                iCell = cellsOnVertex(i, iVertex)
@@ -690,9 +691,11 @@ contains
                areaDual = areaDual + &
                           cellMask(k, iCell) * kiteAreasOnVertex(i, iVertex)
             end do
-            if (boundaryVertex(k, iVertex) .gt. 0.0_RKIND) then
-               circulation(k, iVertex) = wall_slip_factor * circulation(k, iVertex)
-            end if
+            ! no-slip: curl(u) unchanged
+            ! free-slip: curl(u) = 0.0
+            ! partial-slip: curl(u) reduced
+            circulation(k, iVertex) = circulation(k, iVertex) * &
+               (1.0_RKIND - wall_slip_factor * boundaryVertex(k, iVertex))
             relativeVorticity(k, iVertex) = circulation(k, iVertex) / areaDual
          end do
       end do

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -673,10 +673,10 @@ contains
       !$acc          present(circulation, relativeVorticity, edgesOnVertex, &
       !$acc                  maxLevelVertexBot, dcEdge, normalVelocity, &
       !$acc                  minLevelVertexTop, areaTriangle, edgeSignOnVertex) &
-      !$acc          private(invAreaTri1, i, iEdge, k, r_tmp, wall_slip_factor)
+      !$acc          private(invAreaTri1, i, iEdge, k, r_tmp)
 #else
       !$omp do schedule(runtime) &
-      !$omp          private(invAreaTri1, i, iEdge, k, r_tmp, wall_slip_factor)
+      !$omp          private(invAreaTri1, i, iEdge, k, r_tmp)
 #endif
       do iVertex = 1, nVerticesAll
          invAreaTri1 = 1.0_RKIND / areaTriangle(iVertex)
@@ -817,6 +817,12 @@ contains
 #ifdef MPAS_OPENACC
          !$acc exit data copyout(wctEdge) delete(baroclinicThickness, deltaSSH, btrVelocity)
 #endif
+
+      case (thickEdgeFluxConstant)
+         do iEdge = 1, nEdgesAll
+            if ( maxLevelEdgeTop(iEdge) == 0 ) cycle
+            wctEdge(iEdge) = baroclinicThickness(iEdge)
+         end do
 
       case default
          ! Should have been caught on init

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -641,9 +641,9 @@ contains
       !
       !-----------------------------------------------------------------
 
-      integer :: iVertex, iEdge, iCell, i, k
+      integer :: iVertex, iEdge, i, k
 
-      real (kind=RKIND) :: r_tmp, wall_slip_factor, areaDual
+      real (kind=RKIND) :: invAreaTri1, r_tmp, wall_slip_factor
 
       err = 0
 
@@ -672,31 +672,27 @@ contains
       !$acc parallel loop &
       !$acc          present(circulation, relativeVorticity, edgesOnVertex, &
       !$acc                  maxLevelVertexBot, dcEdge, normalVelocity, &
-      !$acc                  edgeSignOnVertex, cellMask, &
-      !$acc                  minLevelVertexTop, kiteAreasOnVertex) &
-      !$acc          private(areaDual, i, iEdge, iCell, k, r_tmp, wall_slip_factor)
+      !$acc                  minLevelVertexTop, areaTriangle, edgeSignOnVertex) &
+      !$acc          private(invAreaTri1, i, iEdge, k, r_tmp, wall_slip_factor)
 #else
       !$omp do schedule(runtime) &
-      !$omp          private(areaDual, i, iEdge, iCell, k, r_tmp, wall_slip_factor)
+      !$omp          private(invAreaTri1, i, iEdge, k, r_tmp, wall_slip_factor)
 #endif
       do iVertex = 1, nVerticesAll
+         invAreaTri1 = 1.0_RKIND / areaTriangle(iVertex)
          do k = minLevelVertexTop(iVertex), maxLevelVertexBot(iVertex)
-            areaDual = 0.0_RKIND  ! only unmaksed kites
             do i = 1, vertexDegree
                iEdge = edgesOnVertex(i, iVertex)
-               iCell = cellsOnVertex(i, iVertex)
                r_tmp = edgeSignOnVertex(i, iVertex) * &
                        dcEdge(iEdge) * normalVelocity(k, iEdge)
                circulation(k, iVertex) = circulation(k, iVertex) + r_tmp
-               areaDual = areaDual + &
-                          cellMask(k, iCell) * kiteAreasOnVertex(i, iVertex)
             end do
             ! no-slip: curl(u) unchanged
             ! free-slip: curl(u) = 0.0
             ! partial-slip: curl(u) reduced
             circulation(k, iVertex) = circulation(k, iVertex) * &
                (1.0_RKIND - wall_slip_factor * boundaryVertex(k, iVertex))
-            relativeVorticity(k, iVertex) = circulation(k, iVertex) / areaDual
+            relativeVorticity(k, iVertex) = circulation(k, iVertex) * invAreaTri1
          end do
       end do
 #ifndef MPAS_OPENACC

--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -643,7 +643,8 @@ contains
 
       integer :: iVertex, iEdge, i, k
 
-      real (kind=RKIND) :: invAreaTri1, r_tmp, wall_slip_factor
+      real (kind=RKIND) :: r_tmp, wall_slip_factor
+      real (kind=RKIND), dimension(:), allocatable :: areaDual
 
       err = 0
 
@@ -667,27 +668,31 @@ contains
       ! free-slip = 0.0
       ! partial-slip in-between
       wall_slip_factor = config_wall_slip_factor
+      
+      allocate(areaDual(nVertLevels))
 
 #ifdef MPAS_OPENACC
       !$acc parallel loop &
       !$acc          present(circulation, relativeVorticity, areaTriangle, edgesOnVertex, &
       !$acc                  maxLevelVertexBot, dcEdge, normalVelocity, edgeSignOnVertex, &
       !$acc                  minLevelVertexTop) &
-      !$acc          private(invAreaTri1, iVertex, iEdge, k, r_tmp, wall_slip_factor)
+      !$acc          private(areaDual, iVertex, iEdge, k, r_tmp, wall_slip_factor)
 #else
-      !$omp do schedule(runtime) private(invAreaTri1, i, iEdge, k, r_tmp, wall_slip_factor)
+      !$omp do schedule(runtime) private(areaDual, i, iEdge, iCell, k, r_tmp, wall_slip_factor)
 #endif
       do iVertex = 1, nVerticesAll
-         invAreaTri1 = 1.0_RKIND / areaTriangle(iVertex)
+         areaDual(:) = 0.0_RKIND  ! only the unmasked kites
          do i = 1, vertexDegree
             iEdge = edgesOnVertex(i, iVertex)
+            iCell = cellsOnVertex(i, iVertex)
             do k = minLevelVertexTop(iVertex), maxLevelVertexBot(iVertex)
-              r_tmp = dcEdge(iEdge) * normalVelocity(k, iEdge)
-              circulation(k, iVertex) = circulation(k, iVertex) + edgeSignOnVertex(i, iVertex) * r_tmp
-              relativeVorticity(k, iVertex) = relativeVorticity(k, iVertex) + edgeSignOnVertex(i, iVertex) * r_tmp * invAreaTri1
+              r_tmp = edgeSignOnVertex(i, iVertex) * dcEdge(iEdge) * normalVelocity(k, iEdge)
+              circulation(k, iVertex) = circulation(k, iVertex) + r_tmp
+              areaDual(k) = areaDual(k) + cellMask(k, iCell) * kiteAreasOnVertex(i, iVertex)
             end do
          end do
          do k = minLevelVertexTop(iVertex), maxLevelVertexBot(iVertex)
+            relativeVorticity(k, iVertex) = circulation(k, iVertex) / areaDual(k)
             if (boundaryVertex(k, iVertex) .gt. 0.0_RKIND) then
               circulation(k, iVertex) = wall_slip_factor * circulation(k, iVertex)
               relativeVorticity(k, iVertex) = wall_slip_factor * relativeVorticity(k, iVertex)
@@ -698,6 +703,8 @@ contains
       !$omp end do
       !$omp end parallel
 #endif
+
+      deallocate(areaDual)
 
    !--------------------------------------------------------------------
 
@@ -1350,7 +1357,8 @@ contains
          invAreaCell1,         &! 1/cell area
          invLength,            &! 1/length
          layerThicknessVertex, &! layer thickness at vertex
-         apvm_scale_factor      ! scale factor for APVM form
+         apvm_scale_factor,    &! scale factor for APVM form
+         areaDual
 
       ! Local arrays
       ! normalizedPlanetaryVorticityVertex: earth's rotational rate
@@ -1390,25 +1398,29 @@ contains
       !$acc    present(normalizedRelativeVorticityVertex, &
       !$acc            normalizedPlanetaryVorticityVertex, &
       !$acc            relativeVorticity, fVertex, layerThickness, &
-      !$acc            areaTriangle, kiteAreasOnVertex, cellsOnVertex, &
+      !$acc            kiteAreasOnVertex, cellsOnVertex, &
       !$acc            maxLevelVertexBot) &
-      !$acc    private(i, k, iCell, invAreaTri1, layerThicknessVertex)
+      !$acc    private(i, k, iCell, areaDual, layerThicknessVertex)
 #else
       !$omp parallel
       !$omp do schedule(runtime) &
-      !$omp    private(i, k, iCell, invAreaTri1, layerThicknessVertex)
+      !$omp    private(i, k, iCell, areaDual, layerThicknessVertex)
 #endif
       do iVertex = 1, nVertices
-         invAreaTri1 = 1.0_RKIND / areaTriangle(iVertex)
-         do k = 1, maxLevelVertexBot(iVertex)
+         normalizedRelativeVorticityVertex(:,iVertex) = 0.0_RKIND
+         normalizedPlanetaryVorticityVertex(:,iVertex) = 0.0_RKIND
+         do k = minLevelVertexTop(iVertex), maxLevelVertexBot(iVertex)
             layerThicknessVertex = 0.0_RKIND
+            areaDual = 0.0_RKIND  ! only the unmasked kites
             do i = 1, vertexDegree
                iCell = cellsOnVertex(i,iVertex)
                layerThicknessVertex = layerThicknessVertex &
                                     + layerThickness(k,iCell) &
                                     * kiteAreasOnVertex(i,iVertex)
+               areaDual = areaDual + cellMask(k,iCell) &
+                                    * kiteAreasOnVertex(i,iVertex)
             end do
-            layerThicknessVertex = layerThicknessVertex*invAreaTri1
+            layerThicknessVertex = layerThicknessVertex/areaDual
             if (layerThicknessVertex == 0) cycle
 
             normalizedRelativeVorticityVertex(k,iVertex) = &


### PR DESCRIPTION
This PR updates the way horizontal momentum boundary conditions are computed --- highlighting that the current MPAS discretisation applies no-slip conditions, introducing new free-slip and partial-slip conditions, and cleaning-up the way cell-vertex remapping is handled across partially masked cells/duals in general.

The changes are two-fold:

1. A new `lateral_walls` namelist section for BC settings is introduced, where `config_wall_slip_factor` controls the amount of slip at horizontal walls (both coastlines at the surface and masked boundaries against bathymetry in general). `config_wall_slip_factor = 0.0` is a no-slip condition, `config_wall_slip_factor = 1.0` is a free-slip condition, and values between 0.0 and 1.0 correspond to partial-slip cases.
2. In the current implementation the thicknesses from the two valid cells is remapped along with a 0 value for the masked cell. The result is divided by the full area of the dual (triangle) resulting in a vertex layer-thickness of only $\frac{2}{3} h$, inconsistent with the spatially uniform interior thickness. An alternative approach implemented here is to accumulate only the unmasked area of the dual (triangle) and use this in the remapping.

[NML]
[NCC] - free wall slip (new behavior, activated by namelist change)
[NCC] - no wall slip (default behavior in all configurations)

Credit to @dengwirda for discovering and fixing the layerThicknessVertex bug and for this new feature