### PR TITLE
EAMxx: fix link error in homme f90 interface

### DIFF
--- a/components/eamxx/src/dynamics/homme/interface/homme_grid_mod.F90
+++ b/components/eamxx/src/dynamics/homme/interface/homme_grid_mod.F90
@@ -12,11 +12,12 @@ module homme_grid_mod
   public :: finalize_geometry_f90
 
   ! Routines to get information
-  ! public :: get_cols_gids_f90, get_cols_indices_f90
   public :: get_num_local_columns_f90, get_num_global_columns_f90
   public :: get_num_local_elems_f90, get_num_global_elems_f90
   public :: get_np_f90, get_nlev_f90
   public :: is_planar_geometry_f90
+
+  public :: check_grids_inited
 
 contains
 


### PR DESCRIPTION
Fix a ~compiler warning~ <ins>linker error </ins>in eamxx-homme f90 interfaces, that only appears on pm-cpu with nvidia compilers.

[BFB]

---

I am not entirely sure _why_ this fixes things (or, better, why things were not working before). It is highly likely that this is a compiler-dependent issue, but the fix is relatively innocuous, so I'm ok with it.

Fixes #7910
Fixes #7874 