### PR TITLE
EAMxx: remove manual inclusion of eamxx_config.h

### DIFF
--- a/components/eamxx/src/mct_coupling/eamxx_cxx_f90_interface.cpp
+++ b/components/eamxx/src/mct_coupling/eamxx_cxx_f90_interface.cpp
@@ -1,5 +1,3 @@
-#include "eamxx_config.h"
-
 #include "share/atm_process/atmosphere_process.hpp"
 #include "control/atmosphere_driver.hpp"
 #include "control/surface_coupling_utils.hpp"

--- a/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
+++ b/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
@@ -3,8 +3,6 @@
 #include "share/property_checks/field_lower_bound_check.hpp"
 #include "share/property_checks/field_within_interval_check.hpp"
 
-#include "eamxx_config.h" // for SCREAM_CIME_BUILD
-
 #include <ekat_assert.hpp>
 #include <ekat_team_policy_utils.hpp>
 #include <ekat_reduction_utils.hpp>

--- a/components/eamxx/src/physics/zm/eamxx_zm_process_interface.cpp
+++ b/components/eamxx/src/physics/zm/eamxx_zm_process_interface.cpp
@@ -1,5 +1,3 @@
-#include "eamxx_config.h" // for SCREAM_CIME_BUILD
-
 #include "share/property_checks/field_lower_bound_check.hpp"
 #include "share/property_checks/field_within_interval_check.hpp"
 

--- a/components/eamxx/src/share/core/eamxx_types.hpp
+++ b/components/eamxx/src/share/core/eamxx_types.hpp
@@ -1,7 +1,7 @@
 #ifndef SCREAM_TYPES_HPP
 #define SCREAM_TYPES_HPP
 
-#include "eamxx_config.h"
+#include "eamxx_config.hpp"
 
 #include <ekat_kokkos_types.hpp>
 

--- a/components/eamxx/src/share/remap/coarsening_remapper.hpp
+++ b/components/eamxx/src/share/remap/coarsening_remapper.hpp
@@ -2,7 +2,6 @@
 #define SCREAM_COARSENING_REMAPPER_HPP
 
 #include "share/remap/horiz_interp_remapper_base.hpp"
-#include "eamxx_config.h"
 
 #include <mpi.h>
 

--- a/components/eamxx/src/share/remap/refining_remapper_p2p.hpp
+++ b/components/eamxx/src/share/remap/refining_remapper_p2p.hpp
@@ -3,7 +3,6 @@
 
 #include "share/remap/abstract_remapper.hpp"
 #include "share/remap/horiz_interp_remapper_base.hpp"
-#include "eamxx_config.h"
 
 #include <ekat_pack.hpp>
 

--- a/components/eamxx/src/share/remap/refining_remapper_rma.hpp
+++ b/components/eamxx/src/share/remap/refining_remapper_rma.hpp
@@ -4,7 +4,6 @@
 #include "share/remap/abstract_remapper.hpp"
 #include "share/remap/horiz_interp_remapper_base.hpp"
 #include "share/util/eamxx_utils.hpp"
-#include "eamxx_config.h"
 
 #include <ekat_pack.hpp>
 

--- a/components/eamxx/src/share/scorpio_interface/eamxx_scorpio_interface.cpp
+++ b/components/eamxx/src/share/scorpio_interface/eamxx_scorpio_interface.cpp
@@ -1,7 +1,7 @@
 #include "eamxx_scorpio_interface.hpp"
 #include "eamxx_shr_interface_c2f.hpp"
 
-#include "eamxx_config.h"
+#include "share/core/eamxx_config.hpp"
 
 #include <ekat_std_utils.hpp>
 #include <ekat_string_utils.hpp>


### PR DESCRIPTION
This file is an implementation detail, and customers should not include it directly.

[BFB]

---

Fixes #7225 

Note: some places included this file to get the `SCREAM_CIME_BUILD` macro. This macro is now attached via `target_compile_definitions` as a PUBLIC property to the `eamxx_core` target, which all eamxx target link against (directly or indirectly). Some places still need access to some of the `SCREAM_XYZ` macros, so include `eamxx_config.hpp` instead where needed.