### PR TITLE
Add package to one variable so it matches a stream that includes it

### DIFF
--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -4260,7 +4260,7 @@
 		/>
 		<var name="areaIntegAnnMeanDataIcebergIceShelfFreshwaterFlux"  type="real" dimensions="Time" units="kg s^-1"
 			description="The area integrated, annually averaged freshwater flux into the ocean from both data icebergs and ice-shelf melting."
-			packages="scaledDISMFPKG"
+			packages="scaledDISMFPKG;dataLandIceFluxesPKG"
 		/>
 
 		<!-- Input fields for forcing due to tides -->


### PR DESCRIPTION
Fixes failing tests on pm-cpu by adding the dataLandIceFluxesPKG package to variable areaIntegAnnMeanDataIcebergIceShelfFreshwaterFlux. That variable was included in stream data_land_ice_fluxes which only has the dataLandIceFluxesPKG.

Fixes #8090 
[BFB]