### PR TITLE
Change default sea ice melt pond scheme to sea level melt ponds

### DIFF
--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -219,8 +219,8 @@
 <config_use_ice_age>false</config_use_ice_age>
 <config_use_first_year_ice>false</config_use_first_year_ice>
 <config_use_level_ice>true</config_use_level_ice>
-<config_use_level_meltponds>true</config_use_level_meltponds>
-<config_use_sealevel_meltponds>false</config_use_sealevel_meltponds>
+<config_use_level_meltponds>false</config_use_level_meltponds>
+<config_use_sealevel_meltponds>true</config_use_sealevel_meltponds>
 <config_use_topo_meltponds>false</config_use_topo_meltponds>
 <config_use_aerosols>false</config_use_aerosols>
 <config_use_effective_snow_density>true</config_use_effective_snow_density>

--- a/components/mpas-seaice/src/Registry.xml
+++ b/components/mpas-seaice/src/Registry.xml
@@ -753,12 +753,12 @@
 			possible_values="true or false"
 			icepack_name="tr_lvl"
 		/>
-		<nml_option name="config_use_level_meltponds" type="logical" default_value="true" units="unitless"
+		<nml_option name="config_use_level_meltponds" type="logical" default_value="false" units="unitless"
 			description="If true use the level ice meltponds tracers."
 			possible_values="true or false"
 			icepack_name="tr_pond_lvl"
 		/>
-		<nml_option name="config_use_sealevel_meltponds" type="logical" default_value="false" units="unitless"
+		<nml_option name="config_use_sealevel_meltponds" type="logical" default_value="true" units="unitless"
 			description="If true use the sea-level meltponds tracers."
 			possible_values="true or false"
 			icepack_name="tr_pond_sealvl"


### PR DESCRIPTION
Changes the default melt pond scheme in MPAS-Seaice to a sea level melt pond scheme, which became available with [Icepack v1.5.3](https://github.com/E3SM-Project/E3SM/pull/8054).

[non-BFB] [NCC]
[NML]