### PR TITLE
Add more tests of driver-moab

### DIFF
--- a/cime_config/testmods_dirs/allactive/onlinemaps/shell_commands
+++ b/cime_config/testmods_dirs/allactive/onlinemaps/shell_commands
@@ -1,0 +1,2 @@
+#!/bin/bash
+./xmlchange CPL_COMPUTE_MAPS_ONLINE=TRUE

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -905,6 +905,7 @@ _TESTS = {
             "ERS_Vmoab_Ld3.T62_oQU240.DTESTM",
             "ERS_Vmoab_Ld3.r05_r05.RMOSGPCC",
             "ERS_Vmoab_Ld3.ne4pg2_ne4pg2.F2010-SCREAMv1",
+            "ERS_Vmoab_Ld3.f45_g37.X",
         )
     },
 
@@ -937,6 +938,7 @@ _TESTS = {
             "SMS_Vmoab_Ld1.r05_r05.RMOSGPCC",
             "SMS_Vmoab_Ld1.ne4pg2_ne4pg2.F2010-SCREAMv1",
             "SMS_Vmoab_Ld1.T62_oQU240.DTESTM",
+            "SMS_Vmoab_Ld1.f45_g37.X",
             "SMS_Ld1.ne4pg2_r05_oQU480.WCYCL1850NS",
             "SMS_Ld1.ne4pg2_oQU480.WCYCL1850NS",
             "SMS_Ld1.ne4pg2_oQU480.F1850",
@@ -947,6 +949,7 @@ _TESTS = {
             "SMS_Ld1.r05_r05.RMOSGPCC",
             "SMS_Ld1.ne4pg2_ne4pg2.F2010-SCREAMv1",
             "SMS_Ld1.T62_oQU240.DTESTM",
+            "SMS_Ld1.f45_g37.X",
         )
     },
 

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -970,6 +970,22 @@ _TESTS = {
         )
     },
 
+    "e3sm_moab_dbg" : {
+        "time"  : "01:00:00",
+        "tests" : (
+            "SMS_Vmoab_D_Ld1.ne4pg2_r05_oQU480.WCYCL1850NS",
+            "SMS_Vmoab_D_Ld1.ne4pg2_oQU480.WCYCL1850NS",
+            "SMS_Vmoab_D_Ld1.ne4pg2_oQU480.F1850",
+            "SMS_Vmoab_D_Ld1.ne4pg2_oQU480.F2010-SCREAMv1-MPASSI",
+            "SMS_Vmoab_D_Ld1.ne4pg2_ne4pg2.I1850CNPRDCTCBCTOP",
+            "SMS_Vmoab_D_Ld1.T62_oQU240wLI.GMPAS-IAF",
+            "SMS_Vmoab_D_Ld1.T62_oQU120.CMPASO-NYF",
+            "SMS_Vmoab_D_Ld1.r05_r05.RMOSGPCC",
+            "SMS_Vmoab_D_Ld1.ne4pg2_ne4pg2.F2010-SCREAMv1",
+            "SMS_Vmoab_D_Ld1.T62_oQU240.DTESTM",
+            "SMS_Vmoab_D_Ld1.f45_g37.X",
+        )
+    },
 
     "e3sm_gpuacc" : {
         "tests"    : (

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -939,6 +939,7 @@ _TESTS = {
             "PEM_Vmoab_Ld3.T62_oQU240.DTESTM",
             "PEM_Vmoab_Ld3.r05_r05.RMOSGPCC",
             "PEM_Vmoab_Ld3.ne4pg2_ne4pg2.F2010-SCREAMv1",
+            "PEM_Vmoab_Ld3.f45_g37.X",
         )
     },
 

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -909,6 +909,23 @@ _TESTS = {
         )
     },
 
+    "e3sm_moab_ersonline" : {
+        "time"  : "01:00:00",
+        "tests" : (
+            "ERS_Vmoab_Ld3.ne4pg2_r05_oQU480.WCYCL1850NS.allactive-onlinemaps",
+            "ERS_Vmoab_Ld3.ne4pg2_oQU480.WCYCL1850NS.allactive-onlinemaps",
+            "ERS_Vmoab_Ld3.ne4pg2_oQU480.F1850.allactive-onlinemaps",
+            "ERS_Vmoab_Ld3.ne4pg2_oQU480.F2010-SCREAMv1-MPASSI.allactive-onlinemaps",
+            "ERS_Vmoab_Ld3.ne4pg2_ne4pg2.I1850CNPRDCTCBCTOP.allactive-onlinemaps",
+            "ERS_Vmoab_Ld3.T62_oQU240wLI.GMPAS-IAF.allactive-onlinemaps",
+            "ERS_Vmoab_Ld3.T62_oQU120.CMPASO-NYF.allactive-onlinemaps",
+            "ERS_Vmoab_Ld3.T62_oQU240.DTESTM.allactive-onlinemaps",
+            "ERS_Vmoab_Ld3.r05_r05.RMOSGPCC.allactive-onlinemaps",
+            "ERS_Vmoab_Ld3.ne4pg2_ne4pg2.F2010-SCREAMv1.allactive-onlinemaps",
+            "ERS_Vmoab_Ld3.f45_g37.X.allactive-onlinemaps",
+        )
+    },
+
     "e3sm_moab_pem" : {
         "time"  : "01:00:00",
         "tests" : (

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -1126,9 +1126,8 @@ contains
 
 
       ! Import state from coupler
-      call ocn_import_mct(x2o_o % rAttr, ierr)
-      ! Import state from moab coupler
 #ifdef HAVE_MOAB
+      ! Import state from moab coupler
       tagname = trim(seq_flds_x2o_fields)//C_NULL_CHAR
       ent_type = 1 ! cells
       ierr = iMOAB_GetDoubleTagStorage(MPOID, tagname, totalmbls_r, ent_type, x2o_om)
@@ -1138,6 +1137,7 @@ contains
       x2o_om2 = transpose(x2o_om)
       call ocn_import_mct(x2o_om2, errorCode)
 #else
+      ! Import state from mct coupler
       call ocn_import_mct(x2o_o % rAttr, errorCode)
 #endif
       if (errorCode /= 0) then

--- a/components/xcpl_comps/xrof/src/rof_comp_mct.F90
+++ b/components/xcpl_comps/xrof/src/rof_comp_mct.F90
@@ -136,7 +136,7 @@ CONTAINS
     call dead_init_mct('rof', Eclock, x2d, d2x, &
          seq_flds_x2r_fields, seq_flds_r2x_fields, &
          gsmap, ggrid, gbuf, mpicom, compid, my_task, master_task, &
-         inst_index, inst_suffix, inst_name, logunit, nxg, nyg)
+         inst_index, inst_suffix, inst_name, logunit, nxg, nyg,flood_present)
 
     if (nxg == 0 .and. nyg == 0) then
        rof_present = .false.
@@ -147,7 +147,6 @@ CONTAINS
        rof_present = .true.
        rof_prognostic = .true.
        rofice_present = .false.
-       flood_present = .true.
     end if
 
 #ifdef HAVE_MOAB

--- a/components/xcpl_comps/xshare/dead_mct_mod.F90
+++ b/components/xcpl_comps/xshare/dead_mct_mod.F90
@@ -35,7 +35,7 @@ contains
   subroutine dead_init_mct(model, Eclock, x2d, d2x, &
          flds_x2d, flds_d2x, &
          gsmap, ggrid, gbuf, mpicom, compid, my_task, master_task, &
-         inst_index, inst_suffix, inst_name, logunit, nxg, nyg )
+         inst_index, inst_suffix, inst_name, logunit, nxg, nyg, flood)
 
     ! !INPUT/OUTPUT PARAMETERS:
     character(len=*) , intent(in)    :: model
@@ -57,6 +57,7 @@ contains
     integer(IN)      , intent(in)    :: logunit     ! logging unit number
     integer(IN)      , intent(out)   :: nxg         ! global dim i-direction
     integer(IN)      , intent(out)   :: nyg         ! global dim j-direction
+    logical, intent(out),optional   :: flood
 
     !--- local variables ---
     integer(IN)              :: ierr          ! error code
@@ -68,7 +69,7 @@ contains
     integer(IN)              :: nproc_x
     integer(IN)              :: seg_len
     integer(IN)              :: decomp_type
-    logical                  :: flood=.false. ! rof flood flag
+    logical                  :: lflood=.false.
 
     !--- formats ---
     character(*), parameter :: F00   = "('(',a,'_init_mct) ',8a)"
@@ -89,7 +90,11 @@ contains
 
     call dead_read_inparms(model, mpicom, my_task, master_task, &
        inst_index, inst_suffix, inst_name, logunit, &
-       nxg, nyg, decomp_type, nproc_x, seg_len, flood)
+       nxg, nyg, decomp_type, nproc_x, seg_len, lflood)
+
+    if (present(flood)) then
+      flood=lflood
+    endif
 
     ! Initialize grid
 

--- a/driver-moab/main/prep_atm_mod.F90
+++ b/driver-moab/main/prep_atm_mod.F90
@@ -832,7 +832,7 @@ contains
             mapper_Fl2a%intx_mbid = mbintxla
             mapper_Fl2a%src_context = lnd(1)%cplcompid
             mapper_Fl2a%intx_context = idintx
-            mapper_Fl2a%weight_identifier = wgtIdSl2a
+            mapper_Fl2a%weight_identifier = wgtIdFl2a
             mapper_Fl2a%mbname = 'mapper_Fl2a'
 
             if (.not. samegrid_al) then ! tri grid case

--- a/driver-moab/main/prep_ocn_mod.F90
+++ b/driver-moab/main/prep_ocn_mod.F90
@@ -26,6 +26,7 @@ module prep_ocn_mod
   use seq_comm_mct,     only : CPLALLICEID
   use seq_comm_mct,     only : seq_comm_iamin
   use seq_comm_mct,     only : num_moab_exports
+  use seq_comm_mct,     only : mb_dead_comps
 
   use seq_comm_mct,     only : seq_comm_getinfo => seq_comm_setptrs
 
@@ -473,7 +474,7 @@ contains
                   if (iamroot_CPLID) then
                      write(logunit,*) 'iMOAB mesh intersection completed between ATM and OCN with id:', idintx
                   end if
-                  if (atm_pg_active) then
+                  if (atm_pg_active .or. mb_dead_comps) then
                      type1 = 3; ! FV for ATM; CGLL does not work correctly in parallel at the moment
                   else
                      type1 = 1 ! This projection works (CGLL to FV), but reverse does not (FV - CGLL)
@@ -504,7 +505,7 @@ contains
 
                if (compute_maps_online_a2o) then
                   volumetric = 0 ! can be 1 only for FV->DGLL or FV->CGLL;
-                  if (atm_pg_active) then
+                  if (atm_pg_active .or. mb_dead_comps) then
                      dm1 = "fv"//C_NULL_CHAR
                      dofnameS="GLOBAL_ID"//C_NULL_CHAR
                      orderS = 1 !  fv-fv
@@ -576,7 +577,7 @@ contains
                ! and viceversa, based on element GLOBAL_ID matching. In order to seamless produce the
                ! permutation operator, we will compute a communication graph between ATM and OCN DoFs on the
                ! coupler.
-              if (atm_pg_active) then
+              if (atm_pg_active .or. mb_dead_comps) then
                   type1 = 3; ! FV for ATM; CGLL does not work correctly in parallel at the moment
               else
                   type1 = 2 ! in the spectral case, the type on coupler will be point cloud


### PR DESCRIPTION
Add more tests of driver-moab.

Fix a bug with passing flood_present logical from xrof to coupler.
The recently ported X-case is added to the ERS suite and the SMS-diff suite using f45_g37 grid.
Create an onlinemaps testmod and apply it to a duplicate of the ERS suite.
Make a debug test suite using the moab half of the SMS-diff suite and adding _D_ to each SMS test.

Fixes #8262
[BFB]

