### PR TITLE
Add python to improv env

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -3029,6 +3029,7 @@
       <modules>
         <command name="--force purge"/>
         <command name="load">cmake/3.27.4</command>
+        <command name="load">python/3.11.6</command>
       </modules>
       <modules compiler="gnu">
         <command name="load">gcc/12.3.0</command>


### PR DESCRIPTION
The purge will result in a python too old to run CIME.

[BFB]