### PR TITLE
EAMxx: fix run_t0 num steps before initializing output mgrs

### DIFF
--- a/components/eamxx/src/mct_coupling/eamxx_cxx_f90_interface.cpp
+++ b/components/eamxx/src/mct_coupling/eamxx_cxx_f90_interface.cpp
@@ -174,9 +174,9 @@ void scream_create_atm_instance (const MPI_Fint f_comm, const int atm_id,
 
     ad.set_comm(atm_comm);
     ad.set_params(scream_params);
+    ad.set_provenance_data (caseid,rest_caseid,hostname,username,versionid);
     ad.init_scorpio(atm_id);
     ad.init_time_stamps(run_t0,case_t0,run_type);
-    ad.set_provenance_data (caseid,rest_caseid,hostname,username,versionid);
     ad.create_output_managers ();
     ad.create_atm_processes ();
     ad.create_grids ();


### PR DESCRIPTION
The value of run_t0's num steps may be used to compute the timestamp of the next output during the OM init, so its value must be correct before OM's are created.

[BFB]

--- 

Fixes #7682 .

@whannah1 if you still have that case somewhere and want to give this branch a try, that'd be great. If not, that's fine. I already checked on my workstation that the bug (which I could reproduce with a simple ne4pg2 F2010-SCREAMv1 case with no output streams) is gone with this branch, so I'm quite confident we caught it.

The issue was in the order in which we handled the creation of the output manager(s) and the restart of the num_steps counter inside out timestamps. The OM's were not getting the memo, b/c the restart file was read after the OM were created.