### PR TITLE
EAMxx: fix linoz input files to point to new ones

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -319,8 +319,8 @@ be lost if SCREAM_HACK_XML is not enabled.
       <mam4_o3_sfc    type="real"    doc="Linoz surface parameter">3.0E-008</mam4_o3_sfc>
       <mam4_o3_lbl    type="integer" doc="Linoz lbl parameter">4</mam4_o3_lbl>
       <mam4_psc_T    type="real" doc="Linoz psc ozone loss temperature (K) threshold">193.0</mam4_psc_T>
-      <mam4_linoz_file_name type="file" doc="LINOZ chemistry file"> ${DIN_LOC_ROOT}/atm/scream/mam4xx/linoz/ne30pg2/linoz2010_2010JPL_CMIP6_10deg_58km_ne30pg2_c20250826.nc</mam4_linoz_file_name>
-      <mam4_linoz_file_name hgrid="ne4np4.pg2" type="file" doc="LINOZ chemistry file"> ${DIN_LOC_ROOT}/atm/scream/mam4xx/linoz/ne4pg2/linoz2010_2010JPL_CMIP6_10deg_58km_ne4pg2_c20250826.nc</mam4_linoz_file_name>
+      <mam4_linoz_file_name type="file" doc="LINOZ chemistry file"> ${DIN_LOC_ROOT}/atm/scream/mam4xx/linoz/ne30pg2/linoz2010_2010JPL_CMIP6_10deg_58km_ne30pg2_c20260303.nc</mam4_linoz_file_name>
+      <mam4_linoz_file_name hgrid="ne4np4.pg2" type="file" doc="LINOZ chemistry file"> ${DIN_LOC_ROOT}/atm/scream/mam4xx/linoz/ne4pg2/linoz2010_2010JPL_CMIP6_10deg_58km_ne4pg2_c20260303.nc</mam4_linoz_file_name>
       <!--Invariants-->
       <mam4_oxid_file_name  type="file" doc="File containing oxidants data">${DIN_LOC_ROOT}/atm/scream/mam4xx/invariants/ne30pg2/oxid_1.9x2.5_L26_2015_ne30pg2_c20250813.nc</mam4_oxid_file_name>
       <mam4_oxid_file_name  hgrid="ne4np4.pg2" type="file" doc="File containing oxidants data">${DIN_LOC_ROOT}/atm/scream/mam4xx/invariants/ne4pg2/oxid_1.9x2.5_L26_2015_ne4pg2_c20250813.nc</mam4_oxid_file_name>


### PR DESCRIPTION
Use new files with CF-compliant time units.

[BFB]

---

@odiazib I only found 3 files, but I didn't go through ALL the files used by mam4xx, as I don't run all tests on my machine. If you have other files that need the fix, let me know.

The units of the new files are
```
(bartgol) ac.lbertag@chrlogin1:[linoz]$ find . -name '*20260303.nc' | while IFS= read -r file; do     ncdump -h "$file" | grep "time:units" | awk -v fname="$file" '{printf "%-100s: %s\n", fname, $0}'; done
./ne2np4/linoz1850-2015_2010JPL_CMIP6_10deg_58km_ne2np4_c20260303.nc                                : 		time:units = "days since 2010-01-01 00:00" ;
./ne4pg2/linoz2010_2010JPL_CMIP6_10deg_58km_ne4pg2_c20260303.nc                                     : 		time:units = "days since 2010-01-01 00:00" ;
./ne30pg2/linoz2010_2010JPL_CMIP6_10deg_58km_ne30pg2_c20260303.nc                                   : 		time:units = "days since 2010-01-01 00:00" ;
```