### PR TITLE
EAMxx: Updates the dropmixnuc function signature to match mam4xx.

### DIFF
--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_functions.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_functions.hpp
@@ -240,7 +240,6 @@ void call_function_dropmixnuc(
   //----------------------------------------------------------------------
   MAMAci::view_4d loc_raercol_cw = raercol_cw;
   MAMAci::view_4d loc_raercol = raercol;
-  MAMAci::view_2d loc_qqcw[mam4::ndrop::ncnst_tot];
   MAMAci::view_3d loc_ptend_q = ptend_q;
   MAMAci::view_3d loc_coltend = coltend;
   MAMAci::view_3d loc_coltend_cw = coltend_cw;

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_functions.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_functions.hpp
@@ -401,7 +401,7 @@ void call_function_dropmixnuc(
 
 // Update cloud borne aerosols
 void update_cloud_borne_aerosols(
-    const MAMAci::view_3d qqcw_fld_work, const int nlev,
+    const MAMAci::view_3d qqcw_fld_work,
     // output
     mam_coupling::AerosolState &dry_aero) {
   int ind_qqcw = 0;

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_functions.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_functions.hpp
@@ -300,7 +300,6 @@ void call_function_dropmixnuc(
       "MAMAci::run_impl::call_function_dropmixnuc", team_policy,
       KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
         const int icol = team.league_rank();
-        // for (int icol=0; icol<5; ++icol){
         MAMAci::view_3d raercol_cw_view = ekat::subview(loc_raercol_cw, icol);
 	MAMAci::view_3d raercol_view    = ekat::subview(loc_raercol, icol);
         MAMAci::view_2d qqcw_view       = ekat::subview(qqcw_fld_work_loc, icol);

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_functions.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_functions.hpp
@@ -200,17 +200,17 @@ void call_function_dropmixnuc(
     const int top_lev, const bool &enable_aero_vertical_mix,
 
     // Following outputs are all diagnostics
-    MAMAci::view_2d coltend[mam4::ndrop::ncnst_tot],
-    MAMAci::view_2d coltend_cw[mam4::ndrop::ncnst_tot], MAMAci::view_2d qcld,
+    MAMAci::view_3d coltend,
+    MAMAci::view_3d coltend_cw, MAMAci::view_2d qcld,
     MAMAci::view_2d ndropcol, MAMAci::view_2d ndropmix, MAMAci::view_2d nsource,
     MAMAci::view_2d wtke, MAMAci::view_3d ccn,
 
     // ## outputs to be used by other processes ##
     // qqcw_fld_work should be directly assigned to the cloud borne aerosols
-    MAMAci::view_2d qqcw_fld_work[mam4::ndrop::ncnst_tot],
+    MAMAci::view_3d qqcw_fld_work,
 
     // ptend_q are the tendencies to the interstitial aerosols
-    MAMAci::view_2d ptend_q[mam4::aero_model::pcnst],
+    MAMAci::view_3d ptend_q,
 
     // factnum is used by the hetrozenous freezing
     MAMAci::view_3d factnum,
@@ -219,8 +219,9 @@ void call_function_dropmixnuc(
     MAMAci::view_2d tendnd,
 
     // ## work arrays ##
-    MAMAci::view_2d raercol_cw[mam4::ndrop::pver][2],
-    MAMAci::view_2d raercol[mam4::ndrop::pver][2], MAMAci::view_3d state_q_work,
+    MAMAci::view_4d raercol_cw, 
+    MAMAci::view_4d raercol, 
+    MAMAci::view_3d state_q_work,
     MAMAci::view_3d nact, MAMAci::view_3d mact,
     MAMAci::view_2d dropmixnuc_scratch_mem[MAMAci::dropmix_scratch_]) {
   using CO = scream::ColumnOps<DefaultDevice, Real>;
@@ -237,30 +238,14 @@ void call_function_dropmixnuc(
   // ## Declare local variables for class variables
   //(FIXME: GPU hack, revisit this)
   //----------------------------------------------------------------------
-  MAMAci::view_2d loc_raercol_cw[mam4::ndrop::pver][2];
-  MAMAci::view_2d loc_raercol[mam4::ndrop::pver][2];
+  MAMAci::view_4d loc_raercol_cw = raercol_cw;
+  MAMAci::view_4d loc_raercol = raercol;
   MAMAci::view_2d loc_qqcw[mam4::ndrop::ncnst_tot];
-  MAMAci::view_2d loc_ptend_q[mam4::aero_model::pcnst];
-  MAMAci::view_2d loc_coltend[mam4::ndrop::ncnst_tot];
-  MAMAci::view_2d loc_coltend_cw[mam4::ndrop::ncnst_tot];
+  MAMAci::view_3d loc_ptend_q = ptend_q;
+  MAMAci::view_3d loc_coltend = coltend;
+  MAMAci::view_3d loc_coltend_cw = coltend_cw;
 
-  for(int i = 0; i < mam4::ndrop::pver; ++i) {
-    for(int j = 0; j < 2; ++j) {
-      loc_raercol_cw[i][j] = raercol_cw[i][j];
-      loc_raercol[i][j]    = raercol[i][j];
-    }
-  }
-
-  for(int i = 0; i < mam4::ndrop::ncnst_tot; ++i) {
-    loc_coltend[i]    = coltend[i];
-    loc_coltend_cw[i] = coltend_cw[i];
-  }
-
-  for(int i = 0; i < mam4::aero_model::pcnst; ++i) loc_ptend_q[i] = ptend_q[i];
-
-  MAMAci::view_2d qqcw_fld_work_loc[25];
-  for(int i = 0; i < mam4::ndrop::ncnst_tot; ++i)
-    qqcw_fld_work_loc[i] = qqcw_fld_work[i];
+  MAMAci::view_3d qqcw_fld_work_loc = qqcw_fld_work;
 
   MAMAci::view_3d state_q_work_loc = state_q_work;
 
@@ -316,28 +301,12 @@ void call_function_dropmixnuc(
       KOKKOS_LAMBDA(const mam4::ThreadTeam &team) {
         const int icol = team.league_rank();
         // for (int icol=0; icol<5; ++icol){
-        mam4::ndrop::View1D raercol_cw_view[mam4::ndrop::pver][2];
-        mam4::ndrop::View1D raercol_view[mam4::ndrop::pver][2];
-        for(int i = 0; i < mam4::ndrop::pver; ++i) {
-          for(int j = 0; j < 2; ++j) {
-            raercol_cw_view[i][j] = ekat::subview(loc_raercol_cw[i][j], icol);
-            raercol_view[i][j]    = ekat::subview(loc_raercol[i][j], icol);
-          }
-        }
-        mam4::ColumnView qqcw_view[mam4::ndrop::ncnst_tot];
-        for(int i = 0; i < mam4::ndrop::ncnst_tot; ++i) {
-          qqcw_view[i] = ekat::subview(qqcw_fld_work_loc[i], icol);
-        }
-        mam4::ColumnView ptend_q_view[mam4::aero_model::pcnst];
-        for(int i = 0; i < mam4::aero_model::pcnst; ++i) {
-          ptend_q_view[i] = ekat::subview(loc_ptend_q[i], icol);
-        }
-        mam4::ColumnView coltend_view[mam4::ndrop::ncnst_tot],
-            coltend_cw_view[mam4::ndrop::ncnst_tot];
-        for(int i = 0; i < mam4::ndrop::ncnst_tot; ++i) {
-          coltend_view[i]    = ekat::subview(loc_coltend[i], icol);
-          coltend_cw_view[i] = ekat::subview(loc_coltend_cw[i], icol);
-        }
+        MAMAci::view_3d raercol_cw_view = ekat::subview(loc_raercol_cw, icol);
+	MAMAci::view_3d raercol_view    = ekat::subview(loc_raercol, icol);
+        MAMAci::view_2d qqcw_view       = ekat::subview(qqcw_fld_work_loc, icol);
+        MAMAci::view_2d ptend_q_view    = ekat::subview(loc_ptend_q, icol);
+        MAMAci::view_2d coltend_view    = ekat::subview(loc_coltend, icol);
+        MAMAci::view_2d coltend_cw_view = ekat::subview(loc_coltend_cw, icol);
 
         // To construct state_q, we need fields from Prognostics (aerosols)
         //  and Atmosphere (water species such as qv, qc etc.)
@@ -373,12 +342,11 @@ void call_function_dropmixnuc(
                   progs_at_col, atm, state_q_at_lev_col, klev);
 
               // get the start index for aerosols species in the state_q array
-              int istart = mam4::utils::aero_start_ind();
-
-              // create colum views of state_q
-              for(int icnst = istart; icnst < mam4::aero_model::pcnst;
-                  ++icnst) {
-                state_q_work_loc(icol, klev, icnst) = state_q_at_lev_col[icnst];
+              const int istart = mam4::utils::aero_start_ind();
+              for (int m = 0, s = istart; m < mam4::AeroConfig::num_modes(); ++m, ++s) {
+                for (int a = 0; a < mam4::num_species_mode(m); ++a, ++s) 
+                  state_q_work_loc(icol, klev, s) = progs_at_col.q_aero_i[m][a](klev);
+                state_q_work_loc(icol, klev, s) = progs_at_col.n_mode_i[m](klev);
               }
 
               // get qqcw at a grid cell (col,lev)
@@ -386,12 +354,12 @@ void call_function_dropmixnuc(
               // dropmixnuc. To mimic that, we are using the following for-loops
               int ind_qqcw = 0;
               for(int m = 0; m < mam_coupling::num_aero_modes(); ++m) {
-                qqcw_view[ind_qqcw](klev) =
+                qqcw_view(ind_qqcw, klev) =
                     dry_aero.cld_aero_nmr[m](icol, klev);
                 ++ind_qqcw;
                 for(int a = 0; a < mam_coupling::num_aero_species(); ++a) {
                   if(dry_aero.cld_aero_mmr[m][a].data()) {
-                    qqcw_view[ind_qqcw](klev) =
+                    qqcw_view(ind_qqcw, klev) =
                         dry_aero.cld_aero_mmr[m][a](icol, klev);
                     ++ind_qqcw;
                   }
@@ -434,16 +402,16 @@ void call_function_dropmixnuc(
 
 // Update cloud borne aerosols
 void update_cloud_borne_aerosols(
-    const MAMAci::view_2d qqcw_fld_work[mam4::ndrop::ncnst_tot], const int nlev,
+    const MAMAci::view_3d qqcw_fld_work, const int nlev,
     // output
     mam_coupling::AerosolState &dry_aero) {
   int ind_qqcw = 0;
   for(int m = 0; m < mam_coupling::num_aero_modes(); ++m) {
-    Kokkos::deep_copy(dry_aero.cld_aero_nmr[m], qqcw_fld_work[ind_qqcw]);
+    Kokkos::deep_copy(dry_aero.cld_aero_nmr[m], Kokkos::subview(qqcw_fld_work, Kokkos::ALL(), ind_qqcw, Kokkos::ALL()));
     ++ind_qqcw;
     for(int a = 0; a < mam_coupling::num_aero_species(); ++a) {
       if(dry_aero.cld_aero_mmr[m][a].data()) {
-        Kokkos::deep_copy(dry_aero.cld_aero_mmr[m][a], qqcw_fld_work[ind_qqcw]);
+        Kokkos::deep_copy(dry_aero.cld_aero_mmr[m][a], Kokkos::subview(qqcw_fld_work, Kokkos::ALL(), ind_qqcw, Kokkos::ALL()));
         ++ind_qqcw;
       }
     }
@@ -453,7 +421,7 @@ void update_cloud_borne_aerosols(
 // Update interstitial aerosols using tendencies- cols and levs
 void update_interstitial_aerosols(
     const int ncol,
-    const MAMAci::view_2d ptend_q[mam4::aero_model::pcnst], const int nlev,
+    const MAMAci::view_3d ptend_q, const int nlev,
     const Real dt,
     // output
     mam_coupling::AerosolState &dry_aero) {
@@ -467,12 +435,11 @@ void update_interstitial_aerosols(
       auto aero_mmr = dry_aero.int_aero_mmr[m][a];
 
       if(aero_mmr.data()) {
-        const auto ptend_view = ptend_q[s_idx];
         Kokkos::parallel_for(
             "MAMAci::run_impl::update_interstitial_aerosols_mmr",
             Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0, 0}, {ncol, nlev}),
             KOKKOS_LAMBDA(const int icol, const int kk) {
-              aero_mmr(icol, kk) += ptend_view(icol, kk) * dt;
+              aero_mmr(icol, kk) += ptend_q(icol, s_idx, kk) * dt;
             });
         // update index for the next species (only if aero_mmr.data() is True)
         ++s_idx;
@@ -480,13 +447,12 @@ void update_interstitial_aerosols(
     }
     auto aero_nmr =
         dry_aero.int_aero_nmr[m];  // number mixing ratio for mode "m"
-    const auto ptend_view = ptend_q[s_idx];
     Kokkos::parallel_for(
         "MAMAci::run_impl::update_interstitial_aerosols_nmr",
         Kokkos::MDRangePolicy<Kokkos::Rank<2>>({0, 0}, {ncol, nlev}),
         KOKKOS_LAMBDA(const int icol, const int kk) {
-          aero_nmr(icol, kk) += ptend_view(icol, kk) * dt;
-        });
+          aero_nmr(icol, kk) += ptend_q(icol, s_idx, kk) * dt; 
+	});
     ++s_idx;  // update index for the next species
   }
 }

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
@@ -559,6 +559,7 @@ void MAMAci::run_impl(const double dt) {
   //  Compute activated CCN number tendency (tendnd_) and updated
   //  cloud borne aerosols (stored in a work array) and interstitial
   //  aerosols tendencies
+  Kokkos::deep_copy(ccn_, 0.0);
   call_function_dropmixnuc(
       team_policy, dt, dry_atm_, rpdel_, kvh_mid_, kvh_int_, wsub_, cloud_frac_,
       cloud_frac_prev_, dry_aero_, nlev_, top_lev_, enable_aero_vertical_mix_,

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
@@ -217,6 +217,10 @@ int MAMAci::get_len_temporary_views() {
   work_len += ncol_ * nlev_ * mam4::ndrop::psat;
   // raercol_cw_ and raercol_
   work_len += 2 * ncol_ * mam4::ndrop::ncnst_tot * nlev_ * 2;
+  // qqcw_fld_work_
+  work_len += ncol_ * nlev_ * mam4::ndrop::ncnst_tot;
+  // coltend_ & coltend_cw_
+  work_len += 2 *  ncol_ * nlev_ * mam4::ndrop::ncnst_tot;
   // factnum_, nact_, mact_
   work_len += 3 * ncol_ * mam_coupling::num_aero_modes() * nlev_;
   // kvh_int_, w_sec_int_
@@ -237,16 +241,21 @@ void MAMAci::init_temporary_views() {
   ccn_ = view_3d(work_ptr, ncol_, nlev_, mam4::ndrop::psat);
   work_ptr += ncol_ * nlev_ * mam4::ndrop::psat;
 
-  for(int i = 0; i < nlev_; ++i) {
-    for(int j = 0; j < 2; ++j) {
-      // Kokkos::resize(raercol_cw_[i][j], ncol_, mam4::ndrop::ncnst_tot);
-      raercol_cw_[i][j] = view_2d(work_ptr, ncol_, mam4::ndrop::ncnst_tot);
-      work_ptr += ncol_ * mam4::ndrop::ncnst_tot;
-      // Kokkos::resize(raercol_[i][j], ncol_, mam4::ndrop::ncnst_tot);
-      raercol_[i][j] = view_2d(work_ptr, ncol_, mam4::ndrop::ncnst_tot);
-      work_ptr += ncol_ * mam4::ndrop::ncnst_tot;
-    }
-  }
+  raercol_cw_ = view_4d(work_ptr, ncol_, nlev_, 2, mam4::ndrop::ncnst_tot);
+  work_ptr += raercol_cw_.size();
+  raercol_ = view_4d(work_ptr, ncol_, nlev_, 2, mam4::ndrop::ncnst_tot);
+  work_ptr += raercol_.size();
+
+  qqcw_fld_work_ = view_3d(work_ptr, ncol_, mam4::ndrop::ncnst_tot, nlev_);
+  work_ptr += qqcw_fld_work_.size();
+
+  // column tendency for diagnostic output
+  coltend_ = view_3d(work_ptr, ncol_, mam4::ndrop::ncnst_tot, nlev_);
+  work_ptr += coltend_.size();
+  // column tendency
+  coltend_cw_ = view_3d(work_ptr, ncol_, mam4::ndrop::ncnst_tot, nlev_);
+  work_ptr += coltend_cw_.size();
+
   // activation fraction for aerosol number [fraction]
   // Kokkos::resize(factnum_, ncol_, num_aero_modes, nlev_);
   factnum_ = view_3d(work_ptr, ncol_, mam_coupling::num_aero_modes(), nlev_);
@@ -449,21 +458,10 @@ void MAMAci::initialize_impl(const RunType run_type) {
     dropmixnuc_scratch_mem_[i] =
         view_2d("dropmixnuc_scratch_mem_", ncol_, nlev_);
   }
-  for(int i = 0; i < mam4::ndrop::ncnst_tot; ++i) {
-    // column tendency for diagnostic output
-    set_field_w_scratch_buffer(coltend_[i], buffer_, true);
-    // column tendency
-    set_field_w_scratch_buffer(coltend_cw_[i], buffer_, true);
-  }
   // NOTE: If we use buffer_ to initialize ptend_q_,
   //  we must reset these values to zero each time run_impl is called.
-  for(int i = 0; i < mam4::aero_model::pcnst; ++i) {
-    ptend_q_[i] = view_2d("ptend_q_", ncol_, nlev_);
-  }
-  // Allocate work arrays
-  for(int icnst = 0; icnst < mam4::ndrop::ncnst_tot; ++icnst) {
-    set_field_w_scratch_buffer(qqcw_fld_work_[icnst], buffer_, true);
-  }
+  ptend_q_ = view_3d("ptend_q_", ncol_, mam4::aero_model::pcnst, nlev_);
+
   //---------------------------------------------------------------------------------
   // Diagnotics variables from the hetrozenous ice nucleation scheme
   //---------------------------------------------------------------------------------

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
@@ -605,7 +605,7 @@ void MAMAci::run_impl(const double dt) {
   //---------------------------------------------------------------
 
   // Update cloud borne aerosols
-  update_cloud_borne_aerosols(qqcw_fld_work_, nlev_,
+  update_cloud_borne_aerosols(qqcw_fld_work_,
                               // output
                               dry_aero_);
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.hpp
@@ -24,7 +24,11 @@ class MAMAci final : public MAMGenericInterface {
   using view_2d       = scream::mam_coupling::view_2d;
   using const_view_2d = scream::mam_coupling::const_view_2d;
   using view_3d       = scream::mam_coupling::view_3d;
+  using view_4d       = scream::mam_coupling::view_4d;;
   using const_view_3d = scream::mam_coupling::const_view_3d;
+  template <int X, int Y>
+  using view_2d_table = typename KT::template view_2d_table<const Real, X, Y>;
+
 
  private:
   using KT = ekat::KokkosTypes<DefaultDevice>;
@@ -82,7 +86,7 @@ class MAMAci final : public MAMGenericInterface {
   view_2d cloud_frac_;
   view_2d cloud_frac_prev_;
   view_2d qcld_;
-  view_2d ptend_q_[mam4::aero_model::pcnst];
+  view_3d ptend_q_;
   view_3d factnum_;
   const_view_3d qqcw_input_;
   view_2d qqcw_[mam4::ndrop::ncnst_tot];
@@ -98,13 +102,13 @@ class MAMAci final : public MAMGenericInterface {
   view_2d ccn_1p0_;        // FIXME: TEMPORARY output
   view_2d wtke_;
   view_3d ccn_;
-  view_2d coltend_[mam4::ndrop::ncnst_tot];
-  view_2d coltend_cw_[mam4::ndrop::ncnst_tot];
+  view_3d coltend_; 
+  view_3d coltend_cw_; 
 
   // raercol_cw_ and raercol_ are work arrays for dropmixnuc, allocated on the
   // stack.
-  view_2d raercol_cw_[mam4::ndrop::pver][2];
-  view_2d raercol_[mam4::ndrop::pver][2];
+  view_4d raercol_cw_;
+  view_4d raercol_;
 
   view_3d nact_;
   view_3d mact_;
@@ -131,7 +135,7 @@ class MAMAci final : public MAMGenericInterface {
   view_2d w_sec_int_;        // Vertical velocity variance at interfaces
 
   // A view array to carry cloud borne aerosol mmrs/nmrs
-  view_2d qqcw_fld_work_[mam4::ndrop::ncnst_tot];
+  view_3d qqcw_fld_work_; //[mam4::ndrop::ncnst_tot];
 
   // A view to carry interstitial aerosol mmrs/nmrs
   view_3d state_q_work_;
@@ -221,7 +225,7 @@ class MAMAci final : public MAMGenericInterface {
   // workspace manager for internal local variables
   mam_coupling::Buffer buffer_;
 
-  int num_2d_scratch_ = 94;
+  int num_2d_scratch_ = 19;
   int len_temporary_views_{0};
 
 };  // MAMAci

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.hpp
@@ -24,7 +24,7 @@ class MAMAci final : public MAMGenericInterface {
   using view_2d       = scream::mam_coupling::view_2d;
   using const_view_2d = scream::mam_coupling::const_view_2d;
   using view_3d       = scream::mam_coupling::view_3d;
-  using view_4d       = scream::mam_coupling::view_4d;;
+  using view_4d       = scream::mam_coupling::view_4d;
   using const_view_3d = scream::mam_coupling::const_view_3d;
   template <int X, int Y>
   using view_2d_table = typename KT::template view_2d_table<const Real, X, Y>;
@@ -105,8 +105,8 @@ class MAMAci final : public MAMGenericInterface {
   view_3d coltend_; 
   view_3d coltend_cw_; 
 
-  // raercol_cw_ and raercol_ are work arrays for dropmixnuc, allocated on the
-  // stack.
+  // raercol_cw_ and raercol_ are work-array views for dropmixnuc whose
+  // storage is allocated from the temporary buffer in init_temporary_views().
   view_4d raercol_cw_;
   view_4d raercol_;
 
@@ -135,7 +135,8 @@ class MAMAci final : public MAMGenericInterface {
   view_2d w_sec_int_;        // Vertical velocity variance at interfaces
 
   // A view array to carry cloud borne aerosol mmrs/nmrs
-  view_3d qqcw_fld_work_; //[mam4::ndrop::ncnst_tot];
+  // Dimensions/order: [ncol][nlev][mam4::ndrop::ncnst_tot]
+  view_3d qqcw_fld_work_;
 
   // A view to carry interstitial aerosol mmrs/nmrs
   view_3d state_q_work_;

--- a/components/eamxx/src/physics/mam/mam_coupling.hpp
+++ b/components/eamxx/src/physics/mam/mam_coupling.hpp
@@ -19,6 +19,7 @@ using KT = ekat::KokkosTypes<ekat::DefaultDevice>;
 using view_1d       = typename KT::template view_1d<Real>;
 using view_2d       = typename KT::template view_2d<Real>;
 using view_3d       = typename KT::template view_3d<Real>;
+using view_4d       = typename KT::template view<Real****>;
 using const_view_1d = typename KT::template view_1d<const Real>;
 using const_view_2d = typename KT::template view_2d<const Real>;
 using const_view_3d = typename KT::template view_3d<const Real>;


### PR DESCRIPTION
Replace 2D arrays of 2D Kokkos Views with 4D views.

The mam4xx merge of:
  Replace arrays of views wtih multidim views in dropmixnuc.  #526
  mam4xx SHA: 1332d65a92dc9d6df45fc881b75e84d822b65eab
changed the function signature of ndrop::dropmixnuc. E3SM needs to update the call before it can use that latest version of mam4xx.

[BFB]