### PR TITLE
EAMxx: fix some warnings in shoc tests that are likely typos/bugs

### DIFF
--- a/components/eamxx/src/physics/shoc/tests/shoc_clip_third_moms_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_clip_third_moms_tests.cpp
@@ -70,7 +70,7 @@ struct UnitWrap::UnitTest<D>::TestClipThirdMoms : public UnitWrap::UnitTest<D>::
         const auto offset = n + s * nlevi;
 
         REQUIRE(SDS.w_sec_zi[offset] <= 1);
-        if (abs(SDS.w3[offset]) > 1000){
+        if (std::abs(SDS.w3[offset]) > 1000){
           w3_large = true;
         }
         SDS.w_sec_zi[offset] = w_sec_zi[n];
@@ -88,8 +88,8 @@ struct UnitWrap::UnitTest<D>::TestClipThirdMoms : public UnitWrap::UnitTest<D>::
       for(Int n = 0; n < nlevi; ++n) {
         const auto offset = n + s * nlevi;
 
-        if (abs(w3_in[n]) > 1000){
-          REQUIRE(abs(SDS.w3[offset]) < abs(w3_in[n]));
+        if (std::abs(w3_in[n]) > 1000){
+          REQUIRE(std::abs(SDS.w3[offset]) < std::abs(w3_in[n]));
         }
 
       }

--- a/components/eamxx/src/physics/shoc/tests/shoc_energy_integral_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_energy_integral_tests.cpp
@@ -96,8 +96,8 @@ struct UnitWrap::UnitTest<D>::TestShocEnergyInt : public UnitWrap::UnitTest<D>::
         if (s == 0){
           const auto offsets = n + (s+1) * nlev;
 
-          REQUIRE(abs(SDS.u_wind[offsets]) > abs(SDS.u_wind[offset]));
-          REQUIRE(abs(SDS.v_wind[offsets]) > abs(SDS.v_wind[offset]));
+          REQUIRE(std::abs(SDS.u_wind[offsets]) > std::abs(SDS.u_wind[offset]));
+          REQUIRE(std::abs(SDS.v_wind[offsets]) > std::abs(SDS.v_wind[offset]));
           REQUIRE(SDS.rcm[offset] == 0);
           REQUIRE(SDS.rcm[offsets] > SDS.rcm[offset]);
         }

--- a/components/eamxx/src/physics/shoc/tests/shoc_main_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_main_tests.cpp
@@ -268,8 +268,8 @@ struct UnitWrap::UnitTest<D>::TestShocMain : public UnitWrap::UnitTest<D>::Base 
         REQUIRE( (SDS.qw[offset] > qw_lbound && SDS.qw[offset] < qw_ubound) );
         REQUIRE( (SDS.tke[offset] > tke_lbound && SDS.tke[offset] < tke_ubound) );
         // Increase wind bounds by 2 m/s to allow for surface flux effects
-        REQUIRE(std::abs(SDS.u_wind[offset] < wind_bounds+2));
-        REQUIRE(std::abs(SDS.v_wind[offset] < wind_bounds+2));
+        REQUIRE(std::abs(SDS.u_wind[offset]) < wind_bounds+2);
+        REQUIRE(std::abs(SDS.v_wind[offset]) < wind_bounds+2);
 
         REQUIRE( (SDS.shoc_mix[offset] >= minlen && SDS.shoc_mix[offset] <= maxlen) );
         REQUIRE( (SDS.isotropy[offset] >= 0 && SDS.isotropy[offset] < maxiso) );
@@ -278,7 +278,7 @@ struct UnitWrap::UnitTest<D>::TestShocMain : public UnitWrap::UnitTest<D>::Base 
         REQUIRE( (SDS.tk[offset] >= 0 && SDS.tk[offset] < 100) );
         REQUIRE( (SDS.tkh[offset] >= 0 && SDS.tkh[offset] < 100) );
         REQUIRE(std::abs(SDS.wthv_sec[offset]) < 1);
-        REQUIRE(std::abs(SDS.brunt[offset] < 1));
+        REQUIRE(std::abs(SDS.brunt[offset]) < 1);
 
         // Make sure there are no "empty" clouds
         if (SDS.shoc_cldfrac[offset] > 0){
@@ -298,7 +298,7 @@ struct UnitWrap::UnitTest<D>::TestShocMain : public UnitWrap::UnitTest<D>::Base 
         REQUIRE(SDS.host_dse[offset] < dse_upper);
 
         // Verify that w2 is less than tke
-        REQUIRE(std::abs(SDS.w_sec[offset] < SDS.tke[offset]));
+        REQUIRE(std::abs(SDS.w_sec[offset]) < SDS.tke[offset]);
 
         // Verify tracer output is reasonable
         for (Int t = 0; t < num_qtracers; ++t){
@@ -314,12 +314,12 @@ struct UnitWrap::UnitTest<D>::TestShocMain : public UnitWrap::UnitTest<D>::Base 
         // Make sure turbulence output is appropriate
         REQUIRE( (SDS.thl_sec[offset] >= 0 && SDS.thl_sec[offset] < 1e2 ) );
         REQUIRE( (SDS.qw_sec[offset] >= 0 && SDS.qw_sec[offset] < 1e-3) );
-        REQUIRE(std::abs(SDS.wthl_sec[offset] < 1));
-        REQUIRE(std::abs(SDS.wqw_sec[offset] < 1e-3));
-        REQUIRE(std::abs(SDS.w3[offset] < 10));
-        REQUIRE(std::abs(SDS.qwthl_sec[offset] < 1));
-        REQUIRE(std::abs(SDS.uw_sec[offset] < 1));
-        REQUIRE(std::abs(SDS.vw_sec[offset] < 1));
+        REQUIRE(std::abs(SDS.wthl_sec[offset]) < 1);
+        REQUIRE(std::abs(SDS.wqw_sec[offset]) < 1e-3);
+        REQUIRE(std::abs(SDS.w3[offset]) < 10);
+        REQUIRE(std::abs(SDS.qwthl_sec[offset]) < 1);
+        REQUIRE(std::abs(SDS.uw_sec[offset]) < 1);
+        REQUIRE(std::abs(SDS.vw_sec[offset]) < 1);
       }
 
     }

--- a/components/eamxx/src/physics/shoc/tests/shoc_pblintd_height_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_pblintd_height_tests.cpp
@@ -71,8 +71,8 @@ struct UnitWrap::UnitTest<D>::TestPblintdHeight : public UnitWrap::UnitTest<D>::
       for(Int n = 0; n < nlev; ++n) {
         const auto offset = n + s * nlev;
         REQUIRE(SDS.z[offset] > 0);
-        REQUIRE(std::abs(SDS.u[offset] < 100));
-        REQUIRE(std::abs(SDS.v[offset] < 100));
+        REQUIRE(std::abs(SDS.u[offset]) < 100);
+        REQUIRE(std::abs(SDS.v[offset]) < 100);
         REQUIRE(SDS.thv[offset] < 1000);
         REQUIRE(SDS.thv[offset] > 150);
       }

--- a/components/eamxx/src/physics/shoc/tests/shoc_pdf_computetemp_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_pdf_computetemp_tests.cpp
@@ -54,7 +54,7 @@ struct UnitWrap::UnitTest<D>::TestShocPdfComputeTemp {
     SDS.thl1 = thl1;
     SDS.pval = pval;
 
-    Int num_tests = SDS.pval/abs(presincr);
+    Int num_tests = SDS.pval/std::abs(presincr);
 
     REQUIRE(num_tests > 1);
     REQUIRE(presincr < 0);

--- a/components/eamxx/src/physics/shoc/tests/shoc_pdf_qw_parameters_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_pdf_qw_parameters_tests.cpp
@@ -84,15 +84,15 @@ struct UnitWrap::UnitTest<D>::TestShocQwParameters {
     REQUIRE(SDS.w1_1 > 0);
     REQUIRE(SDS.w1_2 < 0);
     if (SDS.skew_w > 0){
-      REQUIRE(abs(SDS.w1_1) > abs(SDS.w1_2));
+      REQUIRE(std::abs(SDS.w1_1) > std::abs(SDS.w1_2));
       REQUIRE(SDS.a < 0.5);
     }
     else if (SDS.skew_w < 0){
-      REQUIRE(abs(SDS.w1_1) < abs(SDS.w1_2));
+      REQUIRE(std::abs(SDS.w1_1) < std::abs(SDS.w1_2));
       REQUIRE(SDS.a > 0.5);
     }
     else if (SDS.skew_w == 0){
-      REQUIRE(abs(SDS.w1_1) == abs(SDS.w1_2));
+      REQUIRE(std::abs(SDS.w1_1) == std::abs(SDS.w1_2));
       REQUIRE(SDS.a == 0);
     }
 
@@ -100,7 +100,7 @@ struct UnitWrap::UnitTest<D>::TestShocQwParameters {
     shoc_assumed_pdf_qw_parameters(SDS);
 
     // Save absolute difference between the two gaussian moistures
-    Real qwgaus_diff_result1 = abs(qvconv*SDS.qw1_2 - qvconv*SDS.qw1_1);
+    Real qwgaus_diff_result1 = std::abs(qvconv*SDS.qw1_2 - qvconv*SDS.qw1_1);
 
     // Now laod up value for the large wqwsec test
     SDS.wqwsec = wqwsec_large;
@@ -109,7 +109,7 @@ struct UnitWrap::UnitTest<D>::TestShocQwParameters {
     shoc_assumed_pdf_qw_parameters(SDS);
 
     // Save absolute difference between the two gaussian temps
-    Real qwgaus_diff_result2 = abs(qvconv*SDS.qw1_2 - qvconv*SDS.qw1_1);
+    Real qwgaus_diff_result2 = std::abs(qvconv*SDS.qw1_2 - qvconv*SDS.qw1_1);
 
     // Now check the result
     REQUIRE(qwgaus_diff_result2 > qwgaus_diff_result1);

--- a/components/eamxx/src/physics/shoc/tests/shoc_pdf_thl_parameters_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_pdf_thl_parameters_tests.cpp
@@ -81,15 +81,15 @@ struct UnitWrap::UnitTest<D>::TestShocThlParameters {
     REQUIRE(SDS.w1_1 > 0);
     REQUIRE(SDS.w1_2 < 0);
     if (SDS.skew_w > 0){
-      REQUIRE(abs(SDS.w1_1) > abs(SDS.w1_2));
+      REQUIRE(std::abs(SDS.w1_1) > std::abs(SDS.w1_2));
       REQUIRE(SDS.a < 0.5);
     }
     else if (SDS.skew_w < 0){
-      REQUIRE(abs(SDS.w1_1) < abs(SDS.w1_2));
+      REQUIRE(std::abs(SDS.w1_1) < std::abs(SDS.w1_2));
       REQUIRE(SDS.a > 0.5);
     }
     else if (SDS.skew_w == 0){
-      REQUIRE(abs(SDS.w1_1) == abs(SDS.w1_2));
+      REQUIRE(std::abs(SDS.w1_1) == std::abs(SDS.w1_2));
       REQUIRE(SDS.a == 0);
     }
 
@@ -144,7 +144,7 @@ struct UnitWrap::UnitTest<D>::TestShocThlParameters {
     shoc_assumed_pdf_thl_parameters(SDS);
 
     // Save absolute difference between the two gaussian temps
-    Real thlgaus_diff_result1 = abs(SDS.thl1_2 - SDS.thl1_1);
+    Real thlgaus_diff_result1 = std::abs(SDS.thl1_2 - SDS.thl1_1);
 
     // Now laod up value for the large wthlsec test
     SDS.wthlsec = wthlsec_large;
@@ -153,7 +153,7 @@ struct UnitWrap::UnitTest<D>::TestShocThlParameters {
     shoc_assumed_pdf_thl_parameters(SDS);
 
     // Save absolute difference between the two gaussian temps
-    Real thlgaus_diff_result2 = abs(SDS.thl1_2 - SDS.thl1_1);
+    Real thlgaus_diff_result2 = std::abs(SDS.thl1_2 - SDS.thl1_1);
 
     // Now check the result
     REQUIRE(thlgaus_diff_result2 > thlgaus_diff_result1);

--- a/components/eamxx/src/physics/shoc/tests/shoc_pdf_vv_parameters_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_pdf_vv_parameters_tests.cpp
@@ -90,7 +90,7 @@ struct UnitWrap::UnitTest<D>::TestShocVVParameters {
 
     // Verify that first gaussian absolute value is larger
     //  than second gaussian
-    REQUIRE(abs(SDS.w1_1) > abs(SDS.w1_2));
+    REQUIRE(std::abs(SDS.w1_1) > std::abs(SDS.w1_2));
 
     // TEST THREE
     // Given highly negative skewed distribution, verify that the gaussian
@@ -123,7 +123,7 @@ struct UnitWrap::UnitTest<D>::TestShocVVParameters {
 
     // Verify that second gaussian absolute value is larger
     //  than first gaussian
-    REQUIRE(abs(SDS.w1_1) < abs(SDS.w1_2));
+    REQUIRE(std::abs(SDS.w1_1) < std::abs(SDS.w1_2));
   }
 
   static void run_bfb()

--- a/components/eamxx/src/physics/shoc/tests/shoc_update_prognostics_implicit_tests.cpp
+++ b/components/eamxx/src/physics/shoc/tests/shoc_update_prognostics_implicit_tests.cpp
@@ -277,8 +277,8 @@ struct UnitWrap::UnitTest<D>::TestUpdatePrognosticsImplicit : public UnitWrap::U
         REQUIRE( (SDS.qw[offset] > qw_lbound && SDS.qw[offset] < qw_ubound) );
         REQUIRE( (SDS.tke[offset] > tke_lbound && SDS.tke[offset] < tke_ubound) );
         // Increase wind bounds by 2 m/s to allow for surface flux effects
-        REQUIRE(std::abs(SDS.u_wind[offset] < wind_bounds+2));
-        REQUIRE(std::abs(SDS.v_wind[offset] < wind_bounds+2));
+        REQUIRE(std::abs(SDS.u_wind[offset]) < wind_bounds+2);
+        REQUIRE(std::abs(SDS.v_wind[offset]) < wind_bounds+2);
 
         // Compute integrals of end result
         // Output total water integral


### PR DESCRIPTION
Fix some calls to C abs as well as wrong parentheses for abs calls.

[BFB]

---

@tcclevenger when you call `abs(x)` for non-integer args some implementations may simply call `std::abs`, but that's not guaranteed (clang, for instance, was giving me a warning), so I fixed those too (replacing `abs(x)` with `std::abs(x)`).