### PR TITLE
For pm-cpu: temporary hotfix to remove cray-libsci module

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -225,7 +225,7 @@
 
       <modules compiler="intel">
         <command name="load">PrgEnv-intel/8.5.0</command>
-        <command name="unload">cray-libsci</command> <!-- tempororary change to allow this hotfix 2024.1.0 module to work -->
+        <command name="unload">cray-libsci</command> <!-- temporary change to allow this hotfix 2024.1.0 module to work -->
         <command name="load">intel/2024.1.0</command>
       </modules>
 


### PR DESCRIPTION
A quick fix while we work on a better solution.
This seems needed after the Feb 2026 NERSC maintenance.
Note the `intel/2024.1.0` module was denoted "Experimental" and was removed during maintenance.
It was brought back temporarily for E3SM. We can remove this after https://github.com/E3SM-Project/E3SM/pull/8113

[bfb]
