### PR TITLE
Add v3.LR wcycl PEs on Crux

### DIFF
--- a/cime_config/allactive/config_pesall.xml
+++ b/cime_config/allactive/config_pesall.xml
@@ -1251,6 +1251,53 @@
         </rootpe>
       </pes>
     </mach>
+    <mach name="crux">
+      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+SGLC.+SWAV.+_SESP$" pesize="PS">
+        <comment> --compset WCYCL* --res ne30pg2_r05_IcoswISC30E3r5 on 15 nodes pure-MPI, ~7 sypd </comment>
+        <ntasks>
+          <ntasks_atm>-11</ntasks_atm>
+          <ntasks_lnd>-5</ntasks_lnd>
+          <ntasks_rof>-5</ntasks_rof>
+          <ntasks_ice>-6</ntasks_ice>
+          <ntasks_ocn>-4</ntasks_ocn>
+          <ntasks_cpl>-11</ntasks_cpl>
+        </ntasks>
+        <rootpe>
+          <rootpe_ice>-5</rootpe_ice>
+          <rootpe_ocn>-11</rootpe_ocn>
+        </rootpe>
+      </pes>
+      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+SGLC.+SWAV.+_SESP$" pesize="PM">
+        <comment> --compset WCYCL* --res ne30pg2_r05_IcoswISC30E3r5 on 30 nodes pure-MPI, ~13 sypd </comment>
+        <ntasks>
+          <ntasks_atm>-22</ntasks_atm>
+          <ntasks_lnd>-8</ntasks_lnd>
+          <ntasks_rof>-8</ntasks_rof>
+          <ntasks_ice>-14</ntasks_ice>
+          <ntasks_ocn>-8</ntasks_ocn>
+          <ntasks_cpl>-22</ntasks_cpl>
+        </ntasks>
+        <rootpe>
+          <rootpe_ice>-8</rootpe_ice>
+          <rootpe_ocn>-22</rootpe_ocn>
+        </rootpe>
+      </pes>
+      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+SGLC.+SWAV.+_SESP$" pesize="PL">
+        <comment> --compset WCYCL* --res ne30pg2_r05_IcoswISC30E3r5 on 58 nodes pure-MPI, ~20 sypd </comment>
+        <ntasks>
+          <ntasks_atm>-43</ntasks_atm>
+          <ntasks_lnd>-11</ntasks_lnd>
+          <ntasks_rof>-11</ntasks_rof>
+          <ntasks_ice>-32</ntasks_ice>
+          <ntasks_ocn>-15</ntasks_ocn>
+          <ntasks_cpl>-43</ntasks_cpl>
+        </ntasks>
+        <rootpe>
+          <rootpe_ice>-11</rootpe_ice>
+          <rootpe_ocn>-43</rootpe_ocn>
+        </rootpe>
+      </pes>
+    </mach>
     <mach name="pm-cpu|muller-cpu|alvarez-cpu">
       <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+SGLC.+SWAV.+" pesize="any">
         <comment> pm-cpu --compset WCYCL* --res ne30pg2_r05_IcoswISC30E3r5 on 8 nodes, stacked layout, 128x1 4-5 sypd</comment>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -3655,13 +3655,11 @@
       <cmd_path lang="sh">module</cmd_path> 
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-        <command name="reset"></command>
         <command name="use">/grand/E3SMinput/soft/modulefiles/crux</command>
         <command name="load">cmake/3.27.9</command>
-        <command name="load">cray-python/3.11.7</command>
         <command name="load">craype-accel-host</command>
-        <command name="load">PrgEnv-gnu/8.5.0</command>   
-        <command name="load">cray-libsci/24.03.0</command>
+        <command name="load">PrgEnv-gnu/8.6.0</command>   
+        <command name="load">cray-libsci/25.09.0</command>
         <command name="load">cray-hdf5-parallel/1.12.2.11</command>
         <command name="load">cray-netcdf-hdf5parallel/4.9.0.11</command>
         <command name="load">cray-parallel-netcdf/1.12.3.11</command>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -3674,6 +3674,8 @@
       <env name="PNETCDF_PATH">$ENV{CRAY_PARALLEL_NETCDF_PREFIX}</env>
       <env name="LD_LIBRARY_PATH">$ENV{CRAY_LD_LIBRARY_PATH}:$ENV{LD_LIBRARY_PATH}</env>
       <env name="FI_CXI_RX_MATCH_MODE">hybrid</env>
+      <env name="PALS_PING_PERIOD">240</env>
+      <env name="PALS_RPC_TIMEOUT">240</env>
     </environment_variables>
     <environment_variables BUILD_THREADED="TRUE">
       <env name="OMP_STACKSIZE">128M</env>  


### PR DESCRIPTION
Add v3.LR wcycl PEs on Crux
- add PS, PM, PL pe-layouts on 15, 30, 58 nodes at 7, 13, 20 sypd
- update modules to newer defaults

Fixes E3SM-Project/E3SM#8158

[BFB]

---
Testing
- S, M, L wcycl runs: https://my.cdash.org/builds/3436445/tests
- v3.HR runs on 50+ nodes at 0.45+ sypd: e.g.
```
> ./pelayout 
Comp  NTASKS  NTHRDS  ROOTPE PSTRIDE
CPL :   6400/     1;      0      1 
ATM :   6400/     1;      0      1 
LND :   1280/     1;      0      1 
ICE :   5120/     1;   1280      1 
OCN :   6400/     1;      0      1 
ROF :   1280/     1;      0      1 
```

