### PR TITLE
Expand the list of IOTypes in EAMxx to include all options in scorpio.

### DIFF
--- a/components/eamxx/src/share/scorpio_interface/eamxx_scorpio_interface.cpp
+++ b/components/eamxx/src/share/scorpio_interface/eamxx_scorpio_interface.cpp
@@ -204,12 +204,16 @@ int pio_iotype (IOType iotype) {
   int iotype_int = {};
   auto& s = ScorpioSession::instance();
   switch(iotype){
-    case IOType::DefaultIOType: iotype_int = s.pio_type_default;                    break;
-    case IOType::NetCDF:        iotype_int = static_cast<int>(PIO_IOTYPE_NETCDF);   break;
-    case IOType::PnetCDF:       iotype_int = static_cast<int>(PIO_IOTYPE_PNETCDF);  break;
-    case IOType::Adios:         iotype_int = static_cast<int>(PIO_IOTYPE_ADIOS);    break;
-    case IOType::Adiosc:        iotype_int = static_cast<int>(PIO_IOTYPE_ADIOSC);   break;
-    case IOType::Hdf5:          iotype_int = static_cast<int>(PIO_IOTYPE_HDF5);     break;
+    case IOType::DefaultIOType:   iotype_int = s.pio_type_default;                           break;
+    case IOType::PnetCDF:         iotype_int = static_cast<int>(PIO_IOTYPE_PNETCDF);         break;
+    case IOType::NetCDF:          iotype_int = static_cast<int>(PIO_IOTYPE_NETCDF);          break;
+    case IOType::NetCDF4C:        iotype_int = static_cast<int>(PIO_IOTYPE_NETCDF4C);        break;
+    case IOType::NetCDF4P:        iotype_int = static_cast<int>(PIO_IOTYPE_NETCDF4P);        break;
+    case IOType::NetCDF4P_NCZARR: iotype_int = static_cast<int>(PIO_IOTYPE_NETCDF4P_NCZARR); break;
+    case IOType::Adios:           iotype_int = static_cast<int>(PIO_IOTYPE_ADIOS);           break;
+    case IOType::Adiosc:          iotype_int = static_cast<int>(PIO_IOTYPE_ADIOSC);          break;
+    case IOType::Hdf5:            iotype_int = static_cast<int>(PIO_IOTYPE_HDF5);            break;
+    case IOType::Hdf5C:           iotype_int = static_cast<int>(PIO_IOTYPE_HDF5C);           break;
     default:
       EKAT_ERROR_MSG ("Unrecognized/unsupported iotype.\n");
   }

--- a/components/eamxx/src/share/scorpio_interface/eamxx_scorpio_types.cpp
+++ b/components/eamxx/src/share/scorpio_interface/eamxx_scorpio_types.cpp
@@ -30,11 +30,11 @@ IOType str2iotype(const std::string &str)
     return IOType::PnetCDF;
   } else if(str == "netcdf") {
     return IOType::NetCDF;
-  } else if(str == "netcdf4" || str == "netcdf4c") {
-    return IOType::NetCDF4C;
-  } else if(str == "pnetcdf4" || str == "netcdf4p") {
+  } else if(str == "netcdf4" || str == "netcdf4p") {
     return IOType::NetCDF4P;
-  } else if(str == "pnetcdf4_zarr" || str == "netcdf4z") {
+  } else if(str == "netcdf4c") {
+    return IOType::NetCDF4C;
+  } else if(str == "netcdf4_zarr" || str == "netcdf4z") {
     return IOType::NetCDF4P_NCZARR;
   } else if(str == "adios") {
     return IOType::Adios;

--- a/components/eamxx/src/share/scorpio_interface/eamxx_scorpio_types.cpp
+++ b/components/eamxx/src/share/scorpio_interface/eamxx_scorpio_types.cpp
@@ -30,11 +30,11 @@ IOType str2iotype(const std::string &str)
     return IOType::PnetCDF;
   } else if(str == "netcdf") {
     return IOType::NetCDF;
-  } else if(str == "netcdf4") {
+  } else if(str == "netcdf4" || str == "netcdf4c") {
     return IOType::NetCDF4C;
-  } else if(str == "pnetcdf4") {
+  } else if(str == "pnetcdf4" || str == "netcdf4p") {
     return IOType::NetCDF4P;
-  } else if(str == "pnetcdf4_zarr") {
+  } else if(str == "pnetcdf4_zarr" || str == "netcdf4z") {
     return IOType::NetCDF4P_NCZARR;
   } else if(str == "adios") {
     return IOType::Adios;
@@ -56,9 +56,9 @@ std::string iotype2str(const IOType iotype)
     case IOType::DefaultIOType:   s = "default";       break;
     case IOType::PnetCDF:         s = "pnetcdf";       break;
     case IOType::NetCDF:          s = "netcdf";        break;
-    case IOType::NetCDF4C:        s = "netcdf4";       break;
-    case IOType::NetCDF4P:        s = "pnetcdf4";      break;
-    case IOType::NetCDF4P_NCZARR: s = "pnetcdf4_zarr"; break;
+    case IOType::NetCDF4C:        s = "netcdf4c";      break;
+    case IOType::NetCDF4P:        s = "netcdf4p";      break;
+    case IOType::NetCDF4P_NCZARR: s = "netcdf4z";      break;
     case IOType::Adios:           s = "adios";         break;
     case IOType::Adiosc:          s = "adiosc";        break;
     case IOType::Hdf5:            s = "hdf5";          break;

--- a/components/eamxx/src/share/scorpio_interface/eamxx_scorpio_types.cpp
+++ b/components/eamxx/src/share/scorpio_interface/eamxx_scorpio_types.cpp
@@ -26,16 +26,26 @@ IOType str2iotype(const std::string &str)
 {
   if(str == "default"){
     return IOType::DefaultIOType;
-  } else if(str == "netcdf") {
-    return IOType::NetCDF;
   } else if(str == "pnetcdf") {
     return IOType::PnetCDF;
+  } else if(str == "netcdf") {
+    return IOType::NetCDF;
+  } else if(str == "netcdf") {
+    return IOType::NetCDF;
+  } else if(str == "netcdf4") {
+    return IOType::NetCDF4C;
+  } else if(str == "pnetcdf4") {
+    return IOType::NetCDF4P;
+  } else if(str == "pnetcdf4_zarr") {
+    return IOType::NetCDF4P_NCZARR;
   } else if(str == "adios") {
     return IOType::Adios;
   } else if (str == "adiosc") {
     return IOType::Adiosc;
   } else if(str == "hdf5") {
     return IOType::Hdf5;
+  } else if(str == "hdf5c") {
+    return IOType::Hdf5C;
   } else {
     return IOType::Invalid;
   }
@@ -45,13 +55,17 @@ std::string iotype2str(const IOType iotype)
 {
   std::string s;
   switch(iotype){
-    case IOType::DefaultIOType: s = "default";  break;
-    case IOType::NetCDF:        s = "netcdf";   break;
-    case IOType::PnetCDF:       s = "pnetcdf";  break;
-    case IOType::Adios:         s = "adios";    break;
-    case IOType::Adiosc:        s = "adiosc";   break;
-    case IOType::Hdf5:          s = "hdf5";     break;
-    case IOType::Invalid:       s = "invalid";  break;
+    case IOType::DefaultIOType:  s = "default";       break;
+    case IOType::PnetCDF:        s = "pnetcdf";       break;
+    case IOType::NetCDF:         s = "netcdf";        break;
+    case IOType::NetCDFC:        s = "netcdf4";       break;
+    case IOType::NetCDFP:        s = "pnetcdf4";      break;
+    case IOType::NetCDFP_NCZARR: s = "pnetcdf4_zarr"; break;
+    case IOType::Adios:          s = "adios";         break;
+    case IOType::Adiosc:         s = "adiosc";        break;
+    case IOType::Hdf5:           s = "hdf5";          break;
+    case IOType::Hdf5C:          s = "hdf5c";         break;
+    case IOType::Invalid:        s = "invalid";       break;
     default:
       EKAT_ERROR_MSG ("Unrecognized iotype.\n");
   }

--- a/components/eamxx/src/share/scorpio_interface/eamxx_scorpio_types.cpp
+++ b/components/eamxx/src/share/scorpio_interface/eamxx_scorpio_types.cpp
@@ -30,8 +30,6 @@ IOType str2iotype(const std::string &str)
     return IOType::PnetCDF;
   } else if(str == "netcdf") {
     return IOType::NetCDF;
-  } else if(str == "netcdf") {
-    return IOType::NetCDF;
   } else if(str == "netcdf4") {
     return IOType::NetCDF4C;
   } else if(str == "pnetcdf4") {
@@ -55,17 +53,17 @@ std::string iotype2str(const IOType iotype)
 {
   std::string s;
   switch(iotype){
-    case IOType::DefaultIOType:  s = "default";       break;
-    case IOType::PnetCDF:        s = "pnetcdf";       break;
-    case IOType::NetCDF:         s = "netcdf";        break;
-    case IOType::NetCDFC:        s = "netcdf4";       break;
-    case IOType::NetCDFP:        s = "pnetcdf4";      break;
-    case IOType::NetCDFP_NCZARR: s = "pnetcdf4_zarr"; break;
-    case IOType::Adios:          s = "adios";         break;
-    case IOType::Adiosc:         s = "adiosc";        break;
-    case IOType::Hdf5:           s = "hdf5";          break;
-    case IOType::Hdf5C:          s = "hdf5c";         break;
-    case IOType::Invalid:        s = "invalid";       break;
+    case IOType::DefaultIOType:   s = "default";       break;
+    case IOType::PnetCDF:         s = "pnetcdf";       break;
+    case IOType::NetCDF:          s = "netcdf";        break;
+    case IOType::NetCDF4C:        s = "netcdf4";       break;
+    case IOType::NetCDF4P:        s = "pnetcdf4";      break;
+    case IOType::NetCDF4P_NCZARR: s = "pnetcdf4_zarr"; break;
+    case IOType::Adios:           s = "adios";         break;
+    case IOType::Adiosc:          s = "adiosc";        break;
+    case IOType::Hdf5:            s = "hdf5";          break;
+    case IOType::Hdf5C:           s = "hdf5c";         break;
+    case IOType::Invalid:         s = "invalid";       break;
     default:
       EKAT_ERROR_MSG ("Unrecognized iotype.\n");
   }

--- a/components/eamxx/src/share/scorpio_interface/eamxx_scorpio_types.hpp
+++ b/components/eamxx/src/share/scorpio_interface/eamxx_scorpio_types.hpp
@@ -23,11 +23,15 @@ std::string e2str (const FileMode mode);
 enum IOType {
   // Default I/O type is used to let the code choose I/O type as needed (via CIME)
   DefaultIOType = 0,
-  NetCDF,
   PnetCDF,
+  NetCDF,
+  NetCDF4C,
+  NetCDF4P,
+  NetCDF4P_NCZARR,
   Adios,
   Adiosc,
   Hdf5,
+  Hdf5C,
   Invalid
 };
 


### PR DESCRIPTION
This commit expands the options for IOType in the EAMxx I/O options to include all of the PIO_TYPE options currently supported by SCORPIO.

See https://docs.e3sm.org/scorpio/html/pio_8h.html#aa81fb241b31a8419bc97c01bce7ef368.

[BFB]