### PR TITLE
EAMxx: add mask-related methods to Field class API

### DIFF
--- a/components/eamxx/src/physics/cosp/eamxx_cosp.cpp
+++ b/components/eamxx/src/physics/cosp/eamxx_cosp.cpp
@@ -136,7 +136,7 @@ void Cosp::initialize_impl (const RunType /* run_type */)
     // the mask here is just the sunlit mask, so set it
     auto& f = get_field_out(field_name);
 
-    f.get_header().set_extra_data("valid_mask", masks.at(field_name));
+    f.set_valid_mask(masks.at(field_name));
     f.get_header().set_may_be_filled(true);
   }
 }
@@ -281,8 +281,8 @@ void Cosp::run_impl (const double dt)
 
     // Update the ctptau and cthtau masks by broadcasting sunlit mask
     const auto& sunlit = get_field_in("sunlit_mask");
-    auto& ctptau = get_field_out("isccp_ctptau").get_header().get_extra_data<Field>("valid_mask");
-    auto& cthtau = get_field_out("misr_cthtau").get_header().get_extra_data<Field>("valid_mask");
+    auto& ctptau = get_field_out("isccp_ctptau").get_valid_mask();
+    auto& cthtau = get_field_out("misr_cthtau").get_valid_mask();
 
     auto sunlit_v = sunlit.get_view<const int*>();
     auto ctptau_v = ctptau.get_view<int***>();

--- a/components/eamxx/src/share/diagnostics/aodvis.cpp
+++ b/components/eamxx/src/share/diagnostics/aodvis.cpp
@@ -42,7 +42,7 @@ create_requests()
 }
 
 void AODVis::initialize_impl(const RunType /*run_type*/) {
-  m_diagnostic_output.get_header().set_extra_data("valid_mask", get_field_in("sunlit_mask"));
+  m_diagnostic_output.set_valid_mask(get_field_in("sunlit_mask"));
 }
 
 void AODVis::compute_diagnostic_impl() {

--- a/components/eamxx/src/share/diagnostics/field_at_pressure_level.cpp
+++ b/components/eamxx/src/share/diagnostics/field_at_pressure_level.cpp
@@ -72,23 +72,8 @@ initialize_impl (const RunType /*run_type*/)
 
   m_pressure_name = tag==LEV ? "p_mid" : "p_int";
 
-  // Take care of mask tracking for this field, in case it is needed.  This has two steps:
-  //   1.  We need to actually track the masked columns, so we create a 2d (COL only) field.
-  //       NOTE: Here we assume that even a source field of rank 3+ will be masked the same
-  //       across all components so the mask is represented by a column-wise slice.
-  //   2.  We also need to create a helper field that may be used w/ the vertical remapper to set
-  //       the mask.  This field is 3d (COLxLEV) to mimic the type of interpolation that is
-  //       being conducted on the source field.
-
   // Add a field representing the mask as extra data to the diagnostic field.
-  auto nondim = ekat::units::Units::nondimensional();
-  const auto& gname = fid.get_grid_name();
-  auto mlayout = layout.clone().strip_dim(tag);
-
-  std::string mask_name = m_diag_name + " mask";
-  FieldIdentifier mask_fid (mask_name,mlayout, nondim, gname, DataType::IntType);
-  Field diag_mask(mask_fid,true);
-  m_diagnostic_output.get_header().set_extra_data("valid_mask",diag_mask);
+  m_diagnostic_output.create_valid_mask();
   m_diagnostic_output.get_header().set_may_be_filled(true);
 
   using stratts_t = std::map<std::string,std::string>;
@@ -125,7 +110,7 @@ void FieldAtPressureLevel::compute_diagnostic_impl()
   if (rank==2) {
     auto policy = KT::RangePolicy(0,ncols);
     auto diag = m_diagnostic_output.get_view<Real*>();
-    auto mask = m_diagnostic_output.get_header().get_extra_data<Field>("valid_mask").get_view<int*>();
+    auto mask = m_diagnostic_output.get_valid_mask().get_view<int*>();
     auto f_v  = f.get_view<const Real**>();
     Kokkos::parallel_for(policy,KOKKOS_LAMBDA(const int icol) {
       auto x1 = ekat::subview(p_src_v,icol);
@@ -156,7 +141,7 @@ void FieldAtPressureLevel::compute_diagnostic_impl()
     const int ndims = f.get_header().get_identifier().get_layout().get_vector_dim();
     auto policy = KT::TeamPolicy(ncols,ndims);
     auto diag = m_diagnostic_output.get_view<Real**>();
-    auto mask = m_diagnostic_output.get_header().get_extra_data<Field>("valid_mask").get_view<int**>();
+    auto mask = m_diagnostic_output.get_valid_mask().get_view<int**>();
     auto f_v  = f.get_view<const Real***>();
     Kokkos::parallel_for(policy,KOKKOS_LAMBDA(const MemberType& team) {
       int icol = team.league_rank();

--- a/components/eamxx/src/share/diagnostics/tests/aodvis_test.cpp
+++ b/components/eamxx/src/share/diagnostics/tests/aodvis_test.cpp
@@ -98,7 +98,7 @@ TEST_CASE("aodvis") {
     const auto sun_h  = sunlit.get_view<const int *, Host>();
     const auto tau_h  = tau.get_view<const Real ***, Host>();
     const auto aod_hf = diag->get_diagnostic();
-    const auto aod_mask = aod_hf.get_header().get_extra_data<Field>("valid_mask");
+    const auto aod_mask = aod_hf.get_valid_mask();
 
     Field aod_tf = diag->get_diagnostic().clone();
     auto aod_t = aod_tf.get_view<Real *, Host>();

--- a/components/eamxx/src/share/diagnostics/tests/field_at_pressure_level_tests.cpp
+++ b/components/eamxx/src/share/diagnostics/tests/field_at_pressure_level_tests.cpp
@@ -103,7 +103,7 @@ TEST_CASE("field_at_pressure_level_p2")
       diag_f.sync_to_host();
       auto test2_diag_v = diag_f.get_view<const Real*, Host>();
       // Check the mask field inside the diag_f
-      auto mask_f = diag_f.get_header().get_extra_data<Field>("valid_mask");
+      auto mask_f = diag_f.get_valid_mask();
       mask_f.sync_to_host();
       auto test2_mask_v = mask_f.get_view<const int*, Host>();
       //
@@ -124,7 +124,7 @@ TEST_CASE("field_at_pressure_level_p2")
       diag_f.sync_to_host();
       auto test2_diag_v = diag_f.get_view<const Real*, Host>();
       // Check the mask field inside the diag_f
-      auto mask_f = diag_f.get_header().get_extra_data<Field>("valid_mask");
+      auto mask_f = diag_f.get_valid_mask();
       mask_f.sync_to_host();
       auto test2_mask_v = mask_f.get_view<const int*, Host>();
 

--- a/components/eamxx/src/share/field/field.cpp
+++ b/components/eamxx/src/share/field/field.cpp
@@ -214,6 +214,11 @@ subfield (const std::string& sf_name, const ekat::units::Units& sf_units,
     sf.m_header->set_extra_data("valid_mask",mask.subfield(mask.name(),mfid.get_units(),idim,index,dynamic));
   }
 
+  if (has_valid_mask()) {
+    const auto& mask = get_valid_mask();
+    sf.set_valid_mask(mask.subfield(mask.name(),idim,index,dynamic));
+  }
+
   return sf;
 }
 
@@ -357,6 +362,68 @@ void Field::allocate_view ()
 
   m_data->d_view = decltype(m_data->d_view)(id.name(),view_dim);
   m_data->h_view = Kokkos::create_mirror_view(m_data->d_view);
+}
+
+bool Field::has_valid_mask () const {
+  return m_header->has_extra_data("valid_mask");
+}
+
+void Field::set_valid_mask (const Field& mask)
+{
+  EKAT_REQUIRE_MSG (not has_valid_mask(),
+      "Error! Cannot reset the mask field.\n"
+      " - field name: " + name() + "\n");
+  EKAT_REQUIRE_MSG (is_allocated(),
+      "Error! Cannot set a mask field until this field has been allocated.\n"
+      " - field name: " + name() + "\n");
+
+  // Check that the input field has the expected properties
+  EKAT_REQUIRE_MSG (mask.data_type()==DataType::IntType,
+      "Error! Input mask field must have IntType data type.\n"
+      " - field name: " + name() + "\n"
+      " - mask name : " + mask.name() + "\n"
+      " - mask data type: " + e2str(mask.data_type()) + "\n");
+  EKAT_REQUIRE_MSG (mask.get_header().get_identifier().get_layout()==get_header().get_identifier().get_layout(),
+      "Error! Input mask field must have same layout as this field.\n"
+      " - field name: " + name() + "\n"
+      " - mask name : " + mask.name() + "\n"
+      " - field layout: " + get_header().get_identifier().get_layout().to_string() + "\n"
+      " - mask layout: " + mask.get_header().get_identifier().get_layout().to_string() + "\n");
+
+  m_header->set_extra_data("valid_mask",mask);
+}
+
+Field& Field::create_valid_mask (const std::string& mask_name)
+{
+  EKAT_REQUIRE_MSG (not has_valid_mask(),
+      "Error! Cannot create mask field, as it was already created.\n"
+      " - field name: " + name() + "\n");
+
+  EKAT_REQUIRE_MSG (is_allocated(),
+      "Error! You cannot create the mask field until the field has been allocated.\n"
+      " - field name: " + name() + "\n");
+
+  const auto& fid = m_header->get_identifier();
+  const auto& props = m_header->get_alloc_properties();
+  const auto nondim = ekat::units::Units::nondimensional();
+
+  auto mfid = fid.clone(mask_name).reset_units(nondim).reset_dtype(DataType::IntType);
+  Field mask(mfid);
+  mask.get_header().get_alloc_properties().request_allocation(props.get_largest_pack_size());
+  mask.allocate_view();
+  set_valid_mask(mask);
+
+  return get_valid_mask();
+}
+
+Field& Field::get_valid_mask ()
+{
+  return m_header->get_extra_data<Field>("valid_mask");
+}
+
+const Field& Field::get_valid_mask () const
+{
+  return m_header->get_extra_data<Field>("valid_mask");
 }
 
 void Field::deep_copy (const ScalarWrapper value)

--- a/components/eamxx/src/share/field/field.cpp
+++ b/components/eamxx/src/share/field/field.cpp
@@ -208,13 +208,12 @@ subfield (const std::string& sf_name, const ekat::units::Units& sf_units,
     sf.initialize_contiguous_helper_field();
   }
 
-  if (m_header->has_extra_data("valid_mask")) {
-    const auto& mask = m_header->get_extra_data<Field>("valid_mask");
-    const auto& mfid = mask.get_header().get_identifier();
-    sf.m_header->set_extra_data("valid_mask",mask.subfield(mask.name(),mfid.get_units(),idim,index,dynamic));
-  }
-
   if (has_valid_mask()) {
+    EKAT_REQUIRE_MSG (not dynamic,
+        "Error! We do not support getting a dynamic subview of a masked field. It's too much work...\n"
+        " - field name: " + name() + "\n"
+        "NOTE: if this is REALLY needed, contact developers, and we can accommodate it.\n");
+
     const auto& mask = get_valid_mask();
     sf.set_valid_mask(mask.subfield(mask.name(),idim,index,dynamic));
   }

--- a/components/eamxx/src/share/field/field.cpp
+++ b/components/eamxx/src/share/field/field.cpp
@@ -372,9 +372,6 @@ void Field::set_valid_mask (const Field& mask)
   EKAT_REQUIRE_MSG (not has_valid_mask(),
       "Error! Cannot reset the mask field.\n"
       " - field name: " + name() + "\n");
-  EKAT_REQUIRE_MSG (is_allocated(),
-      "Error! Cannot set a mask field until this field has been allocated.\n"
-      " - field name: " + name() + "\n");
 
   // Check that the input field has the expected properties
   EKAT_REQUIRE_MSG (mask.data_type()==DataType::IntType,
@@ -392,7 +389,7 @@ void Field::set_valid_mask (const Field& mask)
   m_header->set_extra_data("valid_mask",mask);
 }
 
-Field& Field::create_valid_mask (const std::string& mask_name)
+Field& Field::create_valid_mask (const std::string& mask_name, const MaskInit init)
 {
   EKAT_REQUIRE_MSG (not has_valid_mask(),
       "Error! Cannot create mask field, as it was already created.\n"
@@ -410,6 +407,11 @@ Field& Field::create_valid_mask (const std::string& mask_name)
   Field mask(mfid);
   mask.get_header().get_alloc_properties().request_allocation(props.get_largest_pack_size());
   mask.allocate_view();
+  if (init==MaskInit::Valid) {
+    mask.deep_copy(1);
+  } else if (init==MaskInit::Invalid) {
+    mask.deep_copy(0);
+  }
   set_valid_mask(mask);
 
   return get_valid_mask();

--- a/components/eamxx/src/share/field/field.hpp
+++ b/components/eamxx/src/share/field/field.hpp
@@ -203,6 +203,21 @@ public:
   void sync_to_host (const bool fence = true) const;
   void sync_to_dev (const bool fence = true) const;
 
+  // Querying the valid_mask field is common enough that we provide shortcuts.
+  // NOTE: the user can manually set other "mask" fields in the field header
+  //       via FieldHeader's extra data API.
+  // These methods are for a predefined mask that signals where the data is
+  // valid (mask!=0) or invalid/garbage (mask==0).
+  // When this mask is present, certain users of this field may decide to
+  // perform masked manipulations.
+  bool has_valid_mask () const;
+  Field& create_valid_mask (const std::string& mask_name);
+  Field& create_valid_mask () { return create_valid_mask(name()+"_valid_mask"); }
+
+  void set_valid_mask (const Field& mask);
+  const Field& get_valid_mask () const;
+        Field& get_valid_mask ();
+
   // --------- Field manipulation methods ------------- //
   // NOTE: the versions with a mask field only perform the manip where mask!=0, except
   //       for deep_copy(value,mask,true), which performs the deep copy where mask==0.

--- a/components/eamxx/src/share/field/field.hpp
+++ b/components/eamxx/src/share/field/field.hpp
@@ -210,9 +210,12 @@ public:
   // valid (mask!=0) or invalid/garbage (mask==0).
   // When this mask is present, certain users of this field may decide to
   // perform masked manipulations.
+
+  enum class MaskInit { Valid, Invalid, None };
+
   bool has_valid_mask () const;
-  Field& create_valid_mask (const std::string& mask_name);
-  Field& create_valid_mask () { return create_valid_mask(name()+"_valid_mask"); }
+  Field& create_valid_mask (const std::string& mask_name, const MaskInit init = MaskInit::None);
+  Field& create_valid_mask (const MaskInit init = MaskInit::None) { return create_valid_mask(name()+"_valid_mask", init); }
 
   void set_valid_mask (const Field& mask);
   const Field& get_valid_mask () const;

--- a/components/eamxx/src/share/field/field_utils.hpp
+++ b/components/eamxx/src/share/field/field_utils.hpp
@@ -54,6 +54,7 @@ void horiz_contraction(const Field& f_out, const Field& f_in, const Field& weigh
 // Reduce field to a single scalar, and return an opaque type, to allow hiding impl in cpp file.
 // NOTE: all calculations are done serially HOST
 ScalarWrapper frobenius_norm(const Field& f, const ekat::Comm* comm = nullptr);
+ScalarWrapper inf_norm(const Field& f, const ekat::Comm* comm = nullptr);
 ScalarWrapper field_sum(const Field& f, const ekat::Comm* comm = nullptr);
 ScalarWrapper field_max(const Field& f, const ekat::Comm* comm = nullptr);
 ScalarWrapper field_min(const Field& f, const ekat::Comm* comm = nullptr);

--- a/components/eamxx/src/share/field/tests/field_tests.cpp
+++ b/components/eamxx/src/share/field/tests/field_tests.cpp
@@ -271,6 +271,35 @@ TEST_CASE("field", "") {
     // Attempting to allocate should fail
     REQUIRE_THROWS (f.allocate_view());
   }
+
+  SECTION ("valid_mask") {
+    auto mfid = fid.clone("mask").reset_dtype(DataType::IntType);
+    auto ml = mfid.get_layout();
+
+    Field f1(fid,true);
+    REQUIRE (not f1.has_valid_mask());
+    REQUIRE_THROWS (f1.get_valid_mask()); // no mask stored
+
+    Field badm1(mfid.clone().reset_layout(ml.clone().reset_dim(0,999)),true);
+    Field badm2(mfid.clone().reset_dtype(DataType::RealType),true);
+    REQUIRE_THROWS (f1.set_valid_mask(badm1)); // bad mask layout
+    REQUIRE_THROWS (f1.set_valid_mask(badm2)); // bad mask dtype
+
+    f1.create_valid_mask();
+    REQUIRE_THROWS(f1.create_valid_mask());              // mask already set
+    REQUIRE_THROWS(f1.set_valid_mask(Field(mfid,true))); // mask already set
+
+    Field f2(fid,true),f3(fid,true);
+    f2.create_valid_mask(Field::MaskInit::Valid);
+    f3.create_valid_mask("my_mask",Field::MaskInit::Invalid);
+
+    Field ones(mfid,true), zeros(mfid,true);
+    ones.deep_copy(1);
+    zeros.deep_copy(0);
+    REQUIRE (views_are_equal(f2.get_valid_mask(),ones));
+    REQUIRE (views_are_equal(f3.get_valid_mask(),zeros));
+    REQUIRE (f3.get_valid_mask().name()=="my_mask");
+  }
 }
 
 } // anonymous namespace

--- a/components/eamxx/src/share/field/tests/reductions.cpp
+++ b/components/eamxx/src/share/field/tests/reductions.cpp
@@ -2,9 +2,11 @@
 
 #include "share/field/field.hpp"
 #include "share/field/field_utils.hpp"
+#include "share/core/eamxx_setup_random_test.hpp"
 
 #include <ekat_pack.hpp>
 #include <ekat_subview_utils.hpp>
+#include <random>
 
 namespace scream {
 
@@ -73,6 +75,62 @@ TEST_CASE("field_reductions") {
 
     REQUIRE(frobenius_norm(f1).as<Real>()==std::sqrt(lsum));
     REQUIRE(frobenius_norm(f1,&comm).as<Real>()==std::sqrt(gsum));
+  }
+
+  SECTION ("inf_norm") {
+    using Catch::Matchers::WithinRel;
+    std::uniform_real_distribution<Real> rpdf(-1,1);
+    auto eps = std::numeric_limits<Real>::epsilon();
+    auto tol = 10*eps;
+
+    // Non-negative (0 iff f==0)
+    auto seed = get_random_test_seed();
+    for (int run=0; run<20; ++run) {
+      randomize_uniform(f1,seed++,-1,1);
+      REQUIRE (inf_norm(f1,&comm).as<Real>()>=0);
+    }
+    f1.deep_copy(0);
+    REQUIRE (inf_norm(f1,&comm).as<Real>()==0);
+    f1.deep_copy(eps);
+    REQUIRE (inf_norm(f1,&comm).as<Real>()==eps);
+
+    // Homogeneity
+    for (int run=0; run<20; ++run) {
+      randomize_uniform(f1,seed++,-1,1);
+      auto n1 = inf_norm(f1,&comm).as<Real>();
+
+      std::mt19937_64 engine(seed++);
+      auto factor = rpdf(engine);
+      comm.broadcast(&factor,1,0);
+      f1.scale(factor);
+      auto n2 = inf_norm(f1,&comm).as<Real>();
+      REQUIRE_THAT (n2,WithinRel(n1*std::abs(factor),tol));
+
+      // Sign invariant
+      f1.scale(-1);
+      REQUIRE (inf_norm(f1,&comm).as<Real>()==n2);
+
+      // Check norm is the same across ranks
+      Real max_across_ranks=-1;
+      Real min_across_ranks=-1;
+      comm.all_reduce(&n2,&max_across_ranks,1,MPI_MAX);
+      comm.all_reduce(&n2,&min_across_ranks,1,MPI_MIN);
+      REQUIRE (n2==max_across_ranks);
+      REQUIRE (n2==min_across_ranks);
+    }
+
+    // Triangular ineq
+    auto f2 = f1.clone();
+    for (int run=0; run<20; ++run) {
+      randomize_uniform(f1,seed++,-1,1);
+      randomize_uniform(f2,seed++,-1,1);
+      auto n1 = inf_norm(f1,&comm).as<Real>();
+      auto n2 = inf_norm(f2,&comm).as<Real>();
+      f1.update(f2,1,1);
+      auto n3 = inf_norm(f1,&comm).as<Real>();
+
+      REQUIRE(n3<=(n1+n2+tol));
+    }
   }
 
   SECTION ("max") {

--- a/components/eamxx/src/share/field/tests/subfield_tests.cpp
+++ b/components/eamxx/src/share/field/tests/subfield_tests.cpp
@@ -47,16 +47,14 @@ TEST_CASE("field", "") {
           REQUIRE(v4d_h(i, ivar, j, k) == v3d_h(i, j, k));
         }
 
-    // Check that valid_mask extra data is kept in sync
-    FieldIdentifier mfid("my_mask", {t1, d1}, m / s, "some_grid", DataType::IntType);
-    Field mask(mfid,true);
-    f1.get_header().set_extra_data("valid_mask",mask);
+    // Check that the mask is kept in sync
+    auto mask = f1.create_valid_mask();
 
     auto f3 = f1.subfield(idim,ivar);
     randomize_uniform(mask,seed++,0,1);
 
-    REQUIRE (f3.get_header().has_extra_data("valid_mask"));
-    auto f3_mask = f3.get_header().get_extra_data<Field>("valid_mask");
+    REQUIRE (f3.has_valid_mask());
+    auto f3_mask = f3.get_valid_mask();
     auto mask_sf = mask.subfield(idim,ivar);
     REQUIRE (views_are_equal(f3_mask,mask_sf));
   }

--- a/components/eamxx/src/share/field/utils/reductions.cpp
+++ b/components/eamxx/src/share/field/utils/reductions.cpp
@@ -114,6 +114,89 @@ ST frobenius_norm(const Field& f, const ekat::Comm* comm)
 }
 
 template<typename ST>
+ST inf_norm(const Field& f, const ekat::Comm* comm)
+{
+  const auto& fl = f.get_header().get_identifier().get_layout();
+
+  // TODO: compute directly on device
+  f.sync_to_host();
+
+  ST norm = 0;
+  switch (fl.rank()) {
+    case 1:
+      {
+        auto v = f.template get_strided_view<const ST*,Host>();
+        for (int i=0; i<fl.dim(0); ++i) {
+          norm = std::max(norm,std::abs(v(i)));
+        }
+      }
+      break;
+    case 2:
+      {
+        auto v = f.template get_strided_view<const ST**,Host>();
+        for (int i=0; i<fl.dim(0); ++i) {
+          for (int j=0; j<fl.dim(1); ++j) {
+            norm = std::max(norm,std::abs(v(i,j)));
+        }}
+      }
+      break;
+    case 3:
+      {
+        auto v = f.template get_strided_view<const ST***,Host>();
+        for (int i=0; i<fl.dim(0); ++i) {
+          for (int j=0; j<fl.dim(1); ++j) {
+            for (int k=0; k<fl.dim(2); ++k) {
+              norm = std::max(norm,std::abs(v(i,j,k)));
+        }}}
+      }
+      break;
+    case 4:
+      {
+        auto v = f.template get_strided_view<const ST****,Host>();
+        for (int i=0; i<fl.dim(0); ++i) {
+          for (int j=0; j<fl.dim(1); ++j) {
+            for (int k=0; k<fl.dim(2); ++k) {
+              for (int l=0; l<fl.dim(3); ++l) {
+                norm = std::max(norm,std::abs(v(i,j,k,l)));
+        }}}}
+      }
+      break;
+    case 5:
+      {
+        auto v = f.template get_strided_view<const ST*****,Host>();
+        for (int i=0; i<fl.dim(0); ++i) {
+          for (int j=0; j<fl.dim(1); ++j) {
+            for (int k=0; k<fl.dim(2); ++k) {
+              for (int l=0; l<fl.dim(3); ++l) {
+                for (int m=0; m<fl.dim(4); ++m) {
+                  norm = std::max(norm,std::abs(v(i,j,k,l,m)));
+        }}}}}
+      }
+      break;
+    case 6:
+      {
+        auto v = f.template get_strided_view<const ST******,Host>();
+        for (int i=0; i<fl.dim(0); ++i) {
+          for (int j=0; j<fl.dim(1); ++j) {
+            for (int k=0; k<fl.dim(2); ++k) {
+              for (int l=0; l<fl.dim(3); ++l) {
+                for (int m=0; m<fl.dim(4); ++m) {
+                  for (int n=0; n<fl.dim(5); ++n) {
+                    norm = std::max(norm,std::abs(v(i,j,k,l,m,n)));
+        }}}}}}
+      }
+      break;
+    default:
+      EKAT_ERROR_MSG ("Error! Unsupported field rank.\n");
+  }
+
+  if (comm) {
+    comm->all_reduce(&norm,1,MPI_MAX);
+  }
+  return norm;
+}
+
+template<typename ST>
 ST field_sum(const Field& f, const ekat::Comm* comm)
 {
   const auto& fl = f.get_header().get_identifier().get_layout();
@@ -411,11 +494,36 @@ ScalarWrapper frobenius_norm(const Field& f, const ekat::Comm* comm)
       norm.set(impl::frobenius_norm<double>(f,comm));
       break;
     default:
-      EKAT_ERROR_MSG ("[print_field] Error! Invalid/unsupported data type.\n"
+      EKAT_ERROR_MSG ("[frobenius_norm] Error! Invalid/unsupported data type.\n"
           " - field name: " + f.name() + "\n");
   }
   return norm;
 }
+
+ScalarWrapper inf_norm(const Field& f, const ekat::Comm* comm)
+{
+  EKAT_REQUIRE_MSG (f.is_allocated(),
+    "[inf_norm] Error! Input field was not yet allocated.\n");
+
+  ScalarWrapper norm;
+  switch (f.data_type()) {
+    case DataType::IntType:
+      EKAT_ERROR_MSG ("[inf_norm] Error! IntType fields are not supported.\n"
+          " - field name: " + f.name() + "\n");
+      break;
+    case DataType::FloatType:
+      norm.set(impl::inf_norm<float>(f,comm));
+      break;
+    case DataType::DoubleType:
+      norm.set(impl::inf_norm<double>(f,comm));
+      break;
+    default:
+      EKAT_ERROR_MSG ("[inf_norm] Error! Invalid/unsupported data type.\n"
+          " - field name: " + f.name() + "\n");
+  }
+  return norm;
+}
+
 
 ScalarWrapper field_sum(const Field& f, const ekat::Comm* comm)
 {
@@ -434,7 +542,7 @@ ScalarWrapper field_sum(const Field& f, const ekat::Comm* comm)
       norm.set(impl::field_sum<double>(f,comm));
       break;
     default:
-      EKAT_ERROR_MSG ("[print_field] Error! Invalid/unsupported data type.\n"
+      EKAT_ERROR_MSG ("[field_sum] Error! Invalid/unsupported data type.\n"
           " - field name: " + f.name() + "\n");
   }
   return norm;
@@ -457,7 +565,7 @@ ScalarWrapper field_max(const Field& f, const ekat::Comm* comm)
       norm.set(impl::field_max<double>(f,comm));
       break;
     default:
-      EKAT_ERROR_MSG ("[print_field] Error! Invalid/unsupported data type.\n"
+      EKAT_ERROR_MSG ("[field_max] Error! Invalid/unsupported data type.\n"
           " - field name: " + f.name() + "\n");
   }
   return norm;
@@ -480,7 +588,7 @@ ScalarWrapper field_min(const Field& f, const ekat::Comm* comm)
       norm.set(impl::field_min<double>(f,comm));
       break;
     default:
-      EKAT_ERROR_MSG ("[print_field] Error! Invalid/unsupported data type.\n"
+      EKAT_ERROR_MSG ("[field_min] Error! Invalid/unsupported data type.\n"
           " - field name: " + f.name() + "\n");
   }
   return norm;

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -320,7 +320,7 @@ void AtmosphereOutput::restart (const std::string& filename)
     fields.push_back(*f_ptr);
   }
   for (const auto& f : m_avg_counts) {
-    fields.push_back(f);
+    fields.push_back(f.alias(f.name(),fm->get_grid()->name()));
   }
 
   AtmosphereInput hist_restart (filename, fm->get_grid(), fields);
@@ -539,7 +539,7 @@ run (const std::string& filename,
       //    if we later need it. E.g, if no AvgCount AND no hremap, we don't need it.
       //////////////////////////////////////////////////////
       auto field = fm_after_hr->get_field(fname);
-      auto mask  = count.get_header().get_extra_data<Field>("valid_mask");
+      auto mask  = count.get_valid_mask();
 
       // Find where the field is NOT equal to fill_value
       compute_mask(field,constants::fill_value<Real>,Comparison::NE,mask);
@@ -629,7 +629,7 @@ run (const std::string& filename,
 
           f_out.scale_inv(avg_count);
 
-          const auto& mask = avg_count.get_header().get_extra_data<Field>("valid_mask");
+          const auto& mask = avg_count.get_valid_mask();
           f_out.deep_copy(constants::fill_value<Real>,mask);
         } else {
           // Divide by steps count only when the summation is complete
@@ -739,10 +739,8 @@ void AtmosphereOutput::set_avg_cnt_tracking(const FieldIdentifier& fid)
   Field count(count_id);
   count.allocate_view();
 
-  // We will use a helper field for updating cnt, so store it inside the field header.
-  // Create the valid_mask explicitly as an IntType field with the same layout/grid.
-  Field mask(count_id.clone(count.name()+"_mask"),true);
-  count.get_header().set_extra_data("valid_mask",mask);
+  // We will use a mask field for updating cnt (to check where cnt>threshold)
+  count.create_valid_mask();
 
   m_avg_counts.push_back(count);
   m_field_to_avg_count[name] = count;
@@ -1116,14 +1114,14 @@ process_requested_fields()
   // Helper lambda to check if this fm_model field should trigger avg count
   auto check_for_avg_cnt = [&](const Field& f) {
     // We need avg-count tracking for any averaged (non-instant) field that:
-    //  - supplies explicit mask info (mask_data or valid_mask)
+    //  - supplies explicit mask info ("mask_data" extra data, or mask field)
     //  - is marked as potentially containing fill values (may_be_filled()).
     // Without this, fill-aware updates skip fill_value during accumulation (good)
     // but we would still divide by the raw nsteps, biasing the result low.
     if (m_avg_type!=OutputAvgType::Instant) {
-      const bool has_mask = f.get_header().has_extra_data("mask_data") || f.get_header().has_extra_data("valid_mask");
+      const bool has_mask_data = f.get_header().has_extra_data("mask_data");
       const bool may_be_filled = f.get_header().may_be_filled();
-      if (has_mask || may_be_filled) {
+      if (f.has_valid_mask() or has_mask_data or may_be_filled) {
         m_track_avg_cnt = true;
         // Avoid duplicate insertion if already present (e.g., mask + filled both true)
         if (m_field_to_avg_cnt_suffix.count(f.name())==0) {

--- a/components/eamxx/src/share/remap/horizontal_remapper.cpp
+++ b/components/eamxx/src/share/remap/horizontal_remapper.cpp
@@ -124,14 +124,14 @@ registration_ends_impl ()
     // Store copy, since we'll register more fields as we process masks
     int num_orig_fields = m_num_fields;
     for (int i=0; i<num_orig_fields; ++i) {
-      const auto& src_hdr = m_src_fields[i].get_header();
-            auto& tgt_hdr = m_tgt_fields[i].get_header();
-
-      if (not src_hdr.has_extra_data("valid_mask"))
+      if (not m_src_fields[i].has_valid_mask())
         continue;
 
+      const auto& src_hdr = m_src_fields[i].get_header();
+
       const auto& f_name = src_hdr.get_identifier().name();
-      const auto& src_mask = src_hdr.get_extra_data<Field>("valid_mask");
+
+      const auto& src_mask = m_src_fields[i].get_valid_mask();
       const auto& mask_name = src_mask.name();
       const auto ps = src_hdr.get_alloc_properties().get_largest_pack_size();
 
@@ -145,14 +145,14 @@ registration_ends_impl ()
           "  - mask layout: " + m_lt.to_string() + "\n");
 
       // Make sure fields representing masks are not themselves meant to be masked.
-      EKAT_REQUIRE_MSG(not src_mask.get_header().has_extra_data("valid_mask"),
+      EKAT_REQUIRE_MSG(not src_mask.has_valid_mask(),
           "Error! A mask field cannot be itself masked.\n"
           "  - field name: " + f_name + "\n"
           "  - mask field name: " + mask_name + "\n");
 
       if (not m_lt.has_tag(COL)) {
         // This field doesn't really need to be remapped, so tgt can use the same mask field as src
-        tgt_hdr.set_extra_data("valid_mask",src_mask.alias(mask_name,get_tgt_grid()->name()));
+        m_tgt_fields[i].set_valid_mask(src_mask.alias(mask_name,get_tgt_grid()->name()));
         continue;
       }
 
@@ -163,7 +163,7 @@ registration_ends_impl ()
         tgt_mask.get_header().get_alloc_properties().request_allocation(ps);
         m_name_to_src_real_mask[mask_name].get_header().get_alloc_properties().request_allocation(ps);
         m_name_to_tgt_real_mask[mask_name].get_header().get_alloc_properties().request_allocation(ps);
-        tgt_hdr.set_extra_data("valid_mask",tgt_mask);
+        m_tgt_fields[i].set_valid_mask(tgt_mask);
         continue;
       }
 
@@ -183,7 +183,7 @@ registration_ends_impl ()
       auto tgt_fid = create_tgt_fid(src_fid);
       tgt_mask = Field(tgt_fid);
       tgt_mask.get_header().get_alloc_properties().request_allocation(ps);
-      tgt_hdr.set_extra_data("valid_mask",tgt_mask);
+      m_tgt_fields[i].set_valid_mask(tgt_mask);
       m_name_to_tgt_int_mask[mask_name] = tgt_mask;
     }
   }
@@ -309,7 +309,7 @@ void HorizontalRemapper::remap_fwd_impl ()
     const auto& x = coarsen ? m_src_fields[i] : m_ov_fields[i];
     const auto& y = coarsen ? m_ov_fields[i] : m_tgt_fields[i];
 
-    const bool masked = m_track_mask and x.get_header().has_extra_data("valid_mask");
+    const bool masked = m_track_mask and x.has_valid_mask();
     if (masked) {
       // If possible, dispatch kernel with SCREAM_PACK_SIZE
       if (can_pack_field(x) and can_pack_field(y)) {
@@ -345,8 +345,8 @@ void HorizontalRemapper::remap_fwd_impl ()
   if (m_track_mask) {
     for (int i=0; i<m_num_fields; ++i) {
       auto& f_tgt = m_tgt_fields[i];
-      if (f_tgt.get_header().has_extra_data("valid_mask")) {
-        const auto& mask_name = f_tgt.get_header().get_extra_data<Field>("valid_mask").name();
+      if (f_tgt.has_valid_mask()) {
+        const auto& mask_name = f_tgt.get_valid_mask().name();
         const auto& real_mask = m_name_to_tgt_real_mask.at(mask_name);
         // TODO:
         //  1. compute mask=real_mask>thresh via compute_mask
@@ -509,7 +509,7 @@ rescale_masked_fields (const Field& x, const Field& real_mask) const
   const Real mask_threshold = std::numeric_limits<Real>::epsilon();  // TODO: Should we not hardcode the threshold for simply masking out the column.
 
   Pack fv_pack(fill_val);
-  auto& mask = x.get_header().get_extra_data<Field>("valid_mask");
+  auto& mask = x.get_valid_mask();
   switch (rank) {
     case 1:
     {
@@ -632,7 +632,7 @@ local_mat_vec_masked (const Field& x, const Field& y) const
   using PackInfo    = ekat::PackInfo<PackSize>;
 
   const auto& src_layout = x.get_header().get_identifier().get_layout();
-  const auto& mask_name = x.get_header().get_extra_data<Field>("valid_mask").name();
+  const auto& mask_name = x.get_valid_mask().name();
   const auto& mask = m_name_to_src_real_mask.at(mask_name);
   const int rank = src_layout.rank();
   const int nrows  = m_remap_data->m_overlap_grid->get_num_local_dofs();

--- a/components/eamxx/src/share/remap/tests/vertical_remapper_tests.cpp
+++ b/components/eamxx/src/share/remap/tests/vertical_remapper_tests.cpp
@@ -13,7 +13,6 @@ constexpr auto P0 = VerticalRemapper::P0;
 constexpr auto Mask = VerticalRemapper::Mask;
 constexpr auto Top = VerticalRemapper::Top;
 constexpr auto Bot = VerticalRemapper::Bot;
-constexpr auto TopBot = VerticalRemapper::TopAndBot;
 constexpr Real fill_val = constants::fill_value<Real>;
 
 template<typename... Args>
@@ -66,12 +65,7 @@ create_field(const std::string& name,
   f.allocate_view();
 
   if (create_valid_mask) {
-    // Set a mask (1=filled, 0=valid) to be used in testing the results
-    FieldIdentifier mask_id("is_filled",fl,units,grid->name(),DataType::IntType);
-    Field mask(mask_id);
-    mask.allocate_view();
-    mask.deep_copy(0); // Init with "all good"
-    f.get_header().set_extra_data("is_filled",mask);
+    f.create_valid_mask(Field::MaskInit::Valid);
   }
   return f;
 }
@@ -172,7 +166,7 @@ void extrapolate (const Field& p_src, const Field& p_tgt, const Field& f,
   const int ncols = l.dims().front();
   const int nlevs = l.dims().back();
   const int nlevs_src = p_src.get_header().get_identifier().get_layout().dims().back();
-  auto mask = f.get_header().get_extra_data<Field>("is_filled");
+  auto mask = f.get_valid_mask();
 
   switch (l.type()) {
     case LayoutType::Scalar2D: break;
@@ -190,14 +184,14 @@ void extrapolate (const Field& p_src, const Field& p_tgt, const Field& f,
           if (p>pmax) {
             if (etype_bot==Mask) {
               v(i,j) = fill_val;
-              m(i,j) = 1;
+              m(i,j) = 0;
             } else {
               v(i,j) = data_func(i,0,pmax);
             }
           } else if (p<pmin) {
             if (etype_top==Mask) {
               v(i,j) = fill_val;
-              m(i,j) = 1;
+              m(i,j) = 0;
             } else {
               v(i,j) = data_func(i,0,pmin);
             }
@@ -368,27 +362,31 @@ TEST_CASE ("vertical_remapper") {
   // Helper lambda, to create p_int profile. If it is a 3d field, make same profile on each col
   auto create_pint = [&](const auto& grid, const bool one_d, const Real ptop, const Real pbot) {
     using namespace ShortFieldTagsNames;
-    auto layout = one_d ? grid->get_vertical_layout(ILEV)
-                        : grid->get_3d_scalar_layout(ILEV);
+    auto tag = grid->get_vkind()==AbstractGrid::VKind::Model ? ILEV : LEVP;
+    auto layout = one_d ? grid->get_vertical_layout(tag)
+                        : grid->get_3d_scalar_layout(tag);
     FieldIdentifier fid("p_int",layout,ekat::units::Pa,grid->name());
     Field pint (fid);
     pint.get_header().get_alloc_properties().request_allocation(SCREAM_PACK_SIZE);
     pint.allocate_view();
 
-    int nlevs = grid->get_num_vertical_levels();
-    const Real dp = (pbot-ptop)/nlevs;
+    bool p_grid = grid->get_vkind()==AbstractGrid::VKind::Pressure;
+    int num_intervals = grid->get_num_vertical_levels();
+    if (p_grid)
+      --num_intervals;
+    const Real dp = (pbot-ptop)/num_intervals;
 
     if (one_d) {
       auto pv = pint.get_view<Real*,Host>();
-      pv(nlevs) = pbot;
-      for (int k=nlevs; k>0; --k) {
+      pv(num_intervals) = pbot;
+      for (int k=num_intervals; k>0; --k) {
         pv(k-1) = pv(k) - dp;
       }
     } else {
       auto pv = pint.get_view<Real**,Host>();
       for (int i=0; i<nldofs; ++i) {
-        pv(i,nlevs) = pbot;
-        for (int k=nlevs; k>0; --k) {
+        pv(i,num_intervals) = pbot;
+        for (int k=num_intervals; k>0; --k) {
           pv(i,k-1) = pv(i,k) - dp;
         }
       }
@@ -402,6 +400,9 @@ TEST_CASE ("vertical_remapper") {
     using namespace ShortFieldTagsNames;
     auto fid_int = pint.get_header().get_identifier();
     auto layout = fid_int.get_layout();
+    if (layout.tags().back()==LEVP) {
+      return pint;
+    }
     int nlevs = layout.dims().back()-1;
     layout.strip_dim(ILEV);
     layout.append_dim(LEV,nlevs);
@@ -447,7 +448,7 @@ TEST_CASE ("vertical_remapper") {
 
             print (" -> creating tgt grid ...\n",comm);
             auto tgt_grid = src_grid->clone("tgt",true);
-            tgt_grid->reset_vertical_configuration(nlevs_tgt, AbstractGrid::VKind::Model);
+            tgt_grid->reset_vertical_configuration(nlevs_tgt, AbstractGrid::VKind::Pressure);
             print (" -> creating tgt grid ...done!\n",comm);
 
             print (" -> creating src/tgt pressure fields ...\n",comm);
@@ -471,18 +472,18 @@ TEST_CASE ("vertical_remapper") {
 
             auto tgt_s2d   = create_field("s2d",  tgt_grid,false,true,false);
             auto tgt_v2d   = create_field("v2d",  tgt_grid,false,true,true);
-            auto tgt_s3d_m = create_field("s3d_m",tgt_grid,false,false,false,LEV, 1);
-            auto tgt_s3d_i = create_field("s3d_i",tgt_grid,false,false,false,LEV, SCREAM_PACK_SIZE);
-            auto tgt_v3d_m = create_field("v3d_m",tgt_grid,false,false,true ,LEV, 1);
-            auto tgt_v3d_i = create_field("v3d_i",tgt_grid,false,false,true ,LEV, SCREAM_PACK_SIZE);
+            auto tgt_s3d_m = create_field("s3d_m",tgt_grid,false,false,false,LEVP, 1);
+            auto tgt_s3d_i = create_field("s3d_i",tgt_grid,false,false,false,LEVP, SCREAM_PACK_SIZE);
+            auto tgt_v3d_m = create_field("v3d_m",tgt_grid,false,false,true ,LEVP, 1);
+            auto tgt_v3d_i = create_field("v3d_i",tgt_grid,false,false,true ,LEVP, SCREAM_PACK_SIZE);
 
             // For expected fields, also create the mask extra data
             auto expected_s2d   = create_field("s2d",  tgt_grid,true,true,false);
             auto expected_v2d   = create_field("v2d",  tgt_grid,true,true,true);
-            auto expected_s3d_m = create_field("s3d_m",tgt_grid,true,false,false,LEV, 1);
-            auto expected_s3d_i = create_field("s3d_i",tgt_grid,true,false,false,LEV, SCREAM_PACK_SIZE);
-            auto expected_v3d_m = create_field("v3d_m",tgt_grid,true,false,true ,LEV, 1);
-            auto expected_v3d_i = create_field("v3d_i",tgt_grid,true,false,true ,LEV, SCREAM_PACK_SIZE);
+            auto expected_s3d_m = create_field("s3d_m",tgt_grid,true,false,false,LEVP, 1);
+            auto expected_s3d_i = create_field("s3d_i",tgt_grid,true,false,false,LEVP, SCREAM_PACK_SIZE);
+            auto expected_v3d_m = create_field("v3d_m",tgt_grid,true,false,true ,LEVP, 1);
+            auto expected_v3d_i = create_field("v3d_i",tgt_grid,true,false,true ,LEVP, SCREAM_PACK_SIZE);
             print (" -> creating fields ... done!\n",comm);
 
             // -------------------------------------- //
@@ -552,15 +553,16 @@ TEST_CASE ("vertical_remapper") {
             Real tol = 10*std::numeric_limits<Real>::epsilon();
 
             auto check = [&](const Field& computed, Field& expected) {
-              auto diff = computed.clone("diff");
-              diff.update(expected,1,-1);
+              auto rel_diff = computed.clone("rel_diff");
+              rel_diff.update(expected,1,-1);
+              // By construction, expected fields are always > 0, so we can divide
+              rel_diff.scale_inv(expected);
 
-              // Now set expected=0 where it's filled, so we can compute the norm
-              // (summing x[i]*x[i] would overflow in SP, causing NaN's)
-              auto mask = expected.get_header().get_extra_data<Field>("is_filled");
-              expected.deep_copy(0,mask);
-              auto ex_norm = frobenius_norm(expected).as<Real>();
-              REQUIRE (frobenius_norm(diff).as<Real>()<tol*ex_norm);
+              // Now set rel_diff=0 where mask==0, so we don't pollute the norm with masked-out entries
+              auto mask = expected.get_valid_mask();
+              rel_diff.deep_copy(0,mask,true);
+              using Catch::Matchers::WithinAbs;
+              REQUIRE_THAT (inf_norm(rel_diff).as<Real>(), WithinAbs(0,tol));
             };
 
             print (" -> check tgt fields ...\n",comm);

--- a/components/eamxx/src/share/remap/tests/vertical_remapper_tests.cpp
+++ b/components/eamxx/src/share/remap/tests/vertical_remapper_tests.cpp
@@ -49,8 +49,8 @@ build_grid(const ekat::Comm& comm, const int nldofs, const int nlevs)
 Field
 create_field(const std::string& name,
              const std::shared_ptr<const AbstractGrid>& grid,
-             const bool create_mask, const bool twod,
-             const bool vec, const FieldTag vtag = FieldTag::LevelInterface, const int ps = 1)
+             const bool create_valid_mask, const bool twod,
+             const bool vec, const FieldTag vtag = FieldTag::Invalid, const int ps = 1)
 {
   using namespace ShortFieldTagsNames;
   constexpr int vec_dim = 3;
@@ -65,7 +65,7 @@ create_field(const std::string& name,
   f.get_header().get_alloc_properties().request_allocation(ps);
   f.allocate_view();
 
-  if (create_mask) {
+  if (create_valid_mask) {
     // Set a mask (1=filled, 0=valid) to be used in testing the results
     FieldIdentifier mask_id("is_filled",fl,units,grid->name(),DataType::IntType);
     Field mask(mask_id);

--- a/components/eamxx/src/share/remap/vertical_remapper.cpp
+++ b/components/eamxx/src/share/remap/vertical_remapper.cpp
@@ -213,11 +213,11 @@ registration_ends_impl ()
           mask.allocate_view();
         }
 
-        EKAT_REQUIRE_MSG(not tgt.get_header().has_extra_data("valid_mask"),
+        EKAT_REQUIRE_MSG(not tgt.has_valid_mask(),
             "[VerticalRemapper::registration_ends_impl] Error! Target field already has mask data assigned.\n"
             " - tgt field name: " + tgt.name() + "\n");
 
-        tgt.get_header().set_extra_data("valid_mask",mask);
+        tgt.set_valid_mask(mask);
 
         // Since we do mask (at top and/or bot), the tgt field MAY be contain fill_value entries
         tgt.get_header().set_may_be_filled(true);
@@ -227,12 +227,12 @@ registration_ends_impl ()
       // fill_value tracking assigned from somewhere else.
       // For instance, this could be a 2d field computed by FieldAtPressureLevel diagnostic.
       // In those cases we want to copy that fill_value tracking to the target field.
-      if (src.get_header().has_extra_data("valid_mask")) {
-        EKAT_REQUIRE_MSG(not tgt.get_header().has_extra_data("valid_mask"),
+      if (src.has_valid_mask()) {
+        EKAT_REQUIRE_MSG(not tgt.has_valid_mask(),
             "[VerticalRemapper::registration_ends_impl] Error! Target field already has mask data assigned.\n"
             " - tgt field name: " + tgt.name() + "\n");
-        auto src_mask = src.get_header().get_extra_data<Field>("valid_mask");
-        tgt.get_header().set_extra_data("valid_mask",src_mask);
+        auto src_mask = src.get_valid_mask();
+        tgt.set_valid_mask(src_mask);
       }
       if (src.get_header().may_be_filled()) {
         tgt.get_header().set_may_be_filled(true);
@@ -444,9 +444,9 @@ void VerticalRemapper::remap_fwd_impl ()
       // so just copy it over.  Note, if this field has its own mask data make
       // sure that is copied too.
       f_tgt.deep_copy(f_src);
-      if (f_tgt.get_header().has_extra_data("valid_mask")) {
-        auto f_tgt_mask = f_tgt.get_header().get_extra_data<Field>("valid_mask");
-        auto f_src_mask = f_src.get_header().get_extra_data<Field>("valid_mask");
+      if (f_tgt.has_valid_mask()) {
+        auto& f_tgt_mask = f_tgt.get_valid_mask();
+        auto& f_src_mask = f_src.get_valid_mask();
         f_tgt_mask.deep_copy(f_src_mask);
       }
     }
@@ -650,7 +650,7 @@ extrapolate (const Field& f_src,
     {
       auto f_src_v = f_src.get_view<const Real**>();
       auto f_tgt_v = f_tgt.get_view<      Real**>();
-      auto mask_v = do_mask ? f_tgt.get_header().get_extra_data<Field>("valid_mask").get_view<int**>()
+      auto mask_v = do_mask ? f_tgt.get_valid_mask().get_view<int**>()
                             : typename Field::view_dev_t<int**>{};
 
       auto policy = TPF::get_default_team_policy(ncols,nlevs_tgt);
@@ -705,7 +705,7 @@ extrapolate (const Field& f_src,
     {
       auto f_src_v = f_src.get_view<const Real***>();
       auto f_tgt_v = f_tgt.get_view<      Real***>();
-      auto mask_v = do_mask ? f_tgt.get_header().get_extra_data<Field>("valid_mask").get_view<int***>()
+      auto mask_v = do_mask ? f_tgt.get_valid_mask().get_view<int***>()
                             : typename Field::view_dev_t<int***>{};
       const int ncomps = f_tgt_l.get_vector_dim();
       auto policy = TPF::get_default_team_policy(ncols*ncomps,nlevs_tgt);


### PR DESCRIPTION
Allow to set/retrieve a mask field directly from the Field class (rather than having to query the header for a specific extra data key).

[BFB]

---

The mask field replaces all usage along the line of `f.get_header().get_extra_data<Field>("valid_mask")`, which was exposing an implementation detail (namely, how we store the mask field).

This PR could conflict a bit with #8229 (technically, no, but they touch similar files, in lines very close to each other), so I may rebase one or the other when they get integrated.