### PR TITLE
implement initial emulator infrastructure skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ components/eamxx/docs/_presentations_html/
 components/eamxx/src/python/build
 components/eamxx/src/python/build_src
 components/eamxx/src/python/dist
+
+# Emulator Components
+components/emulators/build

--- a/components/emulators/CMakeLists.txt
+++ b/components/emulators/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.16)
+project(emulators LANGUAGES CXX)
+
+# Path to externals (relative to this file)
+get_filename_component(E3SM_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../.." ABSOLUTE)
+set(EXTERNALS_ROOT "${E3SM_ROOT}/externals")
+
+# Catch2 from ekat
+set(CATCH2_INCLUDE_DIR "${EXTERNALS_ROOT}/ekat/extern/Catch2/single_include")
+
+# Verify Catch2 exists
+if(NOT EXISTS "${CATCH2_INCLUDE_DIR}/catch2/catch.hpp")
+  message(FATAL_ERROR "Catch2 not found at ${CATCH2_INCLUDE_DIR}. "
+    "Make sure externals/ekat is available.")
+endif()
+
+# Enable testing at the top level
+enable_testing()
+
+# Add subdirectories
+add_subdirectory(common)

--- a/components/emulators/common/CMakeLists.txt
+++ b/components/emulators/common/CMakeLists.txt
@@ -1,0 +1,4 @@
+# Common utilities for emulator components
+
+add_subdirectory(src)
+add_subdirectory(tests)

--- a/components/emulators/common/src/CMakeLists.txt
+++ b/components/emulators/common/src/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Common source library
+
+add_library(emulator_common
+  emulator.cpp
+)
+
+target_compile_features(emulator_common PUBLIC cxx_std_17)
+
+target_include_directories(emulator_common PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/components/emulators/common/src/emulator.cpp
+++ b/components/emulators/common/src/emulator.cpp
@@ -1,0 +1,39 @@
+/**
+ * @file emulator.cpp
+ * @brief Implementation of the Emulator base class.
+ */
+
+#include "emulator.hpp"
+#include <stdexcept>
+
+namespace emulator {
+
+Emulator::Emulator(EmulatorType type, int id, const std::string &name)
+    : m_type(type), m_id(id), m_name(name), m_initialized(false),
+      m_step_count(0) {}
+
+void Emulator::initialize() {
+  if (m_initialized) {
+    throw std::runtime_error("Emulator already initialized");
+  }
+  init_impl();
+  m_initialized = true;
+}
+
+void Emulator::run(int dt) {
+  if (!m_initialized) {
+    throw std::runtime_error("Emulator::run() called before initialize()");
+  }
+  run_impl(dt);
+  m_step_count++;
+}
+
+void Emulator::finalize() {
+  if (!m_initialized) {
+    return; // Already finalized or never initialized
+  }
+  final_impl();
+  m_initialized = false;
+}
+
+} // namespace emulator

--- a/components/emulators/common/src/emulator.hpp
+++ b/components/emulators/common/src/emulator.hpp
@@ -1,0 +1,70 @@
+/**
+ * @file emulator.hpp
+ * @brief Abstract base class for all E3SM emulators.
+ */
+
+#ifndef EMULATOR_HPP
+#define EMULATOR_HPP
+
+#include <string>
+
+namespace emulator {
+
+/**
+ * @brief Enumeration of emulator types in E3SM.
+ */
+enum class EmulatorType {
+  ATM_COMP = 0, ///< Atmosphere component emulator
+  OCN_COMP = 1, ///< Ocean component emulator
+  ICE_COMP = 2, ///< Sea ice component emulator
+  LND_COMP = 3  ///< Land component emulator
+};
+
+/**
+ * @brief Abstract base class for all E3SM emulators.
+ *
+ * Provides the common infrastructure for emulators.
+ * Derived classes implement the pure virtual methods for
+ * emulator-specific behavior.
+ */
+class Emulator {
+public:
+  /**
+   * @brief Construct a new Emulator.
+   *
+   * @param type Emulator type
+   * @param id Emulator ID (-1 if unassigned)
+   * @param name Emulator name (empty if unassigned)
+   */
+  explicit Emulator(EmulatorType type, int id = -1,
+                    const std::string &name = "");
+  virtual ~Emulator() = default;
+
+  // Lifecycle methods
+  void initialize();
+  void run(int dt);
+  void finalize();
+
+  // Accessors
+  EmulatorType type() const { return m_type; }
+  int id() const { return m_id; }
+  const std::string &name() const { return m_name; }
+  bool is_initialized() const { return m_initialized; }
+  int step_count() const { return m_step_count; }
+
+protected:
+  // Virtual methods for derived classes
+  virtual void init_impl() = 0;
+  virtual void run_impl(int dt) = 0;
+  virtual void final_impl() = 0;
+
+  EmulatorType m_type;
+  int m_id;
+  std::string m_name;
+  bool m_initialized = false;
+  int m_step_count = 0;
+};
+
+} // namespace emulator
+
+#endif // EMULATOR_HPP

--- a/components/emulators/common/src/emulator_registry.hpp
+++ b/components/emulators/common/src/emulator_registry.hpp
@@ -1,0 +1,157 @@
+/**
+ * @file emulator_registry.hpp
+ * @brief Singleton registry for managing emulator instances.
+ *
+ * Inspired by EAMxx's ScreamContext, this provides a type-safe registry
+ * for creating and retrieving emulator instances by name.
+ */
+
+#ifndef EMULATOR_REGISTRY_HPP
+#define EMULATOR_REGISTRY_HPP
+
+#include <any>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <utility>
+
+namespace emulator {
+
+/**
+ * @brief Singleton registry for managing emulator instances.
+ *
+ * Provides type-safe storage and retrieval of emulator instances by name,
+ * allowing multiple instances of the same type with different names.
+ *
+ * ## Usage
+ * ```cpp
+ * // Create an emulator with a name
+ * auto& atm = EmulatorRegistry::instance().create<AtmEmulator>("main_atm",
+ * args...);
+ *
+ * // Later, retrieve it by name
+ * auto& atm = EmulatorRegistry::instance().get_mut<AtmEmulator>("main_atm");
+ *
+ * // Check if it exists
+ * if (EmulatorRegistry::instance().has("main_atm")) { ... }
+ *
+ * // Clean up
+ * cleanup_emulator_registry();
+ * ```
+ */
+class EmulatorRegistry {
+public:
+  /**
+   * @brief Get the singleton instance.
+   * @return Reference to the global EmulatorRegistry
+   */
+  static EmulatorRegistry &instance() {
+    static EmulatorRegistry r;
+    return r;
+  }
+
+  // Prevent copying and moving
+  EmulatorRegistry(const EmulatorRegistry &) = delete;
+  EmulatorRegistry &operator=(const EmulatorRegistry &) = delete;
+  EmulatorRegistry(EmulatorRegistry &&) = delete;
+  EmulatorRegistry &operator=(EmulatorRegistry &&) = delete;
+
+  /**
+   * @brief Create and register a new emulator instance with a name.
+   *
+   * Creates an instance of type T with the given constructor arguments
+   * and stores it in the registry under the specified name.
+   *
+   * @tparam T Emulator type to create
+   * @tparam Args Constructor argument types
+   * @param name Unique name for this instance
+   * @param args Arguments to pass to T's constructor
+   * @return Reference to the newly created instance
+   * @throws std::runtime_error if an instance with the same name already exists
+   */
+  template <typename T, typename... Args>
+  T &create(const std::string &name, Args &&...args) {
+    if (m_objects.find(name) != m_objects.end()) {
+      throw std::runtime_error(
+          "Error! Object with name '" + name +
+          "' was already created in the emulator registry.\n");
+    }
+
+    auto ptr = std::make_shared<T>(std::forward<Args>(args)...);
+    m_objects[name] = std::any(ptr);
+
+    return *ptr;
+  }
+
+  /**
+   * @brief Get a const reference to an existing emulator.
+   *
+   * @tparam T Emulator type to retrieve
+   * @param name Name of the instance
+   * @return Const reference to the emulator
+   * @throws std::runtime_error if no instance with the given name exists
+   * @throws std::bad_any_cast if the type doesn't match
+   */
+  template <typename T> const T &get(const std::string &name) const {
+    auto it = m_objects.find(name);
+    if (it == m_objects.end()) {
+      throw std::runtime_error("Error! Object with name '" + name +
+                               "' not found in the emulator registry.\n");
+    }
+    return *std::any_cast<const std::shared_ptr<T> &>(it->second);
+  }
+
+  /**
+   * @brief Get a mutable reference to an existing emulator.
+   *
+   * @tparam T Emulator type to retrieve
+   * @param name Name of the instance
+   * @return Reference to the emulator
+   * @throws std::runtime_error if no instance with the given name exists
+   * @throws std::bad_any_cast if the type doesn't match
+   */
+  template <typename T> T &get_mut(const std::string &name) {
+    auto it = m_objects.find(name);
+    if (it == m_objects.end()) {
+      throw std::runtime_error("Error! Object with name '" + name +
+                               "' not found in the emulator registry.\n");
+    }
+    return *std::any_cast<const std::shared_ptr<T> &>(it->second);
+  }
+
+  /**
+   * @brief Check if an instance with the given name exists.
+   *
+   * @param name Name of the instance to check
+   * @return true if an instance with the name exists in the registry
+   */
+  bool has(const std::string &name) const {
+    return m_objects.find(name) != m_objects.end();
+  }
+
+  /**
+   * @brief Remove all objects from the registry.
+   *
+   * Should be called during shutdown to release resources.
+   */
+  void clean_up() { m_objects.clear(); }
+
+private:
+  EmulatorRegistry() = default;
+
+  std::unordered_map<std::string, std::any> m_objects; ///< Name-indexed storage
+};
+
+/**
+ * @brief Convenience function to clean up the global emulator registry.
+ *
+ * Equivalent to EmulatorRegistry::instance().clean_up().
+ */
+inline void cleanup_emulator_registry() {
+  EmulatorRegistry::instance().clean_up();
+}
+
+} // namespace emulator
+
+#endif // EMULATOR_REGISTRY_HPP

--- a/components/emulators/common/tests/CMakeLists.txt
+++ b/components/emulators/common/tests/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Common tests
+
+# Test for emulator_registry
+add_executable(test_emulator_registry test_emulator_registry.cpp)
+target_link_libraries(test_emulator_registry PRIVATE emulator_common)
+target_include_directories(test_emulator_registry PRIVATE ${CATCH2_INCLUDE_DIR})
+add_test(NAME emulator_registry_tests COMMAND test_emulator_registry)
+
+# Test for emulator
+add_executable(test_emulator test_emulator.cpp)
+target_link_libraries(test_emulator PRIVATE emulator_common)
+target_include_directories(test_emulator PRIVATE ${CATCH2_INCLUDE_DIR})
+add_test(NAME emulator_tests COMMAND test_emulator)

--- a/components/emulators/common/tests/test_emulator.cpp
+++ b/components/emulators/common/tests/test_emulator.cpp
@@ -1,0 +1,198 @@
+// Catch2 v2 single header
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+
+#include "emulator.hpp"
+#include "emulator_registry.hpp"
+
+namespace emulator {
+namespace test {
+
+// Concrete implementation for testing
+class TestEmulator : public Emulator {
+public:
+  TestEmulator(int id = -1, const std::string &name = "")
+      : Emulator(EmulatorType::ATM_COMP, id, name) {}
+
+  // Track calls for verification
+  bool init_called = false;
+  bool run_called = false;
+  bool final_called = false;
+  int last_dt = 0;
+
+protected:
+  void init_impl() override { init_called = true; }
+  void run_impl(int dt) override {
+    run_called = true;
+    last_dt = dt;
+  }
+  void final_impl() override { final_called = true; }
+};
+
+// Test emulators for different EmulatorTypes
+class TestOcnEmulator : public Emulator {
+public:
+  TestOcnEmulator(int id = -1, const std::string &name = "")
+      : Emulator(EmulatorType::OCN_COMP, id, name) {}
+
+protected:
+  void init_impl() override {}
+  void run_impl(int) override {}
+  void final_impl() override {}
+};
+
+class TestIceEmulator : public Emulator {
+public:
+  TestIceEmulator(int id = -1, const std::string &name = "")
+      : Emulator(EmulatorType::ICE_COMP, id, name) {}
+
+protected:
+  void init_impl() override {}
+  void run_impl(int) override {}
+  void final_impl() override {}
+};
+
+class TestLndEmulator : public Emulator {
+public:
+  TestLndEmulator(int id = -1, const std::string &name = "")
+      : Emulator(EmulatorType::LND_COMP, id, name) {}
+
+protected:
+  void init_impl() override {}
+  void run_impl(int) override {}
+  void final_impl() override {}
+};
+
+TEST_CASE("Emulator construction", "[emulator]") {
+  TestEmulator emu;
+  REQUIRE(emu.type() == EmulatorType::ATM_COMP);
+  REQUIRE(emu.id() == -1);
+  REQUIRE(emu.name().empty());
+  REQUIRE_FALSE(emu.is_initialized());
+  REQUIRE(emu.step_count() == 0);
+}
+
+TEST_CASE("Emulator construction with args", "[emulator]") {
+  TestEmulator emu(42, "test_atm");
+  REQUIRE(emu.id() == 42);
+  REQUIRE(emu.name() == "test_atm");
+}
+
+TEST_CASE("Emulator different types", "[emulator]") {
+  TestEmulator atm;
+  TestOcnEmulator ocn;
+  TestIceEmulator ice;
+  TestLndEmulator lnd;
+
+  REQUIRE(atm.type() == EmulatorType::ATM_COMP);
+  REQUIRE(ocn.type() == EmulatorType::OCN_COMP);
+  REQUIRE(ice.type() == EmulatorType::ICE_COMP);
+  REQUIRE(lnd.type() == EmulatorType::LND_COMP);
+}
+
+TEST_CASE("Emulator lifecycle", "[emulator]") {
+  TestEmulator emu(1, "test");
+
+  SECTION("initialize calls init_impl") {
+    REQUIRE_FALSE(emu.init_called);
+    emu.initialize();
+    REQUIRE(emu.init_called);
+    REQUIRE(emu.is_initialized());
+  }
+
+  SECTION("run calls run_impl and increments step count") {
+    emu.initialize();
+    REQUIRE(emu.step_count() == 0);
+
+    emu.run(3600);
+    REQUIRE(emu.run_called);
+    REQUIRE(emu.last_dt == 3600);
+    REQUIRE(emu.step_count() == 1);
+
+    emu.run(1800);
+    REQUIRE(emu.step_count() == 2);
+  }
+
+  SECTION("finalize calls final_impl") {
+    emu.initialize();
+    REQUIRE_FALSE(emu.final_called);
+    emu.finalize();
+    REQUIRE(emu.final_called);
+    REQUIRE_FALSE(emu.is_initialized());
+  }
+}
+
+TEST_CASE("Emulator error handling", "[emulator]") {
+  TestEmulator emu(1, "test");
+
+  SECTION("run before initialize throws") {
+    REQUIRE_THROWS_AS(emu.run(100), std::runtime_error);
+  }
+
+  SECTION("double initialize throws") {
+    emu.initialize();
+    REQUIRE_THROWS_AS(emu.initialize(), std::runtime_error);
+  }
+
+  SECTION("finalize without initialize is safe") {
+    REQUIRE_NOTHROW(emu.finalize());
+  }
+
+  SECTION("re-initialization after finalize works") {
+    emu.initialize();
+    REQUIRE(emu.is_initialized());
+    emu.run(100);
+    REQUIRE(emu.step_count() == 1);
+
+    emu.finalize();
+    REQUIRE_FALSE(emu.is_initialized());
+
+    // Re-initialize and verify it works
+    emu.initialize();
+    REQUIRE(emu.is_initialized());
+    emu.run(200);
+    REQUIRE(emu.step_count() == 2); // step count persists
+  }
+}
+
+TEST_CASE("Emulator with EmulatorRegistry", "[emulator][integration]") {
+  auto &reg = EmulatorRegistry::instance();
+  reg.clean_up();
+
+  // Create emulator via registry with name
+  auto &emu = reg.create<TestEmulator>("test_emu", 99, "registry_test");
+
+  REQUIRE(reg.has("test_emu"));
+  REQUIRE(emu.type() == EmulatorType::ATM_COMP);
+  REQUIRE(emu.id() == 99);
+
+  // Use emulator from registry
+  emu.initialize();
+  emu.run(100);
+
+  // Verify through registry access
+  const auto &ref = reg.get<TestEmulator>("test_emu");
+  REQUIRE(ref.id() == 99);
+  REQUIRE(ref.step_count() == 1);
+
+  // Test get_mut
+  auto &mut_ref = reg.get_mut<TestEmulator>("test_emu");
+  mut_ref.run(200);
+  REQUIRE(ref.step_count() == 2);
+
+  reg.clean_up();
+}
+
+TEST_CASE("EmulatorRegistry get_mut throws for unknown name",
+          "[emulator_registry]") {
+  auto &reg = EmulatorRegistry::instance();
+  reg.clean_up();
+
+  REQUIRE_THROWS_AS(reg.get_mut<TestEmulator>("nonexistent"),
+                    std::runtime_error);
+
+  reg.clean_up();
+}
+
+} // namespace test
+} // namespace emulator

--- a/components/emulators/common/tests/test_emulator_registry.cpp
+++ b/components/emulators/common/tests/test_emulator_registry.cpp
@@ -1,0 +1,169 @@
+// Catch2 v2 single header - define CATCH_CONFIG_MAIN in one translation unit
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+
+#include "emulator_registry.hpp"
+
+#include <string>
+
+namespace emulator {
+namespace test {
+
+// Simple test type for the registry
+struct TestComponent {
+  int value;
+  std::string name;
+
+  TestComponent() : value(0), name("default") {}
+  TestComponent(int v, const std::string &n) : value(v), name(n) {}
+};
+
+// Another test type to verify multiple types work
+struct AnotherComponent {
+  double data;
+  explicit AnotherComponent(double d = 0.0) : data(d) {}
+};
+
+TEST_CASE("EmulatorRegistry instance access", "[emulator_registry]") {
+  auto &reg1 = EmulatorRegistry::instance();
+  auto &reg2 = EmulatorRegistry::instance();
+  REQUIRE(&reg1 == &reg2);
+}
+
+TEST_CASE("EmulatorRegistry create and retrieve", "[emulator_registry]") {
+  auto &reg = EmulatorRegistry::instance();
+  reg.clean_up(); // Start fresh
+
+  SECTION("Create default-constructed object") {
+    auto &comp = reg.create<TestComponent>("default_comp");
+    REQUIRE(comp.value == 0);
+    REQUIRE(comp.name == "default");
+  }
+
+  SECTION("Create with arguments") {
+    auto &comp = reg.create<TestComponent>("arg_comp", 42, "test");
+    REQUIRE(comp.value == 42);
+    REQUIRE(comp.name == "test");
+  }
+
+  reg.clean_up();
+}
+
+TEST_CASE("EmulatorRegistry get methods", "[emulator_registry]") {
+  auto &reg = EmulatorRegistry::instance();
+  reg.clean_up();
+
+  reg.create<TestComponent>("getter_comp", 100, "getter_test");
+
+  SECTION("get() returns const reference") {
+    const auto &comp = reg.get<TestComponent>("getter_comp");
+    REQUIRE(comp.value == 100);
+    REQUIRE(comp.name == "getter_test");
+  }
+
+  SECTION("get_mut() returns mutable reference") {
+    auto &comp = reg.get_mut<TestComponent>("getter_comp");
+    comp.value = 200;
+    comp.name = "modified";
+
+    const auto &check = reg.get<TestComponent>("getter_comp");
+    REQUIRE(check.value == 200);
+    REQUIRE(check.name == "modified");
+  }
+
+  reg.clean_up();
+}
+
+TEST_CASE("cleanup_emulator_registry free function", "[emulator_registry]") {
+  auto &reg = EmulatorRegistry::instance();
+  reg.clean_up();
+
+  reg.create<TestComponent>("cleanup_comp", 999, "cleanup_test");
+  REQUIRE(reg.has("cleanup_comp"));
+
+  cleanup_emulator_registry(); // Test the convenience function
+  REQUIRE_FALSE(reg.has("cleanup_comp"));
+}
+
+TEST_CASE("EmulatorRegistry has() method", "[emulator_registry]") {
+  auto &reg = EmulatorRegistry::instance();
+  reg.clean_up();
+
+  REQUIRE_FALSE(reg.has("my_comp"));
+
+  reg.create<TestComponent>("my_comp");
+  REQUIRE(reg.has("my_comp"));
+
+  reg.clean_up();
+  REQUIRE_FALSE(reg.has("my_comp"));
+}
+
+TEST_CASE("EmulatorRegistry multiple instances of same type",
+          "[emulator_registry]") {
+  auto &reg = EmulatorRegistry::instance();
+  reg.clean_up();
+
+  // Create multiple instances of the same type with different names
+  auto &comp1 = reg.create<TestComponent>("comp1", 1, "first");
+  auto &comp2 = reg.create<TestComponent>("comp2", 2, "second");
+
+  REQUIRE(reg.has("comp1"));
+  REQUIRE(reg.has("comp2"));
+
+  REQUIRE(comp1.value == 1);
+  REQUIRE(comp2.value == 2);
+
+  // Retrieve by name
+  const auto &ref1 = reg.get<TestComponent>("comp1");
+  const auto &ref2 = reg.get<TestComponent>("comp2");
+
+  REQUIRE(ref1.name == "first");
+  REQUIRE(ref2.name == "second");
+
+  reg.clean_up();
+}
+
+TEST_CASE("EmulatorRegistry multiple types", "[emulator_registry]") {
+  auto &reg = EmulatorRegistry::instance();
+  reg.clean_up();
+
+  reg.create<TestComponent>("test_comp", 1, "first");
+  reg.create<AnotherComponent>("another_comp", 3.14);
+
+  REQUIRE(reg.has("test_comp"));
+  REQUIRE(reg.has("another_comp"));
+
+  const auto &tc = reg.get<TestComponent>("test_comp");
+  const auto &ac = reg.get<AnotherComponent>("another_comp");
+
+  REQUIRE(tc.value == 1);
+  REQUIRE(ac.data == 3.14);
+
+  reg.clean_up();
+}
+
+TEST_CASE("EmulatorRegistry error handling", "[emulator_registry]") {
+  auto &reg = EmulatorRegistry::instance();
+  reg.clean_up();
+
+  SECTION("get() throws when object not found") {
+    REQUIRE_THROWS_AS(reg.get<TestComponent>("nonexistent"),
+                      std::runtime_error);
+  }
+
+  SECTION("get_mut() throws when object not found") {
+    REQUIRE_THROWS_AS(reg.get_mut<TestComponent>("nonexistent"),
+                      std::runtime_error);
+  }
+
+  SECTION("create() throws on duplicate name") {
+    reg.create<TestComponent>("dup_comp");
+    REQUIRE_THROWS_AS(reg.create<TestComponent>("dup_comp"),
+                      std::runtime_error);
+  }
+
+  reg.clean_up();
+}
+
+} // namespace test
+} // namespace emulator

--- a/components/emulators/scripts/colors.sh
+++ b/components/emulators/scripts/colors.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# Color definitions and print utilities for shell scripts
+#
+
+# Colors
+export RED='\033[0;31m'
+export GREEN='\033[0;32m'
+export YELLOW='\033[1;33m'
+export BLUE='\033[0;34m'
+export NC='\033[0m' # No Color
+
+print_status() {
+    echo -e "${GREEN}==>${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}WARNING:${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}ERROR:${NC} $1"
+}
+
+print_info() {
+    echo -e "${BLUE}INFO:${NC} $1"
+}

--- a/components/emulators/scripts/parse_args.sh
+++ b/components/emulators/scripts/parse_args.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# Reusable argument parsing for test scripts
+#
+# Usage: source this file, then call parse_test_args "$@"
+# After calling, the following variables will be set:
+#   CLEAN_ONLY, BUILD_ONLY, VERBOSE
+#
+
+# Default values
+CLEAN_ONLY=false
+BUILD_ONLY=false
+VERBOSE=false
+
+parse_test_args() {
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --clean-only)
+                CLEAN_ONLY=true
+                shift
+                ;;
+            --build-only)
+                BUILD_ONLY=true
+                shift
+                ;;
+            --verbose|-v)
+                VERBOSE=true
+                shift
+                ;;
+            --help|-h)
+                echo "Usage: $0 [OPTIONS]"
+                echo ""
+                echo "Options:"
+                echo "  --clean-only  Remove build directory and exit"
+                echo "  --build-only  Build without running tests"
+                echo "  --verbose     Show verbose test output"
+                echo "  --help        Show this help message"
+                exit 0
+                ;;
+            *)
+                echo "ERROR: Unknown option: $1" >&2
+                exit 1
+                ;;
+        esac
+    done
+}

--- a/components/emulators/test
+++ b/components/emulators/test
@@ -1,0 +1,55 @@
+#!/bin/bash
+#
+# Test script for emulator_comps
+# Builds and runs unit tests
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR="${SCRIPT_DIR}/build"
+
+# Source utilities
+source "${SCRIPT_DIR}/scripts/colors.sh"
+source "${SCRIPT_DIR}/scripts/parse_args.sh"
+
+# Parse command line arguments
+parse_test_args "$@"
+
+# Clean only mode
+if [ "$CLEAN_ONLY" = true ]; then
+    print_status "Cleaning build directory..."
+    rm -rf "${BUILD_DIR}"
+    print_status "Done."
+    exit 0
+fi
+
+# Create build directory
+mkdir -p "${BUILD_DIR}"
+cd "${BUILD_DIR}"
+
+# Configure (only if needed)
+if [ ! -f "CMakeCache.txt" ]; then
+    print_status "Configuring CMake..."
+    cmake "${SCRIPT_DIR}" -DCMAKE_BUILD_TYPE=Release
+fi
+
+# Build
+print_status "Building..."
+cmake --build . --parallel
+
+# Build only mode - exit before running tests
+if [ "$BUILD_ONLY" = true ]; then
+    print_status "Build complete."
+    exit 0
+fi
+
+# Run tests
+print_status "Running tests..."
+if [ "$VERBOSE" = true ]; then
+    ctest --output-on-failure --verbose
+else
+    ctest --output-on-failure
+fi
+
+print_status "All tests passed!"


### PR DESCRIPTION
introducing a new modular C++ "emulator components" framework for E3SM, including a shared base class, a type-safe singleton context for managing component instances, and a unit test suite. 

[BFB]

--

this is mostly a trimmed-down version of stuff #7964 to get the ball rolling in a manageable manner; future PRs will start fleshing out details, including adding dedicated CI runners on github actions as well some cime and non-cime tests on target machines.