### PR TITLE
add CRYO2010-WW3 and WCYCL2010-WW3 compsets

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -1018,6 +1018,7 @@ _TESTS = {
             "PEM_P480.ne30pg2_IcoswISC30E3r5_wQU225Icos30E3r5.WCYCL1850-WW3",
             "PET.ne30pg2_IcoswISC30E3r5_wQU225Icos30E3r5.WCYCL1850-WW3",
             "SMS_D_Ln3.ne30pg2_IcoswISC30E3r5_wQU225Icos30E3r5.WCYCL1850-WW3",
+            "SMS_D_Ln3.ne30pg2_IcoswISC30E3r5_wQU225Icos30E3r5.WCYCL2010-WW3",
             )
     },
 

--- a/components/ww3/cime_config/config_compsets.xml
+++ b/components/ww3/cime_config/config_compsets.xml
@@ -58,4 +58,9 @@
     <alias>CRYO2010-WW3</alias>
     <lname>2010SOI_EAM%CMIP6_ELM%CNPRDCTCBCTOP_MPASSI%DIB_MPASO%IBPISMF_MOSART_SGLC_WW3%sp36x36</lname>
   </compset>
+  
+  <compset>
+    <alias>WCYCL2010-WW3</alias>
+    <lname>2010SOI_EAM%CMIP6_ELM%CNPRDCTCBCTOP_MPASSI_MPASO_MOSART_SGLC_WW3%sp36x36</lname>
+  </compset>
 </compsets>

--- a/components/ww3/cime_config/config_compsets.xml
+++ b/components/ww3/cime_config/config_compsets.xml
@@ -54,4 +54,8 @@
     <lname>1850SOI_EAM%CMIP6_ELM%CNPRDCTCBCTOP_MPASSI_MPASO_MOSART_SGLC_WW3%sp36x36</lname>
   </compset>
 
+  <compset>
+    <alias>CRYO2010-WW3</alias>
+    <lname>2010SOI_EAM%CMIP6_ELM%CNPRDCTCBCTOP_MPASSI%DIB_MPASO%IBPISMF_MOSART_SGLC_WW3%sp36x36</lname>
+  </compset>
 </compsets>


### PR DESCRIPTION
CRYO2010-WW3  and WCYCL2010-WW3 comspets added.
Adds compsets for Bcase+WW3 with repeat 2010 conditions intended for wave-enabled Polar configurations (BluePulse experiments)

The Cryo+ww3 compset configuration exactly matches the cryo2010 compset in https://github.com/E3SM-Project/E3SM/pull/8195, except it uses fully active WW3. 

The WCYCL2010 Compset matches the standard Low Res Waves configuration, except it uses repeat 2010 conditions. 

[BFB] This has no impact on existing compsets/configurations. 

Passes "SMS.ne30pg2_IcoswISC30E3r5_wQU225Icos30E3r5.CRYO2010-WW3" Test.
Passes SMS.ne30pg2_IcoswISC30E3r5_wQU225Icos30E3r5.WCYCL2010-WW3