### PR TITLE
EAMxx: add linear time interpolation option for SPC and SPA to read files containing multiyears

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -489,6 +489,8 @@ be lost if SCREAM_HACK_XML is not enabled.
       <spa_data_file hgrid="ne.*np4.pg2">${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne30pg2_20240111.nc</spa_data_file>
       <spa_data_file hgrid="ne4np4">${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne4_20220428.nc</spa_data_file>
       <spa_data_file hgrid="ne4np4.pg2">${DIN_LOC_ROOT}/atm/scream/init/spa_file_unified_and_complete_ne4pg2_20231222.nc</spa_data_file>
+
+      <time_interpolation_method type="string" doc="Method for interpolating SPA data in time">yearly_periodic</time_interpolation_method>
     </spa>
 
     <!-- Simple Prescribed Chemistry (SPC) -->
@@ -505,6 +507,8 @@ be lost if SCREAM_HACK_XML is not enabled.
       <spc_data_file type="file" doc="File containing chemistry data. Must be on same grid as the atm, or a coarser one">none</spc_data_file>
       <spc_data_file hgrid="ne.*np4.pg2">${DIN_LOC_ROOT}/atm/scream/init/spc_from_v3LRamip_2010_clim_ne30pg2_c20260206.nc</spc_data_file>
       <spc_data_file hgrid="ne4np4.pg2">${DIN_LOC_ROOT}/atm/scream/init/spc_from_v3LRamip_2010_clim_ne4pg2_c20260211.nc</spc_data_file>
+
+      <time_interpolation_method type="string" doc="Method for interpolating SPC data in time">yearly_periodic</time_interpolation_method>
     </spc>
 
     <!-- Radiation -->

--- a/components/eamxx/src/physics/spa/eamxx_spa_process_interface.cpp
+++ b/components/eamxx/src/physics/spa/eamxx_spa_process_interface.cpp
@@ -73,6 +73,7 @@ void SPA::initialize_impl (const RunType /* run_type */)
   };
   auto spa_data_file = m_params.get<std::string>("spa_data_file");
   auto spa_map_file  = m_params.get<std::string>("spa_remap_file","");
+  auto time_interpolation_method = m_params.get<std::string>("time_interpolation_method","yearly_periodic");
 
   // SPA doesn't really *need* pint, but DataInterpolation does. It's important to stress that
   // NO FIELD VALUES from p_int are accessed in the DataInterpolation we build, since we
@@ -86,9 +87,22 @@ void SPA::initialize_impl (const RunType /* run_type */)
   pint.get_header().get_alloc_properties().request_allocation(SCREAM_PACK_SIZE);
   pint.allocate_view();
 
-  util::TimeStamp ref_ts (1,1,1,0,0,0); // Beg of any year, since we use yearly periodic timeline
+  util::TimeLine timeline;
+  util::TimeStamp ref_ts;
+  if (time_interpolation_method=="yearly_periodic") {
+    timeline = util::TimeLine::YearlyPeriodic;
+    ref_ts = util::TimeStamp(1,1,1,0,0,0); // Beg of any year, since we use yearly periodic timeline
+  } else if (time_interpolation_method=="linear") {
+    timeline = util::TimeLine::Linear;
+    // For linear interpolation we read reference timestamp from the input file's time var units
+  } else {
+    EKAT_ERROR_MSG("Error! Invalid time_interpolation_method: " +
+                   time_interpolation_method +
+                   ". Valid options are: yearly_periodic, linear.\n");
+  }
+
   m_data_interpolation = std::make_shared<DataInterpolation>(m_model_grid,spa_fields);
-  m_data_interpolation->setup_time_database ({spa_data_file},util::TimeLine::YearlyPeriodic, DataInterpolation::Linear, ref_ts);
+  m_data_interpolation->setup_time_database ({spa_data_file},timeline, DataInterpolation::Linear, ref_ts);
 
   if (m_iop_data_manager!=nullptr) {
     // IOP cases cannot have a remap file. We will create a IOPRemapper as the horiz remapper

--- a/components/eamxx/src/physics/spc/eamxx_spc_process_interface.cpp
+++ b/components/eamxx/src/physics/spc/eamxx_spc_process_interface.cpp
@@ -51,12 +51,26 @@ void SPC::initialize_impl (const RunType /* run_type */)
   };
   auto spc_data_file = m_params.get<std::string>("spc_data_file");
   auto spc_map_file  = m_params.get<std::string>("spc_remap_file","");
+  auto time_interpolation_method = m_params.get<std::string>("time_interpolation_method","yearly_periodic");
 
   auto pmid = get_field_in("p_mid");
+  
+  util::TimeLine timeline;
+  util::TimeStamp ref_ts;
+  if (time_interpolation_method=="yearly_periodic") {
+    timeline = util::TimeLine::YearlyPeriodic;
+    ref_ts = util::TimeStamp(1,1,1,0,0,0); // Beg of any year, since we use yearly periodic timeline
+  } else if (time_interpolation_method=="linear") {
+    timeline = util::TimeLine::Linear;
+    // For linear interpolation we read reference timestamp from the input file's time var units
+  } else {
+    EKAT_ERROR_MSG("Error! Invalid time_interpolation_method: " + 
+                   time_interpolation_method + 
+                   ". Valid options are: yearly_periodic, linear.\n");
+  }
 
-  util::TimeStamp ref_ts (1,1,1,0,0,0); // Beg of any year, since we use yearly periodic timeline
   m_data_interpolation = std::make_shared<DataInterpolation>(m_model_grid,spc_fields);
-  m_data_interpolation->setup_time_database ({spc_data_file},util::TimeLine::YearlyPeriodic, DataInterpolation::Linear, ref_ts);
+  m_data_interpolation->setup_time_database ({spc_data_file},timeline, DataInterpolation::Linear, ref_ts);
 
   if (m_iop_data_manager!=nullptr) {
     // IOP cases cannot have a remap file. We will create a IOPRemapper as the horiz remapper


### PR DESCRIPTION
Add time interpolation namelist option, linear, for reading SPC file, so that the model can read files containing multi-years.

Add option in DataInterpolation method, so that the model can read files containing date (YYYYMMDD) in addition to time (days after a certain date).