### PR TITLE
Fix cld_fraction cmake

### DIFF
--- a/components/eamxx/tests/single-process/cld_fraction/CMakeLists.txt
+++ b/components/eamxx/tests/single-process/cld_fraction/CMakeLists.txt
@@ -114,9 +114,7 @@ if (EAMXX_ENABLE_PYTHON)
 
     # So that we know, below, that we can run cpp-vs-py test for cld_frac_net output
     set (HAS_CLD_FRAC_NET_PY TRUE)
-  endif()
 
-  if (NOT EAMXX_ENABLE_GPU)
     #####################################
     #         CldFracNet (CPP)          #
     #####################################


### PR DESCRIPTION
I was surprised to find that master fails to configure on latest master on mappy with the test-all-eamxx standard debug build:

```
CMake Error at /home/jgfouca/E3SM/externals/ekat/cmake/EkatCreateUnitTest.cmake:171 (get_target_property):
  get_target_property() called with non-existent target
  "cld_frac_net_standalone".
Call Stack (most recent call first):
  cmake/ScreamUtils.cmake:147 (EkatCreateUnitTestFromExec)
  tests/single-process/cld_fraction/CMakeLists.txt:135 (CreateUnitTestFromExec)
```

Looking at `tests/single-process/cld_fraction/CMakeLists.txt`, the executable `cld_frac_net_standalone` only gets defined if `EAMXX_ENABLE_PYTHON` and `NOT EAMXX_ENABLE_GPU`, but later in the file, the executable is used in an if block that only checks `NOT EAMXX_ENABLE_GPU`, so if `EAMXX_ENABLE_PYTHON` is Off, then it's undefined. Looking at the file, the executable `cld_fraction_standalone` is the only one we know for sure will exist, so I tentatively chose that one.

[BFB]