### PR TITLE
EAMxx: refactor aero microphysics into smaller kernels

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -310,7 +310,7 @@ be lost if SCREAM_HACK_XML is not enabled.
     <mam4_aero_microphys inherit="mam4_atm_proc_base">
       <!--Aerosol Microphysics processes on/off switches -->
       <mam4_do_gas_phase_chemistry type="logical" doc="Switch to enable gas phase chemistry">true</mam4_do_gas_phase_chemistry>
-      <mam4_do_setsox type="logical" doc="Switch to enable aqueous chemistry (setsox)">true</mam4_do_setsox>
+      <mam4_do_aqueous_phase_chemistry type="logical" doc="Switch to enable aqueous chemistry (setsox)">true</mam4_do_aqueous_phase_chemistry>
       <extra_mam4_aero_microphys_diags type="logical" doc="Extra MAM4xx aerosol microphysics diagnostics">false</extra_mam4_aero_microphys_diags>
       <mam4_do_cond   type="logical" doc="Switch to enable aerosol microphysics condensation process">true</mam4_do_cond>
       <mam4_do_newnuc type="logical" doc="Switch to enable aerosol microphysics nucleation process">true</mam4_do_newnuc>

--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -310,6 +310,7 @@ be lost if SCREAM_HACK_XML is not enabled.
     <mam4_aero_microphys inherit="mam4_atm_proc_base">
       <!--Aerosol Microphysics processes on/off switches -->
       <mam4_do_gas_phase_chemistry type="logical" doc="Switch to enable gas phase chemistry">true</mam4_do_gas_phase_chemistry>
+      <mam4_do_setsox type="logical" doc="Switch to enable aqueous chemistry (setsox)">true</mam4_do_setsox>
       <extra_mam4_aero_microphys_diags type="logical" doc="Extra MAM4xx aerosol microphysics diagnostics">false</extra_mam4_aero_microphys_diags>
       <mam4_do_cond   type="logical" doc="Switch to enable aerosol microphysics condensation process">true</mam4_do_cond>
       <mam4_do_newnuc type="logical" doc="Switch to enable aerosol microphysics nucleation process">true</mam4_do_newnuc>

--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -309,6 +309,7 @@ be lost if SCREAM_HACK_XML is not enabled.
     <!-- MAM4xx-Aerosol-Microphysics -->
     <mam4_aero_microphys inherit="mam4_atm_proc_base">
       <!--Aerosol Microphysics processes on/off switches -->
+      <mam4_do_gas_phase_chemistry type="logical" doc="Switch to enable gas phase chemistry">true</mam4_do_gas_phase_chemistry>
       <extra_mam4_aero_microphys_diags type="logical" doc="Extra MAM4xx aerosol microphysics diagnostics">false</extra_mam4_aero_microphys_diags>
       <mam4_do_cond   type="logical" doc="Switch to enable aerosol microphysics condensation process">true</mam4_do_cond>
       <mam4_do_newnuc type="logical" doc="Switch to enable aerosol microphysics nucleation process">true</mam4_do_newnuc>

--- a/components/eamxx/src/physics/mam/CMakeLists.txt
+++ b/components/eamxx/src/physics/mam/CMakeLists.txt
@@ -45,6 +45,7 @@ add_library(mam
   readfiles/vertical_remapper_exo_coldens.cpp
   eamxx_mam_generic_process_interface.cpp
   eamxx_mam_microphysics_process_interface.cpp
+  eamxx_mam_microphysics_process_functions.cpp
   ${SCREAM_BASE_DIR}/src/physics/rrtmgp/shr_orb_mod_c2f.F90
   eamxx_mam_optics_process_interface.cpp
   eamxx_mam_dry_deposition_process_interface.cpp

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_functions.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_functions.hpp
@@ -18,7 +18,8 @@ void compute_w0_and_rho(haero::ThreadTeamPolicy team_policy,
   MAMAci::const_view_2d T_mid = dry_atmosphere.T_mid;
   MAMAci::const_view_2d p_mid = dry_atmosphere.p_mid;
   Kokkos::parallel_for(
-      team_policy, KOKKOS_LAMBDA(const haero::ThreadTeam &team) {
+      "MAMAci::run_impl::compute_w0_and_rho", team_policy,
+      KOKKOS_LAMBDA(const haero::ThreadTeam &team) {
         const int icol = team.league_rank();
         // Get physical constants
         using C                      = physics::Constants<Real>;
@@ -47,7 +48,8 @@ void compute_tke_at_interfaces(haero::ThreadTeamPolicy team_policy,
   using CO = scream::ColumnOps<DefaultDevice, Real>;
 
   Kokkos::parallel_for(
-      team_policy, KOKKOS_LAMBDA(const haero::ThreadTeam &team) {
+      "MAMAci::run_impl::compute_tke_at_interfaces", team_policy,
+      KOKKOS_LAMBDA(const haero::ThreadTeam &team) {
         const int icol = team.league_rank();
 
         const auto var_mid_col   = ekat::subview(var_mid, icol);
@@ -72,7 +74,8 @@ void compute_subgrid_scale_velocities(
     // output
     MAMAci::view_2d wsub, MAMAci::view_2d wsubice, MAMAci::view_2d wsig) {
   Kokkos::parallel_for(
-      team_policy, KOKKOS_LAMBDA(const haero::ThreadTeam &team) {
+      "MAMAci::run_impl::compute_subgrid_scale_velocities", team_policy,
+      KOKKOS_LAMBDA(const haero::ThreadTeam &team) {
         const int icol = team.league_rank();
         // More refined computation of sub-grid vertical velocity
         // Set to be zero at the surface by initialization.
@@ -112,7 +115,8 @@ void compute_nucleate_ice_tendencies(
   //-------------------------------------------------------------
 
   Kokkos::parallel_for(
-      team_policy, KOKKOS_LAMBDA(const haero::ThreadTeam &team) {
+      "MAMAci::run_impl::compute_nucleate_ice_tendencies", team_policy,
+      KOKKOS_LAMBDA(const haero::ThreadTeam &team) {
         const int icol = team.league_rank();
         //---------------------------------------------------------------------
         //   Set up surface, pronostics atmosphere, diagnostics, and tendencies
@@ -175,7 +179,8 @@ void store_liquid_cloud_fraction(
   MAMAci::const_view_2d qc = dry_atmosphere.qc;
   MAMAci::const_view_2d qi = dry_atmosphere.qi;
   Kokkos::parallel_for(
-      team_policy, KOKKOS_LAMBDA(const haero::ThreadTeam &team) {
+      "MAMAci::run_impl::store_liquid_cloud_fraction", team_policy,
+      KOKKOS_LAMBDA(const haero::ThreadTeam &team) {
         const int icol = team.league_rank();
         //-------------------------------------------------------------
         // Get old and new liquid cloud fractions when amount of cloud
@@ -318,7 +323,8 @@ void call_function_dropmixnuc(
   //---------------------------------------------------------------------------
   const bool local_enable_aero_vertical_mix = enable_aero_vertical_mix;
   Kokkos::parallel_for(
-      team_policy, KOKKOS_LAMBDA(const haero::ThreadTeam &team) {
+      "MAMAci::run_impl::call_function_dropmixnuc", team_policy,
+      KOKKOS_LAMBDA(const haero::ThreadTeam &team) {
         const int icol = team.league_rank();
         // for (int icol=0; icol<5; ++icol){
         mam4::ndrop::View1D raercol_cw_view[mam4::ndrop::pver][2];
@@ -474,7 +480,8 @@ void update_interstitial_aerosols(
       if(aero_mmr.data()) {
         const auto ptend_view = ptend_q[s_idx];
         Kokkos::parallel_for(
-            team_policy, KOKKOS_LAMBDA(const haero::ThreadTeam &team) {
+            "MAMAci::run_impl::update_interstitial_aerosols_mmr", team_policy,
+            KOKKOS_LAMBDA(const haero::ThreadTeam &team) {
               const int icol = team.league_rank();
               // update values for all levs at this column
               Kokkos::parallel_for(
@@ -490,7 +497,8 @@ void update_interstitial_aerosols(
         dry_aero.int_aero_nmr[m];  // number mixing ratio for mode "m"
     const auto ptend_view = ptend_q[s_idx];
     Kokkos::parallel_for(
-        team_policy, KOKKOS_LAMBDA(const haero::ThreadTeam &team) {
+        "MAMAci::run_impl::update_interstitial_aerosols_nmr", team_policy,
+        KOKKOS_LAMBDA(const haero::ThreadTeam &team) {
           const int icol = team.league_rank();
           // update values for all levs at this column
           Kokkos::parallel_for(
@@ -520,7 +528,8 @@ void call_hetfrz_compute_tendencies(
     diagnostic_scratch[i] = diagnostic_scratch_[i];
 
   Kokkos::parallel_for(
-      team_policy, KOKKOS_LAMBDA(const haero::ThreadTeam &team) {
+      "MAMAci::run_impl::call_hetfrz_compute_tendencies", team_policy,
+      KOKKOS_LAMBDA(const haero::ThreadTeam &team) {
         const int icol = team.league_rank();
         //   Set up an atmosphere, surface, diagnostics, pronostics and
         //   tendencies class.

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_functions.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_functions.hpp
@@ -162,7 +162,7 @@ void compute_nucleate_ice_tendencies(
       });
 }
 void store_liquid_cloud_fraction(
-    haero::ThreadTeamPolicy team_policy,
+    const int ncol,
     const mam_coupling::DryAtmosphere &dry_atmosphere,
     const MAMAci::const_view_2d liqcldf,
     const MAMAci::const_view_2d liqcldf_prev, const int top_lev, const int nlev,
@@ -170,26 +170,23 @@ void store_liquid_cloud_fraction(
     MAMAci::view_2d cloud_frac, MAMAci::view_2d cloud_frac_prev) {
   MAMAci::const_view_2d qc = dry_atmosphere.qc;
   MAMAci::const_view_2d qi = dry_atmosphere.qi;
+  // cut-off for cloud amount (ice or liquid)
+  static constexpr auto qsmall = 1e-18;  // BAD_CONSTANT
   Kokkos::parallel_for(
-      "MAMAci::run_impl::store_liquid_cloud_fraction", team_policy,
-      KOKKOS_LAMBDA(const haero::ThreadTeam &team) {
-        const int icol = team.league_rank();
+      "MAMAci::run_impl::store_liquid_cloud_fraction",
+      Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0, top_lev}, {ncol, nlev}),
+      KOKKOS_LAMBDA(const int icol, const int kk) {
         //-------------------------------------------------------------
         // Get old and new liquid cloud fractions when amount of cloud
         // is above qsmall threshold value
         //-------------------------------------------------------------
-        // cut-off for cloud amount (ice or liquid)
-        static constexpr auto qsmall = 1e-18;  // BAD_CONSTANT
-        Kokkos::parallel_for(
-            Kokkos::TeamVectorRange(team, top_lev, nlev), [&](int kk) {
-              if((qc(icol, kk) + qi(icol, kk)) > qsmall) {
-                cloud_frac(icol, kk)      = liqcldf(icol, kk);
-                cloud_frac_prev(icol, kk) = liqcldf_prev(icol, kk);
-              } else {
-                cloud_frac(icol, kk)      = 0;
-                cloud_frac_prev(icol, kk) = 0;
-              }
-            });
+        if((qc(icol, kk) + qi(icol, kk)) > qsmall) {
+          cloud_frac(icol, kk)      = liqcldf(icol, kk);
+          cloud_frac_prev(icol, kk) = liqcldf_prev(icol, kk);
+        } else {
+          cloud_frac(icol, kk)      = 0;
+          cloud_frac_prev(icol, kk) = 0;
+        }
       });
 }
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_functions.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_functions.hpp
@@ -9,7 +9,7 @@ namespace scream {
 
 namespace {
 
-void compute_w0_and_rho(haero::ThreadTeamPolicy team_policy,
+void compute_w0_and_rho(const int ncol,
                         const mam_coupling::DryAtmosphere &dry_atmosphere,
                         const int top_lev, const int nlev,
                         // output
@@ -17,25 +17,21 @@ void compute_w0_and_rho(haero::ThreadTeamPolicy team_policy,
   MAMAci::const_view_2d omega = dry_atmosphere.omega;
   MAMAci::const_view_2d T_mid = dry_atmosphere.T_mid;
   MAMAci::const_view_2d p_mid = dry_atmosphere.p_mid;
+  using C                      = physics::Constants<Real>;
+  static constexpr auto gravit = C::gravit.value;  // Gravity [m/s2]
+  // Gas constant for dry air [J/(kg*K) or J/Kg/K]
+  static constexpr auto rair = C::Rair.value;
   Kokkos::parallel_for(
-      "MAMAci::run_impl::compute_w0_and_rho", team_policy,
-      KOKKOS_LAMBDA(const haero::ThreadTeam &team) {
-        const int icol = team.league_rank();
-        // Get physical constants
-        using C                      = physics::Constants<Real>;
-        static constexpr auto gravit = C::gravit.value;  // Gravity [m/s2]
-        // Gas constant for dry air [J/(kg*K) or J/Kg/K]
-        static constexpr auto rair = C::Rair.value;
-        Kokkos::parallel_for(Kokkos::TeamVectorRange(team, 0u, top_lev),
-                             [&](int kk) {
-                               w0(icol, kk)  = 0;
-                               rho(icol, kk) = -999.0;
-                             });
-        Kokkos::parallel_for(
-            Kokkos::TeamVectorRange(team, top_lev, nlev), [&](int kk) {
-              rho(icol, kk) = p_mid(icol, kk) / (rair * T_mid(icol, kk));
-              w0(icol, kk)  = -1.0 * omega(icol, kk) / (rho(icol, kk) * gravit);
-            });
+      "MAMAci::run_impl::compute_w0_and_rho",
+      Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0, 0}, {ncol, nlev}),
+      KOKKOS_LAMBDA(const int icol, const int kk) {
+        if(kk < top_lev) {
+          w0(icol, kk)  = 0;
+          rho(icol, kk) = -999.0;
+        } else {
+          rho(icol, kk) = p_mid(icol, kk) / (rair * T_mid(icol, kk));
+          w0(icol, kk)  = -1.0 * omega(icol, kk) / (rho(icol, kk) * gravit);
+        }
       });
 }
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_functions.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_functions.hpp
@@ -65,33 +65,29 @@ void compute_tke_at_interfaces(haero::ThreadTeamPolicy team_policy,
 }
 
 void compute_subgrid_scale_velocities(
-    haero::ThreadTeamPolicy team_policy, const MAMAci::const_view_2d tke,
+    const int ncol, const MAMAci::const_view_2d tke,
     const Real wsubmin, const int top_lev, const int nlev,
     // output
     MAMAci::view_2d wsub, MAMAci::view_2d wsubice, MAMAci::view_2d wsig) {
   Kokkos::parallel_for(
-      "MAMAci::run_impl::compute_subgrid_scale_velocities", team_policy,
-      KOKKOS_LAMBDA(const haero::ThreadTeam &team) {
-        const int icol = team.league_rank();
+      "MAMAci::run_impl::compute_subgrid_scale_velocities",
+      Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0, 0}, {ncol, nlev}),
+      KOKKOS_LAMBDA(const int icol, const int kk) {
         // More refined computation of sub-grid vertical velocity
         // Set to be zero at the surface by initialization.
-        Kokkos::parallel_for(Kokkos::TeamVectorRange(team, top_lev),
-                             [&](int kk) {
-                               wsub(icol, kk)    = wsubmin;
-                               wsubice(icol, kk) = 0.001;
-                               wsig(icol, kk)    = 0.001;
-                             });
-        // parallel_for ranges do not overlap, no need for barrier.
-        Kokkos::parallel_for(
-            Kokkos::TeamVectorRange(team, top_lev, nlev), [&](int kk) {
-              wsub(icol, kk) = haero::sqrt(
-                  0.5 * (tke(icol, kk) + tke(icol, kk + 1)) * (2.0 / 3.0));
-              wsig(icol, kk) =
-                  mam4::utils::min_max_bound(0.001, 10.0, wsub(icol, kk));
-              wsubice(icol, kk) =
-                  mam4::utils::min_max_bound(0.2, 10.0, wsub(icol, kk));
-              wsub(icol, kk) = haero::max(wsubmin, wsub(icol, kk));
-            });
+        if(kk < top_lev) {
+          wsub(icol, kk)    = wsubmin;
+          wsubice(icol, kk) = 0.001;
+          wsig(icol, kk)    = 0.001;
+        } else {
+          wsub(icol, kk) = haero::sqrt(
+              0.5 * (tke(icol, kk) + tke(icol, kk + 1)) * (2.0 / 3.0));
+          wsig(icol, kk) =
+              mam4::utils::min_max_bound(0.001, 10.0, wsub(icol, kk));
+          wsubice(icol, kk) =
+              mam4::utils::min_max_bound(0.2, 10.0, wsub(icol, kk));
+          wsub(icol, kk) = haero::max(wsubmin, wsub(icol, kk));
+        }
       });
 }
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_functions.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_functions.hpp
@@ -452,7 +452,7 @@ void update_cloud_borne_aerosols(
 
 // Update interstitial aerosols using tendencies- cols and levs
 void update_interstitial_aerosols(
-    haero::ThreadTeamPolicy team_policy,
+    const int ncol,
     const MAMAci::view_2d ptend_q[mam4::aero_model::pcnst], const int nlev,
     const Real dt,
     // output
@@ -469,14 +469,10 @@ void update_interstitial_aerosols(
       if(aero_mmr.data()) {
         const auto ptend_view = ptend_q[s_idx];
         Kokkos::parallel_for(
-            "MAMAci::run_impl::update_interstitial_aerosols_mmr", team_policy,
-            KOKKOS_LAMBDA(const haero::ThreadTeam &team) {
-              const int icol = team.league_rank();
-              // update values for all levs at this column
-              Kokkos::parallel_for(
-                  Kokkos::TeamVectorRange(team, nlev), [&](int kk) {
-                    aero_mmr(icol, kk) += ptend_view(icol, kk) * dt;
-                  });
+            "MAMAci::run_impl::update_interstitial_aerosols_mmr",
+            Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0, 0}, {ncol, nlev}),
+            KOKKOS_LAMBDA(const int icol, const int kk) {
+              aero_mmr(icol, kk) += ptend_view(icol, kk) * dt;
             });
         // update index for the next species (only if aero_mmr.data() is True)
         ++s_idx;
@@ -486,13 +482,10 @@ void update_interstitial_aerosols(
         dry_aero.int_aero_nmr[m];  // number mixing ratio for mode "m"
     const auto ptend_view = ptend_q[s_idx];
     Kokkos::parallel_for(
-        "MAMAci::run_impl::update_interstitial_aerosols_nmr", team_policy,
-        KOKKOS_LAMBDA(const haero::ThreadTeam &team) {
-          const int icol = team.league_rank();
-          // update values for all levs at this column
-          Kokkos::parallel_for(
-              Kokkos::TeamVectorRange(team, nlev),
-              [&](int kk) { aero_nmr(icol, kk) += ptend_view(icol, kk) * dt; });
+        "MAMAci::run_impl::update_interstitial_aerosols_nmr",
+        Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0, 0}, {ncol, nlev}),
+        KOKKOS_LAMBDA(const int icol, const int kk) {
+          aero_nmr(icol, kk) += ptend_view(icol, kk) * dt;
         });
     ++s_idx;  // update index for the next species
   }

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
@@ -546,7 +546,7 @@ void MAMAci::run_impl(const double dt) {
       naai_);
 
   // Compute cloud fractions based on cloud threshold
-  store_liquid_cloud_fraction(team_policy, dry_atm_, liqcldf_, liqcldf_prev_,
+  store_liquid_cloud_fraction(ncol_, dry_atm_, liqcldf_, liqcldf_prev_,
                               top_lev_, nlev_,
                               // output
                               cloud_frac_, cloud_frac_prev_);

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
@@ -611,7 +611,7 @@ void MAMAci::run_impl(const double dt) {
                               dry_aero_);
 
   // Update interstitial aerosols using tendencies
-  update_interstitial_aerosols(team_policy, ptend_q_, nlev_, dt,
+  update_interstitial_aerosols(ncol_, ptend_q_, nlev_, dt,
                                // output
                                dry_aero_);
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
@@ -513,7 +513,7 @@ void MAMAci::run_impl(const double dt) {
   mam_coupling::copy_view_lev_slice(team_policy, wet_atm_.nc, nlev_,  // inputs
                                     nc_inp_to_aci_);                  // output
 
-  compute_w0_and_rho(team_policy, dry_atm_, top_lev_, nlev_,
+  compute_w0_and_rho(ncol_, dry_atm_, top_lev_, nlev_,
                      // output
                      w0_, rho_);
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
@@ -523,7 +523,7 @@ void MAMAci::run_impl(const double dt) {
                             tke_);
 
   Kokkos::fence();  // wait for tke_ to be computed.
-  compute_subgrid_scale_velocities(team_policy, tke_, wsubmin_, top_lev_, nlev_,
+  compute_subgrid_scale_velocities(ncol_, tke_, wsubmin_, top_lev_, nlev_,
                                    // output
                                    wsub_, wsubice_, wsig_);
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
@@ -9,10 +9,8 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
   const auto policy =
       TPF::get_default_team_policy(ncol_, nlev_);
   const int nlev = nlev_;
-  //
-
-
   constexpr int num_oxidants=mam4::mo_setinv::num_tracer_cnst;
+
   view_2d oxidants[num_oxidants];
   for (size_t i = 0; i < var_names_oxi_.size(); ++i) {
     oxidants[i] = get_field_out("oxid_"+var_names_oxi_[i]).get_view<Real **>();
@@ -141,34 +139,23 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
 
 
   const auto& o3_col_dens = buffer_.scratch[8];
+  const auto o3_exo_col = exo_coldens_fields_[0].get_view<Real**>();
+  // FIXME: review len of work_set_het.
   const auto& work_set_het  = work_set_het_;
+  const int o3_ndx = static_cast<int>(mam4::GasId::O3);
+  
   Kokkos::parallel_for(
     "MAMMicrophysics::run_impl::compute_o3_column_density", policy,
     KOKKOS_LAMBDA(const ThreadTeam &team) {
     const int icol     = team.league_rank();   // column index
     // calculate o3 column densities (first component of col_dens in Fortran
     // code)
-    auto o3_col_dens_i = ekat::subview(o3_col_dens, icol);
-    const auto& invariants_icol = ekat::subview(invariants, icol);
+    auto o3_col_dens_icol = ekat::subview(o3_col_dens, icol);
     const auto& atm = mam_coupling::atmosphere_for_column(dry_atm, icol);
-    const auto& vmr_icol = ekat::subview(vmr,icol);
-    const auto work_set_het_icol = ekat::subview(work_set_het, icol);
-    auto work_set_het_ptr = (Real *)work_set_het_icol.data();
-    const auto& o3_col_deltas  = view_1d(work_set_het_ptr, mam4::nlev + 1);
-    // NOTE: if we need o2 column densities, set_ub_col and setcol must be changed
-    const int nlev = mam4::nlev;
-    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev), [&](const int kk) {
-      const Real pdel = atm.hydrostatic_dp(kk);
-      const auto vmr_kk = ekat::subview(vmr_icol,kk);
-      const auto invariants_k = ekat::subview(invariants_icol,kk);
-      // compute the change in o3 density for this column above its neighbor
-      mam4::mo_photo::set_ub_col(o3_col_deltas(kk + 1),     // out
-                               vmr_kk.data(), invariants_k.data(), pdel); // out
-    });
-    team.team_barrier();
-    // sum the o3 column deltas to densities
-    mam4::mo_photo::setcol(team, o3_col_deltas.data(), // in
-                         o3_col_dens_i);        // out
+    const auto& vmr_icol = ekat::subview(vmr,icol);  
+    // const auto vmr_icol_o3 = Kokkos::subview(vmr_icol, Kokkos::ALL(), o3_ndx);
+    mam4::microphysics::compute_o3_column_density(
+      team, atm.hydrostatic_dp, vmr_icol, o3_exo_col(icol, 0), o3_ndx, o3_col_dens_icol);
   });
   // set o3_col_dens ends
 
@@ -666,7 +653,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
         // in
         vmr0_kk, vmr_pregas_kk, vmr_precld_kk, dgncur_a_kk, dgncur_awet_kk, wetdens_kk);
       });
-    });
+    }); 
 
     // modal_aero_amicphys_intr ends
 
@@ -687,10 +674,9 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
        });
     });
     // vmr2mmr_cw ends
-
     // linoz
     if (config.linoz.compute) {
-
+      // NOTE: we only have one field  
       // climatology data for linear stratospheric chemistry
       // ozone (climatology) [vmr]
       view_2d linoz_o3_clim =  buffer_.scratch[0];
@@ -710,6 +696,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
       view_2d linoz_cariolle_pscs = buffer_.scratch[7];
       const auto& linoz_conf=config.linoz;
       const int o3_ndx = static_cast<int>(mam4::GasId::O3);
+      
       Kokkos::parallel_for(
     "MAMMicrophysics::run_impl::linoz", policy,
     KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -720,30 +707,29 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
       // convert column latitude to radians
       const Real rlats = col_lat * M_PI / 180.0;
       mam4::microphysics::LinozData linoz_data;
-      if (config.linoz.compute) {
-          linoz_data.linoz_o3_clim_icol = ekat::subview(linoz_o3_clim, icol);
-          linoz_data.linoz_t_clim_icol  = ekat::subview(linoz_t_clim, icol);
-          linoz_data.linoz_o3col_clim_icol =
-            ekat::subview(linoz_o3col_clim, icol);
-          linoz_data.linoz_PmL_clim_icol = ekat::subview(linoz_PmL_clim, icol);
-          linoz_data.linoz_dPmL_dO3_icol = ekat::subview(linoz_dPmL_dO3, icol);
-          linoz_data.linoz_dPmL_dT_icol  = ekat::subview(linoz_dPmL_dT, icol);
-          linoz_data.linoz_dPmL_dO3col_icol =
-            ekat::subview(linoz_dPmL_dO3col, icol);
-          linoz_data.linoz_cariolle_pscs_icol =
-            ekat::subview(linoz_cariolle_pscs, icol);
-      }
+      linoz_data.linoz_o3_clim_icol = ekat::subview(linoz_o3_clim, icol);
+      linoz_data.linoz_t_clim_icol  = ekat::subview(linoz_t_clim, icol);
+      linoz_data.linoz_o3col_clim_icol = ekat::subview(linoz_o3col_clim, icol);
+      linoz_data.linoz_PmL_clim_icol = ekat::subview(linoz_PmL_clim, icol);
+      linoz_data.linoz_dPmL_dO3_icol = ekat::subview(linoz_dPmL_dO3, icol);
+      linoz_data.linoz_dPmL_dT_icol  = ekat::subview(linoz_dPmL_dT, icol);
+      linoz_data.linoz_dPmL_dO3col_icol = ekat::subview(linoz_dPmL_dO3col, icol);
+      linoz_data.linoz_cariolle_pscs_icol = ekat::subview(linoz_cariolle_pscs, icol);
       const auto& vmr_icol = ekat::subview(vmr,icol);
 
+       //Find tropopause (or quit simulation if not found) as extinction should be
+      // applied only above tropopause */
+      const int ilev_tropp = mam4::aer_rad_props::tropopause_or_quit(atm.pressure, atm.interface_pressure,
+          atm.temperature,  atm.height, ekat::subview(dry_atm.z_iface, icol));
+      // Part 1: LINOZ chemistry
       Kokkos::parallel_for(
-       Kokkos::TeamVectorRange(team, nlev),
+       Kokkos::TeamVectorRange(team, ilev_tropp),
        [&](const int kk) {
       //-----------------
       // LINOZ chemistry
       //-----------------
       const Real temp = atm.temperature(kk);
       const Real pmid = atm.pressure(kk);
-      const Real pdel = atm.hydrostatic_dp(kk);
 
       // the following things are diagnostics, which we're not
       // including in the first rev
@@ -765,26 +751,29 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
           linoz_data.linoz_cariolle_pscs_icol(kk), linoz_conf.chlorine_loading,
           linoz_conf.psc_T,
           // out
-          vmr_kk[o3_ndx],
+          vmr_kk(o3_ndx),
           // outputs that are not used
           do3_linoz, do3_linoz_psc, ss_o3, o3col_du_diag, o3clim_linoz_diag,
           zenith_angle_degrees);
+        });
 
-      // Update source terms above the ozone decay threshold
-      if (kk >= nlev - linoz_conf.o3_lbl) {
-        const Real o3l_vmr_old = vmr_kk(o3_ndx);
-        Real do3mass = 0;
-        const Real o3l_vmr_new =
-            mam4::lin_strat_chem::lin_strat_sfcsink_kk(dt, pdel,          // in
-                                                       o3l_vmr_old,       // in
-                                                       linoz_conf.o3_sfc, // in
-                                                       linoz_conf.o3_tau, // in
-                                                       do3mass);          // out
-        // Update the mixing ratio (vmr) for O3
-        vmr_kk(o3_ndx) = o3l_vmr_new;
-      }
-        });
-        });
+      Kokkos::parallel_for(
+        Kokkos::TeamVectorRange(team, nlev - linoz_conf.o3_lbl, nlev),
+        [&](const int kk) {
+          const Real pdel = atm.hydrostatic_dp(kk);
+          const auto& vmr_kk = ekat::subview(vmr_icol,kk);
+          const Real o3l_vmr_old = vmr_kk(o3_ndx);
+          Real do3mass = 0;
+          const Real o3l_vmr_new =
+              mam4::lin_strat_chem::lin_strat_sfcsink_kk(
+                  dt, pdel,           // in
+                  o3l_vmr_old,        // in
+                  linoz_conf.o3_sfc,  // in
+                  linoz_conf.o3_tau,  // in
+                  do3mass);           // out
+          vmr_kk(o3_ndx) = o3l_vmr_new;
+      });
+    });
 
     }
     // linoz ends

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
@@ -33,23 +33,22 @@ void MAMMicrophysics::run_microphysics_kernels(const double dt, const double ecc
     const auto& field = forcings_[mm].fields[isec];
     if (forcings_[mm].file_alt_data) {
       Kokkos::parallel_for(
-        "MAMMicrophysics::run_impl::forcing", policy,
-        KOKKOS_LAMBDA(const ThreadTeam &team) {
-        const int icol     = team.league_rank();   // column index
-        Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev),
-         [&](int kk) {
-          extfrc(icol,kk,nn) += field(icol,nlev - 1 - kk);
-        });
+        "MAMMicrophysics::run_impl::forcing",
+        Kokkos::RangePolicy<>(0, ncol_ * nlev),
+        KOKKOS_LAMBDA(const int i) {
+        const int icol = i / nlev;
+        const int kk   = i % nlev;
+        extfrc(icol,kk,nn) += field(icol,nlev - 1 - kk);
       });
 
    } else {
      Kokkos::parallel_for(
-      "MAMMicrophysics::run_impl::forcing", policy,
-      KOKKOS_LAMBDA(const ThreadTeam &team) {
-      const int icol     = team.league_rank();   // column index
-      Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev), [&](int kk) {
-        extfrc(icol,kk,nn) += field(icol,kk);
-      });
+      "MAMMicrophysics::run_impl::forcing",
+      Kokkos::RangePolicy<>(0, ncol_ * nlev),
+      KOKKOS_LAMBDA(const int i) {
+      const int icol = i / nlev;
+      const int kk   = i % nlev;
+      extfrc(icol,kk,nn) += field(icol,kk);
     });
    }
   } // isec

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
@@ -517,9 +517,10 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
   const auto& dqdt_aqh2so4 = dqdt_aqh2so4_;
   const unsigned n_so4_monolayers_pcage = config.n_so4_monolayers_pcage;
 
+  if (config_.compute_setsox) {
   MAM_START_TIMER("MAMMicrophysics::run_impl::setsox_single_level");
   Kokkos::parallel_for(
-    "MAMMicrophysics::run_impl::setsox_single_level", policy,
+    "MAMMicrophysics::run_impl::setsox", policy,
     KOKKOS_LAMBDA(const ThreadTeam &team) {
 
     const int icol     = team.league_rank();   // column index
@@ -592,6 +593,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
       });
       MAM_STOP_TIMER("MAMMicrophysics::run_impl::aqueous_chemistry_dvmrdt");
     }
+  } // compute_setsox
     //setsox_single_level ends
 
     // modal_aero_amicphys_intr

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
@@ -5,8 +5,10 @@
 
 // Conditionally enable fine-grained micro-physics timers.
 // Compile with -DMICRO_TIMER to activate.
+#define MICRO_TIMER
+
 #ifdef MICRO_TIMER
-#  define MAM_START_TIMER(name) do { Kokkos::fence(); start_timer(name); } while(0)
+#  define MAM_START_TIMER(name) do { start_timer(name); } while(0)
 #  define MAM_STOP_TIMER(name)  do { stop_timer(name); Kokkos::fence(); } while(0)
 #else
 #  define MAM_START_TIMER(name) ((void)0)

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
@@ -1,19 +1,6 @@
 #include <mam4xx/mam4.hpp>
 #include <physics/mam/eamxx_mam_microphysics_process_interface.hpp>
 #include <ekat_team_policy_utils.hpp>
-#include <share/util/eamxx_timing.hpp>
-
-// Conditionally enable fine-grained micro-physics timers.
-// Compile with -DMICRO_TIMER to activate.
-// #define MICRO_TIMER
-
-#ifdef MICRO_TIMER
-#  define MAM_START_TIMER(name) do { start_timer(name); } while(0)
-#  define MAM_STOP_TIMER(name)  do { stop_timer(name); Kokkos::fence(); } while(0)
-#else
-#  define MAM_START_TIMER(name) ((void)0)
-#  define MAM_STOP_TIMER(name)  ((void)0)
-#endif
 
 namespace scream {
 
@@ -33,7 +20,6 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
   // Flatten the (mm, isec) host loops into fixed-size arrays captured by
   // value inside the gas_phase_chemistry kernel, where extfrc_k is computed
   // inline to avoid a separate kernel launch and HBM buffer round-trip.
-  MAM_START_TIMER("MAMMicrophysics::run_impl::forcing");
   constexpr int extcnt = mam4::gas_chemistry::extcnt;
   const auto& extfrc = extfrc_;
   constexpr int max_forcing_entries =
@@ -52,13 +38,11 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
     }
   }
   const int nfrc_total = nfrc;
-  MAM_STOP_TIMER("MAMMicrophysics::run_impl::forcing");
   // set external forcing ends (applied inline in gas_phase_chemistry below)
 
   // set invariants
   const auto& invariants = invariants_;
   const auto& dry_atm = dry_atm_;
-  MAM_START_TIMER("MAMMicrophysics::run_impl::setinv");
   Kokkos::parallel_for(
       "MAMMicrophysics::run_impl::setinv", policy,
       KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -76,7 +60,6 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
                           cnst_offline_icol, atm.pressure);        // in
 
   });
-  MAM_STOP_TIMER("MAMMicrophysics::run_impl::setinv");
 
   // set invariants ends
 
@@ -100,7 +83,6 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
     adv_mass_kg_per_moles[i] = mam4::gas_chemistry::adv_mass[i] / 1e3;
   }
 
-  MAM_START_TIMER("MAMMicrophysics::run_impl::extract_stateq");
   Kokkos::parallel_for(
       "MAMMicrophysics::run_impl::extract_stateq", policy,
       KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -144,7 +126,6 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
         mam4::microphysics::mmr2vmr(qqcw_kk.data(), adv_mass_kg_per_moles, vmrcw_kk.data());
     });
   });
-  MAM_STOP_TIMER("MAMMicrophysics::run_impl::extract_stateq");
 
 
   const auto& o3_col_dens = buffer_.scratch[8];
@@ -153,7 +134,6 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
   const auto& work_set_het  = work_set_het_;
   const int o3_ndx = static_cast<int>(mam4::GasId::O3);
   
-  MAM_START_TIMER("MAMMicrophysics::run_impl::compute_o3_column_density");
   Kokkos::parallel_for(
     "MAMMicrophysics::run_impl::compute_o3_column_density", policy,
     KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -166,7 +146,6 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
     mam4::microphysics::compute_o3_column_density(
       team, atm.hydrostatic_dp, vmr_icol, o3_exo_col(icol, 0), o3_ndx, o3_col_dens_icol);
   });
-  MAM_STOP_TIMER("MAMMicrophysics::run_impl::compute_o3_column_density");
   // set o3_col_dens ends
 
   // set photo table
@@ -177,7 +156,6 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
   const auto& zenith_angle = acos_cosine_zenith_;
   const auto& photo_table=photo_table_;
 
-  MAM_START_TIMER("MAMMicrophysics::run_impl::photo_table");
   Kokkos::parallel_for(
       "MAMMicrophysics::run_impl::photo_table", policy,
       KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -205,7 +183,6 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
                               eccf, photo_table,                           // in
                               photo_work_arrays_icol); // out
     });
-    MAM_STOP_TIMER("MAMMicrophysics::run_impl::photo_table");
 
     // set photo table ends
     const auto& col_latitudes = col_latitudes_;
@@ -219,7 +196,6 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
     const auto &nevapr = get_field_in("nevapr").get_view<const Real **>();
 
     // set sethet
-    MAM_START_TIMER("MAMMicrophysics::run_impl::sethet");
     Kokkos::parallel_for(
       "MAMMicrophysics::run_impl::sethet", policy,
       KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -244,7 +220,6 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
                           nevapr_icol, dt, invariants_icol, vmr_icol,
                           work_sethet_call);
   });
-  MAM_STOP_TIMER("MAMMicrophysics::run_impl::sethet");
 
   // set_het end
 
@@ -304,7 +279,6 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
   const const_view_1d precip_ice_surf_mass =
       get_field_in("precip_ice_surf_mass").get_view<const Real *>();
 
-  MAM_START_TIMER("MAMMicrophysics::run_impl::drydep_xactive");
   Kokkos::parallel_for(
     "MAMMicrophysics::run_impl::drydep_xactive", policy,
     KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -412,7 +386,6 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
             });
         }
     });
-    MAM_STOP_TIMER("MAMMicrophysics::run_impl::drydep_xactive");
 
 
     // set drydep_xactive ends
@@ -437,7 +410,6 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
       gas_phase_chemistry_dvmrdt = get_field_out("mam4_microphysics_tendency_gas_phase_chemistry").get_view<Real ***>();
     }
 
-    MAM_START_TIMER("MAMMicrophysics::run_impl::gas_phase_chemistry");
     Kokkos::parallel_for(
     "MAMMicrophysics::run_impl::gas_phase_chemistry", policy,
     KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -476,11 +448,9 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
       });
 
     });
-  MAM_STOP_TIMER("MAMMicrophysics::run_impl::gas_phase_chemistry");
 
     if (gas_phase_chemistry_dvmrdt.size()) {
 
-  MAM_START_TIMER("MAMMicrophysics::run_impl::gas_phase_chemistry_dvmrdt");
     Kokkos::parallel_for(
     "MAMMicrophysics::run_impl::gas_phase_chemistry_dvmrdt", policy,
     KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -499,7 +469,6 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
        });
 
     });
-     MAM_STOP_TIMER("MAMMicrophysics::run_impl::gas_phase_chemistry_dvmrdt");
   }
     } // compute_gas_phase_chemistry
   // gas_phase_chemistry ends
@@ -518,7 +487,6 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
   const unsigned n_so4_monolayers_pcage = config.n_so4_monolayers_pcage;
 
   if (config_.compute_setsox) {
-  MAM_START_TIMER("MAMMicrophysics::run_impl::setsox_single_level");
   Kokkos::parallel_for(
     "MAMMicrophysics::run_impl::setsox", policy,
     KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -564,7 +532,6 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
         dqdt_aqso4_k.data(), dqdt_aqh2so4_k.data(), vmrcw_k.data(), vmr_k.data());
     });
     });
-      MAM_STOP_TIMER("MAMMicrophysics::run_impl::setsox_single_level");
 
     view_3d aqueous_chemistry_dvmrdt;
     if (extra_mam4_aero_microphys_diags_) {
@@ -572,7 +539,6 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
     }
 
     if (aqueous_chemistry_dvmrdt.size()) {
-      MAM_START_TIMER("MAMMicrophysics::run_impl::aqueous_chemistry_dvmrdt");
       Kokkos::parallel_for(
       "MAMMicrophysics::run_impl::aqueous_chemistry_dvmrdt", policy,
       KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -591,7 +557,6 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
          });
 
       });
-      MAM_STOP_TIMER("MAMMicrophysics::run_impl::aqueous_chemistry_dvmrdt");
     }
   } // compute_setsox
     //setsox_single_level ends
@@ -607,7 +572,6 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
     auto& dgncur_a_loc = dgncur_a_;
     auto& wetdens_loc = wetdens_;
     constexpr int nmodes = mam4::AeroConfig::num_modes();
-      MAM_START_TIMER("MAMMicrophysics::run_impl::modal_aero_amicphys_intr_precompute");
      Kokkos::parallel_for(
     "MAMMicrophysics::run_impl::modal_aero_amicphys_intr_precompute", policy,
     KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -622,7 +586,6 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
         }
       });
     });
-    MAM_STOP_TIMER("MAMMicrophysics::run_impl::modal_aero_amicphys_intr_precompute");
 
     view_3d gas_aero_exchange_condensation, gas_aero_exchange_renaming,
           gas_aero_exchange_nucleation, gas_aero_exchange_coagulation,
@@ -639,7 +602,6 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
     const bool extra_mam4_aero_microphys_diags  = extra_mam4_aero_microphys_diags_;
 
     const auto& config_amicphys = config.amicphys;
-      MAM_START_TIMER("MAMMicrophysics::run_impl::modal_aero_amicphys_intr");
      Kokkos::parallel_for(
     "MAMMicrophysics::run_impl::modal_aero_amicphys_intr", policy,
     KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -705,12 +667,10 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
         vmr0_kk, vmr_pregas_kk, vmr_precld_kk, dgncur_a_kk, dgncur_awet_kk, wetdens_kk);
       });
     }); 
-    MAM_STOP_TIMER("MAMMicrophysics::run_impl::modal_aero_amicphys_intr");
 
     // modal_aero_amicphys_intr ends
 
     // vmr2mmr_cw
-    MAM_START_TIMER("MAMMicrophysics::run_impl::vmr2mmr_cw");
     Kokkos::parallel_for(
     "MAMMicrophysics::run_impl::vmr2mmr_cw", policy,
     KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -726,7 +686,6 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
            adv_mass_kg_per_moles, qqcw_kk.data());
        });
     });
-        MAM_STOP_TIMER("MAMMicrophysics::run_impl::vmr2mmr_cw");
     // vmr2mmr_cw ends
     // linoz
     if (config_.linoz.compute) {
@@ -764,7 +723,6 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
       const auto& linoz_conf=config.linoz;
       const int o3_ndx = static_cast<int>(mam4::GasId::O3);
       
-      MAM_START_TIMER("MAMMicrophysics::run_impl::linoz");
       Kokkos::parallel_for(
     "MAMMicrophysics::run_impl::linoz", policy,
     KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -842,11 +800,9 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
           vmr_kk(o3_ndx) = o3l_vmr_new;
       });
     });
-    MAM_STOP_TIMER("MAMMicrophysics::run_impl::linoz");
 
     }
     // linoz ends
-    MAM_START_TIMER("MAMMicrophysics::run_impl::inject_to_progs");
     Kokkos::parallel_for(
     "MAMMicrophysics::run_impl::inject_to_progs", policy,
     KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -880,7 +836,6 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
     mam4::utils::inject_qqcw_to_prognostics(qqcw_pcnst_kk, progs, kk);
     });
     });
-    MAM_STOP_TIMER("MAMMicrophysics::run_impl::inject_to_progs");
 
     // diagnostics
     // - dvmr/dt: Tendencies for mixing ratios  [kg/kg/s]
@@ -893,7 +848,6 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
       aqh2so4_incloud_mmr_tendency = get_field_out("mam4_microphysics_tendency_aqh2so4").get_view<Real ***>();
     }
 
-    MAM_START_TIMER("MAMMicrophysics::run_impl::diagnostics");
     Kokkos::parallel_for(
     "MAMMicrophysics::run_impl::diagnostics", policy,
     KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -954,7 +908,6 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
 
 
     });
-  MAM_STOP_TIMER("MAMMicrophysics::run_impl::diagnostics");
 
 
 }//run_small_kernels_microphysics

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
@@ -16,43 +16,33 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
   for (size_t i = 0; i < var_names_oxi_.size(); ++i) {
     oxidants[i] = get_field_out("oxid_"+var_names_oxi_[i]).get_view<Real **>();
   }
+  // set external forcing
+  // Flatten the (mm, isec) host loops into fixed-size arrays captured by
+  // value inside the gas_phase_chemistry kernel, where extfrc_k is computed
+  // inline to avoid a separate kernel launch and HBM buffer round-trip.
   Kokkos::fence();
   start_timer("MAMMicrophysics::run_impl::forcing");
-  // set external forcing
   constexpr int extcnt = mam4::gas_chemistry::extcnt;
   const auto& extfrc = extfrc_;
-  Kokkos::deep_copy(extfrc,0.0);
+  constexpr int max_forcing_entries =
+      extcnt * mam_coupling::MAX_SECTION_NUM_FORCING;
+  Kokkos::Array<int,     max_forcing_entries> forcing_nn{};
+  Kokkos::Array<int,     max_forcing_entries> forcing_alt{};
+  Kokkos::Array<view_2d, max_forcing_entries> forcing_fields{};
+  int nfrc = 0;
   for (int mm = 0; mm < extcnt; ++mm) {
-    // Fortran to C++ indexing
     const int nn = forcings_[mm].frc_ndx - 1;
     for (int isec = 0; isec < forcings_[mm].nsectors; ++isec) {
-    const auto& field = forcings_[mm].fields[isec];
-    if (forcings_[mm].file_alt_data) {
-      Kokkos::parallel_for(
-        "MAMMicrophysics::run_impl::forcing", policy,
-        KOKKOS_LAMBDA(const ThreadTeam &team) {
-        const int icol     = team.league_rank();   // column index
-        Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev),
-         [&](int kk) {
-          extfrc(icol,kk,nn) += field(icol,nlev - 1 - kk);
-        });
-      });
-
-   } else {
-     Kokkos::parallel_for(
-      "MAMMicrophysics::run_impl::forcing", policy,
-      KOKKOS_LAMBDA(const ThreadTeam &team) {
-      const int icol     = team.league_rank();   // column index
-      Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev), [&](int kk) {
-        extfrc(icol,kk,nn) += field(icol,kk);
-      });
-    });
-   }
-  } // isec
-  }   // end mm
-  stop_timer("MAMMicrophysics::run_impl::forcing");
+      forcing_nn[nfrc]     = nn;
+      forcing_alt[nfrc]    = forcings_[mm].file_alt_data ? 1 : 0;
+      forcing_fields[nfrc] = forcings_[mm].fields[isec];
+      ++nfrc;
+    }
+  }
+  const int nfrc_total = nfrc;
+  start_timer("MAMMicrophysics::run_impl::forcing");
+  // set external forcing ends (applied inline in gas_phase_chemistry below)
   Kokkos::fence();
-  // set external forcing ends
 
   // set invariants
   const auto& invariants = invariants_;
@@ -455,14 +445,22 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
       const auto atm = mam_coupling::atmosphere_for_column(dry_atm, icol);
       const auto &photo_rates_icol = ekat::subview(photo_rates, icol);
       const auto invariants_icol = ekat::subview(invariants, icol);
-      const auto extfrc_icol = ekat::subview(extfrc, icol);
       const auto het_rates_icol = ekat::subview(het_rates, icol);
       const auto& vmr_icol = ekat::subview(vmr, icol);
 
       Kokkos::parallel_for(
        Kokkos::TeamVectorRange(team, nlev),
        [&](const int kk) {
-        const auto &extfrc_k = ekat::subview(extfrc_icol, kk);
+        // Compute per-level forcing inline into a register-local array,
+        // avoiding a separate HBM buffer round-trip through extfrc_.
+        // Write back to extfrc_ so the diagnostic output field remains valid.
+        Real extfrc_k[mam4::gas_chemistry::extcnt] = {};
+        for (int ifrc = 0; ifrc < nfrc_total; ++ifrc)
+          extfrc_k[forcing_nn[ifrc]] +=
+              forcing_alt[ifrc] ? forcing_fields[ifrc](icol, nlev - 1 - kk)
+                                : forcing_fields[ifrc](icol, kk);
+        for (int nn = 0; nn < mam4::gas_chemistry::extcnt; ++nn)
+          extfrc(icol, nn, kk) = extfrc_k[nn];
         const auto &invariants_k = ekat::subview(invariants_icol, kk);
         const auto &photo_rates_k = ekat::subview(photo_rates_icol, kk);
         const auto &het_rates_k = ekat::subview(het_rates_icol, kk);
@@ -471,7 +469,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
         const auto &vmr_kk = ekat::subview(vmr_icol, kk);
         mam4::microphysics::gas_phase_chemistry(
         // in
-        temperature, dt, photo_rates_k.data(), extfrc_k.data(), invariants_k.data(),
+        temperature, dt, photo_rates_k.data(), extfrc_k, invariants_k.data(),
         clsmap_4, permute_4, het_rates_k.data(),
         // out
         vmr_kk);

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
@@ -154,7 +154,6 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
     auto o3_col_dens_icol = ekat::subview(o3_col_dens, icol);
     const auto& atm = mam_coupling::atmosphere_for_column(dry_atm, icol);
     const auto& vmr_icol = ekat::subview(vmr,icol);  
-    // const auto vmr_icol_o3 = Kokkos::subview(vmr_icol, Kokkos::ALL(), o3_ndx);
     mam4::microphysics::compute_o3_column_density(
       team, atm.hydrostatic_dp, vmr_icol, o3_exo_col(icol, 0), o3_ndx, o3_col_dens_icol);
   });

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
@@ -4,7 +4,7 @@
 
 namespace scream {
 
-void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const double eccf)
+void MAMMicrophysics::run_microphysics_kernels(const double dt, const double eccf)
 {
    using TPF = ekat::TeamPolicyFactory<KT::ExeSpace>;
   const auto policy =
@@ -15,7 +15,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
   // Ensure configuration provides exactly the expected number of oxidant fields.
   EKAT_REQUIRE_MSG(
       var_names_oxi_.size() == static_cast<std::size_t>(num_oxidants),
-      "MAMMicrophysics::run_small_kernels_microphysics: "
+      "MAMMicrophysics::run_microphysics_kernels: "
       "var_names_oxi_ size does not match mam4::mo_setinv::num_tracer_cnst.");
 
   view_2d oxidants[num_oxidants];
@@ -367,7 +367,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
         sfc_pressure(icol),     // surface pressure [Pa]
         pressure_10m,     // 10-meter pressure [Pa]
         spec_hum,         // specific humidity [kg/kg]
-        wind_speed,       // 10-meter wind spped [m/s]
+        wind_speed,       // 10-meter wind speed [m/s]
         rain,             // rain content [??]
         solar_flux,       // direct shortwave surface radiation [W/m^2]
         qq_sfc.data(),               // constituent MMRs [kg/kg]

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
@@ -491,7 +491,7 @@ void MAMMicrophysics::run_microphysics_kernels(const double dt, const double ecc
   const auto& dqdt_aqh2so4 = dqdt_aqh2so4_;
   const unsigned n_so4_monolayers_pcage = config_.n_so4_monolayers_pcage;
 
-  if (config_.compute_setsox) {
+  if (config_.compute_aqueous_phase_chemistry) {
   Kokkos::parallel_for(
     "MAMMicrophysics::run_impl::setsox", policy,
     KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -563,7 +563,7 @@ void MAMMicrophysics::run_microphysics_kernels(const double dt, const double ecc
 
       });
     }
-  } // compute_setsox
+  } // compute_aqueous_phase_chemistry
     //setsox_single_level ends
 
     // modal_aero_amicphys_intr

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
@@ -10,11 +10,17 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
   const auto policy =
       TPF::get_default_team_policy(ncol_, nlev_);
   const int nlev = nlev_;
-  constexpr int num_oxidants=mam4::mo_setinv::num_tracer_cnst;
+  constexpr int num_oxidants = mam4::mo_setinv::num_tracer_cnst;
+
+  // Ensure configuration provides exactly the expected number of oxidant fields.
+  EKAT_REQUIRE_MSG(
+      var_names_oxi_.size() == static_cast<std::size_t>(num_oxidants),
+      "MAMMicrophysics::run_small_kernels_microphysics: "
+      "var_names_oxi_ size does not match mam4::mo_setinv::num_tracer_cnst.");
 
   view_2d oxidants[num_oxidants];
-  for (size_t i = 0; i < var_names_oxi_.size(); ++i) {
-    oxidants[i] = get_field_out("oxid_"+var_names_oxi_[i]).get_view<Real **>();
+  for (int i = 0; i < num_oxidants; ++i) {
+    oxidants[i] = get_field_out("oxid_" + var_names_oxi_[i]).get_view<Real **>();
   }
   // set external forcing
   // Flatten the (mm, isec) host loops into fixed-size arrays captured by

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
@@ -281,6 +281,12 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
   view_2d constituent_fluxes =
       get_field_out("constituent_fluxes").get_view<Real **>();
 
+  view_2d mam4_gas_dry_deposition_flux;
+  if (extra_mam4_aero_microphys_diags_) {
+    mam4_gas_dry_deposition_flux =
+      get_field_out("mam4_gas_dry_deposition_flux").get_view<Real **>();
+  }
+
   // Ice precip [kg/m2]
   const const_view_1d precip_ice_surf_mass =
       get_field_in("precip_ice_surf_mass").get_view<const Real *>();
@@ -386,6 +392,14 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
         Kokkos::parallel_for(Kokkos::TeamVectorRange(team, offset_aerosol, pcnst), [&](int ispc) {
           constituent_fluxes(icol, ispc) -= dflx_col(ispc - offset_aerosol);
         });
+
+        if (mam4_gas_dry_deposition_flux.size()) {
+          Kokkos::parallel_for(
+            Kokkos::TeamVectorRange(team, num_gas_aerosol_constituents),
+            [&](const int ispc) {
+              mam4_gas_dry_deposition_flux(icol, ispc) = dflx_col(ispc);
+            });
+        }
     });
 
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
@@ -1,6 +1,7 @@
 #include <mam4xx/mam4.hpp>
 #include <physics/mam/eamxx_mam_microphysics_process_interface.hpp>
-
+#include <ekat_team_policy_utils.hpp>
+#include <share/util/eamxx_timing.hpp>
 namespace scream {
 
 void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const double eccf)
@@ -15,8 +16,8 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
   for (size_t i = 0; i < var_names_oxi_.size(); ++i) {
     oxidants[i] = get_field_out("oxid_"+var_names_oxi_[i]).get_view<Real **>();
   }
-  
-
+  Kokkos::fence();
+  start_timer("MAMMicrophysics::run_impl::forcing");
   // set external forcing
   constexpr int extcnt = mam4::gas_chemistry::extcnt;
   const auto& extfrc = extfrc_;
@@ -49,11 +50,15 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
    }
   } // isec
   }   // end mm
+  stop_timer("MAMMicrophysics::run_impl::forcing");
+  Kokkos::fence();
   // set external forcing ends
 
   // set invariants
   const auto& invariants = invariants_;
   const auto& dry_atm = dry_atm_;
+  Kokkos::fence();
+  start_timer("MAMMicrophysics::run_impl::setinv");
   Kokkos::parallel_for(
       "MAMMicrophysics::run_impl::setinv", policy,
       KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -71,6 +76,8 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
                           cnst_offline_icol, atm.pressure);        // in
 
   });
+  stop_timer("MAMMicrophysics::run_impl::setinv");
+  Kokkos::fence();
 
   // set invariants ends
 
@@ -94,6 +101,8 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
     adv_mass_kg_per_moles[i] = mam4::gas_chemistry::adv_mass[i] / 1e3;
   }
 
+  Kokkos::fence();
+  start_timer("MAMMicrophysics::run_impl::extract_stateq");
   Kokkos::parallel_for(
       "MAMMicrophysics::run_impl::extract_stateq", policy,
       KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -137,6 +146,8 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
         mam4::microphysics::mmr2vmr(qqcw_kk.data(), adv_mass_kg_per_moles, vmrcw_kk.data());
     });
   });
+  stop_timer("MAMMicrophysics::run_impl::extract_stateq");
+  Kokkos::fence();
 
 
   const auto& o3_col_dens = buffer_.scratch[8];
@@ -145,6 +156,8 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
   const auto& work_set_het  = work_set_het_;
   const int o3_ndx = static_cast<int>(mam4::GasId::O3);
   
+  Kokkos::fence();
+  start_timer("MAMMicrophysics::run_impl::compute_o3_column_density");
   Kokkos::parallel_for(
     "MAMMicrophysics::run_impl::compute_o3_column_density", policy,
     KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -157,6 +170,8 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
     mam4::microphysics::compute_o3_column_density(
       team, atm.hydrostatic_dp, vmr_icol, o3_exo_col(icol, 0), o3_ndx, o3_col_dens_icol);
   });
+  stop_timer("MAMMicrophysics::run_impl::compute_o3_column_density");
+  Kokkos::fence();
   // set o3_col_dens ends
 
   // set photo table
@@ -167,6 +182,8 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
   const auto& zenith_angle = acos_cosine_zenith_;
   const auto& photo_table=photo_table_;
 
+  Kokkos::fence();
+  start_timer("MAMMicrophysics::run_impl::photo_table");
   Kokkos::parallel_for(
       "MAMMicrophysics::run_impl::photo_table", policy,
       KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -194,6 +211,8 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
                               eccf, photo_table,                           // in
                               photo_work_arrays_icol); // out
     });
+                  stop_timer("MAMMicrophysics::run_impl::photo_table");
+                  Kokkos::fence();
 
     // set photo table ends
     const auto& col_latitudes = col_latitudes_;
@@ -207,6 +226,8 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
     const auto &nevapr = get_field_in("nevapr").get_view<const Real **>();
 
     // set sethet
+    Kokkos::fence();
+    start_timer("MAMMicrophysics::run_impl::sethet");
     Kokkos::parallel_for(
       "MAMMicrophysics::run_impl::sethet", policy,
       KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -231,6 +252,8 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
                           nevapr_icol, dt, invariants_icol, vmr_icol,
                           work_sethet_call);
   });
+  stop_timer("MAMMicrophysics::run_impl::sethet");
+  Kokkos::fence();
 
   // set_het end
 
@@ -290,6 +313,8 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
   const const_view_1d precip_ice_surf_mass =
       get_field_in("precip_ice_surf_mass").get_view<const Real *>();
 
+  Kokkos::fence();
+  start_timer("MAMMicrophysics::run_impl::drydep_xactive");
   Kokkos::parallel_for(
     "MAMMicrophysics::run_impl::drydep_xactive", policy,
     KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -397,6 +422,8 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
             });
         }
     });
+        stop_timer("MAMMicrophysics::run_impl::drydep_xactive");
+        Kokkos::fence();
 
 
     // set drydep_xactive ends
@@ -419,6 +446,8 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
       gas_phase_chemistry_dvmrdt = get_field_out("mam4_microphysics_tendency_gas_phase_chemistry").get_view<Real ***>();
     }
 
+    Kokkos::fence();
+    start_timer("MAMMicrophysics::run_impl::gas_phase_chemistry");
     Kokkos::parallel_for(
     "MAMMicrophysics::run_impl::gas_phase_chemistry", policy,
     KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -449,9 +478,13 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
       });
 
     });
+  stop_timer("MAMMicrophysics::run_impl::gas_phase_chemistry");
+  Kokkos::fence();
 
     if (gas_phase_chemistry_dvmrdt.size()) {
 
+  Kokkos::fence();
+  start_timer("MAMMicrophysics::run_impl::gas_phase_chemistry_dvmrdt");
     Kokkos::parallel_for(
     "MAMMicrophysics::run_impl::gas_phase_chemistry_dvmrdt", policy,
     KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -470,6 +503,8 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
        });
 
     });
+     stop_timer("MAMMicrophysics::run_impl::gas_phase_chemistry_dvmrdt");
+     Kokkos::fence();
   }
   // gas_phase_chemistry ends
 
@@ -486,6 +521,8 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
   const auto& dqdt_aqh2so4 = dqdt_aqh2so4_;
   const unsigned n_so4_monolayers_pcage = config.n_so4_monolayers_pcage;
 
+  Kokkos::fence();
+  start_timer("MAMMicrophysics::run_impl::setsox_single_level");
   Kokkos::parallel_for(
     "MAMMicrophysics::run_impl::setsox_single_level", policy,
     KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -531,6 +568,8 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
         dqdt_aqso4_k.data(), dqdt_aqh2so4_k.data(), vmrcw_k.data(), vmr_k.data());
     });
     });
+      stop_timer("MAMMicrophysics::run_impl::setsox_single_level");
+      Kokkos::fence();
 
     view_3d aqueous_chemistry_dvmrdt;
     if (extra_mam4_aero_microphys_diags_) {
@@ -538,6 +577,8 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
     }
 
     if (aqueous_chemistry_dvmrdt.size()) {
+      Kokkos::fence();
+      start_timer("MAMMicrophysics::run_impl::aqueous_chemistry_dvmrdt");
       Kokkos::parallel_for(
       "MAMMicrophysics::run_impl::aqueous_chemistry_dvmrdt", policy,
       KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -556,6 +597,8 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
          });
 
       });
+      stop_timer("MAMMicrophysics::run_impl::aqueous_chemistry_dvmrdt");
+      Kokkos::fence();
     }
     //setsox_single_level ends
 
@@ -570,6 +613,8 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
     auto& dgncur_a_loc = dgncur_a_;
     auto& wetdens_loc = wetdens_;
     constexpr int nmodes = mam4::AeroConfig::num_modes();
+      Kokkos::fence();
+      start_timer("MAMMicrophysics::run_impl::modal_aero_amicphys_intr_precompute");
      Kokkos::parallel_for(
     "MAMMicrophysics::run_impl::modal_aero_amicphys_intr_precompute", policy,
     KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -584,6 +629,8 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
         }
       });
     });
+    stop_timer("MAMMicrophysics::run_impl::modal_aero_amicphys_intr_precompute");
+    Kokkos::fence();
 
     view_3d gas_aero_exchange_condensation, gas_aero_exchange_renaming,
           gas_aero_exchange_nucleation, gas_aero_exchange_coagulation,
@@ -600,6 +647,8 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
     const bool extra_mam4_aero_microphys_diags  = extra_mam4_aero_microphys_diags_;
 
     const auto& config_amicphys = config.amicphys;
+      Kokkos::fence();
+      start_timer("MAMMicrophysics::run_impl::modal_aero_amicphys_intr");
      Kokkos::parallel_for(
     "MAMMicrophysics::run_impl::modal_aero_amicphys_intr", policy,
     KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -665,10 +714,14 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
         vmr0_kk, vmr_pregas_kk, vmr_precld_kk, dgncur_a_kk, dgncur_awet_kk, wetdens_kk);
       });
     }); 
+    stop_timer("MAMMicrophysics::run_impl::modal_aero_amicphys_intr");
+    Kokkos::fence();
 
     // modal_aero_amicphys_intr ends
 
     // vmr2mmr_cw
+    Kokkos::fence();
+    start_timer("MAMMicrophysics::run_impl::vmr2mmr_cw");
     Kokkos::parallel_for(
     "MAMMicrophysics::run_impl::vmr2mmr_cw", policy,
     KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -684,6 +737,8 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
            adv_mass_kg_per_moles, qqcw_kk.data());
        });
     });
+        stop_timer("MAMMicrophysics::run_impl::vmr2mmr_cw");
+        Kokkos::fence();
     // vmr2mmr_cw ends
     // linoz
     if (config_.linoz.compute) {
@@ -705,7 +760,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
       // Cariolle parameter for PSC loss of ozone [1/s]
       view_2d linoz_cariolle_pscs;
       view_2d linoz_views[8];
-      data_interp_linoz_->run(end_of_step_ts());
+      
       for (size_t i = 0; i < var_names_linoz_.size(); ++i) {
         linoz_views[i] = get_field_out(var_names_linoz_[i]).get_view<Real **>();
       }
@@ -721,6 +776,8 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
       const auto& linoz_conf=config.linoz;
       const int o3_ndx = static_cast<int>(mam4::GasId::O3);
       
+      Kokkos::fence();
+      start_timer("MAMMicrophysics::run_impl::linoz");
       Kokkos::parallel_for(
     "MAMMicrophysics::run_impl::linoz", policy,
     KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -798,9 +855,13 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
           vmr_kk(o3_ndx) = o3l_vmr_new;
       });
     });
+    stop_timer("MAMMicrophysics::run_impl::linoz");
+    Kokkos::fence();
 
     }
     // linoz ends
+    Kokkos::fence();
+    start_timer("MAMMicrophysics::run_impl::inject_to_progs");
     Kokkos::parallel_for(
     "MAMMicrophysics::run_impl::inject_to_progs", policy,
     KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -834,6 +895,8 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
     mam4::utils::inject_qqcw_to_prognostics(qqcw_pcnst_kk, progs, kk);
     });
     });
+    stop_timer("MAMMicrophysics::run_impl::inject_to_progs");
+    Kokkos::fence();
 
     // diagnostics
     // - dvmr/dt: Tendencies for mixing ratios  [kg/kg/s]
@@ -846,6 +909,8 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
       aqh2so4_incloud_mmr_tendency = get_field_out("mam4_microphysics_tendency_aqh2so4").get_view<Real ***>();
     }
 
+    Kokkos::fence();
+    start_timer("MAMMicrophysics::run_impl::diagnostics");
     Kokkos::parallel_for(
     "MAMMicrophysics::run_impl::diagnostics", policy,
     KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -906,6 +971,8 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
 
 
     });
+  stop_timer("MAMMicrophysics::run_impl::diagnostics");
+  Kokkos::fence();
 
 
 }//run_small_kernels_microphysics

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
@@ -5,7 +5,7 @@
 
 // Conditionally enable fine-grained micro-physics timers.
 // Compile with -DMICRO_TIMER to activate.
-#define MICRO_TIMER
+// #define MICRO_TIMER
 
 #ifdef MICRO_TIMER
 #  define MAM_START_TIMER(name) do { start_timer(name); } while(0)
@@ -422,6 +422,8 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
     // Store mixing ratios before gas chemistry changes the mixing ratios
     const auto& vmr0 = vmr0_;
     Kokkos::deep_copy(vmr0,vmr);
+
+    if (config_.compute_gas_phase_chemistry) {
     // NOTE: Making copies of clsmap_4 and permute_4 to fix undefined arrays on
     // the device.
     int clsmap_4[num_gas_aerosol_constituents], permute_4[num_gas_aerosol_constituents];
@@ -499,6 +501,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
     });
      MAM_STOP_TIMER("MAMMicrophysics::run_impl::gas_phase_chemistry_dvmrdt");
   }
+    } // compute_gas_phase_chemistry
   // gas_phase_chemistry ends
 
   // setsox_single_level

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
@@ -243,28 +243,28 @@ void MAMMicrophysics::run_microphysics_kernels(const double dt, const double ecc
   const auto& index_season_lai=index_season_lai_;
 
   // U wind component [m/s]
-  const const_view_2d u_wind =
+  const auto& u_wind =
       get_field_in("horiz_winds").get_component(0).get_view<const Real **>();
 
   // V wind component [m/s]
-  const const_view_2d v_wind =
+  const auto& v_wind =
       get_field_in("horiz_winds").get_component(1).get_view<const Real **>();
 
   // Liquid precip [kg/m2]
-  const const_view_1d precip_liq_surf_mass =
+  const auto& precip_liq_surf_mass =
       get_field_in("precip_liq_surf_mass").get_view<const Real *>();
 
   // drydep_xactive
   // Snow depth on land [m]
-  const const_view_1d snow_depth_land =
+  const auto& snow_depth_land =
       get_field_in("snow_depth_land").get_view<const Real *>();
 
   // Fractional land use [fraction]
-  const const_view_2d fraction_landuse =
+  const auto& fraction_landuse =
       get_field_in("fraction_landuse").get_view<const Real **>();
 
     // Downwelling solar flux at the surface [w/m2]
-  const const_view_2d sw_flux_dn =
+  const auto& sw_flux_dn =
       get_field_in("SW_flux_dn").get_view<const Real **>();
 
   const mam4::seq_drydep::Data drydep_data =
@@ -273,15 +273,15 @@ void MAMMicrophysics::run_microphysics_kernels(const double dt, const double ecc
   const int month              = start_of_step_ts().get_month();  // 1-based
 
   // Surface temperature [K]
-  const const_view_1d sfc_temperature =
+  const auto& sfc_temperature =
       get_field_in("surf_radiative_T").get_view<const Real *>();
 
   // Surface pressure [Pa]
-  const const_view_1d sfc_pressure =
+  const auto& sfc_pressure =
       get_field_in("ps").get_view<const Real *>();
 
   // Constituent fluxes of gas and aerosol species
-  view_2d constituent_fluxes =
+  const auto& constituent_fluxes =
       get_field_out("constituent_fluxes").get_view<Real **>();
 
   view_2d mam4_gas_dry_deposition_flux;
@@ -291,7 +291,7 @@ void MAMMicrophysics::run_microphysics_kernels(const double dt, const double ecc
   }
 
   // Ice precip [kg/m2]
-  const const_view_1d precip_ice_surf_mass =
+  const auto& precip_ice_surf_mass =
       get_field_in("precip_ice_surf_mass").get_view<const Real *>();
 
   Kokkos::parallel_for(

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
@@ -299,10 +299,11 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
 
     const auto work_set_het_icol = ekat::subview(work_set_het, icol);
     auto work_set_het_ptr = (Real *)work_set_het_icol.data();
-    // deposition velocity [1/cm/s]
+    
+    // deposition flux [1/cm^2/s]
     const auto& dflx_col = view_1d(work_set_het_ptr, num_gas_aerosol_constituents);
     work_set_het_ptr += num_gas_aerosol_constituents;
-    // deposition flux [1/cm^2/s]
+    // deposition velocity [1/cm/s]
     const auto& dvel_col = view_1d(work_set_het_ptr, num_gas_aerosol_constituents);
     work_set_het_ptr += num_gas_aerosol_constituents;
 
@@ -361,11 +362,6 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
       const auto qq_icol = ekat::subview(qq,icol);
       const auto qq_sfc = ekat::subview(qq_icol,surface_lev);
 
-
-
-      Kokkos::parallel_for(
-       Kokkos::TeamVectorRange(team, nlev),
-       [&](const int kk) {
        mam4::mo_drydep::drydep_xactive(
         drydep_data,
         fraction_landuse_icol, // fraction of land use for column by land type
@@ -384,7 +380,8 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
         dvel_col.data(),             // deposition velocity [1/cm/s]
         dflx_col.data()              // deposition flux [1/cm^2/s]
       );
-      });
+      team.team_barrier();
+
       // Update constituent fluxes with gas drydep fluxes (dflx)
         // FIXME: Possible units mismatch (dflx is in kg/cm2/s but
         // constituent_fluxes is kg/m2/s) (Following mimics Fortran code

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
@@ -23,28 +23,38 @@ void MAMMicrophysics::run_microphysics_kernels(const double dt, const double ecc
     oxidants[i] = get_field_out("oxid_" + var_names_oxi_[i]).get_view<Real **>();
   }
   // set external forcing
-  // Flatten the (mm, isec) host loops into fixed-size arrays captured by
-  // value inside the gas_phase_chemistry kernel, where extfrc_k is computed
-  // inline to avoid a separate kernel launch and HBM buffer round-trip.
   constexpr int extcnt = mam4::gas_chemistry::extcnt;
   const auto& extfrc = extfrc_;
-  constexpr int max_forcing_entries =
-      extcnt * mam_coupling::MAX_SECTION_NUM_FORCING;
-  Kokkos::Array<int,     max_forcing_entries> forcing_nn{};
-  Kokkos::Array<int,     max_forcing_entries> forcing_alt{};
-  Kokkos::Array<view_2d, max_forcing_entries> forcing_fields{};
-  int nfrc = 0;
+  Kokkos::deep_copy(extfrc,0.0);
   for (int mm = 0; mm < extcnt; ++mm) {
+    // Fortran to C++ indexing
     const int nn = forcings_[mm].frc_ndx - 1;
     for (int isec = 0; isec < forcings_[mm].nsectors; ++isec) {
-      forcing_nn[nfrc]     = nn;
-      forcing_alt[nfrc]    = forcings_[mm].file_alt_data ? 1 : 0;
-      forcing_fields[nfrc] = forcings_[mm].fields[isec];
-      ++nfrc;
-    }
-  }
-  const int nfrc_total = nfrc;
-  // set external forcing ends (applied inline in gas_phase_chemistry below)
+    const auto& field = forcings_[mm].fields[isec];
+    if (forcings_[mm].file_alt_data) {
+      Kokkos::parallel_for(
+        "MAMMicrophysics::run_impl::forcing", policy,
+        KOKKOS_LAMBDA(const ThreadTeam &team) {
+        const int icol     = team.league_rank();   // column index
+        Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev),
+         [&](int kk) {
+          extfrc(icol,kk,nn) += field(icol,nlev - 1 - kk);
+        });
+      });
+
+   } else {
+     Kokkos::parallel_for(
+      "MAMMicrophysics::run_impl::forcing", policy,
+      KOKKOS_LAMBDA(const ThreadTeam &team) {
+      const int icol     = team.league_rank();   // column index
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev), [&](int kk) {
+        extfrc(icol,kk,nn) += field(icol,kk);
+      });
+    });
+   }
+  } // isec
+  }   // end mm
+  // set external forcing ends
 
   // set invariants
   const auto& invariants = invariants_;
@@ -423,22 +433,14 @@ void MAMMicrophysics::run_microphysics_kernels(const double dt, const double ecc
       const auto atm = mam_coupling::atmosphere_for_column(dry_atm, icol);
       const auto &photo_rates_icol = ekat::subview(photo_rates, icol);
       const auto invariants_icol = ekat::subview(invariants, icol);
+      const auto extfrc_icol = ekat::subview(extfrc, icol);
       const auto het_rates_icol = ekat::subview(het_rates, icol);
       const auto& vmr_icol = ekat::subview(vmr, icol);
 
       Kokkos::parallel_for(
        Kokkos::TeamVectorRange(team, nlev),
        [&](const int kk) {
-        // Compute per-level forcing inline into a register-local array,
-        // avoiding a separate HBM buffer round-trip through extfrc_.
-        // Write back to extfrc_ so the diagnostic output field remains valid.
-        Real extfrc_k[mam4::gas_chemistry::extcnt] = {};
-        for (int ifrc = 0; ifrc < nfrc_total; ++ifrc)
-          extfrc_k[forcing_nn[ifrc]] +=
-              forcing_alt[ifrc] ? forcing_fields[ifrc](icol, nlev - 1 - kk)
-                                : forcing_fields[ifrc](icol, kk);
-        for (int nn = 0; nn < mam4::gas_chemistry::extcnt; ++nn)
-          extfrc(icol, nn, kk) = extfrc_k[nn];
+        const auto &extfrc_k = ekat::subview(extfrc_icol, kk);
         const auto &invariants_k = ekat::subview(invariants_icol, kk);
         const auto &photo_rates_k = ekat::subview(photo_rates_icol, kk);
         const auto &het_rates_k = ekat::subview(het_rates_icol, kk);
@@ -447,7 +449,7 @@ void MAMMicrophysics::run_microphysics_kernels(const double dt, const double ecc
         const auto &vmr_kk = ekat::subview(vmr_icol, kk);
         mam4::microphysics::gas_phase_chemistry(
         // in
-        temperature, dt, photo_rates_k.data(), extfrc_k, invariants_k.data(),
+        temperature, dt, photo_rates_k.data(), extfrc_k.data(), invariants_k.data(),
         clsmap_4, permute_4, het_rates_k.data(),
         // out
         vmr_kk);

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
@@ -2,6 +2,17 @@
 #include <physics/mam/eamxx_mam_microphysics_process_interface.hpp>
 #include <ekat_team_policy_utils.hpp>
 #include <share/util/eamxx_timing.hpp>
+
+// Conditionally enable fine-grained micro-physics timers.
+// Compile with -DMICRO_TIMER to activate.
+#ifdef MICRO_TIMER
+#  define MAM_START_TIMER(name) do { Kokkos::fence(); start_timer(name); } while(0)
+#  define MAM_STOP_TIMER(name)  do { stop_timer(name); Kokkos::fence(); } while(0)
+#else
+#  define MAM_START_TIMER(name) ((void)0)
+#  define MAM_STOP_TIMER(name)  ((void)0)
+#endif
+
 namespace scream {
 
 void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const double eccf)
@@ -20,8 +31,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
   // Flatten the (mm, isec) host loops into fixed-size arrays captured by
   // value inside the gas_phase_chemistry kernel, where extfrc_k is computed
   // inline to avoid a separate kernel launch and HBM buffer round-trip.
-  Kokkos::fence();
-  start_timer("MAMMicrophysics::run_impl::forcing");
+  MAM_START_TIMER("MAMMicrophysics::run_impl::forcing");
   constexpr int extcnt = mam4::gas_chemistry::extcnt;
   const auto& extfrc = extfrc_;
   constexpr int max_forcing_entries =
@@ -40,15 +50,13 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
     }
   }
   const int nfrc_total = nfrc;
-  start_timer("MAMMicrophysics::run_impl::forcing");
+  MAM_STOP_TIMER("MAMMicrophysics::run_impl::forcing");
   // set external forcing ends (applied inline in gas_phase_chemistry below)
-  Kokkos::fence();
 
   // set invariants
   const auto& invariants = invariants_;
   const auto& dry_atm = dry_atm_;
-  Kokkos::fence();
-  start_timer("MAMMicrophysics::run_impl::setinv");
+  MAM_START_TIMER("MAMMicrophysics::run_impl::setinv");
   Kokkos::parallel_for(
       "MAMMicrophysics::run_impl::setinv", policy,
       KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -66,8 +74,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
                           cnst_offline_icol, atm.pressure);        // in
 
   });
-  stop_timer("MAMMicrophysics::run_impl::setinv");
-  Kokkos::fence();
+  MAM_STOP_TIMER("MAMMicrophysics::run_impl::setinv");
 
   // set invariants ends
 
@@ -91,8 +98,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
     adv_mass_kg_per_moles[i] = mam4::gas_chemistry::adv_mass[i] / 1e3;
   }
 
-  Kokkos::fence();
-  start_timer("MAMMicrophysics::run_impl::extract_stateq");
+  MAM_START_TIMER("MAMMicrophysics::run_impl::extract_stateq");
   Kokkos::parallel_for(
       "MAMMicrophysics::run_impl::extract_stateq", policy,
       KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -136,8 +142,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
         mam4::microphysics::mmr2vmr(qqcw_kk.data(), adv_mass_kg_per_moles, vmrcw_kk.data());
     });
   });
-  stop_timer("MAMMicrophysics::run_impl::extract_stateq");
-  Kokkos::fence();
+  MAM_STOP_TIMER("MAMMicrophysics::run_impl::extract_stateq");
 
 
   const auto& o3_col_dens = buffer_.scratch[8];
@@ -146,8 +151,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
   const auto& work_set_het  = work_set_het_;
   const int o3_ndx = static_cast<int>(mam4::GasId::O3);
   
-  Kokkos::fence();
-  start_timer("MAMMicrophysics::run_impl::compute_o3_column_density");
+  MAM_START_TIMER("MAMMicrophysics::run_impl::compute_o3_column_density");
   Kokkos::parallel_for(
     "MAMMicrophysics::run_impl::compute_o3_column_density", policy,
     KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -160,8 +164,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
     mam4::microphysics::compute_o3_column_density(
       team, atm.hydrostatic_dp, vmr_icol, o3_exo_col(icol, 0), o3_ndx, o3_col_dens_icol);
   });
-  stop_timer("MAMMicrophysics::run_impl::compute_o3_column_density");
-  Kokkos::fence();
+  MAM_STOP_TIMER("MAMMicrophysics::run_impl::compute_o3_column_density");
   // set o3_col_dens ends
 
   // set photo table
@@ -172,8 +175,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
   const auto& zenith_angle = acos_cosine_zenith_;
   const auto& photo_table=photo_table_;
 
-  Kokkos::fence();
-  start_timer("MAMMicrophysics::run_impl::photo_table");
+  MAM_START_TIMER("MAMMicrophysics::run_impl::photo_table");
   Kokkos::parallel_for(
       "MAMMicrophysics::run_impl::photo_table", policy,
       KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -201,8 +203,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
                               eccf, photo_table,                           // in
                               photo_work_arrays_icol); // out
     });
-                  stop_timer("MAMMicrophysics::run_impl::photo_table");
-                  Kokkos::fence();
+    MAM_STOP_TIMER("MAMMicrophysics::run_impl::photo_table");
 
     // set photo table ends
     const auto& col_latitudes = col_latitudes_;
@@ -216,8 +217,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
     const auto &nevapr = get_field_in("nevapr").get_view<const Real **>();
 
     // set sethet
-    Kokkos::fence();
-    start_timer("MAMMicrophysics::run_impl::sethet");
+    MAM_START_TIMER("MAMMicrophysics::run_impl::sethet");
     Kokkos::parallel_for(
       "MAMMicrophysics::run_impl::sethet", policy,
       KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -242,8 +242,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
                           nevapr_icol, dt, invariants_icol, vmr_icol,
                           work_sethet_call);
   });
-  stop_timer("MAMMicrophysics::run_impl::sethet");
-  Kokkos::fence();
+  MAM_STOP_TIMER("MAMMicrophysics::run_impl::sethet");
 
   // set_het end
 
@@ -303,8 +302,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
   const const_view_1d precip_ice_surf_mass =
       get_field_in("precip_ice_surf_mass").get_view<const Real *>();
 
-  Kokkos::fence();
-  start_timer("MAMMicrophysics::run_impl::drydep_xactive");
+  MAM_START_TIMER("MAMMicrophysics::run_impl::drydep_xactive");
   Kokkos::parallel_for(
     "MAMMicrophysics::run_impl::drydep_xactive", policy,
     KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -412,8 +410,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
             });
         }
     });
-        stop_timer("MAMMicrophysics::run_impl::drydep_xactive");
-        Kokkos::fence();
+    MAM_STOP_TIMER("MAMMicrophysics::run_impl::drydep_xactive");
 
 
     // set drydep_xactive ends
@@ -436,8 +433,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
       gas_phase_chemistry_dvmrdt = get_field_out("mam4_microphysics_tendency_gas_phase_chemistry").get_view<Real ***>();
     }
 
-    Kokkos::fence();
-    start_timer("MAMMicrophysics::run_impl::gas_phase_chemistry");
+    MAM_START_TIMER("MAMMicrophysics::run_impl::gas_phase_chemistry");
     Kokkos::parallel_for(
     "MAMMicrophysics::run_impl::gas_phase_chemistry", policy,
     KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -476,13 +472,11 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
       });
 
     });
-  stop_timer("MAMMicrophysics::run_impl::gas_phase_chemistry");
-  Kokkos::fence();
+  MAM_STOP_TIMER("MAMMicrophysics::run_impl::gas_phase_chemistry");
 
     if (gas_phase_chemistry_dvmrdt.size()) {
 
-  Kokkos::fence();
-  start_timer("MAMMicrophysics::run_impl::gas_phase_chemistry_dvmrdt");
+  MAM_START_TIMER("MAMMicrophysics::run_impl::gas_phase_chemistry_dvmrdt");
     Kokkos::parallel_for(
     "MAMMicrophysics::run_impl::gas_phase_chemistry_dvmrdt", policy,
     KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -501,8 +495,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
        });
 
     });
-     stop_timer("MAMMicrophysics::run_impl::gas_phase_chemistry_dvmrdt");
-     Kokkos::fence();
+     MAM_STOP_TIMER("MAMMicrophysics::run_impl::gas_phase_chemistry_dvmrdt");
   }
   // gas_phase_chemistry ends
 
@@ -519,8 +512,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
   const auto& dqdt_aqh2so4 = dqdt_aqh2so4_;
   const unsigned n_so4_monolayers_pcage = config.n_so4_monolayers_pcage;
 
-  Kokkos::fence();
-  start_timer("MAMMicrophysics::run_impl::setsox_single_level");
+  MAM_START_TIMER("MAMMicrophysics::run_impl::setsox_single_level");
   Kokkos::parallel_for(
     "MAMMicrophysics::run_impl::setsox_single_level", policy,
     KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -566,8 +558,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
         dqdt_aqso4_k.data(), dqdt_aqh2so4_k.data(), vmrcw_k.data(), vmr_k.data());
     });
     });
-      stop_timer("MAMMicrophysics::run_impl::setsox_single_level");
-      Kokkos::fence();
+      MAM_STOP_TIMER("MAMMicrophysics::run_impl::setsox_single_level");
 
     view_3d aqueous_chemistry_dvmrdt;
     if (extra_mam4_aero_microphys_diags_) {
@@ -575,8 +566,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
     }
 
     if (aqueous_chemistry_dvmrdt.size()) {
-      Kokkos::fence();
-      start_timer("MAMMicrophysics::run_impl::aqueous_chemistry_dvmrdt");
+      MAM_START_TIMER("MAMMicrophysics::run_impl::aqueous_chemistry_dvmrdt");
       Kokkos::parallel_for(
       "MAMMicrophysics::run_impl::aqueous_chemistry_dvmrdt", policy,
       KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -595,8 +585,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
          });
 
       });
-      stop_timer("MAMMicrophysics::run_impl::aqueous_chemistry_dvmrdt");
-      Kokkos::fence();
+      MAM_STOP_TIMER("MAMMicrophysics::run_impl::aqueous_chemistry_dvmrdt");
     }
     //setsox_single_level ends
 
@@ -611,8 +600,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
     auto& dgncur_a_loc = dgncur_a_;
     auto& wetdens_loc = wetdens_;
     constexpr int nmodes = mam4::AeroConfig::num_modes();
-      Kokkos::fence();
-      start_timer("MAMMicrophysics::run_impl::modal_aero_amicphys_intr_precompute");
+      MAM_START_TIMER("MAMMicrophysics::run_impl::modal_aero_amicphys_intr_precompute");
      Kokkos::parallel_for(
     "MAMMicrophysics::run_impl::modal_aero_amicphys_intr_precompute", policy,
     KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -627,8 +615,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
         }
       });
     });
-    stop_timer("MAMMicrophysics::run_impl::modal_aero_amicphys_intr_precompute");
-    Kokkos::fence();
+    MAM_STOP_TIMER("MAMMicrophysics::run_impl::modal_aero_amicphys_intr_precompute");
 
     view_3d gas_aero_exchange_condensation, gas_aero_exchange_renaming,
           gas_aero_exchange_nucleation, gas_aero_exchange_coagulation,
@@ -645,8 +632,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
     const bool extra_mam4_aero_microphys_diags  = extra_mam4_aero_microphys_diags_;
 
     const auto& config_amicphys = config.amicphys;
-      Kokkos::fence();
-      start_timer("MAMMicrophysics::run_impl::modal_aero_amicphys_intr");
+      MAM_START_TIMER("MAMMicrophysics::run_impl::modal_aero_amicphys_intr");
      Kokkos::parallel_for(
     "MAMMicrophysics::run_impl::modal_aero_amicphys_intr", policy,
     KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -712,14 +698,12 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
         vmr0_kk, vmr_pregas_kk, vmr_precld_kk, dgncur_a_kk, dgncur_awet_kk, wetdens_kk);
       });
     }); 
-    stop_timer("MAMMicrophysics::run_impl::modal_aero_amicphys_intr");
-    Kokkos::fence();
+    MAM_STOP_TIMER("MAMMicrophysics::run_impl::modal_aero_amicphys_intr");
 
     // modal_aero_amicphys_intr ends
 
     // vmr2mmr_cw
-    Kokkos::fence();
-    start_timer("MAMMicrophysics::run_impl::vmr2mmr_cw");
+    MAM_START_TIMER("MAMMicrophysics::run_impl::vmr2mmr_cw");
     Kokkos::parallel_for(
     "MAMMicrophysics::run_impl::vmr2mmr_cw", policy,
     KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -735,8 +719,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
            adv_mass_kg_per_moles, qqcw_kk.data());
        });
     });
-        stop_timer("MAMMicrophysics::run_impl::vmr2mmr_cw");
-        Kokkos::fence();
+        MAM_STOP_TIMER("MAMMicrophysics::run_impl::vmr2mmr_cw");
     // vmr2mmr_cw ends
     // linoz
     if (config_.linoz.compute) {
@@ -774,8 +757,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
       const auto& linoz_conf=config.linoz;
       const int o3_ndx = static_cast<int>(mam4::GasId::O3);
       
-      Kokkos::fence();
-      start_timer("MAMMicrophysics::run_impl::linoz");
+      MAM_START_TIMER("MAMMicrophysics::run_impl::linoz");
       Kokkos::parallel_for(
     "MAMMicrophysics::run_impl::linoz", policy,
     KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -853,13 +835,11 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
           vmr_kk(o3_ndx) = o3l_vmr_new;
       });
     });
-    stop_timer("MAMMicrophysics::run_impl::linoz");
-    Kokkos::fence();
+    MAM_STOP_TIMER("MAMMicrophysics::run_impl::linoz");
 
     }
     // linoz ends
-    Kokkos::fence();
-    start_timer("MAMMicrophysics::run_impl::inject_to_progs");
+    MAM_START_TIMER("MAMMicrophysics::run_impl::inject_to_progs");
     Kokkos::parallel_for(
     "MAMMicrophysics::run_impl::inject_to_progs", policy,
     KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -893,8 +873,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
     mam4::utils::inject_qqcw_to_prognostics(qqcw_pcnst_kk, progs, kk);
     });
     });
-    stop_timer("MAMMicrophysics::run_impl::inject_to_progs");
-    Kokkos::fence();
+    MAM_STOP_TIMER("MAMMicrophysics::run_impl::inject_to_progs");
 
     // diagnostics
     // - dvmr/dt: Tendencies for mixing ratios  [kg/kg/s]
@@ -907,8 +886,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
       aqh2so4_incloud_mmr_tendency = get_field_out("mam4_microphysics_tendency_aqh2so4").get_view<Real ***>();
     }
 
-    Kokkos::fence();
-    start_timer("MAMMicrophysics::run_impl::diagnostics");
+    MAM_START_TIMER("MAMMicrophysics::run_impl::diagnostics");
     Kokkos::parallel_for(
     "MAMMicrophysics::run_impl::diagnostics", policy,
     KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -969,8 +947,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
 
 
     });
-  stop_timer("MAMMicrophysics::run_impl::diagnostics");
-  Kokkos::fence();
+  MAM_STOP_TIMER("MAMMicrophysics::run_impl::diagnostics");
 
 
 }//run_small_kernels_microphysics

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
@@ -474,17 +474,16 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
   // gas_phase_chemistry ends
 
   // setsox_single_level
-  const Config &config                        = config_;
   const auto& vmr_pregas =vmr_pregas_;
   const auto& vmr_precld=vmr_precld_;
   Kokkos::deep_copy(vmr_pregas, vmr);
   Kokkos::deep_copy(vmr_precld, vmrcw );
 
   const auto& vmr_bef_aq_chem = vmr_pregas;
-  const auto& config_setsox = config.setsox;
+  const auto& config_setsox = config_.setsox;
   const auto& dqdt_aqso4 = dqdt_aqso4_;
   const auto& dqdt_aqh2so4 = dqdt_aqh2so4_;
-  const unsigned n_so4_monolayers_pcage = config.n_so4_monolayers_pcage;
+  const unsigned n_so4_monolayers_pcage = config_.n_so4_monolayers_pcage;
 
   if (config_.compute_setsox) {
   Kokkos::parallel_for(
@@ -601,7 +600,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
 
     const bool extra_mam4_aero_microphys_diags  = extra_mam4_aero_microphys_diags_;
 
-    const auto& config_amicphys = config.amicphys;
+    const auto& config_amicphys = config_.amicphys;
      Kokkos::parallel_for(
     "MAMMicrophysics::run_impl::modal_aero_amicphys_intr", policy,
     KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -720,7 +719,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
       linoz_dPmL_dO3col = linoz_views[6];
       linoz_cariolle_pscs = linoz_views[7];
 
-      const auto& linoz_conf=config.linoz;
+      const auto& linoz_conf=config_.linoz;
       const int o3_ndx = static_cast<int>(mam4::GasId::O3);
       
       Kokkos::parallel_for(

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
@@ -459,22 +459,19 @@ void MAMMicrophysics::run_microphysics_kernels(const double dt, const double ecc
     if (gas_phase_chemistry_dvmrdt.size()) {
 
     Kokkos::parallel_for(
-    "MAMMicrophysics::run_impl::gas_phase_chemistry_dvmrdt", policy,
-    KOKKOS_LAMBDA(const ThreadTeam &team) {
-      const int icol     = team.league_rank();   // column index
+    "MAMMicrophysics::run_impl::gas_phase_chemistry_dvmrdt",
+    Kokkos::RangePolicy<>(0, ncol_ * nlev),
+    KOKKOS_LAMBDA(const int i) {
+      const int icol = i / nlev;
+      const int kk   = i % nlev;
       const auto atm = mam_coupling::atmosphere_for_column(dry_atm, icol);
-      Kokkos::parallel_for(
-       Kokkos::TeamVectorRange(team, nlev),
-       [&](const int kk) {
-        Real pdel = atm.hydrostatic_dp(kk);
-        const Real mbar = haero::Constants::molec_weight_dry_air;
+      const Real pdel = atm.hydrostatic_dp(kk);
+      const Real mbar = haero::Constants::molec_weight_dry_air;
       const Real gravit = haero::Constants::gravity;
       const Real x = 1.0 / mbar * pdel / gravit;
       for (int m = 0; m < num_gas_aerosol_constituents; ++m)
         gas_phase_chemistry_dvmrdt(icol, m, kk) =
             x * adv_mass_kg_per_moles[m] * (vmr(icol,kk,m) - vmr0(icol,kk,m)) / dt;
-       });
-
     });
   }
     } // compute_gas_phase_chemistry
@@ -546,22 +543,19 @@ void MAMMicrophysics::run_microphysics_kernels(const double dt, const double ecc
 
     if (aqueous_chemistry_dvmrdt.size()) {
       Kokkos::parallel_for(
-      "MAMMicrophysics::run_impl::aqueous_chemistry_dvmrdt", policy,
-      KOKKOS_LAMBDA(const ThreadTeam &team) {
-        const int icol     = team.league_rank();   // column index
+      "MAMMicrophysics::run_impl::aqueous_chemistry_dvmrdt",
+      Kokkos::RangePolicy<>(0, ncol_ * nlev),
+      KOKKOS_LAMBDA(const int i) {
+        const int icol = i / nlev;
+        const int kk   = i % nlev;
         const auto atm = mam_coupling::atmosphere_for_column(dry_atm, icol);
-        Kokkos::parallel_for(
-         Kokkos::TeamVectorRange(team, nlev),
-         [&](const int kk) {
-         Real pdel = atm.hydrostatic_dp(kk);
-         const Real mbar = haero::Constants::molec_weight_dry_air;
-         const Real gravit = haero::Constants::gravity;
-         const Real x = 1.0 / mbar * pdel / gravit;
-         for (int m = 0; m < num_gas_aerosol_constituents; ++m)
+        const Real pdel = atm.hydrostatic_dp(kk);
+        const Real mbar = haero::Constants::molec_weight_dry_air;
+        const Real gravit = haero::Constants::gravity;
+        const Real x = 1.0 / mbar * pdel / gravit;
+        for (int m = 0; m < num_gas_aerosol_constituents; ++m)
           aqueous_chemistry_dvmrdt(icol, m, kk) =
             x * adv_mass_kg_per_moles[m] * (vmr(icol,kk,m) - vmr_bef_aq_chem(icol,kk,m)) / dt;
-         });
-
       });
     }
   } // compute_aqueous_phase_chemistry
@@ -579,18 +573,16 @@ void MAMMicrophysics::run_microphysics_kernels(const double dt, const double ecc
     auto& wetdens_loc = wetdens_;
     constexpr int nmodes = mam4::AeroConfig::num_modes();
      Kokkos::parallel_for(
-    "MAMMicrophysics::run_impl::modal_aero_amicphys_intr_precompute", policy,
-    KOKKOS_LAMBDA(const ThreadTeam &team) {
-      const int icol     = team.league_rank();   // column index
-    Kokkos::parallel_for(
-       Kokkos::TeamVectorRange(team, nlev),
-       [&](const int kk) {
-        for (int imode = 0; imode < nmodes; imode++) {
-         dgncur_awet_loc(icol, kk, imode) = wet_diameter(icol, imode, kk);
-         dgncur_a_loc(icol, kk, imode) = dry_diameter(icol, imode, kk);
-         wetdens_loc(icol, kk, imode) = wetdens(icol, imode, kk);
-        }
-      });
+    "MAMMicrophysics::run_impl::modal_aero_amicphys_intr_precompute",
+    Kokkos::RangePolicy<>(0, ncol_ * nlev),
+    KOKKOS_LAMBDA(const int i) {
+      const int icol = i / nlev;
+      const int kk   = i % nlev;
+      for (int imode = 0; imode < nmodes; imode++) {
+        dgncur_awet_loc(icol, kk, imode) = wet_diameter(icol, imode, kk);
+        dgncur_a_loc(icol, kk, imode) = dry_diameter(icol, imode, kk);
+        wetdens_loc(icol, kk, imode) = wetdens(icol, imode, kk);
+      }
     });
 
     view_3d gas_aero_exchange_condensation, gas_aero_exchange_renaming,

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
@@ -11,6 +11,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
   const int nlev = nlev_;
   //
 
+
   constexpr int num_oxidants=mam4::mo_setinv::num_tracer_cnst;
   view_2d oxidants[num_oxidants];
   for (size_t i = 0; i < var_names_oxi_.size(); ++i) {
@@ -485,6 +486,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
   const auto& config_setsox = config.setsox;
   const auto& dqdt_aqso4 = dqdt_aqso4_;
   const auto& dqdt_aqh2so4 = dqdt_aqh2so4_;
+  const unsigned n_so4_monolayers_pcage = config.n_so4_monolayers_pcage;
 
   Kokkos::parallel_for(
     "MAMMicrophysics::run_impl::setsox_single_level", policy,
@@ -652,7 +654,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
     // coagulation)
     mam4::microphysics::modal_aero_amicphys_intr(
         // in
-        config_amicphys, dt, temp, pmid, pdel, zm, pblh, qv, cldfrac,
+        config_amicphys, dt, n_so4_monolayers_pcage, temp, pmid, pdel, zm, pblh, qv, cldfrac,
         // out
         vmr_kk, vmrcw_kk,
         // diagnostics (out)

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
@@ -15,6 +15,7 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
   for (size_t i = 0; i < var_names_oxi_.size(); ++i) {
     oxidants[i] = get_field_out("oxid_"+var_names_oxi_[i]).get_view<Real **>();
   }
+  
 
   // set external forcing
   constexpr int extcnt = mam4::gas_chemistry::extcnt;
@@ -675,25 +676,38 @@ void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const doub
     });
     // vmr2mmr_cw ends
     // linoz
-    if (config.linoz.compute) {
-      // NOTE: we only have one field  
+    if (config_.linoz.compute) {
       // climatology data for linear stratospheric chemistry
       // ozone (climatology) [vmr]
-      view_2d linoz_o3_clim =  buffer_.scratch[0];
+      view_2d linoz_o3_clim;
       // column o3 above box (climatology) [Dobson Units (DU)]
-      view_2d linoz_o3col_clim = buffer_.scratch[1];
+      view_2d linoz_o3col_clim;
       // temperature (climatology) [K]
-      view_2d linoz_t_clim = buffer_.scratch[2];
+      view_2d linoz_t_clim;
       // P minus L (climatology) [vmr/s]
-      view_2d linoz_PmL_clim = buffer_.scratch[3];
+      view_2d linoz_PmL_clim;
       // sensitivity of P minus L to O3 [1/s]
-      view_2d linoz_dPmL_dO3 = buffer_.scratch[4];
+      view_2d linoz_dPmL_dO3;
       // sensitivity of P minus L to T3 [K]
-      view_2d linoz_dPmL_dT = buffer_.scratch[5];
+      view_2d linoz_dPmL_dT;
       // sensitivity of P minus L to overhead O3 column [vmr/DU]
-      view_2d linoz_dPmL_dO3col = buffer_.scratch[6];
+      view_2d linoz_dPmL_dO3col;
       // Cariolle parameter for PSC loss of ozone [1/s]
-      view_2d linoz_cariolle_pscs = buffer_.scratch[7];
+      view_2d linoz_cariolle_pscs;
+      view_2d linoz_views[8];
+      data_interp_linoz_->run(end_of_step_ts());
+      for (size_t i = 0; i < var_names_linoz_.size(); ++i) {
+        linoz_views[i] = get_field_out(var_names_linoz_[i]).get_view<Real **>();
+      }
+      linoz_o3_clim = linoz_views[0];
+      linoz_o3col_clim = linoz_views[1];
+      linoz_t_clim = linoz_views[2];
+      linoz_PmL_clim = linoz_views[3];
+      linoz_dPmL_dO3 = linoz_views[4];
+      linoz_dPmL_dT = linoz_views[5];
+      linoz_dPmL_dO3col = linoz_views[6];
+      linoz_cariolle_pscs = linoz_views[7];
+
       const auto& linoz_conf=config.linoz;
       const int o3_ndx = static_cast<int>(mam4::GasId::O3);
       

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_functions.cpp
@@ -1,0 +1,898 @@
+#include <mam4xx/mam4.hpp>
+#include <physics/mam/eamxx_mam_microphysics_process_interface.hpp>
+
+namespace scream {
+
+void MAMMicrophysics::run_small_kernels_microphysics(const double dt, const double eccf)
+{
+   using TPF = ekat::TeamPolicyFactory<KT::ExeSpace>;
+  const auto policy =
+      TPF::get_default_team_policy(ncol_, nlev_);
+  const int nlev = nlev_;
+  //
+
+  constexpr int num_oxidants=mam4::mo_setinv::num_tracer_cnst;
+  view_2d oxidants[num_oxidants];
+  for (size_t i = 0; i < var_names_oxi_.size(); ++i) {
+    oxidants[i] = get_field_out("oxid_"+var_names_oxi_[i]).get_view<Real **>();
+  }
+
+  // set external forcing
+  constexpr int extcnt = mam4::gas_chemistry::extcnt;
+  const auto& extfrc = extfrc_;
+  Kokkos::deep_copy(extfrc,0.0);
+  for (int mm = 0; mm < extcnt; ++mm) {
+    // Fortran to C++ indexing
+    const int nn = forcings_[mm].frc_ndx - 1;
+    for (int isec = 0; isec < forcings_[mm].nsectors; ++isec) {
+    const auto& field = forcings_[mm].fields[isec];
+    if (forcings_[mm].file_alt_data) {
+      Kokkos::parallel_for(
+        "MAMMicrophysics::run_impl::forcing", policy,
+        KOKKOS_LAMBDA(const ThreadTeam &team) {
+        const int icol     = team.league_rank();   // column index
+        Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev),
+         [&](int kk) {
+          extfrc(icol,kk,nn) += field(icol,nlev - 1 - kk);
+        });
+      });
+
+   } else {
+     Kokkos::parallel_for(
+      "MAMMicrophysics::run_impl::forcing", policy,
+      KOKKOS_LAMBDA(const ThreadTeam &team) {
+      const int icol     = team.league_rank();   // column index
+      Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev), [&](int kk) {
+        extfrc(icol,kk,nn) += field(icol,kk);
+      });
+    });
+   }
+  } // isec
+  }   // end mm
+  // set external forcing ends
+
+  // set invariants
+  const auto& invariants = invariants_;
+  const auto& dry_atm = dry_atm_;
+  Kokkos::parallel_for(
+      "MAMMicrophysics::run_impl::setinv", policy,
+      KOKKOS_LAMBDA(const ThreadTeam &team) {
+      const int icol     = team.league_rank();   // column index
+      // fetch column-specific atmosphere state data
+      const auto atm = mam_coupling::atmosphere_for_column(dry_atm, icol);
+      const auto invariants_icol = ekat::subview(invariants, icol);
+      view_1d cnst_offline_icol[mam4::mo_setinv::num_tracer_cnst];
+      for(int i = 0; i < mam4::mo_setinv::num_tracer_cnst; ++i) {
+        cnst_offline_icol[i] = ekat::subview(oxidants[i], icol);
+      }
+      mam4::mo_setinv::setinv(team,                                    // in
+                          invariants_icol,                         // out
+                          atm.temperature, atm.vapor_mixing_ratio, // in
+                          cnst_offline_icol, atm.pressure);        // in
+
+  });
+
+  // set invariants ends
+
+  // set o3_col_dens
+  // set extract_stateq
+  const int offset_aerosol = mam4::utils::gasses_start_ind();
+  const auto& dry_aero = dry_aero_;
+  const int pcnst              = mam4::pcnst;
+  const auto& state_q = state_q_;
+  const auto& qqcw_pcnst = qqcw_pcnst_;
+  const auto& qq = qq_;
+  const auto& qqcw = qqcw_;
+  const auto& vmr = vmr_;
+  const auto& vmrcw = vmrcw_;
+  constexpr int num_gas_aerosol_constituents = mam_coupling::gas_pcnst();
+  Real adv_mass_kg_per_moles[num_gas_aerosol_constituents];
+  for(int i = 0; i < num_gas_aerosol_constituents; ++i) {
+    // NOTE: state_q is kg/kg-dry-air; adv_mass is in g/mole.
+    // Convert adv_mass to kg/mole as vmr_from_mmr function uses
+    // molec_weight_dry_air with kg/mole units
+    adv_mass_kg_per_moles[i] = mam4::gas_chemistry::adv_mass[i] / 1e3;
+  }
+
+  Kokkos::parallel_for(
+      "MAMMicrophysics::run_impl::extract_stateq", policy,
+      KOKKOS_LAMBDA(const ThreadTeam &team) {
+  // extract aerosol state variables into "working arrays" (mass
+    // mixing ratios) (in EAM, this is done in the gas_phase_chemdr
+    // subroutine defined within
+    //  mozart/mo_gas_phase_chemdr.F90)
+    const int icol     = team.league_rank();   // column index
+    const auto atm = mam_coupling::atmosphere_for_column(dry_atm, icol);
+    mam4::Prognostics progs =
+            mam_coupling::aerosols_for_column(dry_aero, icol);
+
+    const auto state_q_icol = ekat::subview(state_q,icol);
+    const auto qqcw_pcnst_icol = ekat::subview(qqcw_pcnst,icol);
+    const auto qq_icol = ekat::subview(qq,icol);
+    const auto qqcw_icol = ekat::subview(qqcw,icol);
+    const auto vmr_icol = ekat::subview(vmr,icol);
+    const auto vmrcw_icol = ekat::subview(vmrcw,icol);
+    Kokkos::parallel_for(
+      Kokkos::TeamVectorRange(team, nlev),
+      [&](const int kk) {
+        const auto state_q_kk = ekat::subview(state_q_icol,kk);
+        const auto qqcw_pcnst_kk = ekat::subview(qqcw_pcnst_icol,kk);
+        const auto qq_kk = ekat::subview(qq_icol,kk);
+        const auto qqcw_kk = ekat::subview(qqcw_icol,kk);
+        const auto vmr_kk = ekat::subview(vmr_icol,kk);
+        const auto vmrcw_kk = ekat::subview(vmrcw_icol,kk);
+        // output (state_q)
+        mam4::utils::extract_stateq_from_prognostics(progs, atm, state_q_kk, kk);
+        // output (qqcw_pcnst)
+        mam4::utils::extract_qqcw_from_prognostics(progs, qqcw_pcnst_kk, kk);
+        for (int i = offset_aerosol; i < pcnst; ++i) {
+          qq_kk[i - offset_aerosol] = state_q_kk[i];
+          qqcw_kk[i - offset_aerosol] = qqcw_pcnst_kk[i];
+        }
+        // convert mass mixing ratios to volume mixing ratios (VMR),
+        // equivalent to tracer mixing ratios (TMR)
+        // output (vmr)
+        mam4::microphysics::mmr2vmr(qq_kk.data(), adv_mass_kg_per_moles, vmr_kk.data());
+        // output (vmrcw)
+        mam4::microphysics::mmr2vmr(qqcw_kk.data(), adv_mass_kg_per_moles, vmrcw_kk.data());
+    });
+  });
+
+
+  const auto& o3_col_dens = buffer_.scratch[8];
+  const auto& work_set_het  = work_set_het_;
+  Kokkos::parallel_for(
+    "MAMMicrophysics::run_impl::compute_o3_column_density", policy,
+    KOKKOS_LAMBDA(const ThreadTeam &team) {
+    const int icol     = team.league_rank();   // column index
+    // calculate o3 column densities (first component of col_dens in Fortran
+    // code)
+    auto o3_col_dens_i = ekat::subview(o3_col_dens, icol);
+    const auto& invariants_icol = ekat::subview(invariants, icol);
+    const auto& atm = mam_coupling::atmosphere_for_column(dry_atm, icol);
+    const auto& vmr_icol = ekat::subview(vmr,icol);
+    const auto work_set_het_icol = ekat::subview(work_set_het, icol);
+    auto work_set_het_ptr = (Real *)work_set_het_icol.data();
+    const auto& o3_col_deltas  = view_1d(work_set_het_ptr, mam4::nlev + 1);
+    // NOTE: if we need o2 column densities, set_ub_col and setcol must be changed
+    const int nlev = mam4::nlev;
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev), [&](const int kk) {
+      const Real pdel = atm.hydrostatic_dp(kk);
+      const auto vmr_kk = ekat::subview(vmr_icol,kk);
+      const auto invariants_k = ekat::subview(invariants_icol,kk);
+      // compute the change in o3 density for this column above its neighbor
+      mam4::mo_photo::set_ub_col(o3_col_deltas(kk + 1),     // out
+                               vmr_kk.data(), invariants_k.data(), pdel); // out
+    });
+    team.team_barrier();
+    // sum the o3 column deltas to densities
+    mam4::mo_photo::setcol(team, o3_col_deltas.data(), // in
+                         o3_col_dens_i);        // out
+  });
+  // set o3_col_dens ends
+
+  // set photo table
+  const auto &photo_rates                     = photo_rates_;
+  const auto& d_sfc_alb_dir_vis = d_sfc_alb_dir_vis_;
+  Kokkos::deep_copy(photo_rates_,0.0);
+  const auto& work_photo_table =work_photo_table_;
+  const auto& zenith_angle = acos_cosine_zenith_;
+  const auto& photo_table=photo_table_;
+
+  Kokkos::parallel_for(
+      "MAMMicrophysics::run_impl::photo_table", policy,
+      KOKKOS_LAMBDA(const ThreadTeam &team) {
+    const int icol     = team.league_rank();   // column index
+    const auto o3_col_dens_i = ekat::subview(o3_col_dens, icol);
+    const auto &work_photo_table_icol =
+            ekat::subview(work_photo_table, icol);
+    const auto atm = mam_coupling::atmosphere_for_column(dry_atm, icol);
+    const auto &photo_rates_icol = ekat::subview(photo_rates, icol);
+        // set up photolysis work arrays for this column.
+    mam4::mo_photo::PhotoTableWorkArrays photo_work_arrays_icol;
+
+    //  set work view using 1D photo_work_arrays_icol
+    // Note: We are not allocating views here.
+    mam4::mo_photo::set_photo_table_work_arrays(photo_table,
+                                              work_photo_table_icol,   // in
+                                              photo_work_arrays_icol); // out
+
+    team.team_barrier();
+    mam4::mo_photo::table_photo(team, photo_rates_icol,                    // out
+                              atm.pressure, atm.hydrostatic_dp,          // in
+                              atm.temperature, o3_col_dens_i,            // in
+                              zenith_angle(icol), d_sfc_alb_dir_vis(icol), // in
+                              atm.liquid_mixing_ratio, atm.cloud_fraction, // in
+                              eccf, photo_table,                           // in
+                              photo_work_arrays_icol); // out
+    });
+
+    // set photo table ends
+    const auto& col_latitudes = col_latitudes_;
+    const auto& het_rates =het_rates_;
+    const auto &cmfdqr       = cmfdqr_;
+
+    // Stratiform rain production rate [kg/kg/s]
+    const auto &prain =
+      get_field_in("precip_total_tend").get_view<const Real **>();
+    // Evaporation from stratiform rain [kg/kg/s]
+    const auto &nevapr = get_field_in("nevapr").get_view<const Real **>();
+
+    // set sethet
+    Kokkos::parallel_for(
+      "MAMMicrophysics::run_impl::sethet", policy,
+      KOKKOS_LAMBDA(const ThreadTeam &team) {
+    const int icol     = team.league_rank();   // column index
+    const auto atm = mam_coupling::atmosphere_for_column(dry_atm, icol);
+    const auto phis= dry_atm.phis(icol);
+    const Real col_lat = col_latitudes(icol);  // column latitude (degrees?)
+    // convert column latitude to radians
+    const Real rlats = col_lat * M_PI / 180.0;
+    const auto prain_icol        = ekat::subview(prain, icol);
+    const auto nevapr_icol       = ekat::subview(nevapr, icol);
+    const auto invariants_icol = ekat::subview(invariants, icol);
+    const auto het_rates_icol  = ekat::subview(het_rates, icol);
+    const auto vmr_icol = ekat::subview(vmr, icol);
+
+    const auto work_set_het_icol = ekat::subview(work_set_het, icol);
+    auto work_set_het_ptr = (Real *)work_set_het_icol.data();
+    const int sethet_work_len = mam4::mo_sethet::get_work_len_sethet();
+    const auto work_sethet_call = view_1d(work_set_het_ptr, sethet_work_len);
+    work_set_het_ptr += sethet_work_len;
+    mam4::mo_sethet::sethet(team, atm, het_rates_icol, rlats, phis, cmfdqr, prain_icol,
+                          nevapr_icol, dt, invariants_icol, vmr_icol,
+                          work_sethet_call);
+  });
+
+  // set_het end
+
+  // set drydep_xactive
+
+  const auto& index_season_lai=index_season_lai_;
+
+  // U wind component [m/s]
+  const const_view_2d u_wind =
+      get_field_in("horiz_winds").get_component(0).get_view<const Real **>();
+
+  // V wind component [m/s]
+  const const_view_2d v_wind =
+      get_field_in("horiz_winds").get_component(1).get_view<const Real **>();
+
+  // Liquid precip [kg/m2]
+  const const_view_1d precip_liq_surf_mass =
+      get_field_in("precip_liq_surf_mass").get_view<const Real *>();
+
+  // drydep_xactive
+  // Snow depth on land [m]
+  const const_view_1d snow_depth_land =
+      get_field_in("snow_depth_land").get_view<const Real *>();
+
+  // Fractional land use [fraction]
+  const const_view_2d fraction_landuse =
+      get_field_in("fraction_landuse").get_view<const Real **>();
+
+    // Downwelling solar flux at the surface [w/m2]
+  const const_view_2d sw_flux_dn =
+      get_field_in("SW_flux_dn").get_view<const Real **>();
+
+  const mam4::seq_drydep::Data drydep_data =
+      mam4::seq_drydep::set_gas_drydep_data();
+
+  const int month              = start_of_step_ts().get_month();  // 1-based
+
+  // Surface temperature [K]
+  const const_view_1d sfc_temperature =
+      get_field_in("surf_radiative_T").get_view<const Real *>();
+
+  // Surface pressure [Pa]
+  const const_view_1d sfc_pressure =
+      get_field_in("ps").get_view<const Real *>();
+
+  // Constituent fluxes of gas and aerosol species
+  view_2d constituent_fluxes =
+      get_field_out("constituent_fluxes").get_view<Real **>();
+
+  // Ice precip [kg/m2]
+  const const_view_1d precip_ice_surf_mass =
+      get_field_in("precip_ice_surf_mass").get_view<const Real *>();
+
+  Kokkos::parallel_for(
+    "MAMMicrophysics::run_impl::drydep_xactive", policy,
+    KOKKOS_LAMBDA(const ThreadTeam &team) {
+    const int icol     = team.league_rank();   // column index
+    const auto atm = mam_coupling::atmosphere_for_column(dry_atm, icol);
+
+    const auto work_set_het_icol = ekat::subview(work_set_het, icol);
+    auto work_set_het_ptr = (Real *)work_set_het_icol.data();
+    // deposition velocity [1/cm/s]
+    const auto& dflx_col = view_1d(work_set_het_ptr, num_gas_aerosol_constituents);
+    work_set_het_ptr += num_gas_aerosol_constituents;
+    // deposition flux [1/cm^2/s]
+    const auto& dvel_col = view_1d(work_set_het_ptr, num_gas_aerosol_constituents);
+    work_set_het_ptr += num_gas_aerosol_constituents;
+
+    // Snow depth on land [m]
+    const Real snow_height = snow_depth_land(icol);
+
+    Real fraction_landuse_icol[mam4::mo_drydep::n_land_type];
+    for(int i = 0; i < mam4::mo_drydep::n_land_type; ++i) {
+      fraction_landuse_icol[i] = fraction_landuse(icol, i);
+    }
+
+    int index_season[mam4::mo_drydep::n_land_type];
+    {
+      //-------------------------------------------------------------------------------------
+      // define which season (relative to Northern hemisphere climate)
+      //-------------------------------------------------------------------------------------
+
+      //-------------------------------------------------------------------------------------
+      // define season index based on fixed LAI
+      //-------------------------------------------------------------------------------------
+      for(int lt = 0; lt < mam4::mo_drydep::n_land_type; ++lt) {
+            index_season[lt] = index_season_lai(icol, month - 1);
+      }
+
+      //-------------------------------------------------------------------------------------
+      // special case for snow covered terrain
+      //-------------------------------------------------------------------------------------
+      if(snow_height > 0.01) {  // BAD_CONSTANT
+        for(int lt = 0; lt < mam4::mo_drydep::n_land_type; ++lt) {
+          index_season[lt] = 3;
+        }
+        }
+      }
+      const int surface_lev = nlev - 1; // Surface level
+      // specific humidity [kg/kg]
+      const Real spec_hum = atm.vapor_mixing_ratio(surface_lev);
+      // surface air temperature [K]
+      const Real air_temp = atm.temperature(surface_lev);
+      // potential temperature [K] *(temp*(1+vapor_mixing_ratio))
+      //(FIXME: We followed Fortran, compare it with MAM4xx's potential temp
+      // func)
+      const Real tv = air_temp * (1.0 + spec_hum);
+      // 10-meter pressure [Pa]
+      // Surface pressure at 10m (Followed the fortran code)
+      const Real pressure_10m = atm.pressure(surface_lev);
+
+      // Wind speed at the surface
+      const Real wind_speed =
+            haero::sqrt(u_wind(icol, surface_lev) * u_wind(icol, surface_lev) +
+                        v_wind(icol, surface_lev) * v_wind(icol, surface_lev));
+      // Total rain at the surface
+      const Real rain =
+            precip_liq_surf_mass(icol) + precip_ice_surf_mass(icol);
+      // Downwelling solar flux at the surface (value at interface) [w/m2]
+      const Real solar_flux = sw_flux_dn(icol, surface_lev + 1);
+      const auto qq_icol = ekat::subview(qq,icol);
+      const auto qq_sfc = ekat::subview(qq_icol,surface_lev);
+
+
+
+      Kokkos::parallel_for(
+       Kokkos::TeamVectorRange(team, nlev),
+       [&](const int kk) {
+       mam4::mo_drydep::drydep_xactive(
+        drydep_data,
+        fraction_landuse_icol, // fraction of land use for column by land type
+        index_season,     // column-specific mapping of month indices to
+                          // seasonal land-type indices [-]
+        sfc_temperature(icol),         // surface temperature [K]
+        air_temp,         // surface air temperature [K]
+        tv,               // potential temperature [K]
+        sfc_pressure(icol),     // surface pressure [Pa]
+        pressure_10m,     // 10-meter pressure [Pa]
+        spec_hum,         // specific humidity [kg/kg]
+        wind_speed,       // 10-meter wind spped [m/s]
+        rain,             // rain content [??]
+        solar_flux,       // direct shortwave surface radiation [W/m^2]
+        qq_sfc.data(),               // constituent MMRs [kg/kg]
+        dvel_col.data(),             // deposition velocity [1/cm/s]
+        dflx_col.data()              // deposition flux [1/cm^2/s]
+      );
+      });
+      // Update constituent fluxes with gas drydep fluxes (dflx)
+        // FIXME: Possible units mismatch (dflx is in kg/cm2/s but
+        // constituent_fluxes is kg/m2/s) (Following mimics Fortran code
+        // behavior but we should look into it)
+        Kokkos::parallel_for(Kokkos::TeamVectorRange(team, offset_aerosol, pcnst), [&](int ispc) {
+          constituent_fluxes(icol, ispc) -= dflx_col(ispc - offset_aerosol);
+        });
+    });
+
+
+    // set drydep_xactive ends
+
+    // gas_phase_chemistry
+
+    // Store mixing ratios before gas chemistry changes the mixing ratios
+    const auto& vmr0 = vmr0_;
+    Kokkos::deep_copy(vmr0,vmr);
+    // NOTE: Making copies of clsmap_4 and permute_4 to fix undefined arrays on
+    // the device.
+    int clsmap_4[num_gas_aerosol_constituents], permute_4[num_gas_aerosol_constituents];
+    for(int i = 0; i < num_gas_aerosol_constituents; ++i) {
+      clsmap_4[i]              = mam4::gas_chemistry::clsmap_4[i];
+      permute_4[i]             = mam4::gas_chemistry::permute_4[i];
+    }
+
+    view_3d gas_phase_chemistry_dvmrdt;
+    if (extra_mam4_aero_microphys_diags_) {
+      gas_phase_chemistry_dvmrdt = get_field_out("mam4_microphysics_tendency_gas_phase_chemistry").get_view<Real ***>();
+    }
+
+    Kokkos::parallel_for(
+    "MAMMicrophysics::run_impl::gas_phase_chemistry", policy,
+    KOKKOS_LAMBDA(const ThreadTeam &team) {
+      const int icol     = team.league_rank();   // column index
+      const auto atm = mam_coupling::atmosphere_for_column(dry_atm, icol);
+      const auto &photo_rates_icol = ekat::subview(photo_rates, icol);
+      const auto invariants_icol = ekat::subview(invariants, icol);
+      const auto extfrc_icol = ekat::subview(extfrc, icol);
+      const auto het_rates_icol = ekat::subview(het_rates, icol);
+      const auto& vmr_icol = ekat::subview(vmr, icol);
+
+      Kokkos::parallel_for(
+       Kokkos::TeamVectorRange(team, nlev),
+       [&](const int kk) {
+        const auto &extfrc_k = ekat::subview(extfrc_icol, kk);
+        const auto &invariants_k = ekat::subview(invariants_icol, kk);
+        const auto &photo_rates_k = ekat::subview(photo_rates_icol, kk);
+        const auto &het_rates_k = ekat::subview(het_rates_icol, kk);
+        // extract atm state variables (input)
+        const Real temperature = atm.temperature(kk);
+        const auto &vmr_kk = ekat::subview(vmr_icol, kk);
+        mam4::microphysics::gas_phase_chemistry(
+        // in
+        temperature, dt, photo_rates_k.data(), extfrc_k.data(), invariants_k.data(),
+        clsmap_4, permute_4, het_rates_k.data(),
+        // out
+        vmr_kk);
+      });
+
+    });
+
+    if (gas_phase_chemistry_dvmrdt.size()) {
+
+    Kokkos::parallel_for(
+    "MAMMicrophysics::run_impl::gas_phase_chemistry_dvmrdt", policy,
+    KOKKOS_LAMBDA(const ThreadTeam &team) {
+      const int icol     = team.league_rank();   // column index
+      const auto atm = mam_coupling::atmosphere_for_column(dry_atm, icol);
+      Kokkos::parallel_for(
+       Kokkos::TeamVectorRange(team, nlev),
+       [&](const int kk) {
+        Real pdel = atm.hydrostatic_dp(kk);
+        const Real mbar = haero::Constants::molec_weight_dry_air;
+      const Real gravit = haero::Constants::gravity;
+      const Real x = 1.0 / mbar * pdel / gravit;
+      for (int m = 0; m < num_gas_aerosol_constituents; ++m)
+        gas_phase_chemistry_dvmrdt(icol, m, kk) =
+            x * adv_mass_kg_per_moles[m] * (vmr(icol,kk,m) - vmr0(icol,kk,m)) / dt;
+       });
+
+    });
+  }
+  // gas_phase_chemistry ends
+
+  // setsox_single_level
+  const Config &config                        = config_;
+  const auto& vmr_pregas =vmr_pregas_;
+  const auto& vmr_precld=vmr_precld_;
+  Kokkos::deep_copy(vmr_pregas, vmr);
+  Kokkos::deep_copy(vmr_precld, vmrcw );
+
+  const auto& vmr_bef_aq_chem = vmr_pregas;
+  const auto& config_setsox = config.setsox;
+  const auto& dqdt_aqso4 = dqdt_aqso4_;
+  const auto& dqdt_aqh2so4 = dqdt_aqh2so4_;
+
+  Kokkos::parallel_for(
+    "MAMMicrophysics::run_impl::setsox_single_level", policy,
+    KOKKOS_LAMBDA(const ThreadTeam &team) {
+
+    const int icol     = team.league_rank();   // column index
+    const auto atm = mam_coupling::atmosphere_for_column(dry_atm, icol);
+    //----------------------
+    // Aerosol microphysics
+    //----------------------
+    // the logic below is taken from the aero_model_gasaerexch
+    // subroutine in eam/src/chemistry/modal_aero/aero_model.F90
+    const auto dqdt_aqso4_icol = ekat::subview(dqdt_aqso4,icol);
+    const auto dqdt_aqh2so4_icol =ekat::subview(dqdt_aqh2so4,icol);
+
+    const auto invariants_icol = ekat::subview(invariants, icol);
+    const auto & vmrcw_icol = ekat::subview(vmrcw,icol);
+    const auto & vmr_icol = ekat::subview(vmr,icol);
+
+    Kokkos::parallel_for(
+       Kokkos::TeamVectorRange(team, nlev),
+       [&](const int kk) {
+        // extract atm state variables (input)
+        Real temp = atm.temperature(kk);
+        Real pmid = atm.pressure(kk);
+        Real pdel = atm.hydrostatic_dp(kk);
+        Real lwc = atm.liquid_mixing_ratio(kk);
+        Real cldfrac = atm.cloud_fraction(kk);
+        Real cldnum = atm.cloud_liquid_number_mixing_ratio(kk);
+        const auto &invariants_k = ekat::subview(invariants_icol, kk);
+        // aqueous chemistry ...
+       constexpr Real mbar = haero::Constants::molec_weight_dry_air;
+       constexpr int indexm = mam4::gas_chemistry::indexm;
+       const auto &dqdt_aqso4_k = ekat::subview(dqdt_aqso4_icol, kk);
+       const auto &dqdt_aqh2so4_k = ekat::subview(dqdt_aqh2so4_icol, kk);
+       const auto & vmrcw_k = ekat::subview(vmrcw_icol,kk);
+       const auto & vmr_k = ekat::subview(vmr_icol,kk);
+
+    mam4::mo_setsox::setsox_single_level(
+        // in
+        offset_aerosol, dt, pmid, pdel, temp, mbar, lwc, cldfrac, cldnum,
+        invariants_k(indexm), config_setsox,
+        // out
+        dqdt_aqso4_k.data(), dqdt_aqh2so4_k.data(), vmrcw_k.data(), vmr_k.data());
+    });
+    });
+
+    view_3d aqueous_chemistry_dvmrdt;
+    if (extra_mam4_aero_microphys_diags_) {
+      aqueous_chemistry_dvmrdt = get_field_out("mam4_microphysics_tendency_aqueous_chemistry").get_view<Real ***>();
+    }
+
+    if (aqueous_chemistry_dvmrdt.size()) {
+      Kokkos::parallel_for(
+      "MAMMicrophysics::run_impl::aqueous_chemistry_dvmrdt", policy,
+      KOKKOS_LAMBDA(const ThreadTeam &team) {
+        const int icol     = team.league_rank();   // column index
+        const auto atm = mam_coupling::atmosphere_for_column(dry_atm, icol);
+        Kokkos::parallel_for(
+         Kokkos::TeamVectorRange(team, nlev),
+         [&](const int kk) {
+         Real pdel = atm.hydrostatic_dp(kk);
+         const Real mbar = haero::Constants::molec_weight_dry_air;
+         const Real gravit = haero::Constants::gravity;
+         const Real x = 1.0 / mbar * pdel / gravit;
+         for (int m = 0; m < num_gas_aerosol_constituents; ++m)
+          aqueous_chemistry_dvmrdt(icol, m, kk) =
+            x * adv_mass_kg_per_moles[m] * (vmr(icol,kk,m) - vmr_bef_aq_chem(icol,kk,m)) / dt;
+         });
+
+      });
+    }
+    //setsox_single_level ends
+
+    // modal_aero_amicphys_intr
+    const auto wet_diameter =
+      get_field_in("dgnumwet").get_view<const Real ***>();
+    const auto dry_diameter =
+      get_field_in("dgnum").get_view<const Real ***>();
+    const auto wetdens = get_field_in("wetdens").get_view<const Real ***>();
+
+    auto& dgncur_awet_loc = dgncur_awet_;
+    auto& dgncur_a_loc = dgncur_a_;
+    auto& wetdens_loc = wetdens_;
+    constexpr int nmodes = mam4::AeroConfig::num_modes();
+     Kokkos::parallel_for(
+    "MAMMicrophysics::run_impl::modal_aero_amicphys_intr_precompute", policy,
+    KOKKOS_LAMBDA(const ThreadTeam &team) {
+      const int icol     = team.league_rank();   // column index
+    Kokkos::parallel_for(
+       Kokkos::TeamVectorRange(team, nlev),
+       [&](const int kk) {
+        for (int imode = 0; imode < nmodes; imode++) {
+         dgncur_awet_loc(icol, kk, imode) = wet_diameter(icol, imode, kk);
+         dgncur_a_loc(icol, kk, imode) = dry_diameter(icol, imode, kk);
+         wetdens_loc(icol, kk, imode) = wetdens(icol, imode, kk);
+        }
+      });
+    });
+
+    view_3d gas_aero_exchange_condensation, gas_aero_exchange_renaming,
+          gas_aero_exchange_nucleation, gas_aero_exchange_coagulation,
+          gas_aero_exchange_renaming_cloud_borne;
+
+    if (extra_mam4_aero_microphys_diags_) {
+      gas_aero_exchange_condensation = get_field_out("mam4_microphysics_tendency_condensation").get_view<Real***>();
+      gas_aero_exchange_renaming = get_field_out("mam4_microphysics_tendency_renaming").get_view<Real***>();
+      gas_aero_exchange_nucleation = get_field_out("mam4_microphysics_tendency_nucleation").get_view<Real***>();
+      gas_aero_exchange_coagulation = get_field_out("mam4_microphysics_tendency_coagulation").get_view<Real***>();
+      gas_aero_exchange_renaming_cloud_borne = get_field_out("mam4_microphysics_tendency_renaming_cloud_borne").get_view<Real***>();
+    }
+
+    const bool extra_mam4_aero_microphys_diags  = extra_mam4_aero_microphys_diags_;
+
+    const auto& config_amicphys = config.amicphys;
+     Kokkos::parallel_for(
+    "MAMMicrophysics::run_impl::modal_aero_amicphys_intr", policy,
+    KOKKOS_LAMBDA(const ThreadTeam &team) {
+
+      const int icol     = team.league_rank();   // column index
+      const auto atm = mam_coupling::atmosphere_for_column(dry_atm, icol);
+
+      mam4::MicrophysDiagnosticArrays diag_arrays;
+      if (extra_mam4_aero_microphys_diags) {
+          diag_arrays.gas_aero_exchange_condensation = ekat::subview(gas_aero_exchange_condensation, icol);
+          diag_arrays.gas_aero_exchange_renaming = ekat::subview(gas_aero_exchange_renaming, icol);
+          diag_arrays.gas_aero_exchange_nucleation = ekat::subview(gas_aero_exchange_nucleation, icol);
+          diag_arrays.gas_aero_exchange_coagulation = ekat::subview(gas_aero_exchange_coagulation, icol);
+          diag_arrays.gas_aero_exchange_renaming_cloud_borne = ekat::subview(gas_aero_exchange_renaming_cloud_borne, icol);
+      }
+      auto vmrcw_icol = ekat::subview(vmrcw,icol);
+      auto vmr_icol = ekat::subview(vmr,icol);
+      const auto & vmr0_icol = ekat::subview(vmr0,icol);
+      const auto & vmr_pregas_icol = ekat::subview(vmr_pregas,icol);
+      const auto & vmr_precld_icol = ekat::subview(vmr_precld,icol);
+
+      const auto& dgncur_awet_icol = ekat::subview(dgncur_awet_loc,icol);
+      const auto& dgncur_a_icol = ekat::subview(dgncur_a_loc,icol);
+      const auto& wetdens_icol = ekat::subview(wetdens_loc,icol);
+
+      Kokkos::parallel_for(
+       Kokkos::TeamVectorRange(team, nlev),
+       [&](const int kk) {
+        // calculate aerosol water content using water uptake treatment
+        // * dry and wet diameters [m]
+        // * wet densities [kg/m3]
+        // * aerosol water mass mixing ratio [kg/kg]
+        const Real temp = atm.temperature(kk);
+        const Real pmid = atm.pressure(kk);
+        const Real pdel = atm.hydrostatic_dp(kk);
+        const Real zm = atm.height(kk);
+        const Real pblh = atm.planetary_boundary_layer_height;
+        const Real qv = atm.vapor_mixing_ratio(kk);
+        const Real cldfrac = atm.cloud_fraction(kk);
+        const auto& dgncur_awet_kk = ekat::subview(dgncur_awet_icol,kk);
+        const auto& dgncur_a_kk = ekat::subview(dgncur_a_icol,kk);
+        const auto& wetdens_kk = ekat::subview(wetdens_icol,kk);
+
+        auto vmr_kk = ekat::subview(vmr_icol,kk);
+        auto vmrcw_kk = ekat::subview(vmrcw_icol,kk);
+        const auto & vmr0_kk = ekat::subview(vmr0_icol,kk);
+        const auto & vmr_pregas_kk = ekat::subview(vmr_pregas_icol,kk);
+        const auto & vmr_precld_kk = ekat::subview(vmr_precld_icol,kk);
+    // Perform aerosol microphysics (gas-aerosol exchange, nucleation,
+    // coagulation)
+    mam4::microphysics::modal_aero_amicphys_intr(
+        // in
+        config_amicphys, dt, temp, pmid, pdel, zm, pblh, qv, cldfrac,
+        // out
+        vmr_kk, vmrcw_kk,
+        // diagnostics (out)
+        kk, diag_arrays.gas_aero_exchange_condensation,
+        diag_arrays.gas_aero_exchange_renaming,
+        diag_arrays.gas_aero_exchange_nucleation,
+        diag_arrays.gas_aero_exchange_coagulation,
+        diag_arrays.gas_aero_exchange_renaming_cloud_borne,
+        // in
+        vmr0_kk, vmr_pregas_kk, vmr_precld_kk, dgncur_a_kk, dgncur_awet_kk, wetdens_kk);
+      });
+    });
+
+    // modal_aero_amicphys_intr ends
+
+    // vmr2mmr_cw
+    Kokkos::parallel_for(
+    "MAMMicrophysics::run_impl::vmr2mmr_cw", policy,
+    KOKKOS_LAMBDA(const ThreadTeam &team) {
+      const int icol     = team.league_rank();   // column index
+      auto vmrcw_icol = ekat::subview(vmrcw,icol);
+      auto qqcw_icol = ekat::subview(qqcw,icol);
+      Kokkos::parallel_for(
+       Kokkos::TeamVectorRange(team, nlev),
+       [&](const int kk) {
+        auto vmrcw_kk = ekat::subview(vmrcw_icol,kk);
+        auto qqcw_kk = ekat::subview(qqcw_icol,kk);
+        mam4::microphysics::vmr2mmr(vmrcw_kk.data(),
+           adv_mass_kg_per_moles, qqcw_kk.data());
+       });
+    });
+    // vmr2mmr_cw ends
+
+    // linoz
+    if (config.linoz.compute) {
+
+      // climatology data for linear stratospheric chemistry
+      // ozone (climatology) [vmr]
+      view_2d linoz_o3_clim =  buffer_.scratch[0];
+      // column o3 above box (climatology) [Dobson Units (DU)]
+      view_2d linoz_o3col_clim = buffer_.scratch[1];
+      // temperature (climatology) [K]
+      view_2d linoz_t_clim = buffer_.scratch[2];
+      // P minus L (climatology) [vmr/s]
+      view_2d linoz_PmL_clim = buffer_.scratch[3];
+      // sensitivity of P minus L to O3 [1/s]
+      view_2d linoz_dPmL_dO3 = buffer_.scratch[4];
+      // sensitivity of P minus L to T3 [K]
+      view_2d linoz_dPmL_dT = buffer_.scratch[5];
+      // sensitivity of P minus L to overhead O3 column [vmr/DU]
+      view_2d linoz_dPmL_dO3col = buffer_.scratch[6];
+      // Cariolle parameter for PSC loss of ozone [1/s]
+      view_2d linoz_cariolle_pscs = buffer_.scratch[7];
+      const auto& linoz_conf=config.linoz;
+      const int o3_ndx = static_cast<int>(mam4::GasId::O3);
+      Kokkos::parallel_for(
+    "MAMMicrophysics::run_impl::linoz", policy,
+    KOKKOS_LAMBDA(const ThreadTeam &team) {
+      const int icol     = team.league_rank();   // column index
+      const Real col_lat = col_latitudes(icol);  // column latitude (degrees?)
+      const auto atm = mam_coupling::atmosphere_for_column(dry_atm, icol);
+      const auto o3_col_dens_i = ekat::subview(o3_col_dens, icol);
+      // convert column latitude to radians
+      const Real rlats = col_lat * M_PI / 180.0;
+      mam4::microphysics::LinozData linoz_data;
+      if (config.linoz.compute) {
+          linoz_data.linoz_o3_clim_icol = ekat::subview(linoz_o3_clim, icol);
+          linoz_data.linoz_t_clim_icol  = ekat::subview(linoz_t_clim, icol);
+          linoz_data.linoz_o3col_clim_icol =
+            ekat::subview(linoz_o3col_clim, icol);
+          linoz_data.linoz_PmL_clim_icol = ekat::subview(linoz_PmL_clim, icol);
+          linoz_data.linoz_dPmL_dO3_icol = ekat::subview(linoz_dPmL_dO3, icol);
+          linoz_data.linoz_dPmL_dT_icol  = ekat::subview(linoz_dPmL_dT, icol);
+          linoz_data.linoz_dPmL_dO3col_icol =
+            ekat::subview(linoz_dPmL_dO3col, icol);
+          linoz_data.linoz_cariolle_pscs_icol =
+            ekat::subview(linoz_cariolle_pscs, icol);
+      }
+      const auto& vmr_icol = ekat::subview(vmr,icol);
+
+      Kokkos::parallel_for(
+       Kokkos::TeamVectorRange(team, nlev),
+       [&](const int kk) {
+      //-----------------
+      // LINOZ chemistry
+      //-----------------
+      const Real temp = atm.temperature(kk);
+      const Real pmid = atm.pressure(kk);
+      const Real pdel = atm.hydrostatic_dp(kk);
+
+      // the following things are diagnostics, which we're not
+      // including in the first rev
+      Real do3_linoz = 0, do3_linoz_psc = 0, ss_o3 = 0, o3col_du_diag = 0,
+           o3clim_linoz_diag = 0, zenith_angle_degrees = 0;
+
+
+      const auto& vmr_kk = ekat::subview(vmr_icol,kk);
+
+      // index of "O3" in solsym array (in EAM)
+      mam4::lin_strat_chem::lin_strat_chem_solve_kk(
+          // in
+          o3_col_dens_i(kk), temp, zenith_angle(icol), pmid, dt, rlats,
+          linoz_data.linoz_o3_clim_icol(kk), linoz_data.linoz_t_clim_icol(kk),
+          linoz_data.linoz_o3col_clim_icol(kk),
+          linoz_data.linoz_PmL_clim_icol(kk),
+          linoz_data.linoz_dPmL_dO3_icol(kk), linoz_data.linoz_dPmL_dT_icol(kk),
+          linoz_data.linoz_dPmL_dO3col_icol(kk),
+          linoz_data.linoz_cariolle_pscs_icol(kk), linoz_conf.chlorine_loading,
+          linoz_conf.psc_T,
+          // out
+          vmr_kk[o3_ndx],
+          // outputs that are not used
+          do3_linoz, do3_linoz_psc, ss_o3, o3col_du_diag, o3clim_linoz_diag,
+          zenith_angle_degrees);
+
+      // Update source terms above the ozone decay threshold
+      if (kk >= nlev - linoz_conf.o3_lbl) {
+        const Real o3l_vmr_old = vmr_kk(o3_ndx);
+        Real do3mass = 0;
+        const Real o3l_vmr_new =
+            mam4::lin_strat_chem::lin_strat_sfcsink_kk(dt, pdel,          // in
+                                                       o3l_vmr_old,       // in
+                                                       linoz_conf.o3_sfc, // in
+                                                       linoz_conf.o3_tau, // in
+                                                       do3mass);          // out
+        // Update the mixing ratio (vmr) for O3
+        vmr_kk(o3_ndx) = o3l_vmr_new;
+      }
+        });
+        });
+
+    }
+    // linoz ends
+    Kokkos::parallel_for(
+    "MAMMicrophysics::run_impl::inject_to_progs", policy,
+    KOKKOS_LAMBDA(const ThreadTeam &team) {
+      const int icol     = team.league_rank();   // column index
+      const auto& vmr_icol = ekat::subview(vmr,icol);
+      const auto& qq_icol = ekat::subview(qq,icol);
+      const auto& state_q_icol = ekat::subview(state_q,icol);
+      const auto& qqcw_pcnst_icol = ekat::subview(qqcw_pcnst,icol);
+      // fetch column-specific subviews into aerosol prognostics
+      mam4::Prognostics progs =
+            mam_coupling::aerosols_for_column(dry_aero, icol);
+     Kokkos::parallel_for(
+       Kokkos::TeamVectorRange(team, nlev),
+       [&](const int kk) {
+      // Check for negative values and reset to zero
+    for (int i = 0; i < num_gas_aerosol_constituents; ++i) {
+      if (vmr(icol,kk,i) < 0.0)
+        vmr(icol,kk,i) = 0.0;
+    }
+    const auto& vmr_kk = ekat::subview(vmr_icol,kk);
+    const auto& qq_kk = ekat::subview(qq_icol,kk);
+
+    mam4::microphysics::vmr2mmr(vmr_kk.data(), adv_mass_kg_per_moles, qq_kk.data());
+    for (int i = offset_aerosol; i < pcnst; ++i) {
+      state_q(icol, kk,i) = qq(icol, kk,i - offset_aerosol);
+      qqcw_pcnst(icol, kk,i) = qqcw(icol, kk,i - offset_aerosol);
+    }
+    const auto& state_q_kk = ekat::subview(state_q_icol,kk);
+    const auto& qqcw_pcnst_kk = ekat::subview(qqcw_pcnst_icol,kk);
+    mam4::utils::inject_stateq_to_prognostics(state_q_kk, progs, kk);
+    mam4::utils::inject_qqcw_to_prognostics(qqcw_pcnst_kk, progs, kk);
+    });
+    });
+
+    // diagnostics
+    // - dvmr/dt: Tendencies for mixing ratios  [kg/kg/s]
+    view_2d dqdt_so4_aqueous_chemistry, dqdt_h2so4_uptake;
+    view_3d aqso4_incloud_mmr_tendency, aqh2so4_incloud_mmr_tendency;
+    if (extra_mam4_aero_microphys_diags_) {
+      dqdt_so4_aqueous_chemistry = get_field_out("dqdt_so4_aqueous_chemistry").get_view<Real **>();
+      dqdt_h2so4_uptake = get_field_out("dqdt_h2so4_uptake").get_view<Real **>();
+      aqso4_incloud_mmr_tendency   = get_field_out("mam4_microphysics_tendency_aqso4").get_view<Real ***>();
+      aqh2so4_incloud_mmr_tendency = get_field_out("mam4_microphysics_tendency_aqh2so4").get_view<Real ***>();
+    }
+
+    Kokkos::parallel_for(
+    "MAMMicrophysics::run_impl::diagnostics", policy,
+    KOKKOS_LAMBDA(const ThreadTeam &team) {
+      const int icol     = team.league_rank();   // column index
+      const auto atm = mam_coupling::atmosphere_for_column(dry_atm, icol);
+      const auto dqdt_aqso4_icol = ekat::subview(dqdt_aqso4,icol);
+      const auto dqdt_aqh2so4_icol =ekat::subview(dqdt_aqh2so4,icol);
+
+      mam4::MicrophysDiagnosticArrays diag_arrays;
+      if (extra_mam4_aero_microphys_diags) {
+          diag_arrays.dqdt_so4_aqueous_chemistry = ekat::subview(dqdt_so4_aqueous_chemistry, icol);
+          diag_arrays.dqdt_h2so4_uptake          = ekat::subview(dqdt_h2so4_uptake, icol);
+          diag_arrays.aqh2so4_incloud_mmr_tendency = ekat::subview(aqh2so4_incloud_mmr_tendency, icol);
+          diag_arrays.aqso4_incloud_mmr_tendency = ekat::subview(aqso4_incloud_mmr_tendency, icol);
+      }
+
+      // Diagnose the column-integrated flux (kg/m2/s) using
+      // volume mixing ratios ( // kmol/kmol(air) )
+      const auto &pdel = atm.hydrostatic_dp; // layer thickness (Pa)
+      for (int m = 0; m < nmodes; ++m) {
+      const int ll = config_setsox.lptr_so4_cw_amode[m] - offset_aerosol;
+      if (0 <= ll) {
+        const auto adv_mass = adv_mass_kg_per_moles[ll];
+        Real vmr_so4 = 0.0;
+        const Real gravit = mam4::Constants::gravity;
+        Kokkos::parallel_reduce(
+          Kokkos::TeamVectorRange(team, nlev),
+          [&](int kk, Real &lsum) { lsum += dqdt_aqso4_icol(kk,ll) * pdel(kk) / gravit; },
+          vmr_so4);
+        Real vmr_h2s = 0.0;
+        Kokkos::parallel_reduce(
+          Kokkos::TeamVectorRange(team, nlev),
+          [&](int kk, Real &lsum) { lsum += dqdt_aqh2so4_icol(kk,ll) * pdel(kk) / gravit; },
+          vmr_h2s);
+
+
+      if (dqdt_so4_aqueous_chemistry.size())
+        diag_arrays.dqdt_so4_aqueous_chemistry(m) =
+            mam4::conversions::mmr_from_vmr(vmr_so4, adv_mass);
+      if (dqdt_h2so4_uptake.size())
+        diag_arrays.dqdt_h2so4_uptake(m) = mam4::conversions::mmr_from_vmr(vmr_h2s, adv_mass);
+      if (aqso4_incloud_mmr_tendency.size()) {
+        Kokkos::parallel_for(
+            Kokkos::TeamVectorRange(team, nlev), [&](const int kk) {
+              diag_arrays.aqso4_incloud_mmr_tendency(m, kk) =
+                  mam4::conversions::mmr_from_vmr(dqdt_aqso4_icol(kk,ll), adv_mass);
+            });
+      }
+      if (aqh2so4_incloud_mmr_tendency.size()) {
+        Kokkos::parallel_for(
+            Kokkos::TeamVectorRange(team, nlev), [&](const int kk) {
+              diag_arrays.aqh2so4_incloud_mmr_tendency(m, kk) =
+                  mam4::conversions::mmr_from_vmr(dqdt_aqh2so4_icol(kk,ll), adv_mass);
+            });
+      }
+    } // (if 0 <= ll)
+  } // for loop over num_modes
+
+
+    });
+
+
+}//run_small_kernels_microphysics
+
+}  // namespace scream

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -45,6 +45,9 @@ MAMMicrophysics::MAMMicrophysics(const ekat::Comm &comm, const ekat::ParameterLi
   //   12 = use final value from mam_gasaerexch_1subarea
   config_.amicphys.newnuc_h2so4_conc_optaa = 2;
 
+  config_.compute_gas_phase_chemistry =
+    m_params.get<bool>("mam4_do_gas_phase_chemistry", true);
+
   // LINOZ namelist parameters
   // Compute LINOZ only for prognostic Ozone (i.e. !use_prescribed_ozone_)
   config_.linoz.compute = !use_prescribed_ozone_;

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -853,7 +853,7 @@ void MAMMicrophysics::run_impl(const double dt) {
   const auto &extfrc   = extfrc_;
   constexpr int extcnt = mam4::gas_chemistry::extcnt;
 
-  run_small_kernels_microphysics(dt, eccf);
+  run_microphysics_kernels(dt, eccf);
 
   auto extfrc_fm = get_field_out("mam4_external_forcing").get_view<Real***>();
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -10,8 +10,6 @@
 #include "share/algorithm/eamxx_data_interpolation.hpp"
 
 #include <ekat_team_policy_utils.hpp>
-
-#define MICRO_SMALL_KERNELS
 #include <physics/mam/eamxx_mam_microphysics_process_functions.cpp>
 namespace scream
 {
@@ -769,159 +767,15 @@ void MAMMicrophysics::initialize_impl(const RunType run_type) {
 //  RUN_IMPL
 // ================================================================
 void MAMMicrophysics::run_impl(const double dt) {
-  using TPF = ekat::TeamPolicyFactory<KT::ExeSpace>;
-
   const int ncol = ncol_;
   const int nlev = nlev_;
-
-  //NOTE: get_default_team_policy produces a team size of 96 (nlev=72).
-  // This interface hangs with this team size. Therefore,
-  // let's use a team size of nlev.
-#ifdef EKAT_ENABLE_GPU
-       const int team_size=nlev;
-#else
-       const int team_size=1;
-#endif
-  const auto policy = TPF::get_default_team_policy(ncol, team_size);
 
   // preprocess input -- needs a scan for the calculation of atm height
   pre_process(wet_aero_, dry_aero_, wet_atm_, dry_atm_);
   Kokkos::fence();
-
-  //----------- Variables from microphysics scheme -------------
-
-#ifndef MICRO_SMALL_KERNELS
-  // Evaporation from stratiform rain [kg/kg/s]
-  const auto &nevapr = get_field_in("nevapr").get_view<const Real **>();
-
-  // Stratiform rain production rate [kg/kg/s]
-  const auto &prain =
-      get_field_in("precip_total_tend").get_view<const Real **>();
-
-  const auto wet_geometric_mean_diameter_i =
-      get_field_in("dgnumwet").get_view<const Real ***>();
-  const auto dry_geometric_mean_diameter_i =
-      get_field_in("dgnum").get_view<const Real ***>();
-  const auto wetdens = get_field_in("wetdens").get_view<const Real ***>();
-
-  // U wind component [m/s]
-  const const_view_2d u_wind =
-      get_field_in("horiz_winds").get_component(0).get_view<const Real **>();
-
-  // V wind component [m/s]
-  const const_view_2d v_wind =
-      get_field_in("horiz_winds").get_component(1).get_view<const Real **>();
-
-  // Liquid precip [kg/m2]
-  const const_view_1d precip_liq_surf_mass =
-      get_field_in("precip_liq_surf_mass").get_view<const Real *>();
-
-  // Ice precip [kg/m2]
-  const const_view_1d precip_ice_surf_mass =
-      get_field_in("precip_ice_surf_mass").get_view<const Real *>();
-
-  // Fractional land use [fraction]
-  const const_view_2d fraction_landuse =
-      get_field_in("fraction_landuse").get_view<const Real **>();
-
-  // Downwelling solar flux at the surface [w/m2]
-  const const_view_2d sw_flux_dn =
-      get_field_in("SW_flux_dn").get_view<const Real **>();
-
-  // Constituent fluxes of gas and aerosol species
-  view_2d constituent_fluxes =
-      get_field_out("constituent_fluxes").get_view<Real **>();
-
-  // Surface temperature [K]
-  const const_view_1d sfc_temperature =
-      get_field_in("surf_radiative_T").get_view<const Real *>();
-
-  // Surface pressure [Pa]
-  const const_view_1d sfc_pressure =
-      get_field_in("ps").get_view<const Real *>();
-
-  // Snow depth on land [m]
-  const const_view_1d snow_depth_land =
-      get_field_in("snow_depth_land").get_view<const Real *>();
-
-  // - dvmr/dt: Tendencies for mixing ratios  [kg/kg/s]
-  view_2d dqdt_so4_aqueous_chemistry, dqdt_h2so4_uptake, gas_dry_deposition_flux;
-  view_3d gas_phase_chemistry_dvmrdt, aqueous_chemistry_dvmrdt;
-  view_3d aqso4_incloud_mmr_tendency, aqh2so4_incloud_mmr_tendency;
-  view_3d gas_aero_exchange_condensation, gas_aero_exchange_renaming,
-          gas_aero_exchange_nucleation, gas_aero_exchange_coagulation,
-          gas_aero_exchange_renaming_cloud_borne;
-
-  if (extra_mam4_aero_microphys_diags_) {
-    dqdt_so4_aqueous_chemistry = get_field_out("dqdt_so4_aqueous_chemistry").get_view<Real **>();
-    dqdt_h2so4_uptake = get_field_out("dqdt_h2so4_uptake").get_view<Real **>();
-    gas_phase_chemistry_dvmrdt = get_field_out("mam4_microphysics_tendency_gas_phase_chemistry").get_view<Real ***>();
-    aqueous_chemistry_dvmrdt = get_field_out("mam4_microphysics_tendency_aqueous_chemistry").get_view<Real ***>();
-    aqso4_incloud_mmr_tendency   = get_field_out("mam4_microphysics_tendency_aqso4").get_view<Real ***>();
-    aqh2so4_incloud_mmr_tendency = get_field_out("mam4_microphysics_tendency_aqh2so4").get_view<Real ***>();
-    gas_aero_exchange_condensation = get_field_out("mam4_microphysics_tendency_condensation").get_view<Real***>();
-    gas_aero_exchange_renaming = get_field_out("mam4_microphysics_tendency_renaming").get_view<Real***>();
-    gas_aero_exchange_nucleation = get_field_out("mam4_microphysics_tendency_nucleation").get_view<Real***>();
-    gas_aero_exchange_coagulation = get_field_out("mam4_microphysics_tendency_coagulation").get_view<Real***>();
-    gas_aero_exchange_renaming_cloud_borne = get_field_out("mam4_microphysics_tendency_renaming_cloud_borne").get_view<Real***>();
-    gas_dry_deposition_flux = get_field_out("mam4_gas_dry_deposition_flux").get_view<Real**>();
-  }
-#endif
   
   data_interp_oxid_->run(end_of_step_ts());
-#ifndef MICRO_SMALL_KERNELS
-  // climatology data for linear stratospheric chemistry
-  // ozone (climatology) [vmr]
-  view_2d linoz_o3_clim;
-  // column o3 above box (climatology) [Dobson Units (DU)]
-  view_2d linoz_o3col_clim;
-  // temperature (climatology) [K]
-  view_2d linoz_t_clim;
-  // P minus L (climatology) [vmr/s]
-  view_2d linoz_PmL_clim;
-  // sensitivity of P minus L to O3 [1/s]
-  view_2d linoz_dPmL_dO3;
-  // sensitivity of P minus L to T3 [K]
-  view_2d linoz_dPmL_dT;
-  // sensitivity of P minus L to overhead O3 column [vmr/DU]
-  view_2d linoz_dPmL_dO3col;
-  // Cariolle parameter for PSC loss of ozone [1/s]
-  view_2d linoz_cariolle_pscs;
-  view_2d linoz_views[8];
-
-  
-
-  if (config_.linoz.compute) {
-    data_interp_linoz_->run(end_of_step_ts());
-    for (size_t i = 0; i < var_names_linoz_.size(); ++i) {
-      linoz_views[i] = get_field_out(var_names_linoz_[i]).get_view<Real **>();
-    }
-    linoz_o3_clim = linoz_views[0];
-    linoz_o3col_clim = linoz_views[1];
-    linoz_t_clim = linoz_views[2];
-    linoz_PmL_clim = linoz_views[3];
-    linoz_dPmL_dO3 = linoz_views[4];
-    linoz_dPmL_dT = linoz_views[5];
-    linoz_dPmL_dO3col = linoz_views[6];
-    linoz_cariolle_pscs = linoz_views[7];
-  
-    
-  }
-#endif
   data_interp_exo_coldens_->run(end_of_step_ts());  
-  
-#ifndef MICRO_SMALL_KERNELS  
-  constexpr int num_oxidants=4;
-  view_2d oxidants[num_oxidants];
-  for (size_t i = 0; i < var_names_oxi_.size(); ++i) {
-    oxidants[i] = get_field_out("oxid_"+var_names_oxi_[i]).get_view<Real **>();
-  }
-  // it's a bit wasteful to store this for all columns, but simpler from an
-  // allocation perspective
-  auto o3_col_dens = buffer_.scratch[8];
-#endif
-  
-
 
   /* Gather time and state information for interpolation */
   const auto ts = end_of_step_ts();
@@ -935,19 +789,7 @@ void MAMMicrophysics::run_impl(const double dt) {
   for (size_t i = 0; i < elevated_emis_var_names_.size(); ++i) {
     data_interp_elevated_emissions_[i]->run(end_of_step_ts());
   }
-#ifndef MICRO_SMALL_KERNELS
-  const_view_1d &col_latitudes     = col_latitudes_;
-  const_view_1d &d_sfc_alb_dir_vis = d_sfc_alb_dir_vis_;
 
-  mam_coupling::DryAtmosphere &dry_atm = dry_atm_;
-  mam_coupling::AerosolState &dry_aero = dry_aero_;
-
-  mam4::mo_photo::PhotoTableData &photo_table = photo_table_;
-  const Config &config                        = config_;
-  const auto &work_photo_table                = work_photo_table_;
-  const auto &photo_rates                     = photo_rates_;
-  const auto &invariants   = invariants_;
-#endif
   // Compute orbital parameters; these are used both for computing
   // the solar zenith angle.
   // Note: We are following the RRTMGP EAMxx interface to compute the zenith
@@ -1000,223 +842,13 @@ void MAMMicrophysics::run_impl(const double dt) {
     }
     Kokkos::deep_copy(acos_cosine_zenith_, acos_cosine_zenith_host_);
   }
-  const auto zenith_angle = acos_cosine_zenith_;
+
   constexpr int num_gas_aerosol_constituents = mam_coupling::gas_pcnst();
 
   const auto &extfrc   = extfrc_;
   constexpr int extcnt = mam4::gas_chemistry::extcnt;
 
-#ifndef MICRO_SMALL_KERNELS
-  const auto &forcings = forcings_;
-  const int offset_aerosol = mam4::utils::gasses_start_ind();
-  Real adv_mass_kg_per_moles[num_gas_aerosol_constituents];
-  // NOTE: Making copies of clsmap_4 and permute_4 to fix undefined arrays on
-  // the device.
-  int clsmap_4[num_gas_aerosol_constituents], permute_4[num_gas_aerosol_constituents];
-  for(int i = 0; i < num_gas_aerosol_constituents; ++i) {
-    // NOTE: state_q is kg/kg-dry-air; adv_mass is in g/mole.
-    // Convert adv_mass to kg/mole as vmr_from_mmr function uses
-    // molec_weight_dry_air with kg/mole units
-    adv_mass_kg_per_moles[i] = mam4::gas_chemistry::adv_mass[i] / 1e3;
-    clsmap_4[i]              = mam4::gas_chemistry::clsmap_4[i];
-    permute_4[i]             = mam4::gas_chemistry::permute_4[i];
-  }
-  const auto &cmfdqr       = cmfdqr_;
-  const auto &work_set_het = work_set_het_;
-  const mam4::seq_drydep::Data drydep_data =
-      mam4::seq_drydep::set_gas_drydep_data();
-  const auto qv                = wet_atm_.qv;
-  const int month              = start_of_step_ts().get_month();  // 1-based
-  const int surface_lev        = nlev - 1;                 // Surface level
-  const auto &index_season_lai = index_season_lai_;
-  const int pcnst              = mam4::pcnst;
-  const bool extra_mam4_aero_microphys_diags  = extra_mam4_aero_microphys_diags_;
-  //NOTE: we need to initialize photo_rates_
-  Kokkos::deep_copy(photo_rates_,0.0);
-  // loop over atmosphere columns and compute aerosol microphysics
-#endif
-
-  // loop over atmosphere columns and compute aerosol microphysics
-#if defined(MICRO_SMALL_KERNELS)
-    run_small_kernels_microphysics(dt, eccf);
-#else
-   // NOTE: we only have one field
-  // exo absorber columns [molecules/cm^2]
-  const auto o3_exo_col = exo_coldens_fields_[0].get_view<Real**>();
-  Kokkos::parallel_for(
-      "MAMMicrophysics::run_impl", policy,
-      KOKKOS_LAMBDA(const ThreadTeam &team) {
-        const int icol     = team.league_rank();   // column index
-        const Real col_lat = col_latitudes(icol);  // column latitude (degrees?)
-
-        // convert column latitude to radians
-        const Real rlats = col_lat * M_PI / 180.0;
-
-        const Real o3_col_deltas_0 = o3_exo_col(icol,0);
-        // fetch column-specific atmosphere state data
-        const auto atm = mam_coupling::atmosphere_for_column(dry_atm, icol);
-        const auto wet_diameter_icol =
-            ekat::subview(wet_geometric_mean_diameter_i, icol);
-        const auto dry_diameter_icol =
-            ekat::subview(dry_geometric_mean_diameter_i, icol);
-        const auto wetdens_icol = ekat::subview(wetdens, icol);
-
-        const auto zi   = ekat::subview(dry_atm.z_iface, icol);
-
-        // fetch column-specific subviews into aerosol prognostics
-        mam4::Prognostics progs =
-            mam_coupling::aerosols_for_column(dry_aero, icol);
-
-        const auto invariants_icol = ekat::subview(invariants, icol);
-        mam4::mo_setext::Forcing forcings_in[extcnt];
-
-        for(int i = 0; i < extcnt; ++i) {
-          const int nsectors       = forcings[i].nsectors;
-          const int frc_ndx        = forcings[i].frc_ndx;
-          const auto file_alt_data = forcings[i].file_alt_data;
-
-          forcings_in[i].nsectors = nsectors;
-          forcings_in[i].frc_ndx  = frc_ndx;
-          // We may need to move this line where we read files.
-          forcings_in[i].file_alt_data = file_alt_data;
-          for(int isec = 0; isec < forcings[i].nsectors; ++isec) {
-            const auto& field = forcings[i].fields[isec];
-            forcings_in[i].fields_data[isec] = ekat::subview(field, icol);
-          }
-        }  // extcnt for loop
-
-        const auto extfrc_icol = ekat::subview(extfrc, icol);
-
-        view_1d cnst_offline_icol[mam4::mo_setinv::num_tracer_cnst];
-        for (size_t i = 0; i < num_oxidants; i++)
-        {
-          cnst_offline_icol[i] = ekat::subview(oxidants[i], icol);
-        }
-
-        // calculate o3 column densities (first component of col_dens in Fortran
-        // code)
-        auto o3_col_dens_i = ekat::subview(o3_col_dens, icol);
-        const auto &work_photo_table_icol =
-            ekat::subview(work_photo_table, icol);
-
-        const auto &photo_rates_icol = ekat::subview(photo_rates, icol);
-
-        mam4::microphysics::LinozData linoz_data;
-        if (config.linoz.compute) {
-          linoz_data.linoz_o3_clim_icol = ekat::subview(linoz_o3_clim, icol);
-          linoz_data.linoz_t_clim_icol  = ekat::subview(linoz_t_clim, icol);
-          linoz_data.linoz_o3col_clim_icol =
-            ekat::subview(linoz_o3col_clim, icol);
-          linoz_data.linoz_PmL_clim_icol = ekat::subview(linoz_PmL_clim, icol);
-          linoz_data.linoz_dPmL_dO3_icol = ekat::subview(linoz_dPmL_dO3, icol);
-          linoz_data.linoz_dPmL_dT_icol  = ekat::subview(linoz_dPmL_dT, icol);
-          linoz_data.linoz_dPmL_dO3col_icol =
-            ekat::subview(linoz_dPmL_dO3col, icol);
-          linoz_data.linoz_cariolle_pscs_icol =
-            ekat::subview(linoz_cariolle_pscs, icol);
-        }
-        const auto nevapr_icol       = ekat::subview(nevapr, icol);
-        const auto prain_icol        = ekat::subview(prain, icol);
-        const auto work_set_het_icol = ekat::subview(work_set_het, icol);
-        view_1d diag_arrays_gas_dry_deposition_flux;
-        mam4::MicrophysDiagnosticArrays diag_arrays;
-        if (extra_mam4_aero_microphys_diags) {
-          diag_arrays.dqdt_so4_aqueous_chemistry = ekat::subview(dqdt_so4_aqueous_chemistry, icol);
-          diag_arrays.dqdt_h2so4_uptake          = ekat::subview(dqdt_h2so4_uptake, icol);
-          diag_arrays.gas_phase_chemistry_dvmrdt = ekat::subview(gas_phase_chemistry_dvmrdt, icol);
-
-          diag_arrays.aqueous_chemistry_dvmrdt   = ekat::subview(aqueous_chemistry_dvmrdt, icol);
-          diag_arrays.aqso4_incloud_mmr_tendency = ekat::subview(aqso4_incloud_mmr_tendency, icol);
-          diag_arrays.aqh2so4_incloud_mmr_tendency = ekat::subview(aqh2so4_incloud_mmr_tendency, icol);
-
-          diag_arrays.gas_aero_exchange_condensation = ekat::subview(gas_aero_exchange_condensation, icol);
-          diag_arrays.gas_aero_exchange_renaming = ekat::subview(gas_aero_exchange_renaming, icol);
-          diag_arrays.gas_aero_exchange_nucleation = ekat::subview(gas_aero_exchange_nucleation, icol);
-          diag_arrays.gas_aero_exchange_coagulation = ekat::subview(gas_aero_exchange_coagulation, icol);
-          diag_arrays.gas_aero_exchange_renaming_cloud_borne = ekat::subview(gas_aero_exchange_renaming_cloud_borne, icol);
-          diag_arrays_gas_dry_deposition_flux = ekat::subview(gas_dry_deposition_flux, icol);
-        }
-        // Wind speed at the surface
-        const Real wind_speed =
-            haero::sqrt(u_wind(icol, surface_lev) * u_wind(icol, surface_lev) +
-                        v_wind(icol, surface_lev) * v_wind(icol, surface_lev));
-
-        // Total rain at the surface
-        const Real rain =
-            precip_liq_surf_mass(icol) + precip_ice_surf_mass(icol);
-
-        // Snow depth on land [m]
-        const Real snow_height = snow_depth_land(icol);
-
-        // Downwelling solar flux at the surface (value at interface) [w/m2]
-        const Real solar_flux = sw_flux_dn(icol, surface_lev + 1);
-
-        Real fraction_landuse_icol[mam4::mo_drydep::n_land_type];
-        for(int i = 0; i < mam4::mo_drydep::n_land_type; ++i) {
-          fraction_landuse_icol[i] = fraction_landuse(icol, i);
-        }
-        int index_season[mam4::mo_drydep::n_land_type];
-        {
-          //-------------------------------------------------------------------------------------
-          // define which season (relative to Northern hemisphere climate)
-          //-------------------------------------------------------------------------------------
-
-          //-------------------------------------------------------------------------------------
-          // define season index based on fixed LAI
-          //-------------------------------------------------------------------------------------
-          for(int lt = 0; lt < mam4::mo_drydep::n_land_type; ++lt) {
-            index_season[lt] = index_season_lai(icol, month - 1);
-          }
-
-          //-------------------------------------------------------------------------------------
-          // special case for snow covered terrain
-          //-------------------------------------------------------------------------------------
-          if(snow_height > 0.01) {  // BAD_CONSTANT
-            for(int lt = 0; lt < mam4::mo_drydep::n_land_type; ++lt) {
-              index_season[lt] = 3;
-            }
-          }
-        }
-        // These output values need to be put somewhere:
-        Real dflx_col[num_gas_aerosol_constituents] = {};  // deposition flux [1/cm^2/s]
-        Real dvel_col[num_gas_aerosol_constituents] = {};  // deposition velocity [1/cm/s]
-        // Output: values are dvel, dflx
-        // Input/Output: progs::stateq, progs::qqcw
-        team.team_barrier();
-        const unsigned n_so4_monolayers_pcage = config.n_so4_monolayers_pcage;
-        mam4::microphysics::perform_atmospheric_chemistry_and_microphysics(
-            team, dt, rlats, n_so4_monolayers_pcage,
-            sfc_temperature(icol), sfc_pressure(icol),
-            wind_speed, rain, solar_flux, cnst_offline_icol, forcings_in, atm,
-            photo_table,  config.setsox, config.amicphys,
-             zenith_angle(icol), d_sfc_alb_dir_vis(icol),
-            o3_col_dens_i, photo_rates_icol, extfrc_icol, invariants_icol,
-            work_photo_table_icol,
-            config.linoz, linoz_data,
-             eccf, adv_mass_kg_per_moles,
-            fraction_landuse_icol, index_season, clsmap_4, permute_4,
-            offset_aerosol,
-            dry_diameter_icol, wet_diameter_icol,
-            wetdens_icol, dry_atm.phis(icol), cmfdqr, prain_icol, nevapr_icol, o3_col_deltas_0,
-            zi,
-            work_set_het_icol, drydep_data, diag_arrays, dvel_col, dflx_col, progs);
-
-        team.team_barrier();
-        // Update constituent fluxes with gas drydep fluxes (dflx)
-        // FIXME: Possible units mismatch (dflx is in kg/cm2/s but
-        // constituent_fluxes is kg/m2/s) (Following mimics Fortran code
-        // behavior but we should look into it)
-        Kokkos::parallel_for(Kokkos::TeamVectorRange(team, offset_aerosol, pcnst), [&](int ispc) {
-          constituent_fluxes(icol, ispc) -= dflx_col[ispc - offset_aerosol];
-        });
-        if (diag_arrays_gas_dry_deposition_flux.size()) {
-          Kokkos::parallel_for(Kokkos::TeamVectorRange(team, num_gas_aerosol_constituents), [&](int ispc) {
-            diag_arrays_gas_dry_deposition_flux[ispc] = dflx_col[ispc];
-          });
-        }
-      });  // parallel_for for the column loop
-  Kokkos::fence();
- #endif
+  run_small_kernels_microphysics(dt, eccf);
 
   auto extfrc_fm = get_field_out("mam4_external_forcing").get_view<Real***>();
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -47,8 +47,8 @@ MAMMicrophysics::MAMMicrophysics(const ekat::Comm &comm, const ekat::ParameterLi
 
   config_.compute_gas_phase_chemistry =
     m_params.get<bool>("mam4_do_gas_phase_chemistry", true);
-  config_.compute_setsox =
-    m_params.get<bool>("mam4_do_setsox", true);
+  config_.compute_aqueous_phase_chemistry =
+    m_params.get<bool>("mam4_do_aqueous_phase_chemistry", true);
 
   // LINOZ namelist parameters
   // Compute LINOZ only for prognostic Ozone (i.e. !use_prescribed_ozone_)

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -783,6 +783,7 @@ void MAMMicrophysics::run_impl(const double dt) {
   const Real chlorine_loading = scream::mam_coupling::chlorine_loading_advance(
       ts, chlorine_values_, chlorine_time_secs_);
     config_.linoz.chlorine_loading=chlorine_loading;
+    data_interp_linoz_->run(end_of_step_ts());
   }
 
   for (size_t i = 0; i < elevated_emis_var_names_.size(); ++i) {

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -406,8 +406,8 @@ void MAMMicrophysics::init_temporary_views() {
   work_ptr += ncol_ * nlev_ * mam4::mo_photo::phtcnt;
   invariants_ = view_3d(work_ptr, ncol_, nlev_, mam4::gas_chemistry::nfs);
   work_ptr += ncol_ * nlev_ * mam4::gas_chemistry::nfs;
-  extfrc_ = view_3d(work_ptr, ncol_, extcnt, nlev_);
-  work_ptr += ncol_ * extcnt * nlev_;
+  extfrc_ = view_3d(work_ptr, ncol_, nlev_, extcnt);
+  work_ptr += ncol_ * nlev_ * extcnt;
   state_q_=view_3d(work_ptr, ncol_, nlev_, pcnst );
   work_ptr += ncol_ * nlev_*pcnst;
   qqcw_pcnst_=view_3d(work_ptr, ncol_, nlev_,pcnst );
@@ -869,13 +869,13 @@ void MAMMicrophysics::run_impl(const double dt) {
   }
 
   Kokkos::parallel_for("copy_extfrc",
-    Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0,0,0}, {ncol, extcnt, nlev}),
-    KOKKOS_LAMBDA(const int i, const int j, const int k) {
+     Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0,0,0}, {ncol, extcnt, nlev}),
+     KOKKOS_LAMBDA(const int i, const int j, const int k) {
       const int pcnst_idx = extfrc_pcnst_index[j];
       const Real molar_mass_g_per_mol = molar_mass_g_per_mol_tmp[pcnst_idx]; // g/mol
       // Modify units to MKS units: [molec/cm3/s] to [kg/m3/s]
       // Convert g → kg (× 1e-3), cm³ → m³ (× 1e6) → total factor: 1e-3 × 1e6 = 1e3 = 1000.0
-      extfrc_fm(i,j,k) = extfrc(i,j,k) * (molar_mass_g_per_mol / Avogadro) * 1000.0;
+      extfrc_fm(i,j,k) = extfrc(i,k,j) * (molar_mass_g_per_mol / Avogadro) * 1000.0;
   });
 
   // postprocess output

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -11,6 +11,8 @@
 
 #include <ekat_team_policy_utils.hpp>
 
+#define MICRO_SMALL_KERNELS
+#include <physics/mam/eamxx_mam_microphysics_process_functions.cpp>
 namespace scream
 {
 
@@ -356,6 +358,9 @@ int MAMMicrophysics::get_len_temporary_views() {
   const int photo_table_len = get_photo_table_work_len(photo_table_);
   const int sethet_work_len = mam4::mo_sethet::get_total_work_len_sethet();
   constexpr int extcnt      = mam4::gas_chemistry::extcnt;
+  constexpr int pcnst              = mam4::pcnst;
+  constexpr int gas_pcnst = mam_coupling::gas_pcnst();
+  constexpr int nmodes = mam4::AeroConfig::num_modes();
   int work_len              = 0;
   // work_photo_table_
   work_len += ncol_ * photo_table_len;
@@ -367,12 +372,27 @@ int MAMMicrophysics::get_len_temporary_views() {
   work_len += ncol_ * nlev_ * mam4::gas_chemistry::nfs;
   // extfrc_
   work_len += ncol_ * nlev_ * extcnt;
+  //state_q_, qqcw_pcnst_
+  work_len += 2*ncol_ * nlev_*pcnst;
+  //qq_, qqcw_, vmr_,vmr0_, vmrcw_
+  work_len += 5 * ncol_ * nlev_*gas_pcnst;
+  // het_rates_
+  work_len += ncol_ * nlev_*gas_pcnst;
+  //   vmr_pregas_ vmr_precld_
+  work_len += 2* ncol_ * nlev_*gas_pcnst;
+  // dqdt_aqso4_, dqdt_aqh2so4_
+  work_len += 2*ncol_ *nlev_*gas_pcnst;
+  // dgncur_awet_, dgncur_a_, wetdens_;
+  work_len += 3*ncol_ *nlev_*nmodes;
   return work_len;
 }
 void MAMMicrophysics::init_temporary_views() {
   const int photo_table_len = get_photo_table_work_len(photo_table_);
   const int sethet_work_len = mam4::mo_sethet::get_total_work_len_sethet();
   constexpr int extcnt      = mam4::gas_chemistry::extcnt;
+  constexpr int pcnst              = mam4::pcnst;
+  constexpr int gas_pcnst = mam_coupling::gas_pcnst();
+  constexpr int nmodes = mam4::AeroConfig::num_modes();
   auto work_ptr             = (Real *)buffer_.temporary_views.data();
 
   work_photo_table_ = view_2d(work_ptr, ncol_, photo_table_len);
@@ -386,6 +406,39 @@ void MAMMicrophysics::init_temporary_views() {
   work_ptr += ncol_ * nlev_ * mam4::gas_chemistry::nfs;
   extfrc_ = view_3d(work_ptr, ncol_, nlev_, extcnt);
   work_ptr += ncol_ * nlev_ * extcnt;
+  state_q_=view_3d(work_ptr, ncol_, nlev_, pcnst );
+  work_ptr += ncol_ * nlev_*pcnst;
+  qqcw_pcnst_=view_3d(work_ptr, ncol_, nlev_,pcnst );
+  work_ptr += ncol_ * nlev_*pcnst;
+  qq_=view_3d(work_ptr, ncol_, nlev_,gas_pcnst );
+  work_ptr += ncol_ * nlev_*gas_pcnst;
+  qqcw_=view_3d(work_ptr, ncol_, nlev_,gas_pcnst );
+  work_ptr += ncol_ * nlev_*gas_pcnst;
+  vmr_=view_3d(work_ptr, ncol_, nlev_,gas_pcnst );
+  work_ptr += ncol_ * nlev_*gas_pcnst;
+  vmr0_=view_3d(work_ptr, ncol_, nlev_,gas_pcnst );
+  work_ptr += ncol_ * nlev_*gas_pcnst;
+  vmrcw_=view_3d(work_ptr, ncol_, nlev_,gas_pcnst );
+  work_ptr += ncol_ * nlev_*gas_pcnst;
+  het_rates_ = view_3d(work_ptr, ncol_, nlev_, gas_pcnst );
+  work_ptr += ncol_ *nlev_*gas_pcnst;
+
+  vmr_pregas_ = view_3d(work_ptr, ncol_, nlev_,gas_pcnst );
+  work_ptr += ncol_ *nlev_*gas_pcnst;
+  vmr_precld_ =view_3d(work_ptr, ncol_, nlev_,gas_pcnst );
+  work_ptr += ncol_ *nlev_*gas_pcnst;
+
+  dqdt_aqso4_=view_3d(work_ptr, ncol_, nlev_,gas_pcnst );
+  work_ptr += ncol_ *nlev_*gas_pcnst;
+  dqdt_aqh2so4_=view_3d(work_ptr, ncol_, nlev_,gas_pcnst );
+  work_ptr += ncol_ *nlev_*gas_pcnst;
+
+  dgncur_awet_ = view_3d(work_ptr, ncol_, nlev_,nmodes );
+  work_ptr += ncol_ *nlev_*nmodes;
+  dgncur_a_ = view_3d(work_ptr, ncol_, nlev_,nmodes );
+  work_ptr += ncol_ *nlev_*nmodes;
+  wetdens_ = view_3d(work_ptr, ncol_, nlev_,nmodes );
+  work_ptr += ncol_ *nlev_*nmodes;
 
   // Error check
   // NOTE: workspace_provided can be larger than workspace_used, but let's try
@@ -737,6 +790,7 @@ void MAMMicrophysics::run_impl(const double dt) {
 
   //----------- Variables from microphysics scheme -------------
 
+#ifndef MICRO_SMALL_KERNELS
   // Evaporation from stratiform rain [kg/kg/s]
   const auto &nevapr = get_field_in("nevapr").get_view<const Real **>();
 
@@ -812,6 +866,7 @@ void MAMMicrophysics::run_impl(const double dt) {
     gas_aero_exchange_renaming_cloud_borne = get_field_out("mam4_microphysics_tendency_renaming_cloud_borne").get_view<Real***>();
     gas_dry_deposition_flux = get_field_out("mam4_gas_dry_deposition_flux").get_view<Real**>();
   }
+#endif
 
   // climatology data for linear stratospheric chemistry
   // ozone (climatology) [vmr]
@@ -848,6 +903,7 @@ void MAMMicrophysics::run_impl(const double dt) {
     linoz_dPmL_dO3col = linoz_views[6];
     linoz_cariolle_pscs = linoz_views[7];
   }
+#ifndef MICRO_SMALL_KERNELS  
   constexpr int num_oxidants=4;
   view_2d oxidants[num_oxidants];
   for (size_t i = 0; i < var_names_oxi_.size(); ++i) {
@@ -874,6 +930,7 @@ void MAMMicrophysics::run_impl(const double dt) {
   for (size_t i = 0; i < elevated_emis_var_names_.size(); ++i) {
     data_interp_elevated_emissions_[i]->run(end_of_step_ts());
   }
+#ifndef MICRO_SMALL_KERNELS
   const_view_1d &col_latitudes     = col_latitudes_;
   const_view_1d &d_sfc_alb_dir_vis = d_sfc_alb_dir_vis_;
 
@@ -885,6 +942,7 @@ void MAMMicrophysics::run_impl(const double dt) {
   const auto &work_photo_table                = work_photo_table_;
   const auto &photo_rates                     = photo_rates_;
   const auto &invariants   = invariants_;
+#endif
   // Compute orbital parameters; these are used both for computing
   // the solar zenith angle.
   // Note: We are following the RRTMGP EAMxx interface to compute the zenith
@@ -941,9 +999,10 @@ void MAMMicrophysics::run_impl(const double dt) {
   constexpr int num_gas_aerosol_constituents = mam_coupling::gas_pcnst();
 
   const auto &extfrc   = extfrc_;
-  const auto &forcings = forcings_;
   constexpr int extcnt = mam4::gas_chemistry::extcnt;
 
+#ifndef MICRO_SMALL_KERNELS
+  const auto &forcings = forcings_;
   const int offset_aerosol = mam4::utils::gasses_start_ind();
   Real adv_mass_kg_per_moles[num_gas_aerosol_constituents];
   // NOTE: Making copies of clsmap_4 and permute_4 to fix undefined arrays on
@@ -970,6 +1029,12 @@ void MAMMicrophysics::run_impl(const double dt) {
   //NOTE: we need to initialize photo_rates_
   Kokkos::deep_copy(photo_rates_,0.0);
   // loop over atmosphere columns and compute aerosol microphysics
+#endif
+
+  // loop over atmosphere columns and compute aerosol microphysics
+#if defined(MICRO_SMALL_KERNELS)
+    run_small_kernels_microphysics(dt, eccf);
+#else
   Kokkos::parallel_for(
       "MAMMicrophysics::run_impl", policy,
       KOKKOS_LAMBDA(const ThreadTeam &team) {
@@ -1143,6 +1208,7 @@ void MAMMicrophysics::run_impl(const double dt) {
         }
       });  // parallel_for for the column loop
   Kokkos::fence();
+ #endif
 
   auto extfrc_fm = get_field_out("mam4_external_forcing").get_view<Real***>();
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -867,7 +867,9 @@ void MAMMicrophysics::run_impl(const double dt) {
     gas_dry_deposition_flux = get_field_out("mam4_gas_dry_deposition_flux").get_view<Real**>();
   }
 #endif
-
+  
+  data_interp_oxid_->run(end_of_step_ts());
+#ifndef MICRO_SMALL_KERNELS
   // climatology data for linear stratospheric chemistry
   // ozone (climatology) [vmr]
   view_2d linoz_o3_clim;
@@ -887,7 +889,7 @@ void MAMMicrophysics::run_impl(const double dt) {
   view_2d linoz_cariolle_pscs;
   view_2d linoz_views[8];
 
-  data_interp_oxid_->run(end_of_step_ts());
+  
 
   if (config_.linoz.compute) {
     data_interp_linoz_->run(end_of_step_ts());
@@ -905,7 +907,7 @@ void MAMMicrophysics::run_impl(const double dt) {
   
     
   }
-
+#endif
   data_interp_exo_coldens_->run(end_of_step_ts());  
   
 #ifndef MICRO_SMALL_KERNELS  

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -902,18 +902,20 @@ void MAMMicrophysics::run_impl(const double dt) {
     linoz_dPmL_dT = linoz_views[5];
     linoz_dPmL_dO3col = linoz_views[6];
     linoz_cariolle_pscs = linoz_views[7];
+  
+    
   }
+
+  data_interp_exo_coldens_->run(end_of_step_ts());  
+  
 #ifndef MICRO_SMALL_KERNELS  
   constexpr int num_oxidants=4;
   view_2d oxidants[num_oxidants];
   for (size_t i = 0; i < var_names_oxi_.size(); ++i) {
     oxidants[i] = get_field_out("oxid_"+var_names_oxi_[i]).get_view<Real **>();
   }
-
-  data_interp_exo_coldens_->run(end_of_step_ts());
-  // NOTE: we only have one field
-  // exo absorber columns [molecules/cm^2]
-  const auto o3_exo_col = exo_coldens_fields_[0].get_view<Real**>();
+#endif
+  
   // it's a bit wasteful to store this for all columns, but simpler from an
   // allocation perspective
   auto o3_col_dens = buffer_.scratch[8];
@@ -1035,6 +1037,9 @@ void MAMMicrophysics::run_impl(const double dt) {
 #if defined(MICRO_SMALL_KERNELS)
     run_small_kernels_microphysics(dt, eccf);
 #else
+   // NOTE: we only have one field
+  // exo absorber columns [molecules/cm^2]
+  const auto o3_exo_col = exo_coldens_fields_[0].get_view<Real**>();
   Kokkos::parallel_for(
       "MAMMicrophysics::run_impl", policy,
       KOKKOS_LAMBDA(const ThreadTeam &team) {

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -916,11 +916,12 @@ void MAMMicrophysics::run_impl(const double dt) {
   for (size_t i = 0; i < var_names_oxi_.size(); ++i) {
     oxidants[i] = get_field_out("oxid_"+var_names_oxi_[i]).get_view<Real **>();
   }
-#endif
-  
   // it's a bit wasteful to store this for all columns, but simpler from an
   // allocation perspective
   auto o3_col_dens = buffer_.scratch[8];
+#endif
+  
+
 
   /* Gather time and state information for interpolation */
   const auto ts = end_of_step_ts();

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -401,8 +401,8 @@ void MAMMicrophysics::init_temporary_views() {
   work_ptr += ncol_ * nlev_ * mam4::mo_photo::phtcnt;
   invariants_ = view_3d(work_ptr, ncol_, nlev_, mam4::gas_chemistry::nfs);
   work_ptr += ncol_ * nlev_ * mam4::gas_chemistry::nfs;
-  extfrc_ = view_3d(work_ptr, ncol_, nlev_, extcnt);
-  work_ptr += ncol_ * nlev_ * extcnt;
+  extfrc_ = view_3d(work_ptr, ncol_, extcnt, nlev_);
+  work_ptr += ncol_ * extcnt * nlev_;
   state_q_=view_3d(work_ptr, ncol_, nlev_, pcnst );
   work_ptr += ncol_ * nlev_*pcnst;
   qqcw_pcnst_=view_3d(work_ptr, ncol_, nlev_,pcnst );
@@ -863,17 +863,17 @@ void MAMMicrophysics::run_impl(const double dt) {
     molar_mass_g_per_mol_tmp[i] = mam4::gas_chemistry::adv_mass[i];  // host-only access
   }
 
-  // Transpose extfrc_ from internal layout [ncol][nlev][extcnt]
-  // to output layout [ncol][extcnt][nlev]
+  // Copy extfrc_ from internal layout [ncol][extcnt][nlev]
+  // to output layout [ncol][extcnt][nlev] — layouts match, no transpose needed.
   // This aligns with expected field storage in the EAMxx infrastructure.
-  Kokkos::parallel_for("transpose_extfrc",
+  Kokkos::parallel_for("copy_extfrc",
     Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0,0,0}, {ncol, extcnt, nlev}),
     KOKKOS_LAMBDA(const int i, const int j, const int k) {
       const int pcnst_idx = extfrc_pcnst_index[j];
       const Real molar_mass_g_per_mol = molar_mass_g_per_mol_tmp[pcnst_idx]; // g/mol
       // Modify units to MKS units: [molec/cm3/s] to [kg/m3/s]
       // Convert g → kg (× 1e-3), cm³ → m³ (× 1e6) → total factor: 1e-3 × 1e6 = 1e3 = 1000.0
-      extfrc_fm(i,j,k) = extfrc(i,k,j) * (molar_mass_g_per_mol / Avogadro) * 1000.0;
+      extfrc_fm(i,j,k) = extfrc(i,j,k) * (molar_mass_g_per_mol / Avogadro) * 1000.0;
   });
 
   // postprocess output

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -47,6 +47,8 @@ MAMMicrophysics::MAMMicrophysics(const ekat::Comm &comm, const ekat::ParameterLi
 
   config_.compute_gas_phase_chemistry =
     m_params.get<bool>("mam4_do_gas_phase_chemistry", true);
+  config_.compute_setsox =
+    m_params.get<bool>("mam4_do_setsox", true);
 
   // LINOZ namelist parameters
   // Compute LINOZ only for prognostic Ozone (i.e. !use_prescribed_ozone_)

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -10,7 +10,6 @@
 #include "share/algorithm/eamxx_data_interpolation.hpp"
 
 #include <ekat_team_policy_utils.hpp>
-#include <physics/mam/eamxx_mam_microphysics_process_functions.cpp>
 namespace scream
 {
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -868,9 +868,6 @@ void MAMMicrophysics::run_impl(const double dt) {
     molar_mass_g_per_mol_tmp[i] = mam4::gas_chemistry::adv_mass[i];  // host-only access
   }
 
-  // Copy extfrc_ from internal layout [ncol][extcnt][nlev]
-  // to output layout [ncol][extcnt][nlev] — layouts match, no transpose needed.
-  // This aligns with expected field storage in the EAMxx infrastructure.
   Kokkos::parallel_for("copy_extfrc",
     Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0,0,0}, {ncol, extcnt, nlev}),
     KOKKOS_LAMBDA(const int i, const int j, const int k) {

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.hpp
@@ -59,7 +59,7 @@ class MAMMicrophysics final : public MAMGenericInterface {
   void finalize_impl(){/*Do nothing*/};
 
  private:
-  void run_small_kernels_microphysics(const double dt, const double eccf);
+  void run_microphysics_kernels(const double dt, const double eccf);
   // Output extra mam4xx diagnostics.
   bool extra_mam4_aero_microphys_diags_ = false;
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.hpp
@@ -59,6 +59,7 @@ class MAMMicrophysics final : public MAMGenericInterface {
   void finalize_impl(){/*Do nothing*/};
 
  private:
+  void run_small_kernels_microphysics(const double dt, const double eccf);
   // Output extra mam4xx diagnostics.
   bool extra_mam4_aero_microphys_diags_ = false;
 
@@ -158,6 +159,13 @@ class MAMMicrophysics final : public MAMGenericInterface {
   int get_len_temporary_views();
   void init_temporary_views();
   int len_temporary_views_{0};
+
+  view_3d state_q_, qqcw_pcnst_, qq_, qqcw_, vmr_,vmr0_, vmrcw_;
+  view_3d het_rates_, vmr_pregas_, vmr_precld_;
+
+  view_3d dqdt_aqso4_,dqdt_aqh2so4_;
+
+  view_3d dgncur_awet_, dgncur_a_, wetdens_;
 
   void add_io_docstring_to_fields_with_mixed_units(const std::map<std::string, std::string> &flds) {
     using str_atts_t = std::map<std::string,std::string>;

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.hpp
@@ -85,8 +85,8 @@ class MAMMicrophysics final : public MAMGenericInterface {
     // turn on/off gas phase chemistry (namelist: mam4_do_gas_phase_chemistry)
     bool compute_gas_phase_chemistry = true;
 
-    // turn on/off aqueous chemistry / setsox (namelist: mam4_do_setsox)
-    bool compute_setsox = true;
+    // turn on/off aqueous chemistry / setsox (namelist: mam4_do_aqueous_phase_chemistry)
+    bool compute_aqueous_phase_chemistry = true;
 
     // stratospheric chemistry parameters
     mam4::microphysics::LinozConf linoz;

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.hpp
@@ -82,6 +82,9 @@ class MAMMicrophysics final : public MAMGenericInterface {
     // From input parameter mam4_number_so4_monolayers_to_age_carbon_particle
     unsigned n_so4_monolayers_pcage = 8;
 
+    // turn on/off gas phase chemistry (namelist: mam4_do_gas_phase_chemistry)
+    bool compute_gas_phase_chemistry = true;
+
     // stratospheric chemistry parameters
     mam4::microphysics::LinozConf linoz;
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.hpp
@@ -85,6 +85,9 @@ class MAMMicrophysics final : public MAMGenericInterface {
     // turn on/off gas phase chemistry (namelist: mam4_do_gas_phase_chemistry)
     bool compute_gas_phase_chemistry = true;
 
+    // turn on/off aqueous chemistry / setsox (namelist: mam4_do_setsox)
+    bool compute_setsox = true;
+
     // stratospheric chemistry parameters
     mam4::microphysics::LinozConf linoz;
 


### PR DESCRIPTION
This PR refactors the microphysics interface by decomposing the previous single kernel into multiple smaller kernels. Each kernel corresponds to an internal aerosol microphysics process (e.g., gas chemistry, Linoz, aqueous chemistry, photolysis, dry deposition, and modal aerosol microphysics).


## Motivation 
•	The original large microphysics kernel was difficult to manage and debug.
•	Kernel-size/complexity issues required setting the Kokkos team size in the execution policy to 1.
•	Finer-grained kernels improve debuggability and make it easier to identify and implement performance improvements.
## Performance
•	ne30, 4 GPUs: MAM4xx process time decreased from 16.9 to 12.3 (~4% improvement relative to total runtime).
•	MAM4xx overall share decreased from 65.9% to 63.9%.

<img width="591" height="641" alt="Compare Model Performance" src="https://github.com/user-attachments/assets/03c7a0ea-8513-43e7-a94e-d2e4b12f53f4" />

<img width="582" height="234" alt="Compare Model Performance copy" src="https://github.com/user-attachments/assets/a3005947-c154-4c5b-b68d-0e8b5b691c16" />

[BFB]