### PR TITLE
EAMxx: fix core tests CMakeLists

### DIFF
--- a/components/eamxx/src/share/core/tests/CMakeLists.txt
+++ b/components/eamxx/src/share/core/tests/CMakeLists.txt
@@ -32,10 +32,10 @@ if (NOT SCREAM_ONLY_GENERATE_BASELINES)
 
   # Ensure that FPE *do* throw when we expect them to
   if (SCREAM_FPE)
-    CreateUnitTestExec (fpe_check "fpe_check.cpp"
+    CreateUnitTest (fpe_check "fpe_check.cpp"
       WILL_FAIL LABELS "check")
   else()
-    CreateUnitTestExec (fpe_check "fpe_check.cpp"
+    CreateUnitTest (fpe_check "fpe_check.cpp"
       LABELS "check")
   endif()
 endif()


### PR DESCRIPTION
Use the right macro, avoiding a cmake warning, and ensuring the tests get the desired label.

[BFB]

---

I found this while working on #8163, but decided to keep it separate, since they are different bug fixes.