### PR TITLE
EAMxx: Address compilation errors from ml correction

### DIFF
--- a/components/eamxx/src/physics/ml_correction/eamxx_ml_correction_process_interface.cpp
+++ b/components/eamxx/src/physics/ml_correction/eamxx_ml_correction_process_interface.cpp
@@ -172,7 +172,7 @@ void MLCorrection::run_impl(const double dt) {
     const auto &pseudo_density       = get_field_in("pseudo_density").get_view<const Real**>();
     const auto &precip_liq_surf_mass = get_field_out("precip_liq_surf_mass").get_view<Real *>();
     const auto &precip_ice_surf_mass = get_field_out("precip_ice_surf_mass").get_view<Real *>();
-    constexpr Real g = PC::gravit;
+    constexpr Real g = PC::gravit.value;
     const auto num_levs = m_num_levs;
     const auto policy = TPF::get_default_team_policy(m_num_cols, m_num_levs);
 

--- a/components/eamxx/tests/single-process/ml_correction/ml_correction_standalone.cpp
+++ b/components/eamxx/tests/single-process/ml_correction/ml_correction_standalone.cpp
@@ -2,7 +2,7 @@
 
 #include "control/atmosphere_driver.hpp"
 #include "physics/register_physics.hpp"
-#include "share/grid/mesh_free_grids_manager.hpp"
+#include "share/data_managers/mesh_free_grids_manager.hpp"
 
 #include <ekat_fpe.hpp>
 #include <ekat_yaml.hpp>


### PR DESCRIPTION
Two changes to address compilation errors from ml_correction:
1. Access `PC::gravit.value` instead of `PC:gravit`
2. Correct include path