### PR TITLE
fixed order of LUxPFT matrix read

### DIFF
--- a/components/elm/src/main/elmfates_interfaceMod.F90
+++ b/components/elm/src/main/elmfates_interfaceMod.F90
@@ -3922,7 +3922,7 @@ end subroutine wrap_update_hifrq_hist
 
    ! Land use name arrays
    character(len=10), parameter  :: landuse_pft_map_varnames(num_landuse_pft_vars) = &
-                    [character(len=10)  :: 'frac_primr','frac_secnd','frac_pastr','frac_range'] !need to move 'frac_surf' to a different variable
+                    [character(len=10)  :: 'frac_primr','frac_secnd','frac_range','frac_pastr'] !need to move 'frac_surf' to a different variable
 
    character(len=*), parameter :: subname = 'GetLandusePFTData'
 


### PR DESCRIPTION
This PR fixes FATES issue https://github.com/NGEET/fates/issues/1551 for E3SM.
It will be answer-changing only for FATES configurations with transient land use in nocomp configurations, otherwise it will be bit-for-bit.