### PR TITLE
EAMxx: do not reset yaml file list in eamxx-prod testmod

### DIFF
--- a/components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/prod/shell_commands
+++ b/components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/prod/shell_commands
@@ -65,7 +65,6 @@ fi
 
 # set the output yaml files
 output_yaml_files=$(find ${cime_root}/../components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/prod/yaml_outs/ -maxdepth 1 -type f)
-$atmchange -b output_yaml_files=""
 for file in ${output_yaml_files[@]}; do
     # Grab the proper map file (if any)
     mapfile=""


### PR DESCRIPTION
Other testmods existing BEFORE eamxx-prod may have already added yaml files.

[BFB]

---

PR #7985 introduced this bug, causing more DIFFs than expected on cdash. I did not catch this, as the eamxx CI does not run eamxx-prod _combined_ with other output-producing testmods.