### PR TITLE
EAMxx: make all field update-like methods const

### DIFF
--- a/components/eamxx/src/share/field/eti/field_deep_copy_double.cpp
+++ b/components/eamxx/src/share/field/eti/field_deep_copy_double.cpp
@@ -3,7 +3,7 @@
 
 namespace scream {
 
-template void Field::deep_copy_impl<true,double>(const double, const Field&);
-template void Field::deep_copy_impl<false,double>(const double, const Field&);
+template void Field::deep_copy_impl<true,double>(const double, const Field&) const;
+template void Field::deep_copy_impl<false,double>(const double, const Field&) const;
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_deep_copy_float.cpp
+++ b/components/eamxx/src/share/field/eti/field_deep_copy_float.cpp
@@ -3,7 +3,7 @@
 
 namespace scream {
 
-template void Field::deep_copy_impl<true,float>(const float, const Field&);
-template void Field::deep_copy_impl<false,float>(const float, const Field&);
+template void Field::deep_copy_impl<true,float>(const float, const Field&) const;
+template void Field::deep_copy_impl<false,float>(const float, const Field&) const;
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_deep_copy_int.cpp
+++ b/components/eamxx/src/share/field/eti/field_deep_copy_int.cpp
@@ -3,7 +3,7 @@
 
 namespace scream {
 
-template void Field::deep_copy_impl<true,int>(const int, const Field&);
-template void Field::deep_copy_impl<false,int>(const int, const Field&);
+template void Field::deep_copy_impl<true,int>(const int, const Field&) const;
+template void Field::deep_copy_impl<false,int>(const int, const Field&) const;
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_update_impl_double_double.cpp
+++ b/components/eamxx/src/share/field/eti/field_update_impl_double_double.cpp
@@ -3,11 +3,11 @@
 
 namespace scream {
 
-template void Field::update_impl<CombineMode::Replace,  false, double, double>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Update,   false, double, double>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Multiply, false, double, double>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Divide,   false, double, double>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Max,      false, double, double>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Min,      false, double, double>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Replace,  false, double, double>(const Field&, const double, const double) const;
+template void Field::update_impl<CombineMode::Update,   false, double, double>(const Field&, const double, const double) const;
+template void Field::update_impl<CombineMode::Multiply, false, double, double>(const Field&, const double, const double) const;
+template void Field::update_impl<CombineMode::Divide,   false, double, double>(const Field&, const double, const double) const;
+template void Field::update_impl<CombineMode::Max,      false, double, double>(const Field&, const double, const double) const;
+template void Field::update_impl<CombineMode::Min,      false, double, double>(const Field&, const double, const double) const;
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_update_impl_double_double_fill_aware.cpp
+++ b/components/eamxx/src/share/field/eti/field_update_impl_double_double_fill_aware.cpp
@@ -3,10 +3,10 @@
 
 namespace scream {
 
-template void Field::update_impl<CombineMode::Update,   true, double, double>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Multiply, true, double, double>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Divide,   true, double, double>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Max,      true, double, double>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Min,      true, double, double>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Update,   true, double, double>(const Field&, const double, const double) const;
+template void Field::update_impl<CombineMode::Multiply, true, double, double>(const Field&, const double, const double) const;
+template void Field::update_impl<CombineMode::Divide,   true, double, double>(const Field&, const double, const double) const;
+template void Field::update_impl<CombineMode::Max,      true, double, double>(const Field&, const double, const double) const;
+template void Field::update_impl<CombineMode::Min,      true, double, double>(const Field&, const double, const double) const;
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_update_impl_double_float.cpp
+++ b/components/eamxx/src/share/field/eti/field_update_impl_double_float.cpp
@@ -3,11 +3,11 @@
 
 namespace scream {
 
-template void Field::update_impl<CombineMode::Replace,  false, double, float>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Update,   false, double, float>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Multiply, false, double, float>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Divide,   false, double, float>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Max,      false, double, float>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Min,      false, double, float>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Replace,  false, double, float>(const Field&, const double, const double) const;
+template void Field::update_impl<CombineMode::Update,   false, double, float>(const Field&, const double, const double) const;
+template void Field::update_impl<CombineMode::Multiply, false, double, float>(const Field&, const double, const double) const;
+template void Field::update_impl<CombineMode::Divide,   false, double, float>(const Field&, const double, const double) const;
+template void Field::update_impl<CombineMode::Max,      false, double, float>(const Field&, const double, const double) const;
+template void Field::update_impl<CombineMode::Min,      false, double, float>(const Field&, const double, const double) const;
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_update_impl_double_float_fill_aware.cpp
+++ b/components/eamxx/src/share/field/eti/field_update_impl_double_float_fill_aware.cpp
@@ -3,10 +3,10 @@
 
 namespace scream {
 
-template void Field::update_impl<CombineMode::Update,   true, double, float>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Multiply, true, double, float>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Divide,   true, double, float>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Max,      true, double, float>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Min,      true, double, float>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Update,   true, double, float>(const Field&, const double, const double) const;
+template void Field::update_impl<CombineMode::Multiply, true, double, float>(const Field&, const double, const double) const;
+template void Field::update_impl<CombineMode::Divide,   true, double, float>(const Field&, const double, const double) const;
+template void Field::update_impl<CombineMode::Max,      true, double, float>(const Field&, const double, const double) const;
+template void Field::update_impl<CombineMode::Min,      true, double, float>(const Field&, const double, const double) const;
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_update_impl_double_int.cpp
+++ b/components/eamxx/src/share/field/eti/field_update_impl_double_int.cpp
@@ -3,11 +3,11 @@
 
 namespace scream {
 
-template void Field::update_impl<CombineMode::Replace,  false, double, int>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Update,   false, double, int>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Multiply, false, double, int>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Divide,   false, double, int>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Max,      false, double, int>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Min,      false, double, int>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Replace,  false, double, int>(const Field&, const double, const double) const;
+template void Field::update_impl<CombineMode::Update,   false, double, int>(const Field&, const double, const double) const;
+template void Field::update_impl<CombineMode::Multiply, false, double, int>(const Field&, const double, const double) const;
+template void Field::update_impl<CombineMode::Divide,   false, double, int>(const Field&, const double, const double) const;
+template void Field::update_impl<CombineMode::Max,      false, double, int>(const Field&, const double, const double) const;
+template void Field::update_impl<CombineMode::Min,      false, double, int>(const Field&, const double, const double) const;
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_update_impl_double_int_fill_aware.cpp
+++ b/components/eamxx/src/share/field/eti/field_update_impl_double_int_fill_aware.cpp
@@ -3,10 +3,10 @@
 
 namespace scream {
 
-template void Field::update_impl<CombineMode::Update,   true, double, int>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Multiply, true, double, int>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Divide,   true, double, int>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Max,      true, double, int>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Min,      true, double, int>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Update,   true, double, int>(const Field&, const double, const double) const;
+template void Field::update_impl<CombineMode::Multiply, true, double, int>(const Field&, const double, const double) const;
+template void Field::update_impl<CombineMode::Divide,   true, double, int>(const Field&, const double, const double) const;
+template void Field::update_impl<CombineMode::Max,      true, double, int>(const Field&, const double, const double) const;
+template void Field::update_impl<CombineMode::Min,      true, double, int>(const Field&, const double, const double) const;
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_update_impl_float_float.cpp
+++ b/components/eamxx/src/share/field/eti/field_update_impl_float_float.cpp
@@ -3,11 +3,11 @@
 
 namespace scream {
 
-template void Field::update_impl<CombineMode::Replace,  false, float, float>(const Field&, const float, const float);
-template void Field::update_impl<CombineMode::Update,   false, float, float>(const Field&, const float, const float);
-template void Field::update_impl<CombineMode::Multiply, false, float, float>(const Field&, const float, const float);
-template void Field::update_impl<CombineMode::Divide,   false, float, float>(const Field&, const float, const float);
-template void Field::update_impl<CombineMode::Max,      false, float, float>(const Field&, const float, const float);
-template void Field::update_impl<CombineMode::Min,      false, float, float>(const Field&, const float, const float);
+template void Field::update_impl<CombineMode::Replace,  false, float, float>(const Field&, const float, const float) const;
+template void Field::update_impl<CombineMode::Update,   false, float, float>(const Field&, const float, const float) const;
+template void Field::update_impl<CombineMode::Multiply, false, float, float>(const Field&, const float, const float) const;
+template void Field::update_impl<CombineMode::Divide,   false, float, float>(const Field&, const float, const float) const;
+template void Field::update_impl<CombineMode::Max,      false, float, float>(const Field&, const float, const float) const;
+template void Field::update_impl<CombineMode::Min,      false, float, float>(const Field&, const float, const float) const;
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_update_impl_float_float_fill_aware.cpp
+++ b/components/eamxx/src/share/field/eti/field_update_impl_float_float_fill_aware.cpp
@@ -3,10 +3,10 @@
 
 namespace scream {
 
-template void Field::update_impl<CombineMode::Update,   true, float, float>(const Field&, const float, const float);
-template void Field::update_impl<CombineMode::Multiply, true, float, float>(const Field&, const float, const float);
-template void Field::update_impl<CombineMode::Divide,   true, float, float>(const Field&, const float, const float);
-template void Field::update_impl<CombineMode::Max,      true, float, float>(const Field&, const float, const float);
-template void Field::update_impl<CombineMode::Min,      true, float, float>(const Field&, const float, const float);
+template void Field::update_impl<CombineMode::Update,   true, float, float>(const Field&, const float, const float) const;
+template void Field::update_impl<CombineMode::Multiply, true, float, float>(const Field&, const float, const float) const;
+template void Field::update_impl<CombineMode::Divide,   true, float, float>(const Field&, const float, const float) const;
+template void Field::update_impl<CombineMode::Max,      true, float, float>(const Field&, const float, const float) const;
+template void Field::update_impl<CombineMode::Min,      true, float, float>(const Field&, const float, const float) const;
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_update_impl_float_int.cpp
+++ b/components/eamxx/src/share/field/eti/field_update_impl_float_int.cpp
@@ -3,11 +3,11 @@
 
 namespace scream {
 
-template void Field::update_impl<CombineMode::Replace,  false, float, int>(const Field&, const float, const float);
-template void Field::update_impl<CombineMode::Update,   false, float, int>(const Field&, const float, const float);
-template void Field::update_impl<CombineMode::Multiply, false, float, int>(const Field&, const float, const float);
-template void Field::update_impl<CombineMode::Divide,   false, float, int>(const Field&, const float, const float);
-template void Field::update_impl<CombineMode::Max,      false, float, int>(const Field&, const float, const float);
-template void Field::update_impl<CombineMode::Min,      false, float, int>(const Field&, const float, const float);
+template void Field::update_impl<CombineMode::Replace,  false, float, int>(const Field&, const float, const float) const;
+template void Field::update_impl<CombineMode::Update,   false, float, int>(const Field&, const float, const float) const;
+template void Field::update_impl<CombineMode::Multiply, false, float, int>(const Field&, const float, const float) const;
+template void Field::update_impl<CombineMode::Divide,   false, float, int>(const Field&, const float, const float) const;
+template void Field::update_impl<CombineMode::Max,      false, float, int>(const Field&, const float, const float) const;
+template void Field::update_impl<CombineMode::Min,      false, float, int>(const Field&, const float, const float) const;
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_update_impl_float_int_fill_aware.cpp
+++ b/components/eamxx/src/share/field/eti/field_update_impl_float_int_fill_aware.cpp
@@ -3,10 +3,10 @@
 
 namespace scream {
 
-template void Field::update_impl<CombineMode::Update,   true, float, int>(const Field&, const float, const float);
-template void Field::update_impl<CombineMode::Multiply, true, float, int>(const Field&, const float, const float);
-template void Field::update_impl<CombineMode::Divide,   true, float, int>(const Field&, const float, const float);
-template void Field::update_impl<CombineMode::Max,      true, float, int>(const Field&, const float, const float);
-template void Field::update_impl<CombineMode::Min,      true, float, int>(const Field&, const float, const float);
+template void Field::update_impl<CombineMode::Update,   true, float, int>(const Field&, const float, const float) const;
+template void Field::update_impl<CombineMode::Multiply, true, float, int>(const Field&, const float, const float) const;
+template void Field::update_impl<CombineMode::Divide,   true, float, int>(const Field&, const float, const float) const;
+template void Field::update_impl<CombineMode::Max,      true, float, int>(const Field&, const float, const float) const;
+template void Field::update_impl<CombineMode::Min,      true, float, int>(const Field&, const float, const float) const;
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_update_impl_int_int.cpp
+++ b/components/eamxx/src/share/field/eti/field_update_impl_int_int.cpp
@@ -3,11 +3,11 @@
 
 namespace scream {
 
-template void Field::update_impl<CombineMode::Replace,  false, int, int>(const Field&, const int, const int);
-template void Field::update_impl<CombineMode::Update,   false, int, int>(const Field&, const int, const int);
-template void Field::update_impl<CombineMode::Multiply, false, int, int>(const Field&, const int, const int);
-template void Field::update_impl<CombineMode::Divide,   false, int, int>(const Field&, const int, const int);
-template void Field::update_impl<CombineMode::Max,      false, int, int>(const Field&, const int, const int);
-template void Field::update_impl<CombineMode::Min,      false, int, int>(const Field&, const int, const int);
+template void Field::update_impl<CombineMode::Replace,  false, int, int>(const Field&, const int, const int) const;
+template void Field::update_impl<CombineMode::Update,   false, int, int>(const Field&, const int, const int) const;
+template void Field::update_impl<CombineMode::Multiply, false, int, int>(const Field&, const int, const int) const;
+template void Field::update_impl<CombineMode::Divide,   false, int, int>(const Field&, const int, const int) const;
+template void Field::update_impl<CombineMode::Max,      false, int, int>(const Field&, const int, const int) const;
+template void Field::update_impl<CombineMode::Min,      false, int, int>(const Field&, const int, const int) const;
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_update_impl_int_int_fill_aware.cpp
+++ b/components/eamxx/src/share/field/eti/field_update_impl_int_int_fill_aware.cpp
@@ -3,10 +3,10 @@
 
 namespace scream {
 
-template void Field::update_impl<CombineMode::Update,   true, int, int>(const Field&, const int, const int);
-template void Field::update_impl<CombineMode::Multiply, true, int, int>(const Field&, const int, const int);
-template void Field::update_impl<CombineMode::Divide,   true, int, int>(const Field&, const int, const int);
-template void Field::update_impl<CombineMode::Max,      true, int, int>(const Field&, const int, const int);
-template void Field::update_impl<CombineMode::Min,      true, int, int>(const Field&, const int, const int);
+template void Field::update_impl<CombineMode::Update,   true, int, int>(const Field&, const int, const int) const;
+template void Field::update_impl<CombineMode::Multiply, true, int, int>(const Field&, const int, const int) const;
+template void Field::update_impl<CombineMode::Divide,   true, int, int>(const Field&, const int, const int) const;
+template void Field::update_impl<CombineMode::Max,      true, int, int>(const Field&, const int, const int) const;
+template void Field::update_impl<CombineMode::Min,      true, int, int>(const Field&, const int, const int) const;
 
 } // namespace scream

--- a/components/eamxx/src/share/field/field.cpp
+++ b/components/eamxx/src/share/field/field.cpp
@@ -297,7 +297,8 @@ void Field::allocate_view ()
 }
 
 
-void Field::deep_copy (const ScalarWrapper value) {
+void Field::deep_copy (const ScalarWrapper value) const
+{
   EKAT_REQUIRE_MSG (not m_is_read_only,
       "Error! Cannot call deep_copy on read-only fields.\n");
 
@@ -317,7 +318,7 @@ void Field::deep_copy (const ScalarWrapper value) {
   }
 }
 
-void Field::deep_copy (const Field& x)
+void Field::deep_copy (const Field& x) const
 {
   // Check consistency of inputs
   update_checks(*this,&x,nullptr,nullptr);
@@ -344,7 +345,7 @@ void Field::deep_copy (const Field& x)
   }
 }
 
-void Field::deep_copy (const ScalarWrapper value, const Field& mask)
+void Field::deep_copy (const ScalarWrapper value, const Field& mask) const
 {
   update_checks(*this,nullptr,&value,nullptr);
 
@@ -364,7 +365,7 @@ void Field::deep_copy (const ScalarWrapper value, const Field& mask)
   }
 }
 
-void Field::scale (const ScalarWrapper beta)
+void Field::scale (const ScalarWrapper beta) const
 {
   // Check consistency of inputs
   update_checks(*this,nullptr,nullptr,&beta);
@@ -388,7 +389,7 @@ void Field::scale (const ScalarWrapper beta)
   }
 }
 
-void Field::scale (const Field& x)
+void Field::scale (const Field& x) const
 {
   // Check consistency of inputs
   update_checks(*this,&x,nullptr,nullptr);
@@ -436,7 +437,7 @@ void Field::scale (const Field& x)
   }
 }
 
-void Field::scale_inv (const Field& x)
+void Field::scale_inv (const Field& x) const
 {
   // Check consistency of inputs
   update_checks(*this,&x,nullptr,nullptr);
@@ -484,7 +485,7 @@ void Field::scale_inv (const Field& x)
   }
 }
 
-void Field::max (const Field& x)
+void Field::max (const Field& x) const
 {
   // Check consistency of inputs
   update_checks(*this,&x,nullptr,nullptr);
@@ -532,7 +533,7 @@ void Field::max (const Field& x)
   }
 }
 
-void Field::min (const Field& x)
+void Field::min (const Field& x) const
 {
   // Check consistency of inputs
   update_checks(*this,&x,nullptr,nullptr);
@@ -581,7 +582,7 @@ void Field::min (const Field& x)
 }
 
 void Field::
-update (const Field& x, const ScalarWrapper alpha, const ScalarWrapper beta)
+update (const Field& x, const ScalarWrapper alpha, const ScalarWrapper beta) const
 {
   // Check consistency of inputs
   update_checks(*this,&x,&alpha,&beta);

--- a/components/eamxx/src/share/field/field.hpp
+++ b/components/eamxx/src/share/field/field.hpp
@@ -203,33 +203,33 @@ public:
   void sync_to_dev (const bool fence = true) const;
 
   // Set the field to a constant value (on device view ONLY)
-  void deep_copy (const ScalarWrapper value);
+  void deep_copy (const ScalarWrapper value) const;
 
   // Like the above one, but only sets the value where the mask is active
   // NOTE: mask field must have data type IntType. Runs on device ONLY
-  void deep_copy (const ScalarWrapper value, const Field& mask);
+  void deep_copy (const ScalarWrapper value, const Field& mask) const;
 
   // Copy the data from one field to this field (on device ONLY)
-  void deep_copy (const Field& src);
+  void deep_copy (const Field& src) const;
 
   // Updates this field y as y=beta*y + alpha*x
   // See share/util/eamxx_combine_ops.hpp for more details on CombineMode options
-  void update (const Field& x, const ScalarWrapper alpha, const ScalarWrapper beta);
+  void update (const Field& x, const ScalarWrapper alpha, const ScalarWrapper beta) const;
 
   // Special case of update for particular choices of the combine mode
-  void scale (const ScalarWrapper beta);
+  void scale (const ScalarWrapper beta) const;
 
   // Scale a field y as y=y*x where x is also a field
-  void scale (const Field& x);
+  void scale (const Field& x) const;
 
   // Scale a field y as y=y/x where x is also a field
-  void scale_inv (const Field& x);
+  void scale_inv (const Field& x) const;
 
   // Replace *this with max(*this, x)
-  void max (const Field& x);
+  void max (const Field& x) const;
 
   // Replace *this with min(*this, x)
-  void min (const Field& x);
+  void min (const Field& x) const;
 
   // Returns a subview of this field, slicing at entry k along dimension idim
   // NOTES:
@@ -319,10 +319,10 @@ protected:
   // The field manipulation methods call these two, with ST matching this field data type.
   // Note: use_fill/use_mask are used to resolve some if statements in the impl at compile time
   template<bool use_mask, typename ST>
-  void deep_copy_impl (const ST value, const Field& mask);
+  void deep_copy_impl (const ST value, const Field& mask) const;
 
   template<CombineMode CM, bool use_fill, typename ST, typename STX>
-  void update_impl (const Field& x, const ST alpha, const ST beta);
+  void update_impl (const Field& x, const ST alpha, const ST beta) const;
 
   template<HostOrDevice HD>
   const get_view_type<char*,HD>&

--- a/components/eamxx/src/share/field/field_update_impl.hpp
+++ b/components/eamxx/src/share/field/field_update_impl.hpp
@@ -211,7 +211,7 @@ svm (LhsView lhs,
 
 template<CombineMode CM, bool FillAware, typename ST, typename XST>
 void Field::
-update_impl (const Field& x, const ST alpha, const ST beta)
+update_impl (const Field& x, const ST alpha, const ST beta) const
 {
   const auto& layout = x.get_header().get_identifier().get_layout();
   const auto& dims = layout.dims();
@@ -355,7 +355,7 @@ update_impl (const Field& x, const ST alpha, const ST beta)
 }
 
 template<bool use_mask, typename ST>
-void Field::deep_copy_impl (const ST value, const Field& mask)
+void Field::deep_copy_impl (const ST value, const Field& mask) const
 {
   const auto& layout = get_header().get_identifier().get_layout();
   const auto  rank   = layout.rank();


### PR DESCRIPTION
Updating the stored values does not alter the class direct content. This is similar to Kokkos::View behavior for access operators.

[BFB]

---

This is akin to the distinction between `T*`, `T* const`. This PR is basically switching from the former to the latter, since we do not modify the stored pointer, just the pointed values.

This mod will help to simplify `AtmosphereProcess`'s API.