### PR TITLE
Adding remaining Polar CMIP7 compsets

### DIFF
--- a/cime_config/allactive/config_compsets.xml
+++ b/cime_config/allactive/config_compsets.xml
@@ -422,6 +422,11 @@
 </compset>
 
 <compset>
+  <alias>CRYO1850-CMIP7-4xCO2</alias>
+  <lname>1850SOI%CMIP7-4xCO2_EAM_ELM%CNPRDCTCBCTOP_MPASSI%DIB_MPASO%IBPISMF_MOSART_SGLC_SWAV</lname>
+</compset>
+
+<compset>
   <alias>CRYO1850-1pctCO2</alias>
   <lname>1850SOI_EAM%CMIP6-1pctCO2_ELM%CNPRDCTCBCTOP_MPASSI%DIB_MPASO%IBPISMF_MOSART_SGLC_SWAV</lname>
 </compset>
@@ -437,6 +442,11 @@
 </compset>
 
 <compset>
+  <alias>CRYO1950-CMIP7</alias>
+  <lname>1950SOI%CMIP7_EAM_ELM%CNPRDCTCBCTOP_MPASSI%DIB_MPASO%IBPISMF_MOSART_SGLC_SWAV</lname>
+</compset>
+
+<compset>
   <alias>CRYO1850-DISMF</alias>
   <lname>1850SOI_EAM%CMIP6_ELM%CNPRDCTCBCTOP_MPASSI%DIB_MPASO%IBDISMF_MOSART_SGLC_SWAV</lname>
 </compset>
@@ -449,6 +459,11 @@
 <compset>
   <alias>CRYO1950-DISMF</alias>
   <lname>1950SOI_EAM%CMIP6_ELM%CNPRDCTCBCTOP_MPASSI%DIB_MPASO%IBDISMF_MOSART_SGLC_SWAV</lname>
+</compset>
+
+<compset>
+  <alias>CRYO1950-DISMF-CMIP7</alias>
+  <lname>1950SOI%CMIP7_EAM_ELM%CNPRDCTCBCTOP_MPASSI%DIB_MPASO%IBDISMF_MOSART_SGLC_SWAV</lname>
 </compset>
 
 <compset>


### PR DESCRIPTION
This adds CRYO equivalents of the WCYCL CMIP7 based compsets added in https://github.com/E3SM-Project/E3SM/pull/7735. These were originally in https://github.com/E3SM-Project/E3SM/pull/7881 but removed since they are not working. Leaving as DRAFT until added compsets are functional.

Compsets aliases added

CRYO1950-CMIP7
CRYO1950-DISMF-CMIP7
CRYO1850-CMIP7-4xCO2

[BFB] No impact on existing compsets/configurations/testing.