### PR TITLE
EAMxx: allow requesting physics constants in output streams

### DIFF
--- a/components/eamxx/src/share/io/eamxx_output_manager.cpp
+++ b/components/eamxx/src/share/io/eamxx_output_manager.cpp
@@ -2,6 +2,7 @@
 
 #include "share/scorpio_interface/eamxx_scorpio_interface.hpp"
 #include "share/io/scorpio_input.hpp"
+#include "share/physics/physics_constants.hpp"
 #include "share/util/eamxx_timing.hpp"
 #include "share/core/eamxx_config.hpp"
 
@@ -854,6 +855,15 @@ setup_file (      IOFileSpecs& filespecs,
     }
     scorpio::set_attribute(filename,"GLOBAL","fp_precision",fp_precision);
     set_file_header(filespecs);
+
+    const auto& pc_names = m_params.get<std::vector<std::string>>("constants",{});
+    const auto& pc_dict = physics::Constants<Real>::dictionary();
+    for (const auto& n: pc_names) {
+      const auto& c = pc_dict.at(n);
+      scorpio::define_var (filename, n, c.units.to_string(), {},
+                           "real", "real", false);
+      scorpio::write_var (filename, n, &c.value);
+    }
   }
 
   // Make all output streams register their dims/vars

--- a/components/eamxx/src/share/io/tests/io_basic.cpp
+++ b/components/eamxx/src/share/io/tests/io_basic.cpp
@@ -11,6 +11,7 @@
 
 #include "share/util/eamxx_universal_constants.hpp"
 #include "share/core/eamxx_setup_random_test.hpp"
+#include "share/physics/physics_constants.hpp"
 #include "share/util/eamxx_time_stamp.hpp"
 #include "share/core/eamxx_types.hpp"
 
@@ -143,6 +144,8 @@ void write (const std::string& avg_type, const std::string& freq_units,
   ctrl_pl.set("frequency_units",freq_units);
   ctrl_pl.set("frequency",freq);
   ctrl_pl.set("save_grid_data",false);
+  // Also test writing physics constants to file
+  om_pl.set("constants",std::vector<std::string>{"gravit","Rgas"});
 
   // While setting this is in practice irrelevant (we would close
   // the file anyways at the end of the run), we can test that the OM closes
@@ -270,6 +273,20 @@ void read (const std::string& avg_type, const std::string& freq_units,
     auto att_str = scorpio::get_attribute<std::string>(filename,fn,"test");
     REQUIRE (att_str==fn);
   }
+
+  // Check constants
+  Real Rgas_v, gravit_v;
+
+  auto Rgas_u = scorpio::get_attribute<std::string>(filename,"Rgas","units");
+  auto gravit_u = scorpio::get_attribute<std::string>(filename,"gravit","units");
+  scorpio::read_var(filename,"Rgas",&Rgas_v);
+  scorpio::read_var(filename,"gravit",&gravit_v);
+
+  const auto& dict = physics::Constants<Real>::dictionary();
+  REQUIRE (Rgas_u==dict.at("Rgas").units.to_string());
+  REQUIRE (gravit_u==dict.at("gravit").units.to_string());
+  REQUIRE (Rgas_v==dict.at("Rgas").value);
+  REQUIRE (gravit_v==dict.at("gravit").value);
 }
 
 TEST_CASE ("io_basic") {


### PR DESCRIPTION
Users can request constants via `constants: [foo, bar, baz]` in the output yaml file.

[BFB]

---

This was such a tiny feature that I decided to go ahead and implement it. @mahf708 I went the variable route, so you should be able to do stuff like `ds['Rgas']` in python.

Notice that ONLY the constants that are registered in the physics constants dictionary can be requested. If you have a constant that you need in the output file and is not in the dictionary, well, you know what to do.. :)