### PR TITLE
Add newer coupling capability namelist and flags to driver-moab

### DIFF
--- a/driver-moab/cime_config/buildnml
+++ b/driver-moab/cime_config/buildnml
@@ -274,6 +274,10 @@ def write_seq_maps_file(case, nmlgen, confdir):
                         if "rof2ocn_" in name:
                             if case.get_value("COMP_OCN") == 'docn':
                                 logger.warning("   NOTE: ignoring setting of {}=idmap in seq_maps.rc".format(name))
+                        elif "ocn2lnd_" in name:
+                            logger.warning("   NOTE: ignoring setting of {}=idmap in seq_maps.rc".format(name))
+                        elif "lnd2ocn_" in name:
+                            logger.warning("   NOTE: ignoring setting of {}=idmap in seq_maps.rc".format(name))
                         else:
                             expect(gridvalue[component1] == gridvalue[component2],
                                    "Need to provide valid mapping file between {} and {} in xml variable {} ".\

--- a/driver-moab/cime_config/config_component.xml
+++ b/driver-moab/cime_config/config_component.xml
@@ -1985,6 +1985,60 @@
     <desc>ocn2glc state mapping file decomp type</desc>
   </entry>
 
+  <entry id="OCN2GLC_SHELF_FMAPNAME">
+    <type>char</type>
+    <default_value>idmap_ignore</default_value>
+    <group>run_domain</group>
+    <file>env_run.xml</file>
+    <desc>ocn2glc shelf flux mapping file - the default value idmap_ignore, if set, will be ignored by buildnml and
+    will generate a runtime error if in fact a file is required for the given compset</desc>
+  </entry>
+
+  <entry id="OCN2GLC_SHELF_FMAPTYPE">
+    <type>char</type>
+    <valid_values>X,Y</valid_values>
+    <default_value>Y</default_value>
+    <group>run_domain</group>
+    <file>env_run.xml</file>
+    <desc>ocn2glc shelf flux mapping file decomp type</desc>
+  </entry>
+
+  <entry id="OCN2GLC_SHELF_SMAPNAME">
+    <type>char</type>
+    <default_value>idmap_ignore</default_value>
+    <group>run_domain</group>
+    <file>env_run.xml</file>
+    <desc>ocn2glc shelf state mapping file - the default value idmap_ignore, if set, will be ignored by buildnml and
+    will generate a runtime error if in fact a file is required for the given compset</desc>
+  </entry>
+
+  <entry id="OCN2GLC_SHELF_SMAPTYPE">
+    <type>char</type>
+    <valid_values>X,Y</valid_values>
+    <default_value>Y</default_value>
+    <group>run_domain</group>
+    <file>env_run.xml</file>
+    <desc>ocn2glc shelf state mapping file decomp type</desc>
+  </entry>
+
+  <entry id="OCN2GLC_TF_SMAPNAME">
+    <type>char</type>
+    <default_value>idmap_ignore</default_value>
+    <group>run_domain</group>
+    <file>env_run.xml</file>
+    <desc>ocn2glc state mapping file for thermal forcing - the default value idmap_ignore, if set, will be ignored by buildnml and
+    will generate a runtime error if in fact a file is required for the given compset</desc>
+  </entry>
+
+  <entry id="OCN2GLC_TF_SMAPTYPE">
+    <type>char</type>
+    <valid_values>X,Y</valid_values>
+    <default_value>Y</default_value>
+    <group>run_domain</group>
+    <file>env_run.xml</file>
+    <desc>ocn2glc thermal forcing state mapping file decomp type</desc>
+  </entry>
+
   <entry id="OCN2WAV_SMAPNAME">
     <type>char</type>
     <default_value>idmap</default_value>
@@ -2136,6 +2190,74 @@
     <group>run_domain</group>
     <file>env_run.xml</file>
     <desc>iac2lnd state mapping file decomp type</desc>
+  </entry>
+
+  <entry id="OCN2LND_SMAPNAME">
+    <type>char</type>
+    <default_value>idmap</default_value>
+    <group>run_domain</group>
+    <file>env_run.xml</file>
+    <desc>ocn2lnd state mapping file</desc>
+  </entry>
+
+  <entry id="OCN2LND_SMAPTYPE">
+    <type>char</type>
+    <valid_values>X,Y</valid_values>
+    <default_value>Y</default_value>
+    <group>run_domain</group>
+    <file>env_run.xml</file>
+    <desc>ocn2lnd state mapping file decomp type</desc>
+  </entry>
+
+  <entry id="OCN2LND_FMAPNAME">
+    <type>char</type>
+    <default_value>idmap</default_value>
+    <group>run_domain</group>
+    <file>env_run.xml</file>
+    <desc>ocn2lnd flux mapping file</desc>
+  </entry>
+
+  <entry id="OCN2LND_FMAPTYPE">
+    <type>char</type>
+    <valid_values>X,Y</valid_values>
+    <default_value>Y</default_value>
+    <group>run_domain</group>
+    <file>env_run.xml</file>
+    <desc>ocn2lnd flux mapping file decomp type</desc>
+  </entry>
+
+  <entry id="LND2OCN_SMAPNAME">
+    <type>char</type>
+    <default_value>idmap</default_value>
+    <group>run_domain</group>
+    <file>env_run.xml</file>
+    <desc>lnd2ocn state mapping file</desc>
+  </entry>
+
+  <entry id="LND2OCN_SMAPTYPE">
+    <type>char</type>
+    <valid_values>X,Y</valid_values>
+    <default_value>Y</default_value>
+    <group>run_domain</group>
+    <file>env_run.xml</file>
+    <desc>lnd2ocn state mapping file decomp type</desc>
+  </entry>
+
+  <entry id="LND2OCN_FMAPNAME">
+    <type>char</type>
+    <default_value>idmap</default_value>
+    <group>run_domain</group>
+    <file>env_run.xml</file>
+    <desc>lnd2ocn flux mapping file</desc>
+  </entry>
+
+  <entry id="LND2OCN_FMAPTYPE">
+    <type>char</type>
+    <valid_values>X,Y</valid_values>
+    <default_value>Y</default_value>
+    <group>run_domain</group>
+    <file>env_run.xml</file>
+    <desc>lnd2ocn flux mapping file decomp type</desc>
   </entry>
 
   <entry id="VECT_MAP">

--- a/driver-moab/cime_config/namelist_definition_drv.xml
+++ b/driver-moab/cime_config/namelist_definition_drv.xml
@@ -137,15 +137,15 @@
     </values>
   </entry>
 
-  <entry  id="flds_wiso" modify_via_xml="FLDS_WISO">
+  <entry id="flds_polar">
     <type>logical</type>
     <category>seq_flds</category>
     <group>seq_cplflds_inparm</group>
     <desc>
-      Pass water isotopes between components
+      If set to .true. Polar fields will be passed from the ocean to the coupler.
     </desc>
     <values>
-      <value>$FLDS_WISO</value>
+      <value>$FLDS_POLAR</value>
     </values>
   </entry>
 
@@ -161,15 +161,15 @@
     </values>
   </entry>
 
-  <entry id="flds_polar">
+  <entry  id="flds_wiso" modify_via_xml="FLDS_WISO">
     <type>logical</type>
     <category>seq_flds</category>
     <group>seq_cplflds_inparm</group>
     <desc>
-      If set to .true. Polar fields will be passed from the ocean to the coupler.
+      Pass water isotopes between components
     </desc>
     <values>
-      <value>$FLDS_POLAR</value>
+      <value>$FLDS_WISO</value>
     </values>
   </entry>
 
@@ -198,7 +198,7 @@
     <category>seq_flds</category>
     <group>seq_cplflds_inparm</group>
     <desc>
-      Number of cism elevation classes. Set by the xml variable GLC_NEC in env_run.xml
+      Number of GLC elevation classes. Set by the xml variable GLC_NEC in env_run.xml
     </desc>
     <values>
       <value>$GLC_NEC</value>
@@ -216,7 +216,7 @@
       <value>$GLC_NZOC</value>
     </values>
   </entry>
-  
+
   <entry id="ice_ncat" modify_via_xml="ICE_NCAT">
     <type>integer</type>
     <category>seq_flds</category>
@@ -302,6 +302,18 @@
     </values>
   </entry>
 
+  <entry id="ocn_lnd_one_way">
+    <type>logical</type>
+    <category>seq_flds</category>
+    <group>seq_cplflds_inparm</group>
+    <desc>
+      If set to .true., adds fields needed to calculate ocean-land one-way coupling
+    </desc>
+    <values>
+      <value>.false.</value>
+    </values>
+  </entry>
+
   <entry id="rof_sed">
     <type>logical</type>
     <category>seq_flds</category>
@@ -313,7 +325,7 @@
       <value>.false.</value>
     </values>
   </entry>
- 
+
   <entry id="wav_ocn_coup">
     <type>char</type>
     <category>seq_flds</category>
@@ -346,6 +358,16 @@
     <values>
       <value>none</value>
       <value WAV_ICE_COUP="oneway">oneway</value>
+    </values>
+  </entry>
+
+  <entry id="add_iac_to_cplstate">
+    <type>logical</type>
+    <category>seq_flds</category>
+    <group>seq_cplflds_inparm</group>
+    <desc>Flag to control adding IAC component variable to the coupler history files.</desc>
+    <values>
+      <value>.false.</value>
     </values>
   </entry>
 
@@ -661,7 +683,7 @@
     <group>seq_infodata_inparm</group>
     <desc>
       Constant solar zenith angle value in degrees for idealized configurations
-      such as radiative-convective equilibrium experiments. This is disabled when 
+      such as radiative-convective equilibrium experiments. This is disabled when
       the value is less than 0
       Default: -1
     </desc>
@@ -857,7 +879,7 @@
      <category>control</category>
      <group>seq_infodata_inparm</group>
      <desc>
-      0: standard surface flux calculation as in E3SMv1 
+      0: standard surface flux calculation as in E3SMv1
       1: COAREv3.0 flux computation (Fairall et al., 2003)
       2: University of Arizona algorithm (Zeng et al., 1998)
       default: 0
@@ -1389,17 +1411,17 @@
   </entry>
 
   <entry id="histaux_z2x">
-    <type>logical</type>
-    <category>history</category>
-    <group>seq_infodata_inparm</group>
-    <desc>
-      turns on coupler history stream for instantaneous iac to coupler fields.
-      default: false
-    </desc>
-    <values>
-      <value>.false.</value>
-    </values>
-  </entry>
+      <type>logical</type>
+      <category>history</category>
+      <group>seq_infodata_inparm</group>
+      <desc>
+        turns on coupler history stream for instantaneous iac to coupler fields.
+        default: false
+      </desc>
+      <values>
+        <value>.false.</value>
+      </values>
+    </entry>
 
   <entry id="histaux_double_precision">
     <type>logical</type>
@@ -1597,6 +1619,7 @@
       <value atm_grid="ne1024np4.pg2" lnd_grid="ne1024np4.pg2">1.e-10</value>
       <value atm_grid="ne120np4.pg2" lnd_grid="ne120np4.pg2">1.e-10</value>
       <value atm_grid="ne256np4.pg2" lnd_grid="ne256np4.pg2">1.e-10</value>
+      <value atm_grid="ne512np4.pg2" lnd_grid="ne512np4.pg2">1.e-10</value>
     </values>
   </entry>
 
@@ -3340,7 +3363,7 @@
     <category>cime_pes</category>
     <group>cime_pes</group>
     <desc>
-      level of task-to-node mapping output for the whole model 
+      level of task-to-node mapping output for the whole model
       (0: no output; 1: compact; 2: verbose)
     </desc>
     <values>
@@ -4317,6 +4340,36 @@
     </values>
   </entry>
 
+  <entry id="lnd2iac_smapname"    modify_via_xml="LND2IAC_SMAPNAME">
+    <type>char</type>
+    <category>mapping</category>
+    <input_pathname>abs</input_pathname>
+    <group>seq_maps</group>
+    <desc>
+      lnd to iac mapping file for states
+    </desc>
+    <values>
+      <value>$LND2IAC_SMAPNAME</value>
+    </values>
+  </entry>
+  
+  <entry id="lnd2iac_smaptype"    modify_via_xml="LND2IAC_SMAPTYPE">
+    <type>char</type>
+    <category>mapping</category>
+    <group>seq_maps</group>
+    <desc>
+      The type of mapping desired, either "source" or "destination" mapping.
+      X is associated with rearrangement of the source grid to the
+      destination grid and then local mapping.  Y is associated with mapping
+      on the source grid and then rearrangement and sum to the destination
+      grid.
+    </desc>
+    <values>
+      <value>$LND2IAC_SMAPTYPE</value>
+      <value bfbflag="on">X</value>
+    </values>
+  </entry>
+
   <entry id="rof2lnd_fmapname"    modify_via_xml="ROF2LND_FMAPNAME">
     <type>char</type>
     <category>mapping</category>
@@ -4570,20 +4623,20 @@
     </values>
   </entry>
 
-  <entry id="ocn2glc_fmapname"    modify_via_xml="OCN2GLC_FMAPNAME">
+  <entry id="ocn2glc_shelf_fmapname"    modify_via_xml="OCN2GLC_SHELF_FMAPNAME">
     <type>char</type>
     <category>mapping</category>
     <input_pathname>abs</input_pathname>
     <group>seq_maps</group>
     <desc>
-      ocn to glc flux mapping file for fluxes
+      ocn to glc shelf mapping file for fluxes
     </desc>
     <values>
-      <value>$OCN2GLC_FMAPNAME</value>
+      <value>$OCN2GLC_SHELF_FMAPNAME</value>
     </values>
   </entry>
 
-  <entry id="ocn2glc_fmaptype"    modify_via_xml="OCN2GLC_FMAPTYPE">
+  <entry id="ocn2glc_shelf_fmaptype"    modify_via_xml="OCN2GLC_SHELF_FMAPTYPE">
     <type>char</type>
     <category>mapping</category>
     <group>seq_maps</group>
@@ -4595,25 +4648,25 @@
       grid.
     </desc>
     <values>
-      <value>$OCN2GLC_FMAPTYPE</value>
+      <value>$OCN2GLC_SHELF_FMAPTYPE</value>
       <value bfbflag="on">X</value>
     </values>
   </entry>
 
-  <entry id="ocn2glc_smapname"    modify_via_xml="OCN2GLC_SMAPNAME">
+  <entry id="ocn2glc_shelf_smapname"    modify_via_xml="OCN2GLC_SHELF_SMAPNAME">
     <type>char</type>
     <category>mapping</category>
     <input_pathname>abs</input_pathname>
     <group>seq_maps</group>
     <desc>
-      ocn to glc state mapping file for states
+      ocn to glc shelf mapping file for states
     </desc>
     <values>
-      <value>$OCN2GLC_SMAPNAME</value>
+      <value>$OCN2GLC_SHELF_SMAPNAME</value>
     </values>
   </entry>
 
-  <entry id="ocn2glc_smaptype"    modify_via_xml="OCN2GLC_SMAPTYPE">
+  <entry id="ocn2glc_shelf_smaptype"    modify_via_xml="OCN2GLC_SHELF_SMAPTYPE">
     <type>char</type>
     <category>mapping</category>
     <group>seq_maps</group>
@@ -4625,7 +4678,37 @@
       grid.
     </desc>
     <values>
-      <value>$OCN2GLC_SMAPTYPE</value>
+      <value>$OCN2GLC_SHELF_SMAPTYPE</value>
+      <value bfbflag="on">X</value>
+    </values>
+  </entry>
+
+  <entry id="ocn2glc_tf_smapname"    modify_via_xml="OCN2GLC_TF_SMAPNAME">
+    <type>char</type>
+    <category>mapping</category>
+    <input_pathname>abs</input_pathname>
+    <group>seq_maps</group>
+    <desc>
+      ocn to glc state mapping file for thermal forcing state fields
+    </desc>
+    <values>
+      <value>$OCN2GLC_TF_SMAPNAME</value>
+    </values>
+  </entry>
+
+  <entry id="ocn2glc_tf_smaptype"    modify_via_xml="OCN2GLC_TF_SMAPTYPE">
+    <type>char</type>
+    <category>mapping</category>
+    <group>seq_maps</group>
+    <desc>
+      The type of mapping desired, either "source" or "destination" mapping.
+      X is associated with rearrangement of the source grid to the
+      destination grid and then local mapping.  Y is associated with mapping
+      on the source grid and then rearrangement and sum to the destination
+      grid.
+    </desc>
+    <values>
+      <value>$OCN2GLC_TF_SMAPTYPE</value>
       <value bfbflag="on">X</value>
     </values>
   </entry>
@@ -4961,6 +5044,7 @@
     </values>
   </entry>
 
+
   <entry id="ocn2wav_smapname"    modify_via_xml="OCN2WAV_SMAPNAME">
     <type>char</type>
     <category>mapping</category>
@@ -5093,6 +5177,36 @@
     </desc>
     <values>
       <value>Buildconf/eamconf/drv_flds_in,Buildconf/elmconf/drv_flds_in</value>
+    </values>
+  </entry>
+
+  <entry id="atm2iac_smapname"    modify_via_xml="ATM2IAC_SMAPNAME">
+    <type>char</type>
+    <category>mapping</category>
+    <input_pathname>abs</input_pathname>
+    <group>seq_maps</group>
+    <desc>
+      atm to iac mapping file for states
+    </desc>
+    <values>
+      <value>$ATM2IAC_SMAPNAME</value>
+    </values>
+  </entry>
+  
+  <entry id="atm2iac_smaptype"    modify_via_xml="ATM2IAC_SMAPTYPE">
+    <type>char</type>
+    <category>mapping</category>
+    <group>seq_maps</group>
+    <desc>
+      The type of mapping desired, either "source" or "destination" mapping.
+      X is associated with rearrangement of the source grid to the
+      destination grid and then local mapping.  Y is associated with mapping
+      on the source grid and then rearrangement and sum to the destination
+      grid.
+    </desc>
+    <values>
+      <value>$ATM2IAC_SMAPTYPE</value>
+      <value bfbflag="on">X</value>
     </values>
   </entry>
 
@@ -5242,6 +5356,126 @@
     </desc>
     <values>
       <value>$OCN2ROF_SMAPTYPE</value>
+      <value bfbflag="on">X</value>
+    </values>
+  </entry>
+
+  <entry id="ocn2lnd_smapname"    modify_via_xml="OCN2LND_SMAPNAME">
+    <type>char</type>
+    <category>mapping</category>
+    <input_pathname>abs</input_pathname>
+    <group>seq_maps</group>
+    <desc>
+      ocn to lnd mapping file for states
+    </desc>
+    <values>
+      <value>$OCN2LND_SMAPNAME</value>
+    </values>
+  </entry>
+
+  <entry id="ocn2lnd_smaptype"    modify_via_xml="OCN2LND_SMAPTYPE">
+    <type>char</type>
+    <category>mapping</category>
+    <group>seq_maps</group>
+    <desc>
+      The type of mapping desired, either "source" or "destination" mapping.
+      X is associated with rearrangement of the source grid to the
+      destination grid and then local mapping.  Y is associated with mapping
+      on the source grid and then rearrangement and sum to the destination
+      grid.
+    </desc>
+    <values>
+      <value>$OCN2LND_SMAPTYPE</value>
+      <value bfbflag="on">X</value>
+    </values>
+  </entry>
+
+  <entry id="ocn2lnd_fmapname"    modify_via_xml="OCN2LND_FMAPNAME">
+    <type>char</type>
+    <category>mapping</category>
+    <input_pathname>abs</input_pathname>
+    <group>seq_maps</group>
+    <desc>
+      ocn to rof mapping file for fluxes
+    </desc>
+    <values>
+      <value>$OCN2LND_FMAPNAME</value>
+    </values>
+  </entry>
+
+  <entry id="ocn2lnd_fmaptype"    modify_via_xml="OCN2LND_FMAPTYPE">
+    <type>char</type>
+    <category>mapping</category>
+    <group>seq_maps</group>
+    <desc>
+      The type of mapping desired, either "source" or "destination" mapping.
+      X is associated with rearrangement of the source grid to the
+      destination grid and then local mapping.  Y is associated with mapping
+      on the source grid and then rearrangement and sum to the destination
+      grid.
+    </desc>
+    <values>
+      <value>$OCN2LND_FMAPTYPE</value>
+      <value bfbflag="on">X</value>
+    </values>
+  </entry>
+
+  <entry id="lnd2ocn_smapname"    modify_via_xml="LND2OCN_SMAPNAME">
+    <type>char</type>
+    <category>mapping</category>
+    <input_pathname>abs</input_pathname>
+    <group>seq_maps</group>
+    <desc>
+      ocn to rof mapping file for states
+    </desc>
+    <values>
+      <value>$LND2OCN_SMAPNAME</value>
+    </values>
+  </entry>
+
+  <entry id="lnd2ocn_smaptype"    modify_via_xml="LND2OCN_SMAPTYPE">
+    <type>char</type>
+    <category>mapping</category>
+    <group>seq_maps</group>
+    <desc>
+      The type of mapping desired, either "source" or "destination" mapping.
+      X is associated with rearrangement of the source grid to the
+      destination grid and then local mapping.  Y is associated with mapping
+      on the source grid and then rearrangement and sum to the destination
+      grid.
+    </desc>
+    <values>
+      <value>$LND2OCN_SMAPTYPE</value>
+      <value bfbflag="on">X</value>
+    </values>
+  </entry>
+
+  <entry id="lnd2ocn_fmapname"    modify_via_xml="LND2OCN_FMAPNAME">
+    <type>char</type>
+    <category>mapping</category>
+    <input_pathname>abs</input_pathname>
+    <group>seq_maps</group>
+    <desc>
+      ocn to rof mapping file for fluxes
+    </desc>
+    <values>
+      <value>$LND2OCN_FMAPNAME</value>
+    </values>
+  </entry>
+
+  <entry id="lnd2ocn_fmaptype"    modify_via_xml="LND2OCN_FMAPTYPE">
+    <type>char</type>
+    <category>mapping</category>
+    <group>seq_maps</group>
+    <desc>
+      The type of mapping desired, either "source" or "destination" mapping.
+      X is associated with rearrangement of the source grid to the
+      destination grid and then local mapping.  Y is associated with mapping
+      on the source grid and then rearrangement and sum to the destination
+      grid.
+    </desc>
+    <values>
+      <value>$LND2OCN_FMAPTYPE</value>
       <value bfbflag="on">X</value>
     </values>
   </entry>

--- a/driver-moab/shr/seq_flds_mod.F90
+++ b/driver-moab/shr/seq_flds_mod.F90
@@ -18,6 +18,7 @@ module seq_flds_mod
   !    g => glc
   !    r => rof
   !    w => wav
+  !    z => iac
   !
   !  state-name
   !    what follows state prefix
@@ -164,6 +165,7 @@ module seq_flds_mod
   logical            :: rof_heat            ! .true. if river model includes temperature
   logical            :: add_ndep_fields     ! .true. => add ndep fields
   logical            :: fan_have_fields     ! .true. if FAN coupled to atmosphere
+  logical            :: add_iac_to_cplstate  ! .true. if iac fields are added to coupler history files
 
   character(len=CS)  :: atm_flux_method     ! explicit => no extra fields needed
                                             ! implicit_stress => atm provides wsresp and tau_est
@@ -171,6 +173,7 @@ module seq_flds_mod
   logical            :: rof2ocn_nutrients   ! .true. if the runoff model passes nutrient fields to the ocn
   logical            :: lnd_rof_two_way     ! .true. if land-river two-way coupling turned on
   logical            :: ocn_rof_two_way     ! .true. if river-ocean two-way coupling turned on
+  logical            :: ocn_lnd_one_way     ! .true. if ocean to land one-way coupling turned on
   logical            :: rof_sed             ! .true. if river model includes sediment
 
   character(len=CS)  :: wav_ocn_coup     ! 'twoway' if wave-ocean two-way coupling turned on
@@ -218,6 +221,8 @@ module seq_flds_mod
   character(CXX) :: seq_flds_x2o_fluxes
   character(CXX) :: seq_flds_o2x_states_to_rof
   character(CXX) :: seq_flds_o2x_fluxes_to_rof
+  character(CXX) :: seq_flds_o2x_states_to_lnd
+  character(CXX) :: seq_flds_o2x_fluxes_to_lnd
 
   character(CXX) :: seq_flds_g2x_states
   character(CXX) :: seq_flds_g2x_states_to_lnd
@@ -249,8 +254,8 @@ module seq_flds_mod
   character(CXX) :: seq_flds_r2o_liq_fluxes
   character(CXX) :: seq_flds_r2o_ice_fluxes
 
-  !character(CXX) :: seq_flds_x2z_states
-  !character(CXX) :: seq_flds_z2x_states
+  character(CXX) :: seq_flds_x2z_states
+  character(CXX) :: seq_flds_z2x_states
   character(CXX) :: seq_flds_z2x_fluxes
   character(CXX) :: seq_flds_x2z_fluxes
 
@@ -279,6 +284,9 @@ module seq_flds_mod
   character(CXX) :: seq_flds_w2x_fields
   character(CXX) :: seq_flds_x2w_fields
   character(CXX) :: seq_flds_o2x_fields_to_rof
+  character(CXX) :: seq_flds_o2x_fields_to_lnd
+  character(CXX) :: seq_flds_z2x_fields
+  character(CXX) :: seq_flds_x2z_fields
 
   !----------------------------------------------------------------------------
   ! component names
@@ -291,6 +299,7 @@ module seq_flds_mod
   character(32) :: glcname='glc'
   character(32) :: wavname='wav'
   character(32) :: rofname='rof'
+  character(32) :: iacname='iac'
 
   ! namelist variables
   logical :: nan_check_component_fields
@@ -356,6 +365,8 @@ contains
     character(CXX) :: o2x_fluxes = ''
     character(CXX) :: o2x_states_to_rof = ''
     character(CXX) :: o2x_fluxes_to_rof = ''
+    character(CXX) :: o2x_states_to_lnd = ''
+    character(CXX) :: o2x_fluxes_to_lnd = ''
     character(CXX) :: x2o_states = ''
     character(CXX) :: x2o_fluxes = ''
     character(CXX) :: g2x_states = ''
@@ -385,6 +396,11 @@ contains
     character(CXX) :: r2o_liq_fluxes = ''
     character(CXX) :: r2o_ice_fluxes = ''
 
+    character(CXX) :: z2x_states = ''
+    character(CXX) :: z2x_fluxes = ''
+    character(CXX) :: x2z_states = ''
+    character(CXX) :: x2z_fluxes = ''
+
     character(CXX) :: stringtmp  = ''
 
     !------ namelist -----
@@ -392,7 +408,9 @@ contains
 
     type(mct_string)    :: mctOStr  ! mct string for output outfield
     logical :: is_state, is_flux
-    integer :: i,n
+    integer :: i,n,m
+    character(len=3) :: pftstr = ''
+    character(len=2) :: monstr = ''
 
     ! use cases namelists
     logical :: flds_co2a
@@ -406,12 +424,17 @@ contains
     integer :: glc_nec
     integer :: glc_nzoc
 
+    ! set these here because the cplflds namelist is not the right place
+    !    this namelist is called only under special circumstances
+    integer :: iac_npft = 17
+    integer :: iac_nharvest = 5
+
     namelist /seq_cplflds_inparm/  &
          flds_co2a, flds_co2b, flds_co2c, flds_co2_dmsa, flds_wiso, flds_polar, flds_tf, &
          glc_nec, glc_nzoc, ice_ncat, seq_flds_i2o_per_cat, flds_bgc_oi, &
          nan_check_component_fields, rof_heat, atm_flux_method, atm_gustiness, &
-         rof2ocn_nutrients, lnd_rof_two_way, ocn_rof_two_way, rof_sed, &
-         wav_ocn_coup,wav_atm_coup, wav_ice_coup
+         rof2ocn_nutrients, lnd_rof_two_way, ocn_rof_two_way, ocn_lnd_one_way, rof_sed, &
+         wav_ocn_coup, wav_atm_coup, wav_ice_coup, add_iac_to_cplstate
 
     ! user specified new fields
     integer,  parameter :: nfldmax = 200
@@ -455,10 +478,12 @@ contains
        rof2ocn_nutrients = .false.
        lnd_rof_two_way   = .false.
        ocn_rof_two_way   = .false.
+       ocn_lnd_one_way   = .false.
        rof_sed   = .false.
        wav_ocn_coup = 'none'
        wav_atm_coup = 'none'
        wav_ice_coup = 'none'
+       add_iac_to_cplstate = .false.
 
        unitn = shr_file_getUnit()
        write(logunit,"(A)") subname//': read seq_cplflds_inparm namelist from: '&
@@ -494,10 +519,12 @@ contains
     call shr_mpi_bcast(rof2ocn_nutrients, mpicom)
     call shr_mpi_bcast(lnd_rof_two_way,   mpicom)
     call shr_mpi_bcast(ocn_rof_two_way,   mpicom)
+    call shr_mpi_bcast(ocn_lnd_one_way,   mpicom)
     call shr_mpi_bcast(rof_sed,   mpicom)
     call shr_mpi_bcast(wav_ocn_coup, mpicom)
     call shr_mpi_bcast(wav_atm_coup, mpicom)
     call shr_mpi_bcast(wav_ice_coup, mpicom)
+    call shr_mpi_bcast(add_iac_to_cplstate, mpicom)
 
     call glc_elevclass_init(glc_nec)
     call glc_zocnclass_init(glc_nzoc)
@@ -590,6 +617,12 @@ contains
           case('x2g')
              if (is_state) call seq_flds_add(x2g_states,trim(fldname))
              if (is_flux ) call seq_flds_add(x2g_fluxes,trim(fldname))
+          case('z2x')
+             if (add_iac_to_cplstate .and. is_state) call seq_flds_add(z2x_states,trim(fldname))
+             if (add_iac_to_cplstate .and. is_flux ) call seq_flds_add(z2x_fluxes,trim(fldname))
+          case('x2z')
+             if (add_iac_to_cplstate .and. is_state) call seq_flds_add(x2z_states,trim(fldname))
+             if (add_iac_to_cplstate .and. is_flux ) call seq_flds_add(x2z_fluxes,trim(fldname))
           case default
              write(logunit,*) subname//'ERROR: ',trim(cplflds_custom(n)),&
                   ' not a recognized value'
@@ -1120,6 +1153,7 @@ contains
     call seq_flds_add(x2a_states,'Sf_lfrac')
     call seq_flds_add(x2a_states,'Sf_ifrac')
     call seq_flds_add(x2a_states,'Sf_ofrac')
+    if(add_iac_to_cplstate)call seq_flds_add(x2a_states,'Sf_zfrac')
     longname = 'Surface land fraction'
     stdname  = 'land_area_fraction'
     units    = '1'
@@ -1132,6 +1166,10 @@ contains
     longname = 'Surface ocean fraction'
     stdname  = 'sea_area_fraction'
     attname  = 'Sf_ofrac'
+    call metadata_set(attname, longname, stdname, units)
+    longname = 'Surface iac fraction'
+    stdname  = 'iac_area_fraction'
+    attname  = 'Sf_zfrac'
     call metadata_set(attname, longname, stdname, units)
 
     ! Direct albedo (visible radiation)
@@ -1759,12 +1797,27 @@ contains
     call seq_flds_add(o2x_states,"So_ssh")
     call seq_flds_add(x2r_states,"So_ssh")
     call seq_flds_add(o2x_states_to_rof,"So_ssh")
+    if (ocn_lnd_one_way) then
+      call seq_flds_add(x2l_states,"So_ssh") ! ocn -> lnd one-way coupling
+      call seq_flds_add(o2x_states_to_lnd,"So_ssh")
+    endif
     if (wav_ocn_coup .ne. 'none') call seq_flds_add(x2w_states,'So_ssh')
     longname = 'Sea surface height'
     stdname  = 'sea_surface_height'
     units    = 'm'
     attname  = 'So_ssh'
     call metadata_set(attname, longname, stdname, units)
+
+    if (ocn_lnd_one_way) then
+      call seq_flds_add(o2x_states,"So_frac_h2oocn")
+      call seq_flds_add(x2l_states,"So_frac_h2oocn")
+      call seq_flds_add(o2x_states_to_lnd,"So_frac_h2oocn")
+      longname = 'Oceanic inundation fraction'
+      stdname  = 'oceanic_inundation_fraction'
+      units    = '-'
+      attname  = 'So_frac_h2oocn'
+      call metadata_set(attname, longname, stdname, units)
+    endif
 
     ! Meridional sea surface slope
     call seq_flds_add(o2x_states,"So_dhdy")
@@ -2732,6 +2785,123 @@ contains
        call metadata_set(attname, longname, stdname, units)
     endif
 
+   !----------------------------
+   ! lnd->iac, iac->lnd, iac->atm
+   !----------------------------
+   
+   ! lnd/iac coupling needs one field in each class per pft
+   ! Note that this ends up as 17*4=68 coupled fields...
+   ! also send harvest fraction from iac to land
+   ! use the same loop and index string
+ 
+   ! these two variables are hardcoded above because there is not an appropriate
+   !    namelist to put them in: iac_npft and iac_nharvest
+
+   do i = 1,iac_npft
+
+      ! Zero offset the tags, since that's how we access them in lnd and iac
+      write(pftstr,'(I0)') i-1
+      pftstr=trim(pftstr)
+
+      ! Only hr and npp matter, for now
+      if(add_iac_to_cplstate)call seq_flds_add(l2x_states,trim('Sl_hr_pft' // pftstr))
+      call seq_flds_add(x2z_states,trim('Sl_hr_pft' // pftstr))
+      longname = 'Total heterotrophic respiration' // pftstr
+      stdname  = 'lnd_total_heterotrophic_respiration' // pftstr
+      units    = 'gC/m^2/s'
+      attname  = 'Sl_hr_pft' // pftstr
+      attname  = trim(attname)
+      call metadata_set(attname, longname, stdname, units)
+      
+      if(add_iac_to_cplstate)call seq_flds_add(l2x_states,'Sl_npp_pft' // pftstr)
+      call seq_flds_add(x2z_states,'Sl_npp_pft' // pftstr)
+      longname = 'Net primary production for pft ' // pftstr
+      stdname  = 'lnd_net_primary_production_pft' // pftstr
+      units    = 'gC/m^2/s'
+      attname  = 'Sl_npp_pft' // pftstr
+      call metadata_set(attname, longname, stdname, units)
+   
+      ! Review
+      if(add_iac_to_cplstate)call seq_flds_add(l2x_states,'Sl_pftwgt_pft' //pftstr)
+      call seq_flds_add(x2z_states,'Sl_pftwgt_pft' //pftstr)
+      longname = 'PFT weight relative to gridcell for pft ' //pftstr
+      stdname  = 'lnd_pft_weight_pft' //pftstr
+      units    = ''
+      attname  = 'Sl_pftwgt_pft' //pftstr
+      call metadata_set(attname, longname, stdname, units)
+
+      ! iac->lnd
+
+      ! This is pft for beginning of model year + 1
+      ! ts wonders if landfrac should go as well - just to
+      ! verify that we are all using the same values.
+      if(add_iac_to_cplstate)call seq_flds_add(z2x_states,trim('Sz_pct_pft' //pftstr))
+      if(add_iac_to_cplstate)call seq_flds_add(x2l_states,trim('Sz_pct_pft' //pftstr))
+      longname = 'Percent pft of vegetated land unit for pft ' //pftstr
+      stdname  = 'iac_pct_pft' //pftstr
+      stdname  = trim(stdname)
+      units    = 'percent'
+      attname  = 'Sz_pct_pft' //pftstr
+      attname  = trim(attname)
+      call metadata_set(attname, longname, stdname, units)
+
+      ! Need to send the beginning model year pft data as well
+      if(add_iac_to_cplstate)call seq_flds_add(z2x_states,trim('Sz_pct_pft_prev' //pftstr))
+      if(add_iac_to_cplstate)call seq_flds_add(x2l_states,trim('Sz_pct_pft_prev' //pftstr))
+      longname = 'Previous percent pft of vegetated land unit for pft ' //pftstr
+      stdname  = 'iac_pct_pft_prev' //pftstr
+      stdname  = trim(stdname)
+      units    = 'percent'
+      attname  = 'Sz_pct_pft_prev' //pftstr
+      attname  = trim(attname)
+      call metadata_set(attname, longname, stdname, units)
+ 
+      ! send the harvest data also, these are for model year
+      if (i <= iac_nharvest) then
+         call seq_flds_add(z2x_states,trim('Sz_harvest_frac' //pftstr))
+         if(add_iac_to_cplstate)call seq_flds_add(x2l_states,trim('Sz_harvest_frac' //pftstr))
+         longname = 'Harvest fraction of vegetated land unit for category ' //pftstr
+         stdname  = 'iac_harvest_frac' //pftstr
+         stdname  = trim(stdname)
+         units    = 'fraction'
+         attname  = 'Sz_harvest_frac' //pftstr
+         attname  = trim(attname)
+         call metadata_set(attname, longname, stdname, units)
+      end if
+
+   end do
+   ! iac->atm flux.
+   ! Monthly values of surface, low alt, high alt co2 fluxes, so we
+   ! loop over 36 total fields.
+   do m=1,12
+      ! Month index tag
+      write(monstr,'(I0)') m
+      monstr=trim(monstr)
+
+      if(add_iac_to_cplstate)call seq_flds_add(z2x_fluxes,trim("Fazz_co2sfc_mon" //monstr))
+      if(add_iac_to_cplstate)call seq_flds_add(x2a_fluxes,trim("Fazz_co2sfc_mon" //monstr))
+      longname = trim('Surface flux of CO2 from iac for month' //monstr)
+      stdname  = trim('surface_upward_flux_of_carbon_dioxide_from_iac_mon' //monstr)
+      units    = 'moles m-2 s-1'
+      attname  = trim('Fazz_co2sfc_mon' //monstr)
+      call metadata_set(attname, longname, stdname, units)
+
+      if(add_iac_to_cplstate)call seq_flds_add(z2x_fluxes,trim("Fazz_co2airlo_mon" //monstr))
+      if(add_iac_to_cplstate)call seq_flds_add(x2a_fluxes,trim("Fazz_co2airlo_mon" //monstr))
+      longname = trim('Low altitude flux of CO2 from iac for month' //monstr)
+      stdname  = trim('low_alt_upward_flux_of_carbon_dioxide_from_iac_mon' //monstr)
+      units    = 'moles m-2 s-1'
+      attname  = trim('Fazz_co2airlo_mon' //monstr)
+      call metadata_set(attname, longname, stdname, units)
+
+      if(add_iac_to_cplstate)call seq_flds_add(z2x_fluxes,trim("Fazz_co2airhi_mon" //monstr))
+      if(add_iac_to_cplstate)call seq_flds_add(x2a_fluxes,trim("Fazz_co2airhi_mon" //monstr))
+      longname = trim('High altitude flux of CO2 from iac for month' //monstr)
+      stdname  = trim('high_alt_upward_flux_of_carbon_dioxide_from_iac_mon' //monstr)
+      units    = 'moles m-2 s-1'
+      attname  = trim('Fazz_co2airhi_mon' //monstr)
+      call metadata_set(attname, longname, stdname, units)
+   end do
     !-----------------------------
     ! New xao_states diagnostic
     ! fields for history output only
@@ -4067,6 +4237,8 @@ contains
     seq_flds_x2r_states = trim(x2r_states)
     seq_flds_w2x_states = trim(w2x_states)
     seq_flds_x2w_states = trim(x2w_states)
+    seq_flds_x2z_states = trim(x2z_states)
+    seq_flds_z2x_states = trim(z2x_states)
 
     seq_flds_dom_other  = trim(dom_other )
     seq_flds_a2x_fluxes = trim(a2x_fluxes)
@@ -4092,10 +4264,14 @@ contains
     seq_flds_x2r_fluxes = trim(x2r_fluxes)
     seq_flds_w2x_fluxes = trim(w2x_fluxes)
     seq_flds_x2w_fluxes = trim(x2w_fluxes)
+    seq_flds_z2x_fluxes = trim(z2x_fluxes)
+    seq_flds_x2z_fluxes = trim(x2z_fluxes)
     seq_flds_r2o_liq_fluxes = trim(r2o_liq_fluxes)
     seq_flds_r2o_ice_fluxes = trim(r2o_ice_fluxes)
     seq_flds_o2x_states_to_rof = trim(o2x_states_to_rof)
     seq_flds_o2x_fluxes_to_rof = trim(o2x_fluxes_to_rof)
+    seq_flds_o2x_states_to_lnd = trim(o2x_states_to_lnd)
+    seq_flds_o2x_fluxes_to_lnd = trim(o2x_fluxes_to_lnd)
 
     if (seq_comm_iamroot(ID)) then
        write(logunit,*) subname//': seq_flds_a2x_states= ',trim(seq_flds_a2x_states)
@@ -4147,6 +4323,11 @@ contains
        write(logunit,*) subname//': seq_flds_x2w_states= ',trim(seq_flds_x2w_states)
        write(logunit,*) subname//': seq_flds_x2w_fluxes= ',trim(seq_flds_x2w_fluxes)
        write(logunit,*) subname//': seq_flds_o2x_states_to_rof=',trim(seq_flds_o2x_states_to_rof)
+       write(logunit,*) subname//': seq_flds_z2x_states= ',trim(seq_flds_z2x_states)
+       write(logunit,*) subname//': seq_flds_z2x_fluxes= ',trim(seq_flds_z2x_fluxes)
+       write(logunit,*) subname//': seq_flds_x2z_states= ',trim(seq_flds_x2z_states)
+       write(logunit,*) subname//': seq_flds_x2z_fluxes= ',trim(seq_flds_x2z_fluxes)
+       write(logunit,*) subname//': seq_flds_o2x_states_to_lnd=',trim(seq_flds_o2x_states_to_lnd)
     end if
 
     call catFields(seq_flds_dom_fields, seq_flds_dom_coord , seq_flds_dom_other )
@@ -4172,6 +4353,9 @@ contains
     call catFields(seq_flds_w2x_fields, seq_flds_w2x_states, seq_flds_w2x_fluxes)
     call catFields(seq_flds_x2w_fields, seq_flds_x2w_states, seq_flds_x2w_fluxes)
     call catFields(seq_flds_o2x_fields_to_rof, seq_flds_o2x_states_to_rof, seq_flds_o2x_fluxes_to_rof)
+    call catFields(seq_flds_z2x_fields, seq_flds_z2x_states, seq_flds_z2x_fluxes)
+    call catFields(seq_flds_x2z_fields, seq_flds_x2z_states, seq_flds_x2z_fluxes)
+    call catFields(seq_flds_o2x_fields_to_lnd, seq_flds_o2x_states_to_lnd, seq_flds_o2x_fluxes_to_lnd)
  
     if (seq_comm_iamroot(ID)) then
       write(logunit,*) subname//': seq_flds_dom_fields= ',trim(seq_flds_dom_fields)

--- a/driver-moab/shr/seq_infodata_mod.F90
+++ b/driver-moab/shr/seq_infodata_mod.F90
@@ -195,6 +195,7 @@ MODULE seq_infodata_mod
      logical                 :: rofice_present  ! does rof have iceberg coupling on
      logical                 :: rof_prognostic  ! does rof component need input data
      logical                 :: rofocn_prognostic ! does component need ocn data
+     logical                 :: lndocn_prognostic ! does component need ocn data
      logical                 :: flood_present   ! does rof have flooding on
      logical                 :: ocn_present     ! does component model exist
      logical                 :: ocn_prognostic  ! does component model need input data from driver
@@ -771,6 +772,7 @@ CONTAINS
        infodata%lnd_prognostic = .false.
        infodata%rof_prognostic = .false.
        infodata%rofocn_prognostic = .false.
+       infodata%lndocn_prognostic = .false.
        infodata%ocn_prognostic = .false.
        infodata%ocnrof_prognostic = .false.
        infodata%ocn_c2_glcshelf = .false.
@@ -1023,7 +1025,7 @@ CONTAINS
        single_column, scmlat,scmlon,logFilePostFix, outPathRoot,&
        scm_multcols, scm_nx, scm_ny,                                      &
        atm_present, atm_prognostic,                                       &
-       lnd_present, lnd_prognostic,                                       &
+       lnd_present, lnd_prognostic, lndocn_prognostic,                    &
        rof_present, rof_prognostic, rofocn_prognostic,                    &
        ocn_present, ocn_prognostic, ocnrof_prognostic,                    &
        ocn_c2_glcshelf, ocn_c2_glctf,                                     &
@@ -1193,6 +1195,7 @@ CONTAINS
     logical,                optional, intent(OUT) :: atm_prognostic          ! need data
     logical,                optional, intent(OUT) :: lnd_present
     logical,                optional, intent(OUT) :: lnd_prognostic
+    logical,                optional, intent(OUT) :: lndocn_prognostic
     logical,                optional, intent(OUT) :: rof_present
     logical,                optional, intent(OUT) :: rofice_present
     logical,                optional, intent(OUT) :: rof_prognostic
@@ -1389,6 +1392,7 @@ CONTAINS
     if ( present(atm_prognostic) ) atm_prognostic = infodata%atm_prognostic
     if ( present(lnd_present)    ) lnd_present    = infodata%lnd_present
     if ( present(lnd_prognostic) ) lnd_prognostic = infodata%lnd_prognostic
+    if ( present(lndocn_prognostic) ) lndocn_prognostic = infodata%lndocn_prognostic
     if ( present(rof_present)    ) rof_present    = infodata%rof_present
     if ( present(rofice_present) ) rofice_present = infodata%rofice_present
     if ( present(rof_prognostic) ) rof_prognostic = infodata%rof_prognostic
@@ -1597,7 +1601,7 @@ CONTAINS
        single_column, scmlat,scmlon,logFilePostFix, outPathRoot,          &
        scm_multcols, scm_nx, scm_ny,                                      &
        atm_present, atm_prognostic,                                       &
-       lnd_present, lnd_prognostic,                                       &
+       lnd_present, lnd_prognostic, lndocn_prognostic,                    &
        rof_present, rof_prognostic, rofocn_prognostic,                    &
        ocn_present, ocn_prognostic, ocnrof_prognostic,                    &
        ocn_c2_glcshelf, ocn_c2_glctf,                                     &
@@ -1768,6 +1772,7 @@ CONTAINS
     logical,                optional, intent(IN)    :: atm_prognostic     ! need data
     logical,                optional, intent(IN)    :: lnd_present
     logical,                optional, intent(IN)    :: lnd_prognostic
+    logical,                optional, intent(IN)    :: lndocn_prognostic
     logical,                optional, intent(IN)    :: rof_present
     logical,                optional, intent(IN)    :: rofice_present
     logical,                optional, intent(IN)    :: rof_prognostic
@@ -1963,6 +1968,7 @@ CONTAINS
     if ( present(atm_prognostic) ) infodata%atm_prognostic = atm_prognostic
     if ( present(lnd_present)    ) infodata%lnd_present    = lnd_present
     if ( present(lnd_prognostic) ) infodata%lnd_prognostic = lnd_prognostic
+    if ( present(lndocn_prognostic) ) infodata%lndocn_prognostic = lndocn_prognostic
     if ( present(rof_present)    ) infodata%rof_present    = rof_present
     if ( present(rofice_present) ) infodata%rofice_present = rofice_present
     if ( present(rof_prognostic) ) infodata%rof_prognostic = rof_prognostic
@@ -2281,6 +2287,7 @@ CONTAINS
     call shr_mpi_bcast(infodata%atm_prognostic,          mpicom)
     call shr_mpi_bcast(infodata%lnd_present,             mpicom)
     call shr_mpi_bcast(infodata%lnd_prognostic,          mpicom)
+    call shr_mpi_bcast(infodata%lndocn_prognostic,       mpicom)
     call shr_mpi_bcast(infodata%rof_present,             mpicom)
     call shr_mpi_bcast(infodata%rofice_present,          mpicom)
     call shr_mpi_bcast(infodata%rof_prognostic,          mpicom)
@@ -2558,6 +2565,7 @@ CONTAINS
     if (lnd2cpli) then
        call shr_mpi_bcast(infodata%lnd_present,        mpicom, pebcast=cmppe)
        call shr_mpi_bcast(infodata%lnd_prognostic,     mpicom, pebcast=cmppe)
+       call shr_mpi_bcast(infodata%lndocn_prognostic,  mpicom, pebcast=cmppe)
        call shr_mpi_bcast(infodata%lnd_nx,             mpicom, pebcast=cmppe)
        call shr_mpi_bcast(infodata%lnd_ny,             mpicom, pebcast=cmppe)
        call shr_mpi_bcast(infodata%lnd_domain,         mpicom, pebcast=cmppe)
@@ -2659,6 +2667,7 @@ CONTAINS
        call shr_mpi_bcast(infodata%atm_prognostic,     mpicom, pebcast=cplpe)
        call shr_mpi_bcast(infodata%lnd_present,        mpicom, pebcast=cplpe)
        call shr_mpi_bcast(infodata%lnd_prognostic,     mpicom, pebcast=cplpe)
+       call shr_mpi_bcast(infodata%lndocn_prognostic,  mpicom, pebcast=cplpe)
        call shr_mpi_bcast(infodata%rof_present,        mpicom, pebcast=cplpe)
        call shr_mpi_bcast(infodata%rofice_present,     mpicom, pebcast=cplpe)
        call shr_mpi_bcast(infodata%rof_prognostic,     mpicom, pebcast=cplpe)
@@ -3015,6 +3024,7 @@ CONTAINS
     write(logunit,F0L) subname,'atm_prognostic           = ', infodata%atm_prognostic
     write(logunit,F0L) subname,'lnd_present              = ', infodata%lnd_present
     write(logunit,F0L) subname,'lnd_prognostic           = ', infodata%lnd_prognostic
+    write(logunit,F0L) subname,'lndocn_prognostic        = ', infodata%lndocn_prognostic
     write(logunit,F0L) subname,'rof_present              = ', infodata%rof_present
     write(logunit,F0L) subname,'rofice_present           = ', infodata%rofice_present
     write(logunit,F0L) subname,'rof_prognostic           = ', infodata%rof_prognostic


### PR DESCRIPTION
Add newer coupling capability namelist and flags to driver-moab

Update the driver-moab component to support newer coupling capabilities, addressing build errors on master associated
 with ocean-to-land coupling additions.

New Coupling Capabilities Partially Supported
One-way ocean-to-land coupling
IAC coupling
Glacier-wave coupling
Additional coupling fields for these configurations

Notes
Adds logical flags and namelist entries required by other components
Does not yet implement the new coupling functionality (foundation work only)
Fixes build errors related to ocean-to-land coupling additions

[BFB]
[NML]

PR description Co-Authored-By: Warp <agent@warp.dev>