### PR TITLE
Add MOAB module to be loaded on Aurora setups

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -3483,6 +3483,7 @@
         <command name="load">netcdf/4.9.3c-4.6.2f</command>
         <command name="load">pnetcdf/1.14.0</command>
         <command name="load">adios2/2.10.2</command>
+        <command name="load">moab/5.6.0</command>
         </modules>
       <modules mpilib="mpich1024">
         <command name="load">mpich-config/collective-tuning/1024</command>


### PR DESCRIPTION
Add the MOAB module to the Aurora build environment, needed for `--driver moab`.

[BFB]