### PR TITLE
Update oneapi compiler on Chrysalis maint-3.0

### DIFF
--- a/cime_config/machines/cmake_macros/oneapi-ifx.cmake
+++ b/cime_config/machines/cmake_macros/oneapi-ifx.cmake
@@ -13,7 +13,7 @@ string(APPEND CMAKE_CXX_FLAGS_DEBUG " -O0 -g")
 string(APPEND CMAKE_C_FLAGS   " -fp-model precise -std=gnu99 -gline-tables-only -g")
 string(APPEND CMAKE_CXX_FLAGS " -fp-model precise -gline-tables-only -g")
 # -mllvm -disable-hir-temp-cleanup for oneapi v2025.2.0 https://github.com/argonne-lcf/AuroraBugTracking/issues/64
-string(APPEND CMAKE_Fortran_FLAGS   " -traceback -convert big_endian -assume byterecl -assume realloc_lhs -fp-model precise -gline-tables-only -g -mllvm -disable-hir-temp-cleanup")
+string(APPEND CMAKE_Fortran_FLAGS   " -traceback -convert big_endian -assume byterecl -assume realloc_lhs -fp-model precise -g -mllvm -disable-hir-temp-cleanup")
 string(APPEND CPPDEFS " -DFORTRANUNDERSCORE -DNO_R16 -DCPRINTEL -DHAVE_SLASHPROC -DHIDE_MPI")
 string(APPEND CMAKE_Fortran_FORMAT_FIXED_FLAG " -fixed -132")
 string(APPEND CMAKE_Fortran_FORMAT_FREE_FLAG " -free")

--- a/cime_config/machines/cmake_macros/oneapi-ifx_chrysalis.cmake
+++ b/cime_config/machines/cmake_macros/oneapi-ifx_chrysalis.cmake
@@ -1,0 +1,3 @@
+
+string(APPEND CMAKE_EXE_LINKER_FLAGS " -L/gpfs/fs1/soft/chrysalis/spack-latest/opt/spack/linux-rhel8-x86_64/gcc-8.5.0/gcc-11.3.0-jkpmtgq/lib64 -lstdc++")
+

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -2786,15 +2786,15 @@ commented out until "*** No rule to make target '.../libadios2pio-nm-lib.a'" iss
         <command name="load">parallel-netcdf/1.11.0-ifdodru</command>
       </modules>
       <modules compiler="oneapi-ifx">
-        <command name="load">intel-oneapi-compilers/2022.2.0-dioefq5</command>
-        <command name="load">intel-oneapi-mkl/2022.2.0-w2y75l6</command>
+        <command name="load">intel-oneapi-compilers/2025.2.0-mdlxe55</command>
       </modules>
       <modules compiler="oneapi-ifx" mpilib="openmpi">
-        <command name="load">openmpi/4.1.3-ti25nay</command>
-        <command name="load">hdf5/1.10.7-clocd2t</command>
-        <command name="load">netcdf-c/4.7.4-nw7dztf</command>
-        <command name="load">netcdf-fortran/4.5.3-qa6rhpj</command>
-        <command name="load">parallel-netcdf/1.11.0-ejxy7kk</command>
+        <command name="load">openmpi/4.1.8-nygtpa3</command>
+        <command name="load">intel-oneapi-mkl/2025.2.0-bcimxay</command>
+        <command name="load">hdf5/1.14.6-5cgownf</command>
+        <command name="load">netcdf-c/4.9.3-mekqsor</command>
+        <command name="load">netcdf-fortran/4.6.2-cjqpiwp</command>
+        <command name="load">parallel-netcdf/1.14.1-f2fwvr2</command>
       </modules>
     </module_system>
     <RUNDIR>$CIME_OUTPUT_ROOT/$CASE/run</RUNDIR>


### PR DESCRIPTION
Update oneapi compiler on Chrysalis maint-3.0.

[BFB]

---
Testing:
- e3sm_prod: 9 of 9 pass -- https://my.cdash.org/builds/3351887/tests