### PR TITLE
Fix undefined behavior in MPAS registry parser

### DIFF
--- a/components/mpas-framework/src/tools/registry/gen_inc.c
+++ b/components/mpas-framework/src/tools/registry/gen_inc.c
@@ -176,6 +176,7 @@ int build_struct_package_lists(ezxml_t currentPosition, char * out_packages){/*{
 	const char *name;
 
 	char *token, *string, *tofree;
+	char out_packages_tmp[2048];
 	int empty_packages;
 	int empty_struct;
 
@@ -227,12 +228,14 @@ int build_struct_package_lists(ezxml_t currentPosition, char * out_packages){/*{
 				if(out_packages[0] == '\0'){
 					sprintf(out_packages, "%s", token);
 				} else if(add_package_to_list(token, out_packages)){
-					sprintf(out_packages, "%s;%s", out_packages, token);
+					snprintf(out_packages_tmp, sizeof(out_packages_tmp), "%s;%s", out_packages, token);
+					snprintf(out_packages, 2048, "%s", out_packages_tmp);
 				}
 
 				while( (token = strsep(&string, ";")) != NULL){
 					if(add_package_to_list(token, out_packages)){
-						sprintf(out_packages, "%s;%s", out_packages, token);
+						snprintf(out_packages_tmp, sizeof(out_packages_tmp), "%s;%s", out_packages, token);
+						snprintf(out_packages, 2048, "%s", out_packages_tmp);
 					}
 				}
 
@@ -251,12 +254,14 @@ int build_struct_package_lists(ezxml_t currentPosition, char * out_packages){/*{
 					if(out_packages[0] == '\0'){
 						sprintf(out_packages, "%s", token);
 					} else if(add_package_to_list(token, out_packages)){
-						sprintf(out_packages, "%s;%s", out_packages, token);
+						snprintf(out_packages_tmp, sizeof(out_packages_tmp), "%s;%s", out_packages, token);
+						snprintf(out_packages, 2048, "%s", out_packages_tmp);
 					}
 
 					while( (token = strsep(&string, ";")) != NULL){
 						if(add_package_to_list(token, out_packages)){
-							sprintf(out_packages, "%s;%s", out_packages, token);
+							snprintf(out_packages_tmp, sizeof(out_packages_tmp), "%s;%s", out_packages, token);
+							snprintf(out_packages, 2048, "%s", out_packages_tmp);
 						}
 					}
 
@@ -277,12 +282,14 @@ int build_struct_package_lists(ezxml_t currentPosition, char * out_packages){/*{
 				if(out_packages[0] == '\0'){
 					sprintf(out_packages, "%s", token);
 				} else if(add_package_to_list(token, out_packages)){
-					sprintf(out_packages, "%s;%s", out_packages, token);
+					snprintf(out_packages_tmp, sizeof(out_packages_tmp), "%s;%s", out_packages, token);
+					snprintf(out_packages, 2048, "%s", out_packages_tmp);
 				}
 
 				while( (token = strsep(&string, ";")) != NULL){
 					if(add_package_to_list(token, out_packages)){
-						sprintf(out_packages, "%s;%s", out_packages, token);
+						snprintf(out_packages_tmp, sizeof(out_packages_tmp), "%s;%s", out_packages, token);
+						snprintf(out_packages, 2048, "%s", out_packages_tmp);
 					}
 				}
 


### PR DESCRIPTION
With `gcc` v13.3.0, I'm seeing unparsable `if (Active .or. analysisModeActive)` clauses in the file `components/mpas-ocean/src/inc/structs_and_variables.inc` generated by the registry parser.

The issue appears to be that the registry parser is reading from and writing to the same string in statements like:
```
sprintf(out_packages, "%s;%s", out_packages, token);
```
This is not allowed, as it can lead to race conditions and bad output like I am seeing. This fix avoids this undefined behavior when appending to `out_packages` in the registry parser by writing to a temporary string and copying back.

[BFB]