### PR TITLE
Limit warning messages on STDEV_ELEV and manunitro to masterproc

### DIFF
--- a/components/elm/src/main/pftvarcon.F90
+++ b/components/elm/src/main/pftvarcon.F90
@@ -782,6 +782,7 @@ contains
     if ( .not. readv ) call endrun(msg=' ERROR: error in reading in pft data'//errMsg(__FILE__, __LINE__))
     call ncd_io('manunitro',manunitro, 'read', ncid, readvar=readv, posNOTonfile=.true.)
     if (.not. readv) then
+         if (masterproc) &
          write(iulog,*) trim(subname),' WARNING: manunitro  NOT in parameter file. Try to use fertnitro instead.'
          call ncd_io('fertnitro',manunitro, 'read', ncid, readvar=readv, posNOTonfile=.true.)
          if ( .not. readv ) call endrun(msg=' ERROR: both manunitro and fertnitro not in parameter file'//errMsg(__FILE__, __LINE__))

--- a/components/elm/src/main/surfrdMod.F90
+++ b/components/elm/src/main/surfrdMod.F90
@@ -1680,6 +1680,7 @@ contains
     call ncd_io(ncid=ncid, varname='STDEV_ELEV', flag='read', data=domain%stdev_elev, &
          dim1name=grlnd, readvar=readvar)
     if (.not. readvar) then
+         if (masterproc) &
          write(iulog,*) trim(subname),' WARNING: STDEV_ELEV  NOT on fsurdat file. Try to use STD_ELEV instead.'
          call ncd_io(ncid=ncid, varname='STD_ELEV', flag='read', data=domain%stdev_elev, &
               dim1name=grlnd, readvar=readvar)


### PR DESCRIPTION
When the first choice variable for stdev_elev in surfrdMod and manunitro in pftvarcon modules 
are not available, it sets to print a warning message then read the alternative. The changes here
are to minimize the warning printout.

[BFB]

-----------------------------------
Example of current printout as recorded in e3sm.log (for coupled ne256 eamxx)
 
1153:  surfrd_get_topo_for_solar_rad WARNING: STDEV_ELEV  NOT on fsurdat file. Try to use STD_ELEV instead.
2497:  surfrd_get_topo_for_solar_rad WARNING: STDEV_ELEV  NOT on fsurdat file. Try to use STD_ELEV instead.
1089:  surfrd_get_topo_for_solar_rad WARNING: STDEV_ELEV  NOT on fsurdat file. Try to use STD_ELEV instead.

... (omitting numerous repetition)

1811:  pftconrd WARNING: manunitro  NOT in parameter file. Try to use fertnitro instead.
1410:  pftconrd WARNING: manunitro  NOT in parameter file. Try to use fertnitro instead.
1155:  pftconrd WARNING: manunitro  NOT in parameter file. Try to use fertnitro instead.

... (omitting numerous repetition)

(see more in `/pscratch/sd/w/wlin/E3SM_testings/20251228.ne256.WCYCLXX1850/run/e3sm.log.47433844.260105-230208`)