### PR TITLE
Remove module reset in polaris mach

### DIFF
--- a/cime_config/machines/config_batch.xml
+++ b/cime_config/machines/config_batch.xml
@@ -597,7 +597,6 @@
       <jobid_pattern>(\d+)\.polaris-pbs</jobid_pattern>
       <directives>
         <directive> -l filesystems=home:grand:eagle </directive>
-        <directive> -V </directive>
       </directives>
       <queues>
         <queue walltimemin="00:05:00" walltimemax="01:00:00" nodemin="1"   nodemax="2"   strict="true" default="true">debug</queue>


### PR DESCRIPTION
Remove module reset in polaris mach.
Also rm python load and use pre-loaded python.

[BFB]

---
Testing on next:
- e3sm_eamxx_v1: 38 of 38 pass -- https://my.cdash.org/builds/3351393/tests