### PR TITLE
Update FATES tag to API 44 

### DIFF
--- a/components/elm/bld/ELMBuildNamelist.pm
+++ b/components/elm/bld/ELMBuildNamelist.pm
@@ -841,7 +841,8 @@ sub setup_cmdl_fates_mode {
                      "fates_regeneration_model",
                      "fates_hydro_solver",
                      "fates_radiation_model",
-                     "fates_electron_transport_model");
+                     "fates_electron_transport_model",
+                     "fates_lu_transition_logic");
 
       foreach my $var ( @list ) {
 	  if ( defined($nl->get_value($var))  ) {
@@ -3453,7 +3454,8 @@ sub setup_logic_fates {
                    "fates_regeneration_model",
                    "fates_hydro_solver",
                    "fates_radiation_model",
-	                 "fates_electron_transport_model");
+	               "fates_electron_transport_model",
+                   "fates_lu_transition_logic");
 
     foreach my $var (@list) {
        add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, $var,'use_fates'=>$nl_flags->{'use_fates'},
@@ -3464,6 +3466,7 @@ sub setup_logic_fates {
     add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_fates_luh', 'use_fates'=>$nl_flags->{'use_fates'},
                                                                                       'use_fates_lupft'=>$nl->get_value('use_fates_lupft'),
                                                                                       'use_fates_potentialveg'=>$nl->get_value('use_fates_potentialveg'),
+                                                                                      'fates_lu_transition_logic'=>$nl->get_value('fates_lu_transition_logic'),
                                                                                       'fates_harvest_mode'=>remove_leading_and_trailing_quotes($nl->get_value('fates_harvest_mode')) );
     add_default($test_files, $nl_flags->{'inputdata_rootdir'}, $definition, $defaults, $nl, 'use_fates_nocomp', 'use_fates'=>$nl_flags->{'use_fates'},
 	                                                                              'use_fates_lupft'=>$nl->get_value('use_fates_lupft'),

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -2246,6 +2246,7 @@ this mask will have smb calculated over the entire global land surface
 <fates_spitfire_mode            use_fates=".true.">0</fates_spitfire_mode>
 <fates_spitfire_mode            use_fates=".true." use_fates_managed_fire=".true." >1</fates_spitfire_mode>
 <fates_harvest_mode             use_fates=".true.">no_harvest</fates_harvest_mode>
+<fates_lu_transitions_logic     use_fates=".true.">4</fates_lu_transitions_logic>
 <fates_history_dimlevel         use_fates=".true.">2,2</fates_history_dimlevel>
 <fates_inventory_ctrl_filename  use_fates=".true."> "/dev/null" </fates_inventory_ctrl_filename>
 <fates_parteh_mode              use_fates=".true.">1</fates_parteh_mode>
@@ -2274,6 +2275,7 @@ this mask will have smb calculated over the entire global land surface
 <use_fates_luh                  use_fates=".true." use_fates_lupft=".true.">.true.</use_fates_luh>
 <use_fates_luh                  use_fates=".true." use_fates_potentialveg=".true.">.true.</use_fates_luh>
 <use_fates_luh                  use_fates=".true."                                  >.false.</use_fates_luh>
+<fates_lu_transitions_logic     use_fates=".true." use_fates_luh=".true." >4</fates_lu_transitions_logic>
 <use_fates_inventory_init       use_fates=".true.">.false.</use_fates_inventory_init>
 <use_fates_nocomp               use_fates=".true." use_fates_sp=".true.">.true.</use_fates_nocomp>
 <use_fates_nocomp               use_fates=".true." use_fates_lupft=".true.">.true.</use_fates_nocomp>

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -638,13 +638,13 @@ lnd/clm2/surfdata_map/surfdata_conusx4v1_simyr2000_c160503.nc</fsurdat>
 
 <!-- Land Use Harmonization unified timeseries data sets for dynamic FATES land use change -->
 <fluh_timeseries hgrid="4x5" sim_year_range="1850-2015" use_fates=".true."
- >lnd/clm2/surfdata_map/fates-sci.1.68.3_api.31.0.0_tools.1.0.1/LUH2_states_transitions_management.timeseries_4x5_hist_simyr1850-2015_c231101.nc</fluh_timeseries>
+ >lnd/clm2/surfdata_map/fates-sci.1.77.0_api.36.0.0/LUH2_states_transitions_management.timeseries_4x5_hist_simyr1850-2015_c231101.no_nan_fill.nc</fluh_timeseries>
 
 <fluh_timeseries hgrid="4x5" sim_year_range="constant" use_fates=".true."
->lnd/clm2/surfdata_map/fates-sci.1.68.3_api.31.0.0_tools.1.0.1/LUH2_states_transitions_management.timeseries_4x5_hist_simyr1850-2015_c231101.nc</fluh_timeseries>
+>lnd/clm2/surfdata_map/fates-sci.1.77.0_api.36.0.0/LUH2_states_transitions_management.timeseries_4x5_hist_simyr1850-2015_c231101.no_nan_fill.nc</fluh_timeseries>
 
 <!-- Land Use Harmonization static landuse x pft mapping data sets for FATES land use change -->
-<flandusepftdat hgrid="4x5" use_fates=".true." >lnd/clm2/surfdata_map/fates-sci.1.77.0_api.36.0.0/fates_landuse_pft_map_4x5_240206.nc</flandusepftdat>
+<flandusepftdat hgrid="4x5" use_fates=".true." >lnd/clm2/surfdata_map/fates-sci.1.77.0_api.36.0.0/fates_landuse_pft_map_4x5_240206.no_nan_fill.nc</flandusepftdat>
 
 <!-- GLC mask datasets (relative to {csmdata}) -->
 <!-- Currently glc_grid is not being read from anywhere, so these rules are broken.  -->

--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -638,10 +638,10 @@ lnd/clm2/surfdata_map/surfdata_conusx4v1_simyr2000_c160503.nc</fsurdat>
 
 <!-- Land Use Harmonization unified timeseries data sets for dynamic FATES land use change -->
 <fluh_timeseries hgrid="4x5" sim_year_range="1850-2015" use_fates=".true."
- >lnd/clm2/surfdata_map/fates-sci.1.77.0_api.36.0.0/LUH2_states_transitions_management.timeseries_4x5_hist_simyr1850-2015_c231101.no_nan_fill.nc</fluh_timeseries>
+	>lnd/clm2/surfdata_map/fates-sci.1.68.3_api.31.0.0_tools.1.0.1/LUH2_states_transitions_management.timeseries_4x5_hist_simyr1850-2015_c231101.no_nan_fill.nc</fluh_timeseries>
 
 <fluh_timeseries hgrid="4x5" sim_year_range="constant" use_fates=".true."
->lnd/clm2/surfdata_map/fates-sci.1.77.0_api.36.0.0/LUH2_states_transitions_management.timeseries_4x5_hist_simyr1850-2015_c231101.no_nan_fill.nc</fluh_timeseries>
+>lnd/clm2/surfdata_map/fates-sci.1.68.3_api.31.0.0_tools.1.0.1/LUH2_states_transitions_management.timeseries_4x5_hist_simyr1850-2015_c231101.no_nan_fill.nc</fluh_timeseries>
 
 <!-- Land Use Harmonization static landuse x pft mapping data sets for FATES land use change -->
 <flandusepftdat hgrid="4x5" use_fates=".true." >lnd/clm2/surfdata_map/fates-sci.1.77.0_api.36.0.0/fates_landuse_pft_map_4x5_240206.no_nan_fill.nc</flandusepftdat>
@@ -2246,7 +2246,7 @@ this mask will have smb calculated over the entire global land surface
 <fates_spitfire_mode            use_fates=".true.">0</fates_spitfire_mode>
 <fates_spitfire_mode            use_fates=".true." use_fates_managed_fire=".true." >1</fates_spitfire_mode>
 <fates_harvest_mode             use_fates=".true.">no_harvest</fates_harvest_mode>
-<fates_lu_transitions_logic     use_fates=".true.">4</fates_lu_transitions_logic>
+<fates_lu_transition_logic     use_fates=".true.">4</fates_lu_transition_logic>
 <fates_history_dimlevel         use_fates=".true.">2,2</fates_history_dimlevel>
 <fates_inventory_ctrl_filename  use_fates=".true."> "/dev/null" </fates_inventory_ctrl_filename>
 <fates_parteh_mode              use_fates=".true.">1</fates_parteh_mode>
@@ -2275,7 +2275,7 @@ this mask will have smb calculated over the entire global land surface
 <use_fates_luh                  use_fates=".true." use_fates_lupft=".true.">.true.</use_fates_luh>
 <use_fates_luh                  use_fates=".true." use_fates_potentialveg=".true.">.true.</use_fates_luh>
 <use_fates_luh                  use_fates=".true."                                  >.false.</use_fates_luh>
-<fates_lu_transitions_logic     use_fates=".true." use_fates_luh=".true." >4</fates_lu_transitions_logic>
+<fates_lu_transition_logic     use_fates=".true." use_fates_luh=".true." >4</fates_lu_transition_logic>
 <use_fates_inventory_init       use_fates=".true.">.false.</use_fates_inventory_init>
 <use_fates_nocomp               use_fates=".true." use_fates_sp=".true.">.true.</use_fates_nocomp>
 <use_fates_nocomp               use_fates=".true." use_fates_lupft=".true.">.true.</use_fates_nocomp>

--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -519,6 +519,14 @@ which processes the raw land use data from the THEMIS tool data sets
 (https://doi.org/10.5065/29s7-7b41)
 </entry>
 
+<entry id="fates_lu_transition_logic" type="integer" category="physics"
+        group="elm_inparm" valid_values="1,2,3,4,5,6,7,8,9">
+Select the logic for land use class transitions.
+Allowed values are 1-9. See the Land Use subsection of the Namelist Options section
+of the FATES user guide for an explanation of the options.
+(Only relevant if FATES with land use is on)
+</entry>
+
 <entry id="use_hydrstress" type="logical" category="physics"
         group="elm_inparm" valid_values="" value=".false.">
 Toggle to turn on if Kennedy et al plant hydraulics model is used.

--- a/components/elm/src/main/controlMod.F90
+++ b/components/elm/src/main/controlMod.F90
@@ -94,7 +94,7 @@ module controlMod
                         fates_leafresp_model, fates_cstarvation_model, &
                         fates_regeneration_model, fates_hydro_solver, &
                         fates_radiation_model, fates_electron_transport_model, &
-                        fates_history_dimlevel, elm_varctl_set, &
+                        fates_history_dimlevel, fates_lu_transition_logic, elm_varctl_set, &
                         use_nofire, use_lch4, use_vertsoilc, use_extralakelayers, &
                         use_vichydro, use_century_decomp, use_cn, use_crop, &
                         use_snicar_frc, use_snicar_ad, use_firn_percolation_and_compaction, &
@@ -328,6 +328,7 @@ contains
           fates_hydro_solver,                           &
           fates_radiation_model,                        &
           fates_electron_transport_model,               &
+          fates_lu_transition_logic,                    &
           fates_history_dimlevel
 
     namelist /elm_inparm / use_betr
@@ -908,6 +909,7 @@ contains
     call mpi_bcast (fates_seeddisp_cadence, 1, MPI_INTEGER, 0, mpicom, ier)
     call mpi_bcast (use_fates_tree_damage, 1, MPI_LOGICAL, 0, mpicom, ier)
     call mpi_bcast (fates_history_dimlevel, 2, MPI_INTEGER, 0, mpicom, ier)
+    call mpi_bcast (fates_lu_transition_logic, 1, MPI_INTEGER, 0, mpicom, ier)
     
     call mpi_bcast (use_betr, 1, MPI_LOGICAL, 0, mpicom, ier)
 
@@ -1362,6 +1364,7 @@ contains
        write(iulog, *) '    fates_inventory_ctrl_filename = ',fates_inventory_ctrl_filename
        write(iulog, *) '    fates_seeddisp_cadence = ', fates_seeddisp_cadence
        write(iulog, *) '    fates_seeddisp_cadence: 0, 1, 2, 3 => off, daily, monthly, or yearly dispersal'
+       write(iulog, *) '    fates_lu_transition_logic = ', fates_lu_transition_logic
     end if
 
     ! VSFM

--- a/components/elm/src/main/elm_varctl.F90
+++ b/components/elm/src/main/elm_varctl.F90
@@ -226,6 +226,7 @@ module elm_varctl
 
   logical, public            :: use_fates = .false.                     ! true => use  ED
   integer, public            :: fates_spitfire_mode = 0                 ! 0 for no fire; 1 for constant ignitions
+  integer, public            :: fates_lu_transition_logic = -9          ! controls logic around transition between land use classes
   logical, public            :: use_fates_managed_fire = .false.        ! true => turn on managed fire
   character(len=256), public :: fates_harvest_mode = ''                 ! five different harvest modes; see namelist_definitions
   character(len=256), public :: fates_photosynth_acclimation = ''       ! nonacclimating, kumarathunge2019

--- a/components/elm/src/main/elmfates_interfaceMod.F90
+++ b/components/elm/src/main/elmfates_interfaceMod.F90
@@ -3929,7 +3929,7 @@ end subroutine wrap_update_hifrq_hist
 
    ! Land use name arrays
    character(len=10), parameter  :: landuse_pft_map_varnames(num_landuse_pft_vars) = &
-                    [character(len=10)  :: 'frac_primr','frac_secnd','frac_pastr','frac_range'] !need to move 'frac_surf' to a different variable
+                    [character(len=10)  :: 'frac_primr','frac_secnd','frac_range','frac_pastr'] !need to move 'frac_surf' to a different variable
 
    character(len=*), parameter :: subname = 'GetLandusePFTData'
 

--- a/components/elm/src/main/elmfates_interfaceMod.F90
+++ b/components/elm/src/main/elmfates_interfaceMod.F90
@@ -1805,9 +1805,6 @@ contains
       ! I think that is it...
       ! ---------------------------------------------------------------------------------
 
-      ! Set the FATES global time and date variables
-      call GetAndSetTime
-
       if(.not.initialized) then
 
          initialized=.true.
@@ -1939,6 +1936,14 @@ contains
       ! ---------------------------------------------------------------------------------
 
       if(flag=='read')then
+
+         ! pass time to FATES internal variables
+         ! since this routine is called on 'define','write','read'
+         ! and the first two can be called whenever, calling this outside 'read'
+         ! will change the time that has been previously set in dynamics_driver
+         ! Set the FATES global time and date variables
+         call GetAndSetTime
+
 
          !$OMP PARALLEL DO PRIVATE (nc,bounds_clump,s)
          do nc = 1, nclumps

--- a/components/elm/src/main/elmfates_interfaceMod.F90
+++ b/components/elm/src/main/elmfates_interfaceMod.F90
@@ -69,6 +69,7 @@ module ELMFatesInterfaceMod
    use elm_varctl        , only : fates_hydro_solver
    use elm_varctl        , only : fates_radiation_model
    use elm_varctl        , only : fates_electron_transport_model
+   use elm_varctl        , only : fates_lu_transition_logic
    use elm_varctl        , only : flandusepftdat
    use elm_varctl        , only : use_fates_tree_damage
    use elm_varctl        , only : nsrest, nsrBranch
@@ -585,6 +586,7 @@ contains
 
         call set_fates_ctrlparms('num_luh2_states',ival=pass_num_luh_states)
         call set_fates_ctrlparms('num_luh2_transitions',ival=pass_num_luh_transitions)
+        call set_fates_ctrlparms('fates_lu_transition_logic',ival=fates_lu_transition_logic)
 
         if ( use_fates_potentialveg ) then
            pass_use_potentialveg = 1


### PR DESCRIPTION
This PR updates the FATES tag to API 44.  It also updates the default fates land use data files.

[non-BFB]  for FATES