### PR TITLE
Change ocean, sea ice namelist defaults for SOwISC12to30E3r3

### DIFF
--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -307,7 +307,9 @@
 <config_use_cvmix>.true.</config_use_cvmix>
 <config_cvmix_prandtl_number>1.0</config_cvmix_prandtl_number>
 <config_cvmix_background_scheme>'constant'</config_cvmix_background_scheme>
+<config_cvmix_background_scheme ocn_grid="SOwISC12to30E3r3">'latitude-dependent'</config_cvmix_background_scheme>
 <config_cvmix_background_diffusion>0.0</config_cvmix_background_diffusion>
+<config_cvmix_background_diffusion ocn_grid="SOwISC12to30E3r3">3.0e-5</config_cvmix_background_diffusion>
 <config_cvmix_background_diffusion_max_latitude>-50.0</config_cvmix_background_diffusion_max_latitude>
 <config_cvmix_background_diffusion_passive>0.0</config_cvmix_background_diffusion_passive>
 <config_cvmix_background_diffusion_passive_enable>.false.</config_cvmix_background_diffusion_passive_enable>
@@ -349,10 +351,13 @@
 <config_cvmix_kpp_nonlocal_with_implicit_mix>.false.</config_cvmix_kpp_nonlocal_with_implicit_mix>
 <config_cvmix_kpp_use_theory_wave>.false.</config_cvmix_kpp_use_theory_wave>
 <config_cvmix_kpp_use_theory_wave ocn_grid="RRSwISC6to18E3r5">.true.</config_cvmix_kpp_use_theory_wave>
+<config_cvmix_kpp_use_theory_wave ocn_grid="SOwISC12to30E3r3">.true.</config_cvmix_kpp_use_theory_wave>
 <config_cvmix_kpp_langmuir_mixing_opt>'NONE'</config_cvmix_kpp_langmuir_mixing_opt>
 <config_cvmix_kpp_langmuir_mixing_opt ocn_grid="RRSwISC6to18E3r5">'LWF16'</config_cvmix_kpp_langmuir_mixing_opt>
+<config_cvmix_kpp_langmuir_mixing_opt ocn_grid="SOwISC12to30E3r3">'LWF16'</config_cvmix_kpp_langmuir_mixing_opt>
 <config_cvmix_kpp_langmuir_entrainment_opt>'NONE'</config_cvmix_kpp_langmuir_entrainment_opt>
 <config_cvmix_kpp_langmuir_entrainment_opt ocn_grid="RRSwISC6to18E3r5">'LWF16'</config_cvmix_kpp_langmuir_entrainment_opt>
+<config_cvmix_kpp_langmuir_entrainment_opt ocn_grid="SOwISC12to30E3r3">'LWF16'</config_cvmix_kpp_langmuir_entrainment_opt>
 <config_cvmix_kpp_use_active_wave>.false.</config_cvmix_kpp_use_active_wave>
 
 <!-- wave_coupling -->

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -442,6 +442,7 @@
 <config_macro_drainage_timescale_topoponds>10.</config_macro_drainage_timescale_topoponds>
 <config_congelation_freezing_method>'two-step'</config_congelation_freezing_method>
 <config_congelation_freezing_method ice_grid="RRSwISC6to18E3r5">'one-step'</config_congelation_freezing_method>
+<config_congelation_freezing_method ice_grid="SOwISC12to30E3r3">'one-step'</config_congelation_freezing_method>
 <config_congelation_ice_porosity>0.85</config_congelation_ice_porosity>
 
 <!-- itd -->

--- a/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
+++ b/components/mpas-seaice/bld/namelist_files/namelist_defaults_mpassi.xml
@@ -180,6 +180,7 @@
 <config_rotate_cartesian_grid>true</config_rotate_cartesian_grid>
 <config_include_metric_terms>true</config_include_metric_terms>
 <config_elastic_subcycle_number>120</config_elastic_subcycle_number>
+<config_elastic_subcycle_number ice_grid="SOwISC12to30E3r3">240</config_elastic_subcycle_number>
 <config_strain_scheme>'variational'</config_strain_scheme>
 <config_constitutive_relation_type>'evp'</config_constitutive_relation_type>
 <config_stress_divergence_scheme>'variational'</config_stress_divergence_scheme>


### PR DESCRIPTION
This PR makes the following changes to the namelist defaults for SOwISC12to30E3r3:

1. Use theory-wave LWF16 settings, enabling Langmuir mixing parameterization for the ocean
2. Use a latitude-dependent background diffusivity for the Southern Ocean, introduced in https://github.com/E3SM-Project/E3SM/pull/8078
3. Use one-step congelation freezing option for sea ice

Both (2) and (3) mirror the default namelist settings for RRSwISC6to18E3r5.

[NML] only for tests with SOwISC12to30E3r3
[non-BFB] only for tests with SOwISC12to30E3r3