### PR TITLE
namelist modifications for LRW configurations

### DIFF
--- a/components/mosart/bld/build-namelist
+++ b/components/mosart/bld/build-namelist
@@ -285,6 +285,8 @@ my $LND_GRID        = $xmlvars{'LND_GRID'};
 my $ROF_NCPL        = $xmlvars{'ROF_NCPL'};
 my $NCPL_BASE_PERIOD = $xmlvars{'NCPL_BASE_PERIOD'};
 
+my $wave_comp        = "$xmlvars{'COMP_WAV'}";
+
 (-d $DIN_LOC_ROOT)  or  mkdir $DIN_LOC_ROOT;
 if ($print>=2) { 
     print "model inputdata root directory: $DIN_LOC_ROOT \n"; 
@@ -330,7 +332,11 @@ else {
     add_default($nl, 'RoutingMethod');
     add_default($nl, 'DLevelH2R');
     add_default($nl, 'DLevelR');
-    add_default($nl, 'redirect_negative_qgwl');
+    if ($wave_comp eq 'ww3') {
+       add_default($nl, 'redirect_negative_qgwl', 'val'=>".true.");
+    } else {
+       add_default($nl, 'redirect_negative_qgwl');
+    }
 #    add_default($nl, 'finidat_rtm' , 'rof_grid'=>$ROF_GRID, 'simyr'=>$opts{'simyr'}, 'nofail'=>1 );
     my $val = 0;
     if ($NCPL_BASE_PERIOD eq "year") {

--- a/components/mpas-seaice/bld/build-namelist
+++ b/components/mpas-seaice/bld/build-namelist
@@ -609,7 +609,11 @@ add_default($nl, 'config_dynamics_mass_minimum');
 add_default($nl, 'config_dynamics_subcycle_number');
 add_default($nl, 'config_rotate_cartesian_grid');
 add_default($nl, 'config_include_metric_terms');
-add_default($nl, 'config_elastic_subcycle_number');
+if ($wave_comp eq 'ww3') {
+   add_default($nl, 'config_elastic_subcycle_number',  'val'=>"240");
+} else {
+   add_default($nl, 'config_elastic_subcycle_number');
+}
 add_default($nl, 'config_strain_scheme');
 add_default($nl, 'config_constitutive_relation_type');
 add_default($nl, 'config_stress_divergence_scheme');
@@ -943,7 +947,11 @@ add_default($nl, 'config_slow_mode_critical_porosity');
 add_default($nl, 'config_macro_drainage_timescale_lvlponds');
 add_default($nl, 'config_macro_drainage_timescale_sealvlponds');
 add_default($nl, 'config_macro_drainage_timescale_topoponds');
-add_default($nl, 'config_congelation_freezing_method');
+if ($wave_comp eq 'ww3') {
+   add_default($nl, 'config_congelation_freezing_method', 'val'=>"one-step");
+} else {
+   add_default($nl, 'config_congelation_freezing_method');
+}
 add_default($nl, 'config_congelation_ice_porosity');
 
 #######################


### PR DESCRIPTION
This PR makes the following changes to the namelist options for Low-Res-Waves (LRW) configurations: 
1)  redirect_negative_qgwl = true   (mosart) 
2) config_elastic_subcycle_number = 240 (mpas-si) 
3) config_congelation_freezing_method = one-step 

These are settings required by the wave-enabled runs for BluePulse/ Polar Simulations. 

