### PR TITLE
EAMxx: refactor sampling diag to rely on field API/utils

### DIFF
--- a/components/eamxx/docs/user/diags/conditional_sampling.md
+++ b/components/eamxx/docs/user/diags/conditional_sampling.md
@@ -50,36 +50,42 @@ Use the special condition field name `lev`.
 - `T_mid_where_lev_gt_5`
 - `p_mid_where_lev_eq_0`
 - `qv_where_lev_le_10`
+- `T_mid_where_qv_at_lev_125_lt_qv_at_lev_128`
 
-## Count-based conditional sampling
+## Mask-only calculation
 
-Count the number of grid points where a condition is met.
-Use the special input field name `count`. The output will be `1.0`
-where the condition is satisfied and `0.0` elsewhere.
+Compute a mask stating where the condition is met.
+Use the special input field name `mask`. The output will be `1`
+where the condition is satisfied and `0` elsewhere.
 This is particularly useful when combined with horizontal or vertical
 reductions to count occurrences of specific conditions.
 
 **Examples**:
 
-- `count_where_qv_gt_0.01`
-- `count_where_T_mid_le_273.15`
-- `count_where_p_mid_lt_50000`
-- `count_where_lev_gt_5`
+- `mask_where_qv_gt_0.01`
+- `mask_where_T_mid_le_273.15`
+- `mask_where_p_mid_lt_50000`
+- `mask_where_lev_gt_5`
+
+To count the percentage of earth where the surface pressure is > 1e5Pa:
+
+- `mask_where_ps_gt_100000_horiz_avg`
 
 ## Caveats
 
-- For now, we only support 1D or 2D fields.
-  These include most fields of interest with the following layouts
-  (ncol,), (nlev,), (ncol,nlev).  
+- For now, we only support 1D, 2D, and 3D fields.
+  These include most fields of interest with any possible sub-layout
+  of (ncol,ncmp,nlev)
   Adding support for higher-dimensioned fields is straightforward,
   but we will add it when requested.
 - The condition and input fields must have the same layout
   (except for level-based sampling). In level-based sampling,
   the level index must be present in the field.
 - The condition is provided as a triplet of information string
-  (`<condition>_<operator>_<value>`). We assume the user knows
-  the standard unit of the condition that is used internally
+  (`<condition_lhs>_<operator>_<condition_rhs>`). We assume the user knows
+  the standard unit of the lhs/rhs that are used internally
   in EAMxx field manager (there is no way to specify it).
+- The RHS in the condition can be a scalar value or another field/diag name
 
 ## Example configuration
 
@@ -99,10 +105,10 @@ fields:
       - T_mid_where_lev_gt_5
       - p_mid_where_lev_eq_0
       - qv_where_lev_le_10
-      # Count-based conditional sampling
-      - count_where_qv_gt_0.01
-      - count_where_T_mid_le_273.15
-      - count_where_lev_gt_5
+      # Mask-based conditional sampling
+      - mask_where_qv_gt_0.01
+      - mask_where_T_mid_le_273.15
+      - mask_where_lev_gt_5
 output_control:
   frequency: 6
   frequency_units: nhours

--- a/components/eamxx/docs/user/diags/parsing_precedence.md
+++ b/components/eamxx/docs/user/diags/parsing_precedence.md
@@ -27,7 +27,7 @@ control — how composite names are parsed.
 
 5. **Specific named patterns** — `_at_<level>`, `_at_<pressure>`, `_at_<height>`,
    `_horiz_avg`, `_vert_avg`, `_vert_sum`, `_zonal_avg`, `_pvert_derivative`,
-   `_zvert_derivative`, `_where_..._op_val` (conditional sampling), etc.
+   `_zvert_derivative`, `_where_..._op_<val|field>` (conditional sampling), etc.
 
 6. **Binary ops** — `A_(plus|minus|times|over)_B`.
    The first capture group is *greedy*, so the left operand extends as far as
@@ -93,8 +93,8 @@ fields:
       - bt_prod:=bt1_times_bt2
 
       # bt_osc_count = indicator that bt_prod is negative (tendency oscillating)
-      - bt_osc_count:=count_where_bt_prod_lt_0
-      # ConditionalSampling: input=count, condition_field=bt_prod, op=lt, value=0
+      - bt_osc_count:=mask_where_bt_prod_lt_0
+      # ConditionalSampling: input=mask, condition_lhs=bt_prod, condition_cmp=lt, condition_rhs=0
 ```
 
 The `aliases` section names intermediate sub-expressions that are needed

--- a/components/eamxx/src/share/diagnostics/conditional_sampling.cpp
+++ b/components/eamxx/src/share/diagnostics/conditional_sampling.cpp
@@ -1,347 +1,226 @@
 #include "conditional_sampling.hpp"
+
+#include "share/field/field_utils.hpp"
 #include "share/util/eamxx_universal_constants.hpp"
+
 #include <ekat_team_policy_utils.hpp>
+
+#include <charconv>
 #include <string>
 
 namespace scream {
 
-// Utility function to apply conditional sampling logic
-KOKKOS_INLINE_FUNCTION
-bool evaluate_condition(const Real &condition_val, const int &op_code, const Real &comparison_val) {
-  // op_code: 0=eq, 1=ne, 2=gt, 3=ge, 4=lt, 5=le
-  switch (op_code) {
-    case 0: return condition_val == comparison_val;  // eq or ==
-    case 1: return condition_val != comparison_val;  // ne or !=
-    case 2: return condition_val > comparison_val;   // gt or >
-    case 3: return condition_val >= comparison_val;  // ge or >=
-    case 4: return condition_val < comparison_val;   // lt or <
-    case 5: return condition_val <= comparison_val;  // le or <=
-    default: return false;
+namespace {
+template<int N>
+using MDRange = Kokkos::MDRangePolicy<
+                  typename KokkosTypes<DefaultDevice>::ExeSpace,
+                  Kokkos::Rank<N,Kokkos::Iterate::Right,Kokkos::Iterate::Right>
+                >;
+}
+
+std::pair<int,bool> str2int (const std::string& s) {
+  // Check if rhs is a value
+  auto beg = s.data();
+  auto end = beg + s.size();
+  int i;
+  auto [ptr,ec] = std::from_chars(beg,end,i);
+  if (ec == std::errc{} && ptr == end) {
+    return std::make_pair(i,true);
   }
+  return std::make_pair(0,false);
 }
 
-// Utility function to convert operator string to code
-int get_operator_code(const std::string& op) {
-  if (op == "eq" || op == "==") return 0;
-  if (op == "ne" || op == "!=") return 1;
-  if (op == "gt" || op == ">")  return 2;
-  if (op == "ge" || op == ">=") return 3;
-  if (op == "lt" || op == "<")  return 4;
-  if (op == "le" || op == "<=") return 5;
-  return -1; // Invalid operator
+std::pair<double,bool> str2dbl (const std::string& s) {
+  // Check if rhs is a value
+  auto beg = s.data();
+  auto end = beg + s.size();
+  double d;
+  auto [ptr,ec] = std::from_chars(beg,end,d);
+  if (ec == std::errc{} && ptr == end) {
+    return std::make_pair(d,true);
+  }
+  return std::make_pair(0.0,false);
 }
 
-// Utility function to apply conditional sampling for 1D fields (either ncols or nlevs)
-void apply_conditional_sampling_1d(
-    const Field &output_field, const Field &input_field, const Field &condition_field,
-    const std::string &condition_op, const Real &condition_val,
-    const Real &fill_value = constants::fill_value<Real>) {
-
-  // if fill_value is 0, we are counting
-  const auto is_counting = (fill_value == 0);
-  const auto output_v    = output_field.get_view<Real *>();
-  const auto mask_v = !is_counting ? output_field.get_header().get_extra_data<Field>("mask_data").get_view<Real *>() : output_v;
-  const auto input_v     = input_field.get_view<const Real *>();
-  const auto condition_v = condition_field.get_view<const Real *>();
-
-  // Try to get input and condition masks, if present
-  bool has_input_mask = input_field.get_header().has_extra_data("mask_data");
-  bool has_condition_mask = condition_field.get_header().has_extra_data("mask_data");
-  auto input_mask_v = has_input_mask ? input_field.get_header().get_extra_data<Field>("mask_data").get_view<const Real *>() : input_v;
-  auto condition_mask_v = has_condition_mask ? condition_field.get_header().get_extra_data<Field>("mask_data").get_view<const Real *>() : condition_v;
-
-  const int n_elements = output_field.get_header().get_identifier().get_layout().dims()[0];
-
-  // Convert operator string to integer code for device use
-  const int op_code = get_operator_code(condition_op);
-
-  Kokkos::parallel_for(
-      "ConditionalSampling1D", Kokkos::RangePolicy<>(0, n_elements), KOKKOS_LAMBDA(const int &idx) {
-        bool input_masked = has_input_mask && (input_mask_v(idx) == 0);
-        bool condition_masked = has_condition_mask && (condition_mask_v(idx) == 0);
-        if (input_masked || condition_masked) {
-          output_v(idx) = fill_value;
-          if (!is_counting) mask_v(idx) = 0;
-        } else if (evaluate_condition(condition_v(idx), op_code, condition_val)) {
-          output_v(idx) = input_v(idx);
-          if (!is_counting) mask_v(idx) = 1;
-        } else {
-          output_v(idx) = fill_value;
-          if (!is_counting) mask_v(idx) = 0;
-        }
-      });
+// This is to avoid using original diag string in output field name,
+// since user may have used >= and similar, which are not great in an nc var name
+std::string cmp2str (const Comparison cmp)
+{
+  std::string s;
+  switch (cmp) {
+    case Comparison::EQ: s = "eq"; break;
+    case Comparison::NE: s = "ne"; break;
+    case Comparison::GT: s = "gt"; break;
+    case Comparison::GE: s = "ge"; break;
+    case Comparison::LT: s = "lt"; break;
+    case Comparison::LE: s = "le"; break;
+    default:
+      EKAT_ERROR_MSG ("Unsupported/unrecognized Comparison enum value.\n");
+  }
+  return s;
 }
 
-// Utility function to apply conditional sampling for 2D fields (ncols x nlevs)
-void apply_conditional_sampling_2d(
-    const Field &output_field, const Field &input_field, const Field &condition_field,
-    const std::string &condition_op, const Real &condition_val,
-    const Real &fill_value = constants::fill_value<Real>) {
-
-  // if fill_value is 0, we are counting
-  const auto is_counting = (fill_value == 0);
-
-  const auto output_v    = output_field.get_view<Real **>();
-  const auto mask_v = !is_counting ? output_field.get_header().get_extra_data<Field>("mask_data").get_view<Real **>() : output_v;
-  const auto input_v     = input_field.get_view<const Real **>();
-  const auto condition_v = condition_field.get_view<const Real **>();
-
-  // Try to get input and condition masks, if present
-  bool has_input_mask = input_field.get_header().has_extra_data("mask_data");
-  bool has_condition_mask = condition_field.get_header().has_extra_data("mask_data");
-  auto input_mask_v = has_input_mask ? input_field.get_header().get_extra_data<Field>("mask_data").get_view<const Real **>() : input_v;
-  auto condition_mask_v = has_condition_mask ? condition_field.get_header().get_extra_data<Field>("mask_data").get_view<const Real **>() : condition_v;
-
-  const int ncols = output_field.get_header().get_identifier().get_layout().dims()[0];
-  const int nlevs = output_field.get_header().get_identifier().get_layout().dims()[1];
-
-  // Convert operator string to integer code for device use
-  const int op_code = get_operator_code(condition_op);
-
-  Kokkos::parallel_for(
-      "ConditionalSampling2D", Kokkos::RangePolicy<>(0, ncols * nlevs),
-      KOKKOS_LAMBDA(const int &idx) {
-        const int icol = idx / nlevs;
-        const int ilev = idx % nlevs;
-        bool input_masked = has_input_mask && (input_mask_v(icol, ilev) == 0);
-        bool condition_masked = has_condition_mask && (condition_mask_v(icol, ilev) == 0);
-        if (input_masked || condition_masked) {
-          output_v(icol, ilev) = fill_value;
-          if (!is_counting) mask_v(icol, ilev) = 0;
-        } else if (evaluate_condition(condition_v(icol, ilev), op_code, condition_val)) {
-          output_v(icol, ilev) = input_v(icol, ilev);
-          if (!is_counting) mask_v(icol, ilev) = 1;
-        } else {
-          output_v(icol, ilev) = fill_value;
-          if (!is_counting) mask_v(icol, ilev) = 0;
-        }
-      });
+Comparison str2cmp (const std::string& cmp_str)
+{
+  Comparison cmp = Comparison::EQ;
+  if (cmp_str == "eq" || cmp_str == "==") {
+    cmp = Comparison::EQ;
+  } else if (cmp_str == "ne" || cmp_str == "!=") {
+    cmp = Comparison::NE;
+  } else if (cmp_str == "gt" || cmp_str == ">") {
+    cmp = Comparison::GT;
+  } else if (cmp_str == "ge" || cmp_str == ">=") {
+    cmp = Comparison::GE;
+  } else if (cmp_str == "lt" || cmp_str == "<") {
+    cmp = Comparison::LT;
+  } else if (cmp_str == "le" || cmp_str == "<=") {
+    cmp = Comparison::LE;
+  } else {
+    EKAT_ERROR_MSG ("Error! Invalid comparison operator string.\n"
+        " - cmp string   : " + cmp_str + "\n"
+        " - valid choices: eq, ==, ne, !=, gt, >, ge, >=, lt, <, le, <=\n");
+  }
+  return cmp;
 }
 
-// Utility function to apply conditional sampling for 1D fields against level indices
-void apply_conditional_sampling_1d_lev(
-    const Field &output_field, const Field &input_field,
-    const std::string &condition_op, const Real &condition_val,
-    const Real &fill_value = constants::fill_value<Real>) {
+ConditionalSampling::
+ConditionalSampling(const ekat::Comm &comm, const ekat::ParameterList &params)
+ : AtmosphereDiagnostic(comm, params)
+{
+  m_input_f = m_params.get<std::string>("field_name");
+  m_condition_lhs = m_params.get<std::string>("condition_lhs");
+  m_condition_rhs = m_params.get<std::string>("condition_rhs");
+  auto cmp = m_params.get<std::string>("condition_cmp");
+  m_condition_cmp = str2cmp(cmp);
 
-  // if fill_value is 0, we are counting
-  const auto is_counting = (fill_value == 0);
+  m_lhs_is_lev = m_condition_lhs=="lev";
 
-  const auto output_v = output_field.get_view<Real *>();
-  const auto mask_v = !is_counting ? output_field.get_header().get_extra_data<Field>("mask_data").get_view<Real *>() : output_v;
-  const auto input_v  = input_field.get_view<const Real *>();
+  auto rhs_as_double = str2dbl(m_condition_rhs);
+  auto rhs_as_int    = str2int(m_condition_rhs);
 
-  // Try to get input mask, if present
-  bool has_input_mask = input_field.get_header().has_extra_data("mask_data");
-  auto input_mask_v = has_input_mask ? input_field.get_header().get_extra_data<Field>("mask_data").get_view<const Real *>() : input_v;
+  EKAT_REQUIRE_MSG (not m_lhs_is_lev or (rhs_as_int.second and rhs_as_int.first>=0),
+      "Error! Conditional sampling of the form X_where_lev_CMP_Z requires Z to be a positive integer.\n"
+      " - X  : " + m_input_f + "\n"
+      " - CMP: " + cmp + "\n"
+      " - Z  : " + m_condition_rhs + "\n");
 
-  const int n_elements = output_field.get_header().get_identifier().get_layout().dims()[0];
+  m_rhs_is_field = not (rhs_as_double.second or rhs_as_int.second);
+  if (rhs_as_int.second)
+    m_rhs_value = rhs_as_int.first;
+  else if (rhs_as_double.second)
+    m_rhs_value = rhs_as_double.first;
 
-  // Convert operator string to integer code for device use
-  const int op_code = get_operator_code(condition_op);
+  m_diag_is_mask = m_input_f == "mask";
 
-  Kokkos::parallel_for(
-      "ConditionalSampling1D_Lev", Kokkos::RangePolicy<>(0, n_elements), 
-      KOKKOS_LAMBDA(const int &idx) {
-        // For 1D case, the level index is just the element index
-        const Real level_idx = static_cast<Real>(idx);
-        bool input_masked = has_input_mask && (input_mask_v(idx) == 0);
-        if (input_masked) {
-          output_v(idx) = fill_value;
-          if (!is_counting) mask_v(idx) = 0;
-        } else if (evaluate_condition(level_idx, op_code, condition_val)) {
-          output_v(idx) = input_v(idx);
-          if (!is_counting) mask_v(idx) = 1;
-        } else {
-          output_v(idx) = fill_value;
-          if (!is_counting) mask_v(idx) = 0;
-        }
-      });
+  m_diag_name = m_input_f + "_where_" + m_condition_lhs + "_" + cmp2str(m_condition_cmp) + "_" + m_condition_rhs;
 }
 
-// Utility function to apply conditional sampling for 2D fields against level indices
-void apply_conditional_sampling_2d_lev(
-    const Field &output_field, const Field &input_field,
-    const std::string &condition_op, const Real &condition_val,
-    const Real &fill_value = constants::fill_value<Real>) {
-
-  // if fill_value is 0, we are counting
-  const auto is_counting = (fill_value == 0);
-
-  const auto output_v = output_field.get_view<Real **>();
-  const auto mask_v = !is_counting ? output_field.get_header().get_extra_data<Field>("mask_data").get_view<Real **>() : output_v;
-  const auto input_v  = input_field.get_view<const Real **>();
-
-  // Try to get input mask, if present
-  bool has_input_mask = input_field.get_header().has_extra_data("mask_data");
-  auto input_mask_v = has_input_mask ? input_field.get_header().get_extra_data<Field>("mask_data").get_view<const Real **>() : input_v;
-
-  const int ncols = output_field.get_header().get_identifier().get_layout().dims()[0];
-  const int nlevs = output_field.get_header().get_identifier().get_layout().dims()[1];
-
-  // Convert operator string to integer code for device use
-  const int op_code = get_operator_code(condition_op);
-
-  Kokkos::parallel_for(
-      "ConditionalSampling2D_Lev", Kokkos::RangePolicy<>(0, ncols * nlevs),
-      KOKKOS_LAMBDA(const int &idx) {
-        const int icol = idx / nlevs;
-        const int ilev = idx % nlevs;
-        // The level index is the second dimension index (ilev)
-        const Real level_idx = static_cast<Real>(ilev);
-        bool input_masked = has_input_mask && (input_mask_v(icol, ilev) == 0);
-        if (input_masked) {
-          output_v(icol, ilev) = fill_value;
-          if (!is_counting) mask_v(icol, ilev) = 0;
-        } else if (evaluate_condition(level_idx, op_code, condition_val)) {
-          output_v(icol, ilev) = input_v(icol, ilev);
-          if (!is_counting) mask_v(icol, ilev) = 1;
-        } else {
-          output_v(icol, ilev) = fill_value;
-          if (!is_counting) mask_v(icol, ilev) = 0;
-        }
-      });
-}
-
-ConditionalSampling::ConditionalSampling(const ekat::Comm &comm, const ekat::ParameterList &params)
-    : AtmosphereDiagnostic(comm, params) {
-
-  m_input_f      = m_params.get<std::string>("input_field");
-  m_condition_f  = m_params.get<std::string>("condition_field");
-  m_condition_op = m_params.get<std::string>("condition_operator");
-
-  const auto str_condition_v = m_params.get<std::string>("condition_value");
-  // TODO: relying on std::stod to throw if bad val is given
-  m_condition_v = static_cast<Real>(std::stod(str_condition_v));
-
-  m_diag_name =
-      m_input_f + "_where_" + m_condition_f + "_" + m_condition_op + "_" + str_condition_v;
-}
-
-void ConditionalSampling::create_requests() {
+void ConditionalSampling::create_requests()
+{
+  using namespace ShortFieldTagsNames;
   const auto &gn = m_params.get<std::string>("grid_name");
   const auto g   = m_grids_manager->get_grid("physics");
 
-  // Special case: if the input field is "count", we don't need to add it
-  if (m_input_f != "count") {
+  // Special case: if the input field is "mask", we're just computing the mask where the condition holds
+  if (not m_diag_is_mask) {
     add_field<Required>(m_input_f, gn);
   }
 
-  // Special case: if condition field is "lev", we don't add it as a required field
-  // since it's geometric information from the grid, not an actual field
-  if (m_condition_f != "lev") {
-    add_field<Required>(m_condition_f, gn);
+  // Special case: if lhs field is "lev", we don't need a lhs field.
+  // We can actually precompute the output mask for a 1d col
+  if (m_lhs_is_lev) {
+    FieldIdentifier lev_fid("lev_mask",g->get_vertical_layout(LEV),ekat::units::Units::nondimensional(),g->name(),DataType::IntType);
+    m_lev_mask = Field(lev_fid,true);
+    auto lev_idx = m_lev_mask.clone("lev_idx");
+    auto lev_idx_h = lev_idx.get_view<int*,Host>();
+    for (int k=0; k<g->get_num_vertical_levels(); ++k)
+      lev_idx_h(k) = k;
+    lev_idx.sync_to_dev();
+    compute_mask(lev_idx,m_rhs_value,m_condition_cmp,m_lev_mask);
   } else {
-    // Store grid info for potential use in count operations
-    m_nlevs = g->get_num_vertical_levels();
-    m_gn = gn;
+    add_field<Required>(m_condition_lhs, gn);
+  }
+
+  if (m_rhs_is_field) {
+    add_field<Required>(m_condition_rhs, gn);
   }
 }
 
-void ConditionalSampling::initialize_impl(const RunType /*run_type*/) {
-
-  if (m_input_f != "count") {
-    auto ifid = get_field_in(m_input_f).get_header().get_identifier();
-    m_diagnostic_output = Field(ifid.clone(m_diag_name));
-    m_diagnostic_output.allocate_view();
-  } else {
-    if (m_condition_f != "lev") {
-      auto ifid = get_field_in(m_condition_f).get_header().get_identifier();
-      m_diagnostic_output = Field(ifid.clone(m_diag_name));
-      m_diagnostic_output.allocate_view();
+void ConditionalSampling::initialize_impl(const RunType /*run_type*/)
+{
+  if (m_diag_is_mask) {
+    if (m_lhs_is_lev) {
+      m_diagnostic_output = m_lev_mask.clone(m_diag_name);
     } else {
-      using namespace ShortFieldTagsNames;
-      using namespace ekat::units;
-      const auto nondim = Units::nondimensional();
-      FieldIdentifier d_fid(m_diag_name, {{LEV},{m_nlevs}}, nondim, m_gn);
-      m_diagnostic_output = Field(d_fid);
-      m_diagnostic_output.allocate_view();
+      auto dfid = get_field_in(m_condition_lhs).get_header().get_identifier().clone(m_diag_name);
+      dfid.reset_dtype(DataType::IntType).reset_units(ekat::units::Units::nondimensional());
+      m_diagnostic_output = Field(dfid,true);
     }
-  }
-
-  auto ifid = m_diagnostic_output.get_header().get_identifier();
-  Field diag_mask(ifid.clone(m_diag_name + "_mask"));
-  diag_mask.allocate_view();
-
-  const auto var_fill_value = constants::fill_value<Real>;
-  m_mask_val = m_params.get<double>("mask_value", var_fill_value);
-  if (m_input_f != "count") {
-    m_diagnostic_output.get_header().set_extra_data("mask_data", diag_mask);
-    m_diagnostic_output.get_header().set_extra_data("mask_value", m_mask_val);
-  }
-  // Special case: if the input field is "count", let's create a field of 1s
-  if (m_input_f == "count") {
-    ones = m_diagnostic_output.clone("count_ones");
-    ones.deep_copy(1.0);
-  }
-  
-  // Special case: if condition field is "lev", we don't need to check layout compatibility
-  // since "lev" is geometric information, not an actual field
-  if (m_condition_f == "lev") {
-    using namespace ShortFieldTagsNames;
-    EKAT_REQUIRE_MSG(ifid.get_layout().tags().back() == LEV,
-                   "Error! ConditionalSampling with \"lev\" condition field must have level in layout.\n"
-                   " - field name: " + ifid.name() + "\n"
-                   " - field layout: " + ifid.get_layout().to_string() + "\n");
   } else {
-    const auto cfid = get_field_in(m_condition_f).get_header().get_identifier();
-    
-    // check that m_input_f and m_condition_f have the same layout
-    EKAT_REQUIRE_MSG(ifid.get_layout() == cfid.get_layout(),
-                     "Error! ConditionalSampling only supports comparing fields of the same layout.\n"
-                     " - input field has layout of " + ifid.get_layout().to_string() + "\n" +
-                     " - condition field has layout of " + cfid.get_layout().to_string() + "\n");
+    auto xfid = get_field_in(m_input_f).get_header().get_identifier();
+    m_diagnostic_output = Field(xfid.clone(m_diag_name),true);
+    m_diagnostic_output.create_valid_mask();
+  }
+
+  // If lhs is "lev" but diag is not "mask", we can still precompute the diag mask by
+  // broadcsting m_lev_mask
+  if (m_lhs_is_lev and not m_diag_is_mask) {
+    auto mask = m_diagnostic_output.get_valid_mask();
+    const auto& dims = mask.get_header().get_identifier().get_layout().dims();
+    auto lev_mask_v = m_lev_mask.get_view<const int*>();
+    switch (mask.rank()) {
+      case 1:
+        mask.deep_copy(m_lev_mask);
+        break;
+      case 2:
+        {
+          auto mask_v = mask.get_view<int**>();
+          auto set_idx = KOKKOS_LAMBDA(int i, int k) {
+            mask_v(i,k) = lev_mask_v(k);
+          };
+          MDRange<2> p({0,0},{dims[0],dims[1]});
+          Kokkos::parallel_for(p,set_idx);
+        } break;
+      case 3:
+        {
+          auto mask_v = mask.get_view<int***>();
+          auto set_idx = KOKKOS_LAMBDA(int i, int j, int k) {
+            mask_v(i,j,k) = lev_mask_v(k);
+          };
+          MDRange<3> p({0,0,0},{dims[0],dims[1],dims[2]});
+          Kokkos::parallel_for(p,set_idx);
+        } break;
+      default:
+        EKAT_ERROR_MSG ("Error! Unsupported rank  in ConditionalSampling initialization.\n"
+            " - diag name: " + m_diag_name + "\n"
+            " - diag rank: " + std::to_string(mask.rank()) + "\n");
+    }
   }
 }
 
-void ConditionalSampling::compute_diagnostic_impl() {
-  Field f;
-  if (m_input_f == "count") {
-    // Special case: if the input field is "count", we use the diagnostic output as the input
-    f = ones;
-  } else {
-    f = get_field_in(m_input_f);
-  }
-  const auto &d = m_diagnostic_output;
-
-  // Validate operator
-  const int op_code = get_operator_code(m_condition_op);
-  EKAT_REQUIRE_MSG(op_code >= 0,
-                   "Error! Invalid condition operator: '" + m_condition_op + "'\n"
-                   "Valid operators are: eq, ==, ne, !=, gt, >, ge, >=, lt, <, le, <=\n");
-
-  // Get the fill value from constants
-  const Real fill_value = (m_input_f == "count") ? 0.0 : m_mask_val;
-
-  // Determine field layout and apply appropriate conditional sampling
-  const auto &layout = f.get_header().get_identifier().get_layout();
-  const int rank     = layout.rank();
-
-  if (rank > 2) {
-      // no support for now, contact devs
-      EKAT_ERROR_MSG("Error! ConditionalSampling only supports 1D or 2D field layouts.\n"
-                     " - field layout: " + layout.to_string() + "\n"
-                     " - field rank: " + std::to_string(rank) + "\n");
-  }
-  if (m_condition_f == "lev") {
-    // Level-based conditional sampling
-    if (rank == 1) {
-      // 1D field: level index is just the element index
-      apply_conditional_sampling_1d_lev(d, f, m_condition_op, m_condition_v, fill_value);
-    } else if (rank == 2) {
-      // 2D field: level index is the second dimension (ilev)
-      apply_conditional_sampling_2d_lev(d, f, m_condition_op, m_condition_v, fill_value);
+void ConditionalSampling::compute_diagnostic_impl()
+{
+  // Compute the mask (unless lhs is "lev", in which case we already did)
+  auto& mask = m_diag_is_mask ? m_diagnostic_output : m_diagnostic_output.get_valid_mask();
+  if (not m_lhs_is_lev) {
+    const auto& lhs = get_field_in(m_condition_lhs);
+    if (m_rhs_is_field) {
+      const auto& rhs = get_field_in(m_condition_rhs);
+      compute_mask(lhs,rhs,m_condition_cmp,mask);
+      if (rhs.has_valid_mask())
+        mask.scale(rhs.get_valid_mask());
+    } else {
+      compute_mask(lhs,m_rhs_value,m_condition_cmp,mask);
     }
-  } else {
-    // Field-based conditional sampling
-    const auto &c = get_field_in(m_condition_f);
-    if (rank == 1) {
-      // 1D field: (ncols) or (nlevs)
-      apply_conditional_sampling_1d(d, f, c, m_condition_op, m_condition_v, fill_value);
-    } else if (rank == 2) {
-      // 2D field: (ncols, nlevs)
-      apply_conditional_sampling_2d(d, f, c, m_condition_op, m_condition_v, fill_value);
-    }
+    if (lhs.has_valid_mask())
+      mask.scale(lhs.get_valid_mask());
+  }
+
+  if (not m_diag_is_mask) {
+    const auto& f = get_field_in(m_input_f);
+    m_diagnostic_output.deep_copy(f,mask);
+    constexpr auto fv = constants::fill_value<Real>;
+    m_diagnostic_output.deep_copy(fv,mask,true);
   }
 }
 

--- a/components/eamxx/src/share/diagnostics/conditional_sampling.hpp
+++ b/components/eamxx/src/share/diagnostics/conditional_sampling.hpp
@@ -28,24 +28,30 @@ public:
 #endif
   void compute_diagnostic_impl();
 
-protected:
   void initialize_impl(const RunType /*run_type*/);
-  // General syntax is X_where_Y_comp_VAL
-  std::string m_diag_name;    // X_where_Y_comp_VAL
-  std::string m_input_f;      // X
-  std::string m_condition_f;  // Y
-  Real m_condition_v;         // VAL
-  std::string m_condition_op; // comp
 
-  // For masking 
-  Real m_mask_val;
+protected:
 
-  // For count we need to save a field of ones
-  Field ones;
+  // General syntax is X_where_Y_comp_Z
+  // where either:
+  //  - X,Y,Z are fields with the same layout
+  //  - X,Y are fields with same layout and Z is a number
+  //  - X is a field, and Y is the string "lev" and Z is an integer
+  //  - all of the above, but with X="mask", which computes the mask field of where the condition holds
+  std::string m_diag_name;      // X_where_Y_comp_Z
+  std::string m_input_f;        // X
+  std::string m_condition_lhs;  // Y
+  std::string m_condition_rhs;  // Z
 
-  // For count and lev, we need to access grid info
-  int m_nlevs;
-  std::string m_gn;
+  bool            m_lhs_is_lev;     // true if we sample w.r.t. level
+  bool            m_rhs_is_field;   // true if Z is a field (not a value)
+  bool            m_diag_is_mask;   // true if X="mask"
+
+  Comparison      m_condition_cmp;
+  ScalarWrapper   m_rhs_value;    // Only if m_rhs_is_field=false
+
+  Field m_lev_mask; // Only used if m_lhs_is_lev=true, both for mask diagnostics
+                    // and for broadcasting in non-mask diagnostics
 };
 
 } // namespace scream

--- a/components/eamxx/src/share/diagnostics/tests/conditional_sampling_test.cpp
+++ b/components/eamxx/src/share/diagnostics/tests/conditional_sampling_test.cpp
@@ -28,41 +28,57 @@ std::shared_ptr<GridsManager> create_gm(const ekat::Comm &comm, const int ncols,
   return gm;
 }
 
+const util::TimeStamp t0() {
+  return util::TimeStamp({2024, 1, 1}, {0, 0, 0});
+}
+
+Field create_field (const std::string& name, int ncol, int ncmp, int nlev, const std::string& gn)
+{
+  using namespace ShortFieldTagsNames;
+  FieldLayout fl{};
+  if (ncol>0)
+    fl.append_dim(COL,ncol);
+  if (ncmp)
+    fl.append_dim(CMP,ncmp);
+  if (nlev)
+    fl.append_dim(LEV,nlev);
+  FieldIdentifier fid(name,fl,ekat::units::kg,gn);
+  Field f(fid,true);
+  f.get_header().get_tracking().update_time_stamp(t0());
+  return f;
+}
+
+template<typename ST>
+void iota_z (const Field& x) {
+  int n1 = x.get_header().get_identifier().get_layout().dim(0);
+  if (x.rank()>1) {
+    for (int i=0; i<n1; ++i) {
+      iota_z<ST>(x.subfield(0,i));
+    }
+  } else {
+    auto vh = x.get_view<ST*,Host>();
+    for (int i=0; i<n1; ++i) {
+      vh(i) = i;
+    }
+    x.sync_to_dev();
+  }
+}
+
 TEST_CASE("conditional_sampling") {
   using namespace ShortFieldTagsNames;
   using namespace ekat::units;
 
-  auto fill_value = constants::fill_value<Real>;
+  constexpr auto fv = constants::fill_value<Real>;
 
   // A world comm
   ekat::Comm comm(MPI_COMM_WORLD);
 
-  // A time stamp
-  util::TimeStamp t0({2024, 1, 1}, {0, 0, 0});
-
   // Create a grids manager - single column for these tests
-  constexpr int nlevs = 256;
-  const int ngcols    = 600 * comm.size();
+  constexpr int nlevs = 10;
+  constexpr int ncols = 8;
 
-  auto gm   = create_gm(comm, ngcols, nlevs);
+  auto gm   = create_gm(comm, ncols, nlevs);
   auto grid = gm->get_grid("physics");
-
-  // Input (randomized) qc
-  FieldLayout scalar1d_layout1{{COL}, {ngcols}};
-  FieldLayout scalar1d_layout2{{LEV}, {nlevs}};
-  FieldLayout scalar2d_layout1{{COL, LEV}, {ngcols, nlevs}};
-
-  FieldIdentifier qc11_fid("qc", scalar1d_layout1, kg / kg, grid->name());
-  FieldIdentifier qc12_fid("qc", scalar1d_layout2, kg / kg, grid->name());
-  FieldIdentifier qc21_fid("qc", scalar2d_layout1, kg / kg, grid->name());
-
-  Field qc11(qc11_fid);
-  Field qc12(qc12_fid);
-  Field qc21(qc21_fid);
-
-  qc11.allocate_view();
-  qc12.allocate_view();
-  qc21.allocate_view();
 
   // Random number generator seed
   int seed = get_random_test_seed();
@@ -75,261 +91,201 @@ TEST_CASE("conditional_sampling") {
   ekat::ParameterList params;
   params.set("grid_name", grid->name());
 
-  SECTION("field_v_field") {
-    const auto comp_val = 0.001;
-    REQUIRE_THROWS(diag_factory.create("ConditionalSampling", comm,
-                                       params)); // No 'field_name' parameter
-    params.set<std::string>("input_field", "qc");
-    REQUIRE_THROWS(diag_factory.create("ConditionalSampling", comm,
-                                       params)); // No 'condition_field' parameter
-    params.set<std::string>("condition_field", "qc");
-    REQUIRE_THROWS(diag_factory.create("ConditionalSampling", comm,
+  SECTION("exceptions") {
+    REQUIRE_THROWS(diag_factory.create("ConditionalSampling", comm, params)); // No 'field_name' parameter
+    params.set<std::string>("field_name", "x");
+    REQUIRE_THROWS(diag_factory.create("ConditionalSampling", comm, params)); // No 'condition_lhs' parameter
+    params.set<std::string>("condition_lhs", "y");
+    REQUIRE_THROWS(diag_factory.create("ConditionalSampling", comm, params)); // No 'condition_cmp' parameter
+    params.set<std::string>("condition_cmp", "z");
+    REQUIRE_THROWS(diag_factory.create("ConditionalSampling", comm, params)); // No 'condition_rhs'
+  }
 
-                                       params)); // No 'condition_operator' parameter
-    params.set<std::string>("condition_operator", "gt");
-    REQUIRE_THROWS(diag_factory.create("ConditionalSampling", comm,
-                                       params)); // No 'condition_value'
-    params.set<std::string>("condition_value", std::to_string(comp_val));
+  SECTION("field_where_field_cmp_val") {
+    const auto val = 0.5;
+    params.set<std::string>("field_name", "x");
+    params.set<std::string>("condition_lhs", "y");
+    params.set<std::string>("condition_rhs", std::to_string(val));
 
-    // Set time for qc and randomize its values
-    qc11.get_header().get_tracking().update_time_stamp(t0);
-    qc12.get_header().get_tracking().update_time_stamp(t0);
-    qc21.get_header().get_tracking().update_time_stamp(t0);
-    randomize_uniform(qc11, seed++, 0, 200);
-    randomize_uniform(qc12, seed++, 0, 200);
-    randomize_uniform(qc21, seed++, 0, 200);
+    for (std::string cmp_s : {"ne", "gt"}) {
+      for (int nx : {0,ncols}) {
+        for (int ncmp : {0,2}) {
+          for (int nz : {0,nlevs}) {
+            auto x = create_field("x",nx,ncmp,nz,grid->name());
+            auto y = create_field("y",nx,ncmp,nz,grid->name());
+            randomize_uniform(x,seed++);
+            randomize_uniform(y,seed++);
+            params.set<std::string>("condition_cmp", cmp_s);
+            auto diag = diag_factory.create("ConditionalSampling", comm, params);
+            diag->set_grids(gm);
+            diag->set_required_field(x);
+            diag->set_required_field(y);
+            diag->initialize(t0(),RunType::Initial);
+            diag->compute_diagnostic();
+            auto d = diag->get_diagnostic();
 
-    // Create and set up the diagnostic
-    auto diag11 = diag_factory.create("ConditionalSampling", comm, params);
-    auto diag12 = diag_factory.create("ConditionalSampling", comm, params);
-    auto diag21 = diag_factory.create("ConditionalSampling", comm, params);
-    diag11->set_grids(gm);
-    diag12->set_grids(gm);
-    diag21->set_grids(gm);
+            REQUIRE (d.has_valid_mask());
+            Field mask = d.get_valid_mask().clone();
 
-    // Set the fields for each diagnostic
-    diag11->set_required_field(qc11);
-    diag11->initialize(t0, RunType::Initial);
-    diag11->compute_diagnostic();
-    auto diag11_f = diag11->get_diagnostic();
-    diag11_f.sync_to_host();
-    auto diag11_v = diag11_f.get_view<const Real *, Host>();
+            auto cmp = cmp_s=="ne" ? Comparison::NE : Comparison::GT;
+            compute_mask(y,val,cmp,mask);
+            if (not views_are_equal(d.get_valid_mask(),mask))
+            {
+              print_field_hyperslab(x);
+              print_field_hyperslab(y);
+              print_field_hyperslab(mask.alias("manual"));
+              print_field_hyperslab(d.get_valid_mask().alias("computed"));
+            }
+            REQUIRE (views_are_equal(d.get_valid_mask(),mask));
 
-    diag12->set_required_field(qc12);
-    diag12->initialize(t0, RunType::Initial);
-    diag12->compute_diagnostic();
-    auto diag12_f = diag12->get_diagnostic();
-    diag12_f.sync_to_host();
-    auto diag12_v = diag12_f.get_view<const Real *, Host>();
-
-    diag21->set_required_field(qc21);
-    diag21->initialize(t0, RunType::Initial);
-    diag21->compute_diagnostic();
-    auto diag21_f = diag21->get_diagnostic();
-    diag21_f.sync_to_host();
-    auto diag21_v = diag21_f.get_view<const Real **, Host>();
-
-    auto qc11_v = qc11.get_view<const Real *, Host>();
-    auto qc12_v = qc12.get_view<const Real *, Host>();
-    auto qc21_v = qc21.get_view<const Real **, Host>();
-
-    // Check the results
-    for (int ilev = 0; ilev < nlevs; ++ilev) {
-      // check qc12
-      if (qc12_v(ilev) > comp_val) {
-        REQUIRE(diag12_v(ilev) == qc12_v(ilev));
-      } else {
-        REQUIRE(diag12_v(ilev) == fill_value);
-      }
-    }
-    for (int icol = 0; icol < ngcols; ++icol) {
-      // Check qc11
-      if (qc11_v(icol) > comp_val) {
-        REQUIRE(diag11_v(icol) == qc11_v(icol));
-      } else {
-        REQUIRE(diag11_v(icol) == fill_value);
-      }
-      for (int ilev = 0; ilev < nlevs; ++ilev) {
-        // check qc21
-        if (qc21_v(icol, ilev) > comp_val) {
-          REQUIRE(diag21_v(icol, ilev) == qc21_v(icol, ilev));
-        } else {
-          REQUIRE(diag21_v(icol, ilev) == fill_value);
-        }
-        // check qc21 again, but the negative
-        if (qc21_v(icol, ilev) <= comp_val) {
-          REQUIRE_FALSE(diag21_v(icol, ilev) == qc21_v(icol, ilev));
-        } else {
-          REQUIRE_FALSE(diag21_v(icol, ilev) == fill_value);
+            x.deep_copy(fv,mask,true);
+            REQUIRE (views_are_equal(x,d));
+          }
         }
       }
     }
   }
-  SECTION("field_vs_index") {
-    const auto comp_lev = static_cast<int>(nlevs / 3);
-    REQUIRE_THROWS(diag_factory.create("ConditionalSampling", comm,
-                                       params)); // No 'field_name' parameter
-    params.set<std::string>("input_field", "qc");
-    REQUIRE_THROWS(diag_factory.create("ConditionalSampling", comm,
-                                       params)); // No 'condition_field' parameter
-    params.set<std::string>("condition_field", "lev");
-    REQUIRE_THROWS(diag_factory.create("ConditionalSampling", comm,
 
-                                       params)); // No 'condition_operator' parameter
-    params.set<std::string>("condition_operator", "lt");
-    REQUIRE_THROWS(diag_factory.create("ConditionalSampling", comm,
-                                       params)); // No 'condition_value'
-    params.set<std::string>("condition_value", std::to_string(comp_lev));
+  SECTION("field_where_field_cmp_field") {
+    params.set<std::string>("field_name", "x");
+    params.set<std::string>("condition_lhs", "y");
+    params.set<std::string>("condition_rhs", "z");
 
-    // Set time for qc and randomize its values
-    qc11.get_header().get_tracking().update_time_stamp(t0);
-    qc12.get_header().get_tracking().update_time_stamp(t0);
-    qc21.get_header().get_tracking().update_time_stamp(t0);
-    randomize_uniform(qc11, seed++, 0, 200);
-    randomize_uniform(qc12, seed++, 0, 200);
-    randomize_uniform(qc21, seed++, 0, 200);
+    for (std::string cmp_s : {"eq", "le"}) {
+      for (int nx : {0,ncols}) {
+        for (int ncmp : {0,2}) {
+          for (int nz : {0,nlevs}) {
+            auto x = create_field("x",nx,ncmp,nz,grid->name());
+            auto y = create_field("y",nx,ncmp,nz,grid->name());
+            auto z = create_field("z",nx,ncmp,nz,grid->name());
+            randomize_uniform(x,seed++);
+            randomize_uniform(y,seed++);
+            randomize_uniform(z,seed++);
+            params.set<std::string>("condition_cmp", cmp_s);
+            auto diag = diag_factory.create("ConditionalSampling", comm, params);
+            diag->set_grids(gm);
+            diag->set_required_field(x);
+            diag->set_required_field(y);
+            diag->set_required_field(z);
+            diag->initialize(t0(),RunType::Initial);
+            diag->compute_diagnostic();
+            auto d = diag->get_diagnostic();
 
-    // Create and set up the diagnostic
-    auto diag11 = diag_factory.create("ConditionalSampling", comm, params);
-    auto diag12 = diag_factory.create("ConditionalSampling", comm, params);
-    auto diag21 = diag_factory.create("ConditionalSampling", comm, params);
-    diag11->set_grids(gm);
-    diag12->set_grids(gm);
-    diag21->set_grids(gm);
+            REQUIRE (d.has_valid_mask());
+            Field mask = d.get_valid_mask().clone();
 
-    // Set the fields for each diagnostic
-    diag11->set_required_field(qc11);
-    REQUIRE_THROWS(diag11->initialize(t0, RunType::Initial)); // bad dimensions (no lev in qc11)
+            auto cmp = cmp_s=="eq" ? Comparison::EQ : Comparison::LE;
+            compute_mask(y,z,cmp,mask);
+            REQUIRE (views_are_equal(d.get_valid_mask(),mask));
 
-    diag12->set_required_field(qc12);
-    
-    diag12->initialize(t0, RunType::Initial);
-    diag12->compute_diagnostic();
-    auto diag12_f = diag12->get_diagnostic();
-    diag12_f.sync_to_host();
-    auto diag12_v = diag12_f.get_view<const Real *, Host>();
-
-    diag21->set_required_field(qc21);
-    diag21->initialize(t0, RunType::Initial);
-    diag21->compute_diagnostic();
-    auto diag21_f = diag21->get_diagnostic();
-    diag21_f.sync_to_host();
-    auto diag21_v = diag21_f.get_view<const Real **, Host>();
-
-    auto qc12_v = qc12.get_view<const Real *, Host>();
-    auto qc21_v = qc21.get_view<const Real **, Host>();
-
-    // Check the results
-    for (int ilev = 0; ilev < nlevs; ++ilev) {
-      // check qc12
-      if (ilev < comp_lev) {
-        REQUIRE(diag12_v(ilev) == qc12_v(ilev));
-      } else {
-        REQUIRE(diag12_v(ilev) == fill_value);
-      }
-    }
-    for (int icol = 0; icol < ngcols; ++icol) {
-      for (int ilev = 0; ilev < nlevs; ++ilev) {
-        // check qc21
-        if (ilev < comp_lev) {
-          REQUIRE(diag21_v(icol, ilev) == qc21_v(icol, ilev));
-        } else {
-          REQUIRE(diag21_v(icol, ilev) == fill_value);
-        }
-        // check qc21 again, but the negative
-        if (ilev >= comp_lev) {
-          REQUIRE_FALSE(diag21_v(icol, ilev) == qc21_v(icol, ilev));
-        } else {
-          REQUIRE_FALSE(diag21_v(icol, ilev) == fill_value);
+            x.deep_copy(fv,mask,true);
+            REQUIRE (views_are_equal(x,d));
+          }
         }
       }
     }
   }
-  SECTION("count_conditional") {
-    const auto comp_val = 50.0;
-    
-    // Test count conditional sampling - count grid points where condition is met
-    params.set<std::string>("input_field", "count");
-    params.set<std::string>("condition_field", "qc");
-    params.set<std::string>("condition_operator", "gt");
-    params.set<std::string>("condition_value", std::to_string(comp_val));
 
-    // Set time for qc and randomize its values
-    qc11.get_header().get_tracking().update_time_stamp(t0);
-    qc12.get_header().get_tracking().update_time_stamp(t0);
-    qc21.get_header().get_tracking().update_time_stamp(t0);
-    randomize_uniform(qc11, seed++, 0, 200);
-    randomize_uniform(qc12, seed++, 0, 200);
-    randomize_uniform(qc21, seed++, 0, 200);
+  SECTION("field_where_lev_cmp_val") {
+    const auto val = nlevs / 2;
+    params.set<std::string>("field_name", "x");
+    params.set<std::string>("condition_lhs", "lev");
+    params.set<std::string>("condition_rhs", std::to_string(val));
 
-    // Create and set up the diagnostic for count
-    auto count_diag11 = diag_factory.create("ConditionalSampling", comm, params);
-    auto count_diag12 = diag_factory.create("ConditionalSampling", comm, params);
-    auto count_diag21 = diag_factory.create("ConditionalSampling", comm, params);
-    count_diag11->set_grids(gm);
-    count_diag12->set_grids(gm);
-    count_diag21->set_grids(gm);
+    for (std::string cmp_s : {"ge", "le"}) {
+      for (int nx : {0,ncols}) {
+        for (int ncmp : {0,2}) {
+          auto x = create_field("x",nx,ncmp,nlevs,grid->name());
+          randomize_uniform(x,seed++);
+          params.set<std::string>("condition_cmp", cmp_s);
+          auto diag = diag_factory.create("ConditionalSampling", comm, params);
+          diag->set_grids(gm);
+          diag->set_required_field(x);
+          diag->initialize(t0(),RunType::Initial);
+          diag->compute_diagnostic();
+          auto d = diag->get_diagnostic();
 
-    // Set the fields for each diagnostic
-    count_diag11->set_required_field(qc11);
-    count_diag11->initialize(t0, RunType::Initial);
-    count_diag11->compute_diagnostic();
-    auto count_diag11_f = count_diag11->get_diagnostic();
-    count_diag11_f.sync_to_host();
-    auto count_diag11_v = count_diag11_f.get_view<const Real *, Host>();
+          Field mask = x.create_valid_mask();
+          Field lev = mask.clone();
+          iota_z<int>(lev);
+          auto cmp = cmp_s=="ge" ? Comparison::GE : Comparison::LE;
+          compute_mask(lev,val,cmp,mask);
+          if (not views_are_equal(d.get_valid_mask(),mask))
+          {
+            print_field_hyperslab(lev.alias("lev"));
+            print_field_hyperslab(mask.alias("manual"));
+            print_field_hyperslab(d.get_valid_mask().alias("computed"));
+          }
+          REQUIRE (views_are_equal(d.get_valid_mask(),mask));
 
-    count_diag12->set_required_field(qc12);
-    count_diag12->initialize(t0, RunType::Initial);
-    count_diag12->compute_diagnostic();
-    auto count_diag12_f = count_diag12->get_diagnostic();
-    count_diag12_f.sync_to_host();
-    auto count_diag12_v = count_diag12_f.get_view<const Real *, Host>();
-
-    count_diag21->set_required_field(qc21);
-    count_diag21->initialize(t0, RunType::Initial);
-    count_diag21->compute_diagnostic();
-    auto count_diag21_f = count_diag21->get_diagnostic();
-    count_diag21_f.sync_to_host();
-    auto count_diag21_v = count_diag21_f.get_view<const Real **, Host>();
-
-    auto qc11_v = qc11.get_view<const Real *, Host>();
-    auto qc12_v = qc12.get_view<const Real *, Host>();
-    auto qc21_v = qc21.get_view<const Real **, Host>();
-
-    // Check the results - count should be 1.0 where condition is met, 0 otherwise
-    for (int ilev = 0; ilev < nlevs; ++ilev) {
-      // check count for qc12
-      if (qc12_v(ilev) > comp_val) {
-        REQUIRE(count_diag12_v(ilev) == 1.0);
-      } else {
-        REQUIRE(count_diag12_v(ilev) == 0.0);
-      }
-    }
-    
-    for (int icol = 0; icol < ngcols; ++icol) {
-      // Check count for qc11
-      if (qc11_v(icol) > comp_val) {
-        REQUIRE(count_diag11_v(icol) == 1.0);
-      } else {
-        REQUIRE(count_diag11_v(icol) == 0.0);
-      }
-      
-      for (int ilev = 0; ilev < nlevs; ++ilev) {
-        // check count for qc21
-        if (qc21_v(icol, ilev) > comp_val) {
-          REQUIRE(count_diag21_v(icol, ilev) == 1.0);
-        } else {
-          REQUIRE(count_diag21_v(icol, ilev) == 0.0);
-        }
-        // check count again, but the negative
-        if (qc21_v(icol, ilev) <= comp_val) {
-          REQUIRE_FALSE(count_diag21_v(icol, ilev) == 1.0);
-        } else {
-          REQUIRE_FALSE(count_diag21_v(icol, ilev) == 0.0);
+          x.deep_copy(fv,mask,true);
+          REQUIRE (views_are_equal(x,d));
         }
       }
     }
   }
+
+  SECTION("mask_where_lev_cmp_val") {
+    const auto val = nlevs / 2;
+    params.set<std::string>("field_name", "mask");
+    params.set<std::string>("condition_lhs", "lev");
+    params.set<std::string>("condition_rhs", std::to_string(val));
+
+    for (std::string cmp_s : {"ge", "le"}) {
+      params.set<std::string>("condition_cmp", cmp_s);
+      auto diag = diag_factory.create("ConditionalSampling", comm, params);
+      diag->set_grids(gm);
+      diag->initialize(t0(),RunType::Initial);
+      diag->compute_diagnostic();
+      auto d = diag->get_diagnostic();
+
+      REQUIRE (d.data_type()==DataType::IntType);
+      REQUIRE (d.rank()==1);
+
+      Field mask = d.clone();
+      Field lev = mask.clone();
+      iota_z<int>(lev);
+      auto cmp = cmp_s=="ge" ? Comparison::GE : Comparison::LE;
+      compute_mask(lev,val,cmp,mask);
+      REQUIRE (views_are_equal(d,mask));
+    }
+  }
+
+  SECTION("mask_where_field_cmp_field") {
+    params.set<std::string>("field_name", "mask");
+    params.set<std::string>("condition_lhs", "y");
+    params.set<std::string>("condition_rhs", "z");
+
+    for (std::string cmp_s : {"eq", "le"}) {
+      for (int nx : {0,ncols}) {
+        for (int ncmp : {0,2}) {
+          for (int nz : {0,nlevs}) {
+            auto y = create_field("y",nx,ncmp,nz,grid->name());
+            auto z = create_field("z",nx,ncmp,nz,grid->name());
+            randomize_uniform(y,seed++);
+            randomize_uniform(z,seed++);
+            params.set<std::string>("condition_cmp", cmp_s);
+            auto diag = diag_factory.create("ConditionalSampling", comm, params);
+            diag->set_grids(gm);
+            diag->set_required_field(y);
+            diag->set_required_field(z);
+            diag->initialize(t0(),RunType::Initial);
+            diag->compute_diagnostic();
+            auto d = diag->get_diagnostic();
+
+            REQUIRE (d.data_type()==DataType::IntType);
+            REQUIRE (d.rank()==y.rank());
+
+            Field mask = d.clone();
+            auto cmp = cmp_s=="eq" ? Comparison::EQ : Comparison::LE;
+            compute_mask(y,z,cmp,mask);
+            REQUIRE (views_are_equal(d,mask));
+          }
+        }
+      }
+    }
+  }
+
 }
 
 } // namespace scream

--- a/components/eamxx/src/share/field/field_utils.hpp
+++ b/components/eamxx/src/share/field/field_utils.hpp
@@ -71,6 +71,7 @@ void print_field_hyperslab (const Field& f,
 // Compute where input field comparese correctly to given value
 void compute_mask (const Field& x, const ScalarWrapper value, Comparison CMP, Field& mask);
 Field compute_mask (const Field& x, const ScalarWrapper value, Comparison CMP);
+void compute_mask (const Field& lhs, const Field& rhs, Comparison CMP, Field& mask);
 
 // Transpose a field layout
 void transpose (const Field& src, Field& tgt);

--- a/components/eamxx/src/share/field/utils/compute_mask.cpp
+++ b/components/eamxx/src/share/field/utils/compute_mask.cpp
@@ -44,7 +44,8 @@ void compute_mask (const Field& f, const ST value, Comparison CMP, Field& mask)
   using range_t   = typename KT::RangePolicy;
 
   const auto& layout = f.get_header().get_identifier().get_layout();
-  const auto lr_ok = f.get_header().get_alloc_properties().allows_layout_right();
+  const auto lr_ok = f.get_header().get_alloc_properties().allows_layout_right() and
+                     mask.get_header().get_alloc_properties().allows_layout_right();
 
   int beg[N] = {};
   int end[N];
@@ -52,8 +53,8 @@ void compute_mask (const Field& f, const ST value, Comparison CMP, Field& mask)
     end[i] = layout.dims()[i];
   }
 
-  auto mv = mask.get_view<int_ND>();
   if (lr_ok) {
+    auto mv = mask.get_view<int_ND>();
     auto v = f.get_view<scalar_ND>();
     if constexpr (N==0) {
       range_t policy(0,1);
@@ -100,7 +101,14 @@ void compute_mask (const Field& f, const ST value, Comparison CMP, Field& mask)
     }
   } else {
     auto v = f.get_strided_view<scalar_ND>();
-    if constexpr (N==1) {
+    auto mv = mask.get_strided_view<int_ND>();
+    if constexpr (N==0) {
+      range_t policy(0,1);
+      auto lambda = KOKKOS_LAMBDA (int) {
+        mv() = compare(v(),value,CMP);
+      };
+      Kokkos::parallel_for(policy,lambda);
+    } else if constexpr (N==1) {
       range_t policy(0,end[0]);
       auto lambda = KOKKOS_LAMBDA (int i) {
         mv(i) = compare(v(i),value,CMP);
@@ -134,6 +142,125 @@ void compute_mask (const Field& f, const ST value, Comparison CMP, Field& mask)
       mdrange_t policy(beg,end);
       auto lambda = KOKKOS_LAMBDA (int i, int j, int k, int l, int m, int n) {
         mv(i,j,k,l,m,n) = compare(v(i,j,k,l,m,n),value,CMP);
+      };
+      Kokkos::parallel_for(policy,lambda);
+    }
+  }
+}
+
+template<int N, typename ST>
+void compute_mask (const Field& lhs, const Field& rhs, Comparison CMP, Field& mask)
+{
+  using scalar_ND = typename ekat::DataND<const ST,N>::type;
+  using int_ND    = typename ekat::DataND<int,N>::type;
+
+  using KT         = Field::kt_dev;
+  using exec_space = typename KT::ExeSpace;
+  using mdrange_t  = Kokkos::MDRangePolicy<exec_space,Kokkos::Rank<N>>;
+  using range_t    = typename KT::RangePolicy;
+
+  const auto& layout = lhs.get_header().get_identifier().get_layout();
+  const auto lr_ok = lhs.get_header().get_alloc_properties().allows_layout_right() and
+                     rhs.get_header().get_alloc_properties().allows_layout_right() and
+                     mask.get_header().get_alloc_properties().allows_layout_right();
+
+  int beg[N] = {};
+  int end[N];
+  for (int i=0; i<N; ++i) {
+    end[i] = layout.dims()[i];
+  }
+
+  if (lr_ok) {
+    auto lhs_v = lhs.get_view<scalar_ND>();
+    auto rhs_v = rhs.get_view<scalar_ND>();
+    auto mv = mask.get_view<int_ND>();
+    if constexpr (N==0) {
+      range_t policy(0,1);
+      auto lambda = KOKKOS_LAMBDA (int) {
+        mv() = compare(lhs_v(),rhs_v(),CMP);
+      };
+      Kokkos::parallel_for(policy,lambda);
+    } else if constexpr (N==1) {
+      range_t policy(0,end[0]);
+      auto lambda = KOKKOS_LAMBDA (int i) {
+        mv(i) = compare(lhs_v(i),rhs_v(i),CMP);
+      };
+      Kokkos::parallel_for(policy,lambda);
+    } else if constexpr (N==2) {
+      mdrange_t policy(beg,end);
+      auto lambda = KOKKOS_LAMBDA (int i, int j) {
+        mv(i,j) = compare(lhs_v(i,j),rhs_v(i,j),CMP);
+      };
+      Kokkos::parallel_for(policy,lambda);
+    } else if constexpr (N==3) {
+      mdrange_t policy(beg,end);
+      auto lambda = KOKKOS_LAMBDA (int i, int j, int k) {
+        mv(i,j,k) = compare(lhs_v(i,j,k),rhs_v(i,j,k),CMP);
+      };
+      Kokkos::parallel_for(policy,lambda);
+    } else if constexpr (N==4) {
+      mdrange_t policy(beg,end);
+      auto lambda = KOKKOS_LAMBDA (int i, int j, int k, int l) {
+        mv(i,j,k,l) = compare(lhs_v(i,j,k,l),rhs_v(i,j,k,l),CMP);
+      };
+      Kokkos::parallel_for(policy,lambda);
+    } else if constexpr (N==5) {
+      mdrange_t policy(beg,end);
+      auto lambda = KOKKOS_LAMBDA (int i, int j, int k, int l, int m) {
+        mv(i,j,k,l,m) = compare(lhs_v(i,j,k,l,m),rhs_v(i,j,k,l,m),CMP);
+      };
+      Kokkos::parallel_for(policy,lambda);
+    } else if constexpr (N==6) {
+      mdrange_t policy(beg,end);
+      auto lambda = KOKKOS_LAMBDA (int i, int j, int k, int l, int m, int n) {
+        mv(i,j,k,l,m,n) = compare(lhs_v(i,j,k,l,m,n),rhs_v(i,j,k,l,m,n),CMP);
+      };
+      Kokkos::parallel_for(policy,lambda);
+    }
+  } else {
+    auto lhs_v = lhs.get_strided_view<scalar_ND>();
+    auto rhs_v = rhs.get_strided_view<scalar_ND>();
+    auto mv = mask.get_strided_view<int_ND>();
+    if constexpr (N==0) {
+      range_t policy(0,1);
+      auto lambda = KOKKOS_LAMBDA (int) {
+        mv() = compare(lhs_v(),rhs_v(),CMP);
+      };
+      Kokkos::parallel_for(policy,lambda);
+    } else if constexpr (N==1) {
+      range_t policy(0,end[0]);
+      auto lambda = KOKKOS_LAMBDA (int i) {
+        mv(i) = compare(lhs_v(i),rhs_v(i),CMP);
+      };
+      Kokkos::parallel_for(policy,lambda);
+    } else if constexpr (N==2) {
+      mdrange_t policy(beg,end);
+      auto lambda = KOKKOS_LAMBDA (int i, int j) {
+        mv(i,j) = compare(lhs_v(i,j),rhs_v(i,j),CMP);
+      };
+      Kokkos::parallel_for(policy,lambda);
+    } else if constexpr (N==3) {
+      mdrange_t policy(beg,end);
+      auto lambda = KOKKOS_LAMBDA (int i, int j, int k) {
+        mv(i,j,k) = compare(lhs_v(i,j,k),rhs_v(i,j,k),CMP);
+      };
+      Kokkos::parallel_for(policy,lambda);
+    } else if constexpr (N==4) {
+      mdrange_t policy(beg,end);
+      auto lambda = KOKKOS_LAMBDA (int i, int j, int k, int l) {
+        mv(i,j,k,l) = compare(lhs_v(i,j,k,l),rhs_v(i,j,k,l),CMP);
+      };
+      Kokkos::parallel_for(policy,lambda);
+    } else if constexpr (N==5) {
+      mdrange_t policy(beg,end);
+      auto lambda = KOKKOS_LAMBDA (int i, int j, int k, int l, int m) {
+        mv(i,j,k,l,m) = compare(lhs_v(i,j,k,l,m),rhs_v(i,j,k,l,m),CMP);
+      };
+      Kokkos::parallel_for(policy,lambda);
+    } else if constexpr (N==6) {
+      mdrange_t policy(beg,end);
+      auto lambda = KOKKOS_LAMBDA (int i, int j, int k, int l, int m, int n) {
+        mv(i,j,k,l,m,n) = compare(lhs_v(i,j,k,l,m,n),rhs_v(i,j,k,l,m,n),CMP);
       };
       Kokkos::parallel_for(policy,lambda);
     }
@@ -209,6 +336,95 @@ void compute_mask (const Field& f, const ScalarWrapper value, Comparison CMP, Fi
         case 4: impl::compute_mask<4>(f,value.as<double>(),CMP,mask); break;
         case 5: impl::compute_mask<5>(f,value.as<double>(),CMP,mask); break;
         case 6: impl::compute_mask<6>(f,value.as<double>(),CMP,mask); break;
+      } break;
+    default:
+      EKAT_ERROR_MSG ("Error! Unexpected/unsupported data type.\n");
+  }
+}
+
+void compute_mask (const Field& lhs, const Field& rhs, Comparison CMP, Field& mask)
+{
+  // Sanity checks
+  const auto& lhs_layout = lhs.get_header().get_identifier().get_layout();
+  const auto& rhs_layout = rhs.get_header().get_identifier().get_layout();
+  const auto& m_layout = mask.get_header().get_identifier().get_layout();
+
+  // Layout
+  EKAT_REQUIRE_MSG (rhs_layout.congruent(lhs_layout),
+      "Error! RHS field layout is incompatible with the lhs field.\n"
+      " - lhs name  : " + lhs.name() + "\n"
+      " - rhs name  : " + rhs.name() + "\n"
+      " - lhs layout: " + lhs_layout.to_string() + "\n"
+      " - rhs layout: " + rhs_layout.to_string() + "\n");
+
+  EKAT_REQUIRE_MSG (m_layout.congruent(lhs_layout),
+      "Error! Mask field layout is incompatible with the lhs/rhs fields.\n"
+      " - lhs name      : " + lhs.name() + "\n"
+      " - rhs name      : " + rhs.name() + "\n"
+      " - mask name     : " + mask.name() + "\n"
+      " - lhs/rhs layout: " + rhs_layout.to_string() + "\n"
+      " - mask layout   : " + m_layout.to_string() + "\n");
+  EKAT_REQUIRE_MSG (lhs.rank()<=6,
+      "Error! LHS field rank not supported.\n"
+      " - LHS name: " + lhs.name() + "\n"
+      " - LHS rank: " + std::to_string(lhs.rank()) + "\n");
+
+  // Allocation
+  EKAT_REQUIRE_MSG (lhs.is_allocated(),
+      "Error! LHS field was not yet allocated.\n"
+      " - LHS name: " + lhs.name() + "\n");
+  EKAT_REQUIRE_MSG (rhs.is_allocated(),
+      "Error! RHS field was not yet allocated.\n"
+      " - RHS name: " + rhs.name() + "\n");
+  EKAT_REQUIRE_MSG (mask.is_allocated(),
+      "Error! Mask field was not yet allocated.\n"
+      " - mask field name: " + mask.name() + "\n");
+  EKAT_REQUIRE_MSG (not mask.is_read_only(),
+      "Error! Cannot update mask field, as it is read-only.\n"
+      " - mask name: " + mask.name() + "\n");
+
+  // Data type
+  EKAT_REQUIRE_MSG (mask.data_type()==DataType::IntType,
+      "Error! The data type of the mask field must be 'int'.\n"
+      " - mask field name: " << mask.name() << "\n"
+      " - mask field data type: " << etoi(mask.data_type()) << "\n");
+  EKAT_REQUIRE_MSG (rhs.data_type()==lhs.data_type(),
+      "Error! RHS and LHS fields have different data type.\n"
+      " - lhs name : " + lhs.name() + "\n"
+      " - rhs name : " + rhs.name() + "\n"
+      " - lhs dtype: " + e2str(lhs.data_type()) + "\n"
+      " - rhs dtype: " + e2str(rhs.data_type()) + "\n");
+
+  switch (lhs.data_type()) {
+    case DataType::IntType:
+      switch(lhs.rank()) {
+        case 0: impl::compute_mask<0,int>(lhs,rhs,CMP,mask); break;
+        case 1: impl::compute_mask<1,int>(lhs,rhs,CMP,mask); break;
+        case 2: impl::compute_mask<2,int>(lhs,rhs,CMP,mask); break;
+        case 3: impl::compute_mask<3,int>(lhs,rhs,CMP,mask); break;
+        case 4: impl::compute_mask<4,int>(lhs,rhs,CMP,mask); break;
+        case 5: impl::compute_mask<5,int>(lhs,rhs,CMP,mask); break;
+        case 6: impl::compute_mask<6,int>(lhs,rhs,CMP,mask); break;
+      } break;
+    case DataType::FloatType:
+      switch(lhs.rank()) {
+        case 0: impl::compute_mask<0,float>(lhs,rhs,CMP,mask); break;
+        case 1: impl::compute_mask<1,float>(lhs,rhs,CMP,mask); break;
+        case 2: impl::compute_mask<2,float>(lhs,rhs,CMP,mask); break;
+        case 3: impl::compute_mask<3,float>(lhs,rhs,CMP,mask); break;
+        case 4: impl::compute_mask<4,float>(lhs,rhs,CMP,mask); break;
+        case 5: impl::compute_mask<5,float>(lhs,rhs,CMP,mask); break;
+        case 6: impl::compute_mask<6,float>(lhs,rhs,CMP,mask); break;
+      } break;
+    case DataType::DoubleType:
+      switch(lhs.rank()) {
+        case 0: impl::compute_mask<0,double>(lhs,rhs,CMP,mask); break;
+        case 1: impl::compute_mask<1,double>(lhs,rhs,CMP,mask); break;
+        case 2: impl::compute_mask<2,double>(lhs,rhs,CMP,mask); break;
+        case 3: impl::compute_mask<3,double>(lhs,rhs,CMP,mask); break;
+        case 4: impl::compute_mask<4,double>(lhs,rhs,CMP,mask); break;
+        case 5: impl::compute_mask<5,double>(lhs,rhs,CMP,mask); break;
+        case 6: impl::compute_mask<6,double>(lhs,rhs,CMP,mask); break;
       } break;
     default:
       EKAT_ERROR_MSG ("Error! Unexpected/unsupported data type.\n");

--- a/components/eamxx/src/share/io/eamxx_io_utils.cpp
+++ b/components/eamxx/src/share/io/eamxx_io_utils.cpp
@@ -262,7 +262,7 @@ create_diagnostic (const std::string& diag_field_name,
   std::regex horiz_avg (generic_field + "_horiz_avg$");
   std::regex vert_contract (generic_field + "_vert_(avg|sum)(_((dp|dz)_weighted))?$");
   std::regex zonal_avg (R"()" + generic_field + R"(_zonal_avg_(\d+)_bins$)");
-  std::regex conditional_sampling (R"()" + generic_field + R"(_where_)" + generic_field + R"(_(gt|ge|eq|ne|le|lt)_([+-]?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)$)");
+  std::regex conditional_sampling (R"()" + generic_field + R"(_where_)" + generic_field + R"(_(gt|ge|eq|ne|le|lt)_)" + generic_field + "$");
   std::regex binary_ops (generic_field + "_" "(plus|minus|times|over)" + "_" + generic_field + "$");
   std::regex histogram (R"()" + generic_field + R"(_histogram_(\d+(\.\d+)?(_\d+(\.\d+)?)+)$)");
   std::regex vert_derivative (generic_field + "_(p|z)vert_derivative$");
@@ -358,10 +358,10 @@ create_diagnostic (const std::string& diag_field_name,
   else if (std::regex_search(diag_field_name,matches,conditional_sampling)) {
     diag_name = "ConditionalSampling";
     params.set("grid_name", grid->name());
-    params.set<std::string>("input_field", matches[1].str());
-    params.set<std::string>("condition_field", matches[2].str());
-    params.set<std::string>("condition_operator", matches[3].str());
-    params.set<std::string>("condition_value", matches[4].str());
+    params.set<std::string>("field_name", matches[1].str());
+    params.set<std::string>("condition_lhs", matches[2].str());
+    params.set<std::string>("condition_cmp", matches[3].str());
+    params.set<std::string>("condition_rhs", matches[4].str());
   }
   else if (std::regex_search(diag_field_name,matches,binary_ops)) {
     diag_name = "BinaryOpsDiag";


### PR DESCRIPTION
Removes code duplication and express the diag in terms of existing field utils.

[BFB]

---

This follows the same idea of horiz/vert contraction diags: the diag is simply a wrapper of an existing field utility, with some minor addition.

Food for thought: I wonder if it would be more powerful to split the mask calculation from the field sampling, so that they are separate diagnostics. But it's not that important probably, and computing a mask is not much used anyways, so what we have is probably fine.

Edit: this also refactors the way mask information is stored in the diag, switching from the "mask_data" extra data to the native valid mask field API.