### PR TITLE
Changes to update module versions on muller/alvarez

### DIFF
--- a/cime_config/machines/cmake_macros/intel_alvarez-cpu.cmake
+++ b/cime_config/machines/cmake_macros/intel_alvarez-cpu.cmake
@@ -20,9 +20,18 @@ if (compile_threaded)
   string(APPEND CMAKE_CXX_FLAGS " -qopenmp")
 endif()
 string(APPEND CMAKE_CXX_FLAGS_DEBUG " -O0 -g")
+
+# Check for Intel LLVM (ifx) version 2025 or newer
+if (CMAKE_Fortran_COMPILER_ID STREQUAL "IntelLLVM")
+    if (CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL "2025.0")
+        #message(STATUS "ndk: Applying Intel 2025.3 sanitization workaround")
+        string(APPEND CMAKE_Fortran_FLAGS_DEBUG " -init=none -check nouninit") # Applying Intel 2025.3 sanitization workaround (to revert -init=snan,arrays)
+    endif()
+endif()
+
+
 string(APPEND CMAKE_CXX_FLAGS_RELEASE " -O2")
 string(APPEND CMAKE_CXX_FLAGS " -fp-model=precise") # and manually add precise
-#message(STATUS "ndk CXXFLAGS=${CXXFLAGS}")
 
 string(APPEND CMAKE_Fortran_FLAGS " -fp-model=consistent -fimf-use-svml")
 #  string(APPEND FFLAGS " -qno-opt-dynamic-align")

--- a/cime_config/machines/cmake_macros/intel_muller-cpu.cmake
+++ b/cime_config/machines/cmake_macros/intel_muller-cpu.cmake
@@ -20,9 +20,37 @@ if (compile_threaded)
   string(APPEND CMAKE_CXX_FLAGS " -qopenmp")
 endif()
 string(APPEND CMAKE_CXX_FLAGS_DEBUG " -O0 -g")
+
+
+#message(STATUS "ndk CMAKE_Fortran_COMPILER_ID=${CMAKE_Fortran_COMPILER_ID}")
+#message(STATUS "ndk CMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER}")
+#message(STATUS "ndk CMAKE_Fortran_COMPILER_VERSION=${CMAKE_Fortran_COMPILER_VERSION}")
+#message(STATUS "ndk CMAKE_CXX_COMPILER_ID=${CMAKE_CXX_COMPILER_ID}")
+#message(STATUS "ndk CMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}")
+#message(STATUS "ndk CMAKE_CXX_COMPILER_VERSION=${CMAKE_CXX_COMPILER_VERSION}")
+#-- ndk CMAKE_Fortran_COMPILER_ID=IntelLLVM
+#-- ndk CMAKE_Fortran_COMPILER=/opt/cray/pe/craype/2.7.35/bin/ftn
+#-- ndk CMAKE_Fortran_COMPILER_VERSION=2025.3.0
+#-- ndk CMAKE_CXX_COMPILER_ID=IntelLLVM
+#-- ndk CMAKE_CXX_COMPILER=/opt/cray/pe/craype/2.7.35/bin/CC
+#-- ndk CMAKE_CXX_COMPILER_VERSION=2025.3.1
+
+# Check for Intel LLVM (ifx) version 2025 or newer
+if (CMAKE_Fortran_COMPILER_ID STREQUAL "IntelLLVM")
+    if (CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL "2025.0")
+        #message(STATUS "ndk: Applying Intel 2025.3 sanitization workaround")
+        string(APPEND CMAKE_Fortran_FLAGS_DEBUG " -init=none -check nouninit") # Applying Intel 2025.3 sanitization workaround (to revert -init=snan,arrays)
+        #string(APPEND CMAKE_Fortran_FLAGS_DEBUG " -init=none")
+        #string(APPEND CMAKE_Fortran_FLAGS_DEBUG " -check nouninit") # may be all that is needed
+        #string(APPEND CMAKE_CXX_FLAGS_DEBUG " -fno-sanitize=all") #ndk or maybe just -fno-sanitize=memory ?
+        #string(APPEND CMAKE_C_FLAGS_DEBUG " -fno-sanitize=all") #ndk
+        #string(APPEND CMAKE_EXE_LINKER_FLAGS_DEBUG " -fno-sanitize=all") #ndk -- needed?
+    endif()
+endif()
+
+
 string(APPEND CMAKE_CXX_FLAGS_RELEASE " -O2")
 string(APPEND CMAKE_CXX_FLAGS " -fp-model=precise") # and manually add precise
-#message(STATUS "ndk CXXFLAGS=${CXXFLAGS}")
 
 string(APPEND CMAKE_Fortran_FLAGS " -fp-model=consistent -fimf-use-svml")
 #  string(APPEND FFLAGS " -qno-opt-dynamic-align")

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -534,13 +534,13 @@
         <arg name="thread_count">-c $SHELL{echo 256/`./xmlquery --value MAX_MPITASKS_PER_NODE`|bc}</arg>
         <arg name="binding"> $SHELL{if [ 128 -ge `./xmlquery --value MAX_MPITASKS_PER_NODE` ]; then echo "--cpu-bind=cores"; else echo "--cpu-bind=threads";fi;} </arg>
         <arg name="placement"> -m plane=$SHELL{echo `./xmlquery --value MAX_MPITASKS_PER_NODE`}</arg>
-    </arguments>
+      </arguments>
     </mpirun>
     <module_system type="module" allow_error="true">
-      <init_path lang="perl">/opt/cray/pe/lmod/8.7.19/init/perl</init_path>
-      <init_path lang="python">/opt/cray/pe/lmod/8.7.19/init/python</init_path>
-      <init_path lang="sh">/opt/cray/pe/lmod/8.7.19/init/sh</init_path>
-      <init_path lang="csh">/opt/cray/pe/lmod/8.7.19/init/csh</init_path>
+      <init_path lang="perl">/opt/cray/pe/lmod/8.7.60/init/perl</init_path>
+      <init_path lang="python">/opt/cray/pe/lmod/8.7.60/init/python</init_path>
+      <init_path lang="sh">/opt/cray/pe/lmod/8.7.60/init/sh</init_path>
+      <init_path lang="csh">/opt/cray/pe/lmod/8.7.60/init/csh</init_path>
       <cmd_path lang="perl">/opt/cray/pe/lmod/lmod/libexec/lmod perl</cmd_path>
       <cmd_path lang="python">/opt/cray/pe/lmod/lmod/libexec/lmod python</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
@@ -575,39 +575,43 @@
       </modules>
 
       <modules compiler="gnu">
-        <command name="load">PrgEnv-gnu/8.5.0</command>
-        <command name="load">gcc-native/13.2</command>
-        <command name="load">cray-libsci/24.07.0</command>
+        <command name="load">PrgEnv-gnu/8.6.0</command>
+        <command name="load">gcc-native/14</command>
+        <command name="load">cray-libsci/25.09.0</command>
       </modules>
 
       <modules compiler="intel">
-        <command name="load">PrgEnv-intel/8.5.0</command>
-        <command name="load">intel/2024.1.0</command>
+        <command name="load">PrgEnv-intel/8.6.0</command>
+        <command name="load">intel/2025.3</command>
       </modules>
 
       <modules compiler="nvidia">
         <command name="load">PrgEnv-nvidia</command>
-        <command name="load">nvidia/25.5</command>
-        <command name="load">cray-libsci/24.07.0</command>
+        <command name="load">nvidia/25.9</command>
+        <command name="load">cray-libsci/25.09.0</command>
       </modules>
 
       <modules compiler="amdclang">
         <command name="load">PrgEnv-aocc</command>
         <command name="load">aocc/4.1.0</command>
-        <command name="load">cray-libsci/24.07.0</command>
+        <command name="load">cray-libsci/25.09.0</command>
       </modules>
 
       <modules>
         <command name="load">craype-accel-host</command>
-        <command name="load">craype/2.7.32</command>
-        <command name="load">cray-mpich/8.1.30</command>
-        <!-- like alvarez-cpu, we still cant use the latest hdf as something not right with env -->
-        <!-- <command name="load">cray-hdf5-parallel/1.14.3.1</command> -->
-        <!-- <command name="load">cray-netcdf-hdf5parallel/4.9.0.13</command> -->
+        <command name="load">craype/2.7.35</command>
+        <command name="load">cray-mpich/9.0.1</command>
+        <command name="load">cmake/3.30.2</command>
+      </modules>
+      <modules DEBUG="TRUE"> <!-- https://github.com/E3SM-Project/E3SM/issues/8062 -->
         <command name="load">cray-hdf5-parallel/1.12.2.9</command>
         <command name="load">cray-netcdf-hdf5parallel/4.9.0.9</command>
         <command name="load">cray-parallel-netcdf/1.12.3.13</command>
-        <command name="load">cmake/3.30.2</command>
+      </modules>
+      <modules DEBUG="FALSE">
+        <command name="load">cray-hdf5-parallel/1.14.3.7</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.9.2.1</command>
+        <command name="load">cray-parallel-netcdf/1.12.3.19</command>
       </modules>
     </module_system>
 
@@ -627,8 +631,10 @@
       <env name="NETCDF_PATH">$ENV{CRAY_NETCDF_HDF5PARALLEL_PREFIX}</env>
       <env name="PNETCDF_PATH">$ENV{CRAY_PARALLEL_NETCDF_PREFIX}</env>
       <env name="GATOR_INITIAL_MB">4000MB</env>
-      <env name="LD_LIBRARY_PATH">$ENV{CRAY_LD_LIBRARY_PATH}:$ENV{LD_LIBRARY_PATH}</env> <!-- https://github.com/E3SM-Project/E3SM/issues/7117 -->
       <env name="MPICH_SMP_SINGLE_COPY_MODE">CMA</env> <!-- https://github.com/E3SM-Project/E3SM/issues/7207 -->
+    </environment_variables>
+    <environment_variables DEBUG="TRUE">
+      <env name="LD_LIBRARY_PATH">$ENV{CRAY_LD_LIBRARY_PATH}:$ENV{LD_LIBRARY_PATH}</env> <!-- https://github.com/E3SM-Project/E3SM/issues/7117 -->
     </environment_variables>
     <environment_variables BUILD_THREADED="TRUE">
       <env name="OMP_STACKSIZE">128M</env>
@@ -733,10 +739,10 @@
       </arguments>
     </mpirun>
     <module_system type="module" allow_error="true">
-      <init_path lang="perl">/opt/cray/pe/lmod/8.7.19/init/perl</init_path>
-      <init_path lang="python">/opt/cray/pe/lmod/8.7.19/init/python</init_path>
-      <init_path lang="sh">/opt/cray/pe/lmod/8.7.19/init/sh</init_path>
-      <init_path lang="csh">/opt/cray/pe/lmod/8.7.19/init/csh</init_path>
+      <init_path lang="perl">/opt/cray/pe/lmod/8.7.60/init/perl</init_path>
+      <init_path lang="python">/opt/cray/pe/lmod/8.7.60/init/python</init_path>
+      <init_path lang="sh">/opt/cray/pe/lmod/8.7.60/init/sh</init_path>
+      <init_path lang="csh">/opt/cray/pe/lmod/8.7.60/init/csh</init_path>
       <cmd_path lang="perl">/opt/cray/pe/lmod/lmod/libexec/lmod perl</cmd_path>
       <cmd_path lang="python">/opt/cray/pe/lmod/lmod/libexec/lmod python</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
@@ -771,13 +777,13 @@
       </modules>
 
       <modules compiler="gnu.*">
-        <command name="load">PrgEnv-gnu/8.5.0</command>
-        <command name="load">gcc-native/13.2</command>
+        <command name="load">PrgEnv-gnu/8.6.0</command>
+        <command name="load">gcc-native/14</command>
       </modules>
 
       <modules compiler="nvidia.*">
         <command name="load">PrgEnv-nvidia</command>
-        <command name="load">nvidia/25.5</command>
+        <command name="load">nvidia/25.9</command>
       </modules>
 
       <modules compiler="gnugpu">
@@ -788,7 +794,7 @@
       <modules compiler="nvidiagpu">
         <command name="load">cudatoolkit/12.9</command>
         <command name="load">craype-accel-nvidia80</command>
-        <command name="load">gcc-native-mixed/13.2</command>
+        <command name="load">gcc-native-mixed/14</command>
       </modules>
 
       <modules compiler="gnu">
@@ -800,13 +806,20 @@
       </modules>
 
       <modules>
-        <command name="load">cray-libsci/24.07.0</command>
-        <command name="load">craype/2.7.32</command>
-        <command name="load">cray-mpich/8.1.30</command>
-        <command name="load">cray-hdf5-parallel/1.14.3.1</command>
-        <command name="load">cray-netcdf-hdf5parallel/4.9.0.13</command>
-        <command name="load">cray-parallel-netcdf/1.12.3.13</command>
+        <command name="load">cray-libsci/25.09.0</command>
+        <command name="load">craype/2.7.35</command>
+        <command name="load">cray-mpich/9.0.1</command>
         <command name="load">cmake/3.30.2</command>
+      </modules>
+      <modules DEBUG="TRUE"> <!-- https://github.com/E3SM-Project/E3SM/issues/8062 -->
+        <command name="load">cray-hdf5-parallel/1.12.2.9</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.9.0.9</command>
+        <command name="load">cray-parallel-netcdf/1.12.3.13</command>
+      </modules>
+      <modules DEBUG="FALSE">
+        <command name="load">cray-hdf5-parallel/1.14.3.7</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.9.2.1</command>
+        <command name="load">cray-parallel-netcdf/1.12.3.19</command>
       </modules>
     </module_system>
 
@@ -825,6 +838,9 @@
       <env name="MPICH_COLL_SYNC">MPI_Bcast</env>
       <env name="NETCDF_PATH">$ENV{CRAY_NETCDF_HDF5PARALLEL_PREFIX}</env>
       <env name="PNETCDF_PATH">$ENV{CRAY_PARALLEL_NETCDF_PREFIX}</env>
+    </environment_variables>
+    <environment_variables DEBUG="TRUE">
+      <env name="LD_LIBRARY_PATH">$ENV{CRAY_LD_LIBRARY_PATH}:$ENV{LD_LIBRARY_PATH}</env> <!-- https://github.com/E3SM-Project/E3SM/issues/7117 -->
     </environment_variables>
     <environment_variables BUILD_THREADED="TRUE">
       <env name="OMP_STACKSIZE">128M</env>
@@ -894,13 +910,13 @@
         <arg name="thread_count">-c $SHELL{echo 256/`./xmlquery --value MAX_MPITASKS_PER_NODE`|bc}</arg>
         <arg name="binding"> $SHELL{if [ 128 -ge `./xmlquery --value MAX_MPITASKS_PER_NODE` ]; then echo "--cpu-bind=cores"; else echo "--cpu-bind=threads";fi;} </arg>
         <arg name="placement"> -m plane=$SHELL{echo `./xmlquery --value MAX_MPITASKS_PER_NODE`}</arg>
-    </arguments>
+      </arguments>
     </mpirun>
     <module_system type="module" allow_error="true">
-      <init_path lang="perl">/opt/cray/pe/lmod/8.7.19/init/perl</init_path>
-      <init_path lang="python">/opt/cray/pe/lmod/8.7.19/init/python</init_path>
-      <init_path lang="sh">/opt/cray/pe/lmod/8.7.19/init/sh</init_path>
-      <init_path lang="csh">/opt/cray/pe/lmod/8.7.19/init/csh</init_path>
+      <init_path lang="perl">/opt/cray/pe/lmod/8.7.60/init/perl</init_path>
+      <init_path lang="python">/opt/cray/pe/lmod/8.7.60/init/python</init_path>
+      <init_path lang="sh">/opt/cray/pe/lmod/8.7.60/init/sh</init_path>
+      <init_path lang="csh">/opt/cray/pe/lmod/8.7.60/init/csh</init_path>
       <cmd_path lang="perl">/opt/cray/pe/lmod/lmod/libexec/lmod perl</cmd_path>
       <cmd_path lang="python">/opt/cray/pe/lmod/lmod/libexec/lmod python</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
@@ -935,38 +951,43 @@
       </modules>
 
       <modules compiler="gnu">
-        <command name="load">PrgEnv-gnu/8.5.0</command>
-        <command name="load">gcc-native/13.2</command>
-        <command name="load">cray-libsci/24.07.0</command>
+        <command name="load">PrgEnv-gnu/8.6.0</command>
+        <command name="load">gcc-native/14</command>
+        <command name="load">cray-libsci/25.09.0</command>
       </modules>
 
       <modules compiler="intel">
-        <command name="load">PrgEnv-intel/8.5.0</command>
-        <command name="load">intel/2024.1.0</command>
+        <command name="load">PrgEnv-intel/8.6.0</command>
+        <command name="load">intel/2025.3</command>
       </modules>
 
       <modules compiler="nvidia">
         <command name="load">PrgEnv-nvidia</command>
-        <command name="load">nvidia/24.5</command>
-        <command name="load">cray-libsci/24.07.0</command>
+        <command name="load">nvidia/25.9</command>
+        <command name="load">cray-libsci/25.09.0</command>
       </modules>
 
       <modules compiler="amdclang">
         <command name="load">PrgEnv-aocc</command>
         <command name="load">aocc/4.1.0</command>
-        <command name="load">cray-libsci/24.07.0</command>
+        <command name="load">cray-libsci/25.09.0</command>
       </modules>
 
       <modules>
         <command name="load">craype-accel-host</command>
-        <command name="load">craype/2.7.32</command>
-        <command name="load">cray-mpich/8.1.30</command>
-        <!-- <command name="load">cray-hdf5-parallel/1.14.3.1</command> -->
-        <!-- <command name="load">cray-netcdf-hdf5parallel/4.9.0.13</command> -->
+        <command name="load">craype/2.7.35</command>
+        <command name="load">cray-mpich/9.0.1</command>
+        <command name="load">cmake/3.30.2</command>
+      </modules>
+      <modules DEBUG="TRUE"> <!-- https://github.com/E3SM-Project/E3SM/issues/8062 -->
         <command name="load">cray-hdf5-parallel/1.12.2.9</command>
         <command name="load">cray-netcdf-hdf5parallel/4.9.0.9</command>
         <command name="load">cray-parallel-netcdf/1.12.3.13</command>
-        <command name="load">cmake/3.30.2</command>
+      </modules>
+      <modules DEBUG="FALSE">
+        <command name="load">cray-hdf5-parallel/1.14.3.7</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.9.2.1</command>
+        <command name="load">cray-parallel-netcdf/1.12.3.19</command>
       </modules>
     </module_system>
 
@@ -986,8 +1007,10 @@
       <env name="NETCDF_PATH">$ENV{CRAY_NETCDF_HDF5PARALLEL_PREFIX}</env>
       <env name="PNETCDF_PATH">$ENV{CRAY_PARALLEL_NETCDF_PREFIX}</env>
       <env name="GATOR_INITIAL_MB">4000MB</env>
-      <env name="LD_LIBRARY_PATH">$ENV{CRAY_LD_LIBRARY_PATH}:$ENV{LD_LIBRARY_PATH}</env> <!-- https://github.com/E3SM-Project/E3SM/issues/7117 -->
       <env name="MPICH_SMP_SINGLE_COPY_MODE">CMA</env> <!-- https://github.com/E3SM-Project/E3SM/issues/7207 -->
+    </environment_variables>
+    <environment_variables DEBUG="TRUE">
+      <env name="LD_LIBRARY_PATH">$ENV{CRAY_LD_LIBRARY_PATH}:$ENV{LD_LIBRARY_PATH}</env> <!-- https://github.com/E3SM-Project/E3SM/issues/7117 -->
     </environment_variables>
     <environment_variables BUILD_THREADED="TRUE">
       <env name="OMP_STACKSIZE">128M</env>
@@ -1092,10 +1115,10 @@
       </arguments>
     </mpirun>
     <module_system type="module" allow_error="true">
-      <init_path lang="perl">/opt/cray/pe/lmod/8.7.19/init/perl</init_path>
-      <init_path lang="python">/opt/cray/pe/lmod/8.7.19/init/python</init_path>
-      <init_path lang="sh">/opt/cray/pe/lmod/8.7.19/init/sh</init_path>
-      <init_path lang="csh">/opt/cray/pe/lmod/8.7.19/init/csh</init_path>
+      <init_path lang="perl">/opt/cray/pe/lmod/8.7.60/init/perl</init_path>
+      <init_path lang="python">/opt/cray/pe/lmod/8.7.60/init/python</init_path>
+      <init_path lang="sh">/opt/cray/pe/lmod/8.7.60/init/sh</init_path>
+      <init_path lang="csh">/opt/cray/pe/lmod/8.7.60/init/csh</init_path>
       <cmd_path lang="perl">/opt/cray/pe/lmod/lmod/libexec/lmod perl</cmd_path>
       <cmd_path lang="python">/opt/cray/pe/lmod/lmod/libexec/lmod python</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
@@ -1130,24 +1153,24 @@
       </modules>
 
       <modules compiler="gnu.*">
-        <command name="load">PrgEnv-gnu/8.5.0</command>
-        <command name="load">gcc-native/13.2</command>
+        <command name="load">PrgEnv-gnu/8.6.0</command>
+        <command name="load">gcc-native/14</command>
       </modules>
 
       <modules compiler="nvidia.*">
         <command name="load">PrgEnv-nvidia</command>
-        <command name="load">nvidia/24.5</command>
+        <command name="load">nvidia/25.9</command>
       </modules>
 
       <modules compiler="gnugpu">
-        <command name="load">cudatoolkit/12.4</command>
+        <command name="load">cudatoolkit/12.9</command>
         <command name="load">craype-accel-nvidia80</command>
       </modules>
 
       <modules compiler="nvidiagpu">
-        <command name="load">cudatoolkit/12.4</command>
+        <command name="load">cudatoolkit/12.9</command>
         <command name="load">craype-accel-nvidia80</command>
-        <command name="load">gcc-native-mixed/13.2</command>
+        <command name="load">gcc-native-mixed/14</command>
       </modules>
 
       <modules compiler="gnu">
@@ -1159,13 +1182,20 @@
       </modules>
 
       <modules>
-        <command name="load">cray-libsci/24.07.0</command>
-        <command name="load">craype/2.7.32</command>
-        <command name="load">cray-mpich/8.1.30</command>
-        <command name="load">cray-hdf5-parallel/1.14.3.1</command>
-        <command name="load">cray-netcdf-hdf5parallel/4.9.0.13</command>
-        <command name="load">cray-parallel-netcdf/1.12.3.13</command>
+        <command name="load">cray-libsci/25.09.0</command>
+        <command name="load">craype/2.7.35</command>
+        <command name="load">cray-mpich/9.0.1</command>
         <command name="load">cmake/3.30.2</command>
+      </modules>
+      <modules DEBUG="TRUE"> <!-- https://github.com/E3SM-Project/E3SM/issues/8062 -->
+        <command name="load">cray-hdf5-parallel/1.12.2.9</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.9.0.9</command>
+        <command name="load">cray-parallel-netcdf/1.12.3.13</command>
+      </modules>
+      <modules DEBUG="FALSE">
+        <command name="load">cray-hdf5-parallel/1.14.3.7</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.9.2.1</command>
+        <command name="load">cray-parallel-netcdf/1.12.3.19</command>
       </modules>
     </module_system>
 
@@ -1185,6 +1215,9 @@
       <env name="NETCDF_PATH">$ENV{CRAY_NETCDF_HDF5PARALLEL_PREFIX}</env>
       <env name="PNETCDF_PATH">$ENV{CRAY_PARALLEL_NETCDF_PREFIX}</env>
     </environment_variables>
+    <environment_variables DEBUG="TRUE">
+      <env name="LD_LIBRARY_PATH">$ENV{CRAY_LD_LIBRARY_PATH}:$ENV{LD_LIBRARY_PATH}</env> <!-- https://github.com/E3SM-Project/E3SM/issues/7117 -->
+    </environment_variables>
     <environment_variables BUILD_THREADED="TRUE">
       <env name="OMP_STACKSIZE">128M</env>
       <env name="OMP_PROC_BIND">spread</env>
@@ -1198,12 +1231,6 @@
     </environment_variables>
     <environment_variables compiler="gnugpu">
       <env name="MOAB_ROOT">$SHELL{if [ -z "$MOAB_ROOT" ]; then echo /global/cfs/cdirs/e3sm/software/moab/gnugpu ; else echo "$MOAB_ROOT"; fi}</env>
-    </environment_variables>
-    <environment_variables compiler="gnu.*" mpilib="mpich">
-      <env name="ADIOS2_ROOT">$SHELL{if [ -z "$ADIOS2_ROOT" ]; then echo /global/cfs/cdirs/e3sm/3rdparty/adios2/2.9.1/cray-mpich-8.1.25/gcc-11.2.0; else echo "$ADIOS2_ROOT"; fi}</env>
-    </environment_variables>
-    <environment_variables compiler="nvidia.*" mpilib="mpich">
-      <env name="ADIOS2_ROOT">$SHELL{if [ -z "$ADIOS2_ROOT" ]; then echo /global/cfs/cdirs/e3sm/3rdparty/adios2/2.9.1/cray-mpich-8.1.25/nvidia-22.7; else echo "$ADIOS2_ROOT"; fi}</env>
     </environment_variables>
     <resource_limits>
       <resource name="RLIMIT_STACK">-1</resource>


### PR DESCRIPTION
These are internal NERSC machines to help us test changes before going to perlmutter.
No impact to pm-cpu/pm-gpu.

In testing the newer compilers, found a few issues. Reported them, and have potential fixes.

https://github.com/E3SM-Project/E3SM/issues/8019
https://github.com/E3SM-Project/E3SM/issues/7988
https://github.com/E3SM-Project/E3SM/issues/8036

[bfb]