### PR TITLE
For pm-cpu/maint-2.0: Update modules after nersc maintenance

### DIFF
--- a/cime_config/machines/cmake_macros/intel_pm-cpu.cmake
+++ b/cime_config/machines/cmake_macros/intel_pm-cpu.cmake
@@ -42,3 +42,5 @@ if (NOT DEBUG)
 endif()
 string(APPEND FFLAGS " -DHAVE_ERF_INTRINSICS")
 string(APPEND CXXFLAGS " -fp-model=consistent")
+
+string (APPEND KOKKOS_OPTIONS " --cxxflags='-include cstdint'")

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -107,6 +107,7 @@
         <command name="unload">cray-parallel-netcdf</command>
         <command name="unload">cray-netcdf</command>
         <command name="unload">cray-hdf5</command>
+        <command name="unload">cray-mpich</command>
         <command name="unload">PrgEnv-gnu</command>
         <command name="unload">PrgEnv-intel</command>
         <command name="unload">PrgEnv-nvidia</command>
@@ -129,46 +130,39 @@
       </modules>
 
       <modules compiler="gnu">
+        <command name="load">cpe/23.12</command>
         <command name="load">PrgEnv-gnu/8.5.0</command>
         <command name="load">gcc-native/12.3</command>
         <command name="load">cray-libsci/23.12.5</command>
       </modules>
 
       <modules compiler="intel">
-        <command name="load">PrgEnv-intel/8.3.3</command>
-        <command name="load">intel/2023.1.0</command>
+        <command name="load">cpe/23.12</command>
+        <command name="load">PrgEnv-intel/8.5.0</command>
+        <command name="unload">cray-libsci</command>
+        <command name="load">intel/2023.2.0</command>
       </modules>
 
       <modules compiler="nvidia">
         <command name="load">PrgEnv-nvidia</command>
-        <command name="load">nvidia/24.5</command>
-        <command name="load">cray-libsci/23.12.5</command>
+        <command name="load">nvidia/25.5</command>
+        <command name="load">cray-libsci/24.07.0</command>
       </modules>
 
       <modules compiler="amdclang">
         <command name="load">PrgEnv-aocc</command>
         <command name="load">aocc/4.1.0</command>
-        <command name="load">cray-libsci/23.12.5</command>
+        <command name="load">cray-libsci/24.07.0</command>
       </modules>
 
-      <modules compiler="intel">
-        <command name="load">craype-accel-host</command>
-        <command name="load">craype/2.7.20</command>
-        <command name="load">cray-mpich/8.1.27</command>
-        <command name="load">cray-hdf5-parallel/1.12.2.3</command>
-        <command name="load">cray-netcdf-hdf5parallel/4.9.0.3</command>
-        <command name="load">cray-parallel-netcdf/1.12.3.3</command>
-        <command name="load">cmake/3.24.3</command>
-      </modules>
-
-      <modules compiler="!intel">
+      <modules>
+        <command name="load">cray-mpich/8.1.28</command>
         <command name="load">craype-accel-host</command>
         <command name="load">craype/2.7.30</command>
-        <command name="load">cray-mpich/8.1.28</command>
         <command name="load">cray-hdf5-parallel/1.12.2.9</command>
         <command name="load">cray-netcdf-hdf5parallel/4.9.0.9</command>
         <command name="load">cray-parallel-netcdf/1.12.3.9</command>
-        <command name="load">cmake/3.24.3</command>
+        <command name="load">cmake/3.30.2</command>
       </modules>
     </module_system>
 
@@ -190,6 +184,8 @@
       <env name="MPICH_COLL_SYNC">MPI_Bcast</env>
       <env name="NETCDF_PATH">$ENV{CRAY_NETCDF_HDF5PARALLEL_PREFIX}</env>
       <env name="PNETCDF_PATH">$ENV{CRAY_PARALLEL_NETCDF_PREFIX}</env>
+      <env name="GATOR_INITIAL_MB">4000MB</env>
+      <env name="LD_LIBRARY_PATH">$ENV{CRAY_LD_LIBRARY_PATH}:$ENV{LD_LIBRARY_PATH}</env> <!-- https://github.com/E3SM-Project/E3SM/issues/7117 -->
       <env name="MPICH_SMP_SINGLE_COPY_MODE">CMA</env> <!-- https://github.com/E3SM-Project/E3SM/issues/7207 -->
     </environment_variables>
     <resource_limits>
@@ -252,6 +248,7 @@
         <command name="unload">cray-parallel-netcdf</command>
         <command name="unload">cray-netcdf</command>
         <command name="unload">cray-hdf5</command>
+        <command name="unload">cray-mpich</command>
         <command name="unload">PrgEnv-gnu</command>
         <command name="unload">PrgEnv-intel</command>
         <command name="unload">PrgEnv-nvidia</command>
@@ -271,8 +268,8 @@
       </modules>
 
       <modules compiler="gnu.*">
-        <command name="load">PrgEnv-gnu/8.3.3</command>
-        <command name="load">gcc/11.2.0</command>
+        <command name="load">PrgEnv-gnu/8.5.0</command>
+        <command name="load">gcc-native/12.3</command>
       </modules>
 
       <modules compiler="nvidia.*">
@@ -281,6 +278,8 @@
       </modules>
 
       <modules compiler="gnugpu">
+        <command name="load">PrgEnv-gnu/8.5.0</command>
+        <command name="load">gcc-native/12.3</command>
         <command name="load">cudatoolkit/11.7</command>
         <command name="load">craype-accel-nvidia80</command>
       </modules>
@@ -299,13 +298,13 @@
       </modules>
 
       <modules>
-        <command name="load">cray-libsci/23.02.1.1</command>
-        <command name="load">craype/2.7.20</command>
-        <command name="load">cray-mpich/8.1.25</command>
-        <command name="load">cray-hdf5-parallel/1.12.2.3</command>
-        <command name="load">cray-netcdf-hdf5parallel/4.9.0.3</command>
-        <command name="load">cray-parallel-netcdf/1.12.3.3</command>
-        <command name="load">cmake/3.24.3</command>
+        <command name="load">cray-libsci/23.12.5</command>
+        <command name="load">cray-mpich/8.1.28</command>
+        <command name="load">craype/2.7.30</command>
+        <command name="load">cray-hdf5-parallel/1.12.2.9</command>
+        <command name="load">cray-netcdf-hdf5parallel/4.9.0.9</command>
+        <command name="load">cray-parallel-netcdf/1.12.3.9</command>
+        <command name="load">cmake/3.30.2</command>
       </modules>
     </module_system>
 
@@ -316,14 +315,17 @@
     <environment_variables>
       <env name="MPICH_ENV_DISPLAY">1</env>
       <env name="MPICH_VERSION_DISPLAY">1</env>
+      <env name="MPICH_MPIIO_DVS_MAXNODES">1</env>
       <env name="OMP_STACKSIZE">128M</env>
       <env name="OMP_PROC_BIND">spread</env>
       <env name="OMP_PLACES">threads</env>
       <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
       <env name="PERL5LIB">/global/cfs/cdirs/e3sm/perl/lib/perl5-only-switch</env>
+      <env name="FI_MR_CACHE_MONITOR">kdreg2</env>
       <env name="MPICH_COLL_SYNC">MPI_Bcast</env>
       <env name="NETCDF_PATH">$ENV{CRAY_NETCDF_HDF5PARALLEL_PREFIX}</env>
       <env name="PNETCDF_PATH">$ENV{CRAY_PARALLEL_NETCDF_PREFIX}</env>
+      <env name="LD_LIBRARY_PATH">$ENV{CRAY_LD_LIBRARY_PATH}:$ENV{LD_LIBRARY_PATH}</env> <!-- https://github.com/E3SM-Project/E3SM/issues/7117 -->
     </environment_variables>
     <environment_variables compiler="gnugpu">
       <env name="MPICH_GPU_SUPPORT_ENABLED">1</env>


### PR DESCRIPTION
Update modules and compiler flags to allow building production example cases on maint-2.0 for pm-cpu.
Similar to https://github.com/E3SM-Project/E3SM/pull/8102

