### PR TITLE
Add COSP dimension coordinate variables and bounds to EAMxx output

### DIFF
--- a/components/eamxx/src/physics/cosp/cosp_c2f.F90
+++ b/components/eamxx/src/physics/cosp/cosp_c2f.F90
@@ -19,7 +19,9 @@ module cosp_c2f
                                  modis_histTauCenters,tau_binCenters,ntauV1p4,            &
                                  tau_binBoundsV1p4,tau_binEdgesV1p4, tau_binCentersV1p4,  &
                                  grLidar532_histBsct,atlid_histBsct,vgrid_zu,vgrid_zl,    &
-                                 Nlvgrid, vgrid_z,cloudsat_preclvl
+                                 Nlvgrid, vgrid_z,cloudsat_preclvl,                       &
+                                 npres,pres_binCenters,pres_binEdges,                     &
+                                 nhgt,hgt_binCenters,hgt_binEdges
   use cosp_phys_constants, only: amw,amd,amO3,amCO2,amCH4,amN2O,amCO
   use mod_quickbeam_optics,only: size_distribution,hydro_class_init,quickbeam_optics,     &
                                  quickbeam_optics_init,gases
@@ -365,6 +367,25 @@ contains
     misr_cthtau(:npoints,:,:) = cospOUT%misr_fq(:npoints,:,:)
 
   end subroutine cosp_c2f_run
+
+  subroutine cosp_c2f_get_bins(tau_centers, tau_edges, prs_centers, prs_edges, &
+       cth_centers, cth_edges) bind(C, name='cosp_c2f_get_bins')
+    ! Returns COSP histogram bin centers and edges (from mod_cosp_config) to C++.
+    ! Array shapes follow Fortran column-major convention (first index varies fastest
+    ! in memory), so tau_edges(1,i) = lower and tau_edges(2,i) = upper for bin i.
+    real(kind=c_double), intent(out), dimension(ntau)      :: tau_centers
+    real(kind=c_double), intent(out), dimension(2,ntau)    :: tau_edges
+    real(kind=c_double), intent(out), dimension(npres)     :: prs_centers
+    real(kind=c_double), intent(out), dimension(2,npres)   :: prs_edges
+    real(kind=c_double), intent(out), dimension(nhgt)      :: cth_centers
+    real(kind=c_double), intent(out), dimension(2,nhgt)    :: cth_edges
+    tau_centers = real(tau_binCenters,  c_double)
+    tau_edges   = real(tau_binEdges,    c_double)
+    prs_centers = real(pres_binCenters, c_double)
+    prs_edges   = real(pres_binEdges,   c_double)
+    cth_centers = real(hgt_binCenters,  c_double)
+    cth_edges   = real(hgt_binEdges,    c_double)
+  end subroutine cosp_c2f_get_bins
 
   subroutine cosp_c2f_final() bind(C, name='cosp_c2f_final')
     call destroy_cospIN(cospIN)

--- a/components/eamxx/src/physics/cosp/cosp_functions.hpp
+++ b/components/eamxx/src/physics/cosp/cosp_functions.hpp
@@ -4,6 +4,9 @@
 using scream::Real;
 extern "C" void cosp_c2f_init(int ncol, int nsubcol, int nlay);
 extern "C" void cosp_c2f_final();
+extern "C" void cosp_c2f_get_bins(Real* tau_centers, Real* tau_edges,
+                                   Real* prs_centers, Real* prs_edges,
+                                   Real* cth_centers, Real* cth_edges);
 extern "C" void cosp_c2f_run(const int ncol, const int nsubcol, const int nlay, const int ntau, const int nctp, const int ncth,
     const Real emsfc_lw, const Real* sunlit, const Real* skt,
     const Real* T_mid, const Real* p_mid, const Real* p_int, const Real* z_mid, const Real* qv, const Real* qc, const Real* qi,

--- a/components/eamxx/src/physics/cosp/eamxx_cosp.cpp
+++ b/components/eamxx/src/physics/cosp/eamxx_cosp.cpp
@@ -194,6 +194,7 @@ void Cosp::initialize_impl (const RunType /* run_type */)
   // Cloud-top height (cth) bin centers and edges (m)
   const std::array<Real,16> cth_centers = {0., 250., 750., 1250., 1750., 2250., 2750., 3500.,
                                             4500., 6000., 8000., 10000., 12000., 14500., 16000., 18000.};
+  // Note: -99000 and 99000 are sentinel values representing unbounded lower/upper bins
   const std::array<Real,32> cth_edges   = {-99000.,  0.,     0.,  500.,   500., 1000.,  1000., 1500.,
                                              1500., 2000.,  2000., 2500.,  2500., 3000.,  3000., 4000.,
                                              4000., 5000.,  5000., 7000.,  7000., 9000.,  9000.,11000.,

--- a/components/eamxx/src/physics/cosp/eamxx_cosp.cpp
+++ b/components/eamxx/src/physics/cosp/eamxx_cosp.cpp
@@ -10,8 +10,6 @@
 #include <ekat_assert.hpp>
 #include <ekat_units.hpp>
 
-#include <array>
-
 namespace scream
 {
 // =========================================================================================
@@ -143,8 +141,7 @@ void Cosp::initialize_impl (const RunType /* run_type */)
   using namespace ekat::units;
 
   // Add COSP dimension coordinate variables and their bounds as geometry data.
-  // These are the bin centers and edges for the ISCCP, MODIS, and MISR histograms.
-  // The values here match the bin definitions in the COSP simulator (mod_cosp_config).
+  // Values come directly from the COSP simulator (mod_cosp_config) via the F90 interface.
 
   // Layouts for 1D coordinate variables
   FieldLayout cosp_tau_layout ({CMP}, {m_num_tau}, {"cosp_tau"});
@@ -162,50 +159,25 @@ void Cosp::initialize_impl (const RunType /* run_type */)
   auto cosp_prs_bnds_f = m_grid->create_geometry_data("cosp_prs_bnds", cosp_prs_bnds_layout, Pa);
   auto cosp_cth_bnds_f = m_grid->create_geometry_data("cosp_cth_bnds", cosp_cth_bnds_layout, m);
 
-  // Optical depth (tau) bin centers and edges
-  const std::array<Real,7> tau_centers = {0.15, 0.80, 2.45, 6.5, 16.2, 41.5, 100.0};
-  const std::array<Real,14> tau_edges  = {0.0, 0.3, 0.3, 1.3, 1.3, 3.6, 3.6, 9.4,
-                                          9.4, 23.0, 23.0, 60.0, 60.0, 100000.0};
+  // Retrieve bin centers and edges from the Fortran COSP interface (mod_cosp_config).
+  // The F90 arrays for edges have shape (2, nbins) in Fortran column-major order, so the
+  // flat memory layout is [lower_0, upper_0, lower_1, upper_1, ...], which maps directly
+  // onto the (nbins, 2) host views below.
   auto tau_h      = cosp_tau_f.get_view<Real*,Host>();
   auto tau_bnds_h = cosp_tau_bnds_f.get_view<Real**,Host>();
-  for (int i = 0; i < m_num_tau; i++) {
-    tau_h(i)        = tau_centers[i];
-    tau_bnds_h(i,0) = tau_edges[2*i];
-    tau_bnds_h(i,1) = tau_edges[2*i+1];
-  }
-  cosp_tau_f.sync_to_dev();
-  cosp_tau_bnds_f.sync_to_dev();
-
-  // Cloud-top pressure (prs) bin centers and edges (Pa)
-  const std::array<Real,7> prs_centers = {90000., 74000., 62000., 50000., 37500., 24500., 9000.};
-  const std::array<Real,14> prs_edges  = {100000.0, 80000.0, 80000.0, 68000.0, 68000.0, 56000.0,
-                                           56000.0, 44000.0, 44000.0, 31000.0, 31000.0, 18000.0,
-                                           18000.0,     0.0};
   auto prs_h      = cosp_prs_f.get_view<Real*,Host>();
   auto prs_bnds_h = cosp_prs_bnds_f.get_view<Real**,Host>();
-  for (int i = 0; i < m_num_ctp; i++) {
-    prs_h(i)        = prs_centers[i];
-    prs_bnds_h(i,0) = prs_edges[2*i];
-    prs_bnds_h(i,1) = prs_edges[2*i+1];
-  }
-  cosp_prs_f.sync_to_dev();
-  cosp_prs_bnds_f.sync_to_dev();
-
-  // Cloud-top height (cth) bin centers and edges (m)
-  const std::array<Real,16> cth_centers = {0., 250., 750., 1250., 1750., 2250., 2750., 3500.,
-                                            4500., 6000., 8000., 10000., 12000., 14500., 16000., 18000.};
-  // Note: -99000 and 99000 are sentinel values representing unbounded lower/upper bins
-  const std::array<Real,32> cth_edges   = {-99000.,  0.,     0.,  500.,   500., 1000.,  1000., 1500.,
-                                             1500., 2000.,  2000., 2500.,  2500., 3000.,  3000., 4000.,
-                                             4000., 5000.,  5000., 7000.,  7000., 9000.,  9000.,11000.,
-                                            11000.,13000., 13000.,15000., 15000.,17000., 17000.,99000.};
   auto cth_h      = cosp_cth_f.get_view<Real*,Host>();
   auto cth_bnds_h = cosp_cth_bnds_f.get_view<Real**,Host>();
-  for (int i = 0; i < m_num_cth; i++) {
-    cth_h(i)        = cth_centers[i];
-    cth_bnds_h(i,0) = cth_edges[2*i];
-    cth_bnds_h(i,1) = cth_edges[2*i+1];
-  }
+
+  cosp_c2f_get_bins(tau_h.data(), tau_bnds_h.data(),
+                    prs_h.data(), prs_bnds_h.data(),
+                    cth_h.data(), cth_bnds_h.data());
+
+  cosp_tau_f.sync_to_dev();
+  cosp_tau_bnds_f.sync_to_dev();
+  cosp_prs_f.sync_to_dev();
+  cosp_prs_bnds_f.sync_to_dev();
   cosp_cth_f.sync_to_dev();
   cosp_cth_bnds_f.sync_to_dev();
 

--- a/components/eamxx/src/physics/cosp/eamxx_cosp.cpp
+++ b/components/eamxx/src/physics/cosp/eamxx_cosp.cpp
@@ -139,6 +139,80 @@ void Cosp::initialize_impl (const RunType /* run_type */)
     f.get_header().set_extra_data("valid_mask", masks.at(field_name));
     f.get_header().set_may_be_filled(true);
   }
+
+  using namespace ekat::units;
+
+  // Add COSP dimension coordinate variables and their bounds as geometry data.
+  // These are the bin centers and edges for the ISCCP, MODIS, and MISR histograms.
+  // The values here match the bin definitions in the COSP simulator (mod_cosp_config).
+
+  // Layouts for 1D coordinate variables
+  FieldLayout cosp_tau_layout ({CMP}, {m_num_tau}, {"cosp_tau"});
+  FieldLayout cosp_prs_layout ({CMP}, {m_num_ctp}, {"cosp_prs"});
+  FieldLayout cosp_cth_layout ({CMP}, {m_num_cth}, {"cosp_cth"});
+  // Layouts for 2D bounds variables (dim x 2)
+  FieldLayout cosp_tau_bnds_layout ({CMP,CMP}, {m_num_tau,2}, {"cosp_tau","nbnd"});
+  FieldLayout cosp_prs_bnds_layout ({CMP,CMP}, {m_num_ctp,2}, {"cosp_prs","nbnd"});
+  FieldLayout cosp_cth_bnds_layout ({CMP,CMP}, {m_num_cth,2}, {"cosp_cth","nbnd"});
+
+  auto cosp_tau_f      = m_grid->create_geometry_data("cosp_tau",      cosp_tau_layout,     nondim);
+  auto cosp_prs_f      = m_grid->create_geometry_data("cosp_prs",      cosp_prs_layout,     Pa);
+  auto cosp_cth_f      = m_grid->create_geometry_data("cosp_cth",      cosp_cth_layout,     m);
+  auto cosp_tau_bnds_f = m_grid->create_geometry_data("cosp_tau_bnds", cosp_tau_bnds_layout, nondim);
+  auto cosp_prs_bnds_f = m_grid->create_geometry_data("cosp_prs_bnds", cosp_prs_bnds_layout, Pa);
+  auto cosp_cth_bnds_f = m_grid->create_geometry_data("cosp_cth_bnds", cosp_cth_bnds_layout, m);
+
+  // Optical depth (tau) bin centers and edges
+  const std::array<Real,7> tau_centers = {0.15, 0.80, 2.45, 6.5, 16.2, 41.5, 100.0};
+  const std::array<Real,14> tau_edges  = {0.0, 0.3, 0.3, 1.3, 1.3, 3.6, 3.6, 9.4,
+                                          9.4, 23.0, 23.0, 60.0, 60.0, 100000.0};
+  auto tau_h      = cosp_tau_f.get_view<Real*,Host>();
+  auto tau_bnds_h = cosp_tau_bnds_f.get_view<Real**,Host>();
+  for (int i = 0; i < m_num_tau; i++) {
+    tau_h(i)        = tau_centers[i];
+    tau_bnds_h(i,0) = tau_edges[2*i];
+    tau_bnds_h(i,1) = tau_edges[2*i+1];
+  }
+  cosp_tau_f.sync_to_dev();
+  cosp_tau_bnds_f.sync_to_dev();
+
+  // Cloud-top pressure (prs) bin centers and edges (Pa)
+  const std::array<Real,7> prs_centers = {90000., 74000., 62000., 50000., 37500., 24500., 9000.};
+  const std::array<Real,14> prs_edges  = {100000.0, 80000.0, 80000.0, 68000.0, 68000.0, 56000.0,
+                                           56000.0, 44000.0, 44000.0, 31000.0, 31000.0, 18000.0,
+                                           18000.0,     0.0};
+  auto prs_h      = cosp_prs_f.get_view<Real*,Host>();
+  auto prs_bnds_h = cosp_prs_bnds_f.get_view<Real**,Host>();
+  for (int i = 0; i < m_num_ctp; i++) {
+    prs_h(i)        = prs_centers[i];
+    prs_bnds_h(i,0) = prs_edges[2*i];
+    prs_bnds_h(i,1) = prs_edges[2*i+1];
+  }
+  cosp_prs_f.sync_to_dev();
+  cosp_prs_bnds_f.sync_to_dev();
+
+  // Cloud-top height (cth) bin centers and edges (m)
+  const std::array<Real,16> cth_centers = {0., 250., 750., 1250., 1750., 2250., 2750., 3500.,
+                                            4500., 6000., 8000., 10000., 12000., 14500., 16000., 18000.};
+  const std::array<Real,32> cth_edges   = {-99000.,  0.,     0.,  500.,   500., 1000.,  1000., 1500.,
+                                             1500., 2000.,  2000., 2500.,  2500., 3000.,  3000., 4000.,
+                                             4000., 5000.,  5000., 7000.,  7000., 9000.,  9000.,11000.,
+                                            11000.,13000., 13000.,15000., 15000.,17000., 17000.,99000.};
+  auto cth_h      = cosp_cth_f.get_view<Real*,Host>();
+  auto cth_bnds_h = cosp_cth_bnds_f.get_view<Real**,Host>();
+  for (int i = 0; i < m_num_cth; i++) {
+    cth_h(i)        = cth_centers[i];
+    cth_bnds_h(i,0) = cth_edges[2*i];
+    cth_bnds_h(i,1) = cth_edges[2*i+1];
+  }
+  cosp_cth_f.sync_to_dev();
+  cosp_cth_bnds_f.sync_to_dev();
+
+  // Set "bounds" CF attribute on each coordinate variable to link to its bounds variable
+  using stratts_t = std::map<std::string,std::string>;
+  cosp_tau_f.get_header().get_extra_data<stratts_t>("io: string attributes")["bounds"] = "cosp_tau_bnds";
+  cosp_prs_f.get_header().get_extra_data<stratts_t>("io: string attributes")["bounds"] = "cosp_prs_bnds";
+  cosp_cth_f.get_header().get_extra_data<stratts_t>("io: string attributes")["bounds"] = "cosp_cth_bnds";
 }
 
 // =========================================================================================

--- a/components/eamxx/src/share/io/eamxx_output_manager.cpp
+++ b/components/eamxx/src/share/io/eamxx_output_manager.cpp
@@ -161,25 +161,21 @@ setup (const std::shared_ptr<fm_type>& field_mgr,
         if (use_suffix) {
           fields.push_back(f.clone(f.name() + grid->m_disambiguation_suffix, gname));
 
-          // Transfer io: string attributes from original field (e.g., "bounds" attribute)
-          if (f.get_header().has_extra_data("io: string attributes")) {
-            const auto& src_atts = f.get_header().get_extra_data<stratts_t>("io: string attributes");
-            auto& dst_atts = fields.back().get_header().get_extra_data<stratts_t>("io: string attributes");
-            dst_atts.insert(src_atts.begin(), src_atts.end());
-          }
-
           // Adjust long/std name, as the default metadata does not recognize the names with suffix
           auto& str_atts = fields.back().get_header().get_extra_data<stratts_t>("io: string attributes");
           str_atts["long_name"] = meta.get_longname(f.name());
           str_atts["standard_name"] = meta.get_standardname(f.name());
         } else {
           fields.push_back(f.clone(f.name(), gname));
+        }
 
-          // Transfer io: string attributes from original field (e.g., "bounds" attribute)
-          if (f.get_header().has_extra_data("io: string attributes")) {
-            const auto& src_atts = f.get_header().get_extra_data<stratts_t>("io: string attributes");
-            auto& dst_atts = fields.back().get_header().get_extra_data<stratts_t>("io: string attributes");
-            dst_atts.insert(src_atts.begin(), src_atts.end());
+        // Transfer io: string attributes from original field (e.g., "bounds" attribute).
+        // Use insert so that we don't override entries already set above (e.g., long_name).
+        if (f.get_header().has_extra_data("io: string attributes")) {
+          const auto& src_atts = f.get_header().get_extra_data<stratts_t>("io: string attributes");
+          auto& dst_atts = fields.back().get_header().get_extra_data<stratts_t>("io: string attributes");
+          for (const auto& [k,v] : src_atts) {
+            dst_atts.emplace(k, v);
           }
         }
       }

--- a/components/eamxx/src/share/io/eamxx_output_manager.cpp
+++ b/components/eamxx/src/share/io/eamxx_output_manager.cpp
@@ -157,16 +157,30 @@ setup (const std::shared_ptr<fm_type>& field_mgr,
           // This field is NOT to be saved as geo data
           continue;
         }
+        using stratts_t = std::map<std::string,std::string>;
         if (use_suffix) {
           fields.push_back(f.clone(f.name() + grid->m_disambiguation_suffix, gname));
 
+          // Transfer io: string attributes from original field (e.g., "bounds" attribute)
+          if (f.get_header().has_extra_data("io: string attributes")) {
+            const auto& src_atts = f.get_header().get_extra_data<stratts_t>("io: string attributes");
+            auto& dst_atts = fields.back().get_header().get_extra_data<stratts_t>("io: string attributes");
+            dst_atts.insert(src_atts.begin(), src_atts.end());
+          }
+
           // Adjust long/std name, as the default metadata does not recognize the names with suffix
-          using stratts_t = std::map<std::string,std::string>;
           auto& str_atts = fields.back().get_header().get_extra_data<stratts_t>("io: string attributes");
           str_atts["long_name"] = meta.get_longname(f.name());
           str_atts["standard_name"] = meta.get_standardname(f.name());
         } else {
           fields.push_back(f.clone(f.name(), gname));
+
+          // Transfer io: string attributes from original field (e.g., "bounds" attribute)
+          if (f.get_header().has_extra_data("io: string attributes")) {
+            const auto& src_atts = f.get_header().get_extra_data<stratts_t>("io: string attributes");
+            auto& dst_atts = fields.back().get_header().get_extra_data<stratts_t>("io: string attributes");
+            dst_atts.insert(src_atts.begin(), src_atts.end());
+          }
         }
       }
 

--- a/components/eamxx/src/share/io/eamxx_output_manager.cpp
+++ b/components/eamxx/src/share/io/eamxx_output_manager.cpp
@@ -138,6 +138,7 @@ setup (const std::shared_ptr<fm_type>& field_mgr,
 
     // If 2+ grids are present, we mandate suffix on all geo_data fields,
     // to avoid clashes of names.
+    using stratts_t = std::map<std::string,std::string>;
     bool use_suffix = grids.size()>1;
     for (const auto& [gname,grid] : grids) {
       std::vector<Field> fields;
@@ -157,7 +158,6 @@ setup (const std::shared_ptr<fm_type>& field_mgr,
           // This field is NOT to be saved as geo data
           continue;
         }
-        using stratts_t = std::map<std::string,std::string>;
         if (use_suffix) {
           fields.push_back(f.clone(f.name() + grid->m_disambiguation_suffix, gname));
 
@@ -174,9 +174,7 @@ setup (const std::shared_ptr<fm_type>& field_mgr,
         if (f.get_header().has_extra_data("io: string attributes")) {
           const auto& src_atts = f.get_header().get_extra_data<stratts_t>("io: string attributes");
           auto& dst_atts = fields.back().get_header().get_extra_data<stratts_t>("io: string attributes");
-          for (const auto& [k,v] : src_atts) {
-            dst_atts.emplace(k, v);
-          }
+          dst_atts.insert(src_atts.begin(), src_atts.end());
         }
       }
 


### PR DESCRIPTION
Add COSP dimension coordinate variables and bounds to EAMxx output.

## Summary

COSP output from EAMxx was missing dimension values and bound values for `cosp_prs`, `cosp_prs_bnds`, `cosp_tau`, `cosp_tau_bnds`, `cosp_cth`, and `cosp_cth_bnds`. These dimensions are needed for e3sm_diags to produce COSP diagnostics.

## Changes

### `components/eamxx/src/physics/cosp/cosp_c2f.F90`

Added a new C-binding subroutine `cosp_c2f_get_bins` that reads `tau_binCenters`/`tau_binEdges`, `pres_binCenters`/`pres_binEdges`, and `hgt_binCenters`/`hgt_binEdges` directly from `mod_cosp_config` and returns them as `c_double` arrays to C++. Also added the necessary imports of `npres`, `pres_binCenters`, `pres_binEdges`, `nhgt`, `hgt_binCenters`, and `hgt_binEdges` from `mod_cosp_config`.

### `components/eamxx/src/physics/cosp/cosp_functions.hpp`

Declared the new `cosp_c2f_get_bins` extern C function.

### `components/eamxx/src/physics/cosp/eamxx_cosp.cpp`

In `initialize_impl`, after the existing mask setup, registers the COSP histogram bin dimensions as geometry data on the physics grid:

- **Coordinate variables** (`cosp_tau`, `cosp_prs`, `cosp_cth`): 1D fields containing the bin center values for the optical depth, cloud-top pressure (Pa), and cloud-top height (m) axes. Values are retrieved directly from the COSP Fortran interface (`mod_cosp_config`) via `cosp_c2f_get_bins`.
- **Bounds variables** (`cosp_tau_bnds`, `cosp_prs_bnds`, `cosp_cth_bnds`): 2D (dim × 2) fields containing the lower/upper edges of each bin, also sourced from `mod_cosp_config`.
- Sets the CF-convention `bounds` attribute on each coordinate variable to link it to its corresponding bounds variable.

### `components/eamxx/src/share/io/eamxx_output_manager.cpp`

When setting up geo data output streams, transfers `io: string attributes` (including the `bounds` attribute) from the original geo data fields to their clones, so that CF metadata is preserved in the output files.

## Testing

The existing COSP standalone test (`cosp_standalone`) does not output the 4D COSP fields, so no baseline changes are expected. The fix can be verified by running a simulation with COSP enabled and confirming that the output NetCDF file contains `cosp_tau`, `cosp_prs`, `cosp_cth` as dimension coordinate variables with their bin values, along with the corresponding `_bnds` variables.

Fixes #7976