### PR TITLE
EAMxx: a couple of upgrades to DataInterpolation

### DIFF
--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -405,7 +405,7 @@ void MAMMicrophysics::set_oxid_reader()
   // Beg of any year, since we use yearly periodic timeline
   util::TimeStamp ref_ts_oxid (1,1,1,0,0,0);
   data_interp_oxid_ = std::make_shared<DataInterpolation>(grid_,oxid_fields);
-  data_interp_oxid_->setup_time_database ({oxid_file_name},util::TimeLine::YearlyPeriodic, ref_ts_oxid);
+  data_interp_oxid_->setup_time_database ({oxid_file_name},util::TimeLine::YearlyPeriodic, DataInterpolation::Linear, ref_ts_oxid);
   data_interp_oxid_->create_horiz_remappers (oxid_map_file=="none" ? "" : oxid_map_file);
   data_interp_oxid_->set_logger(m_atm_logger);
   DataInterpolation::VertRemapData remap_data_oxid;
@@ -441,7 +441,7 @@ void MAMMicrophysics::set_linoz_reader(){
   }
 
   data_interp_linoz_ = std::make_shared<DataInterpolation>(grid_,linoz_fields);
-  data_interp_linoz_->setup_time_database ({m_linoz_file_name},util::TimeLine::YearlyPeriodic, ref_ts_linoz);
+  data_interp_linoz_->setup_time_database ({m_linoz_file_name},util::TimeLine::YearlyPeriodic, DataInterpolation::Linear, ref_ts_linoz);
   data_interp_linoz_->create_horiz_remappers (linoz_map_file=="none" ? "" : linoz_map_file);
   data_interp_linoz_->set_logger(m_atm_logger);
 
@@ -484,7 +484,7 @@ void MAMMicrophysics::set_elevated_emissions_reader()
     std::shared_ptr<DataInterpolation> di_vertical = std::make_shared<DataInterpolation>(grid_,vertical_fields);
     di_vertical->set_input_files_dimname(ShortFieldTagsNames::LEV,"altitude");
     di_vertical->set_input_files_dimname(ShortFieldTagsNames::ILEV,"altitude_int");
-    di_vertical->setup_time_database ({file_name},util::TimeLine::YearlyPeriodic, ref_ts_vertical);
+    di_vertical->setup_time_database ({file_name},util::TimeLine::YearlyPeriodic, DataInterpolation::Linear, ref_ts_vertical);
     di_vertical->create_horiz_remappers (extfrc_map_file=="none" ? "" : extfrc_map_file);
     di_vertical->set_logger(m_atm_logger);
     DataInterpolation::VertRemapData remap_data_vertical;

--- a/components/eamxx/src/physics/spa/eamxx_spa_process_interface.cpp
+++ b/components/eamxx/src/physics/spa/eamxx_spa_process_interface.cpp
@@ -86,7 +86,7 @@ void SPA::initialize_impl (const RunType /* run_type */)
 
   util::TimeStamp ref_ts (1,1,1,0,0,0); // Beg of any year, since we use yearly periodic timeline
   m_data_interpolation = std::make_shared<DataInterpolation>(m_model_grid,spa_fields);
-  m_data_interpolation->setup_time_database ({spa_data_file},util::TimeLine::YearlyPeriodic, ref_ts);
+  m_data_interpolation->setup_time_database ({spa_data_file},util::TimeLine::YearlyPeriodic, DataInterpolation::Linear, ref_ts);
 
   if (m_iop_data_manager!=nullptr) {
     // IOP cases cannot have a remap file. We will create a IOPRemapper as the horiz remapper

--- a/components/eamxx/src/share/algorithm/eamxx_data_interpolation.cpp
+++ b/components/eamxx/src/share/algorithm/eamxx_data_interpolation.cpp
@@ -85,8 +85,16 @@ void DataInterpolation::run (const util::TimeStamp& ts)
     const auto& end = m_horiz_remapper_end->get_tgt_field(i);
           auto  out = m_vert_remapper->get_src_field(i);
 
-    out.deep_copy(beg);
-    out.update(end,alpha,1-alpha);
+    if (m_time_interp_type==Linear) {
+      out.deep_copy(beg);
+      out.update(end,alpha,1-alpha);
+    } else {
+      if (alpha>0.5) {
+        out.deep_copy(end);
+      } else {
+        out.deep_copy(beg);
+      }
+    }
   }
 
   // For Dynamic3D/Dynamic3D profile we also need to compute the source pressure profile
@@ -228,6 +236,7 @@ init_data_interval (const util::TimeStamp& t0)
 void DataInterpolation::
 setup_time_database (const strvec_t& input_files,
                      const util::TimeLine timeline,
+                     const TimeInterpType interp_type,
                      const util::TimeStamp& ref_ts)
 {
   // Log the final list of files, so the user know if something went wrong (e.g. a bad regex)
@@ -326,6 +335,8 @@ setup_time_database (const strvec_t& input_files,
   // we must ensure we have 2+ time slices overall
   EKAT_REQUIRE_MSG (m_time_database.size()>=2,
       "[DataInterpolation] Error! Input file(s) only contain 1 time slice overall.\n");
+
+  m_time_interp_type = interp_type;
 
   m_time_db_created = true;
 }

--- a/components/eamxx/src/share/algorithm/eamxx_data_interpolation.hpp
+++ b/components/eamxx/src/share/algorithm/eamxx_data_interpolation.hpp
@@ -30,6 +30,11 @@ public:
                   // to set up the src pressure profile (the user will take care of it)
   };
 
+  enum TimeInterpType {
+    Linear,
+    Nearest
+  };
+
   struct VertRemapData {
     VertRemapData() = default;
 
@@ -51,6 +56,7 @@ public:
 
   void setup_time_database (const strvec_t& input_files,
                             const util::TimeLine timeline,
+                            const TimeInterpType interp_type = Linear,
                             const util::TimeStamp& ref_ts = util::TimeStamp());
 
   // In case the input files store col/lev dims with exhotic names, the user can provide them here
@@ -125,6 +131,7 @@ protected:
   std::pair<int,int>    m_curr_interval_idx;
 
   TimeDatabase          m_time_database;
+  TimeInterpType        m_time_interp_type;
 
   ekat::Comm            m_comm;
 


### PR DESCRIPTION
- Allow to read data from files without lev and/or without col dimensions
- Allow to perform "nearest-point interpolation"

[BFB]

---

@crterai In order to use the "nearest point" time interpolation, one has to pass an additional arg to the `setup_time_database` call. See the example in the unit tests.
