### PR TITLE
EAMxx: upgrade field update method to accept an additive scalar

### DIFF
--- a/components/eamxx/src/share/field/eti/field_update_fill_aware_double_double.cpp
+++ b/components/eamxx/src/share/field/eti/field_update_fill_aware_double_double.cpp
@@ -3,11 +3,11 @@
 
 namespace scream {
 
-template void Field::update_fill_aware<CombineMode::Replace,  double, double>(const Field&, const double, const double);
-template void Field::update_fill_aware<CombineMode::Update,   double, double>(const Field&, const double, const double);
-template void Field::update_fill_aware<CombineMode::Multiply, double, double>(const Field&, const double, const double);
-template void Field::update_fill_aware<CombineMode::Divide,   double, double>(const Field&, const double, const double);
-template void Field::update_fill_aware<CombineMode::Max,      double, double>(const Field&, const double, const double);
-template void Field::update_fill_aware<CombineMode::Min,      double, double>(const Field&, const double, const double);
+template void Field::update_fill_aware<CombineMode::Replace,  double, double>(const Field&, const double, const double, const double);
+template void Field::update_fill_aware<CombineMode::Update,   double, double>(const Field&, const double, const double, const double);
+template void Field::update_fill_aware<CombineMode::Multiply, double, double>(const Field&, const double, const double, const double);
+template void Field::update_fill_aware<CombineMode::Divide,   double, double>(const Field&, const double, const double, const double);
+template void Field::update_fill_aware<CombineMode::Max,      double, double>(const Field&, const double, const double, const double);
+template void Field::update_fill_aware<CombineMode::Min,      double, double>(const Field&, const double, const double, const double);
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_update_fill_aware_double_float.cpp
+++ b/components/eamxx/src/share/field/eti/field_update_fill_aware_double_float.cpp
@@ -3,11 +3,11 @@
 
 namespace scream {
 
-template void Field::update_fill_aware<CombineMode::Replace,  double, float>(const Field&, const double, const double);
-template void Field::update_fill_aware<CombineMode::Update,   double, float>(const Field&, const double, const double);
-template void Field::update_fill_aware<CombineMode::Multiply, double, float>(const Field&, const double, const double);
-template void Field::update_fill_aware<CombineMode::Divide,   double, float>(const Field&, const double, const double);
-template void Field::update_fill_aware<CombineMode::Max,      double, float>(const Field&, const double, const double);
-template void Field::update_fill_aware<CombineMode::Min,      double, float>(const Field&, const double, const double);
+template void Field::update_fill_aware<CombineMode::Replace,  double, float>(const Field&, const double, const double, const double);
+template void Field::update_fill_aware<CombineMode::Update,   double, float>(const Field&, const double, const double, const double);
+template void Field::update_fill_aware<CombineMode::Multiply, double, float>(const Field&, const double, const double, const double);
+template void Field::update_fill_aware<CombineMode::Divide,   double, float>(const Field&, const double, const double, const double);
+template void Field::update_fill_aware<CombineMode::Max,      double, float>(const Field&, const double, const double, const double);
+template void Field::update_fill_aware<CombineMode::Min,      double, float>(const Field&, const double, const double, const double);
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_update_fill_aware_double_int.cpp
+++ b/components/eamxx/src/share/field/eti/field_update_fill_aware_double_int.cpp
@@ -3,11 +3,11 @@
 
 namespace scream {
 
-template void Field::update_fill_aware<CombineMode::Replace,  double, int>(const Field&, const double, const double);
-template void Field::update_fill_aware<CombineMode::Update,   double, int>(const Field&, const double, const double);
-template void Field::update_fill_aware<CombineMode::Multiply, double, int>(const Field&, const double, const double);
-template void Field::update_fill_aware<CombineMode::Divide,   double, int>(const Field&, const double, const double);
-template void Field::update_fill_aware<CombineMode::Max,      double, int>(const Field&, const double, const double);
-template void Field::update_fill_aware<CombineMode::Min,      double, int>(const Field&, const double, const double);
+template void Field::update_fill_aware<CombineMode::Replace,  double, int>(const Field&, const double, const double, const double);
+template void Field::update_fill_aware<CombineMode::Update,   double, int>(const Field&, const double, const double, const double);
+template void Field::update_fill_aware<CombineMode::Multiply, double, int>(const Field&, const double, const double, const double);
+template void Field::update_fill_aware<CombineMode::Divide,   double, int>(const Field&, const double, const double, const double);
+template void Field::update_fill_aware<CombineMode::Max,      double, int>(const Field&, const double, const double, const double);
+template void Field::update_fill_aware<CombineMode::Min,      double, int>(const Field&, const double, const double, const double);
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_update_fill_aware_float_float.cpp
+++ b/components/eamxx/src/share/field/eti/field_update_fill_aware_float_float.cpp
@@ -3,11 +3,11 @@
 
 namespace scream {
 
-template void Field::update_fill_aware<CombineMode::Replace,  float, float>(const Field&, const float, const float);
-template void Field::update_fill_aware<CombineMode::Update,   float, float>(const Field&, const float, const float);
-template void Field::update_fill_aware<CombineMode::Multiply, float, float>(const Field&, const float, const float);
-template void Field::update_fill_aware<CombineMode::Divide,   float, float>(const Field&, const float, const float);
-template void Field::update_fill_aware<CombineMode::Max,      float, float>(const Field&, const float, const float);
-template void Field::update_fill_aware<CombineMode::Min,      float, float>(const Field&, const float, const float);
+template void Field::update_fill_aware<CombineMode::Replace,  float, float>(const Field&, const float, const float, const float);
+template void Field::update_fill_aware<CombineMode::Update,   float, float>(const Field&, const float, const float, const float);
+template void Field::update_fill_aware<CombineMode::Multiply, float, float>(const Field&, const float, const float, const float);
+template void Field::update_fill_aware<CombineMode::Divide,   float, float>(const Field&, const float, const float, const float);
+template void Field::update_fill_aware<CombineMode::Max,      float, float>(const Field&, const float, const float, const float);
+template void Field::update_fill_aware<CombineMode::Min,      float, float>(const Field&, const float, const float, const float);
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_update_fill_aware_float_int.cpp
+++ b/components/eamxx/src/share/field/eti/field_update_fill_aware_float_int.cpp
@@ -3,11 +3,11 @@
 
 namespace scream {
 
-template void Field::update_fill_aware<CombineMode::Replace,  float, int>(const Field&, const float, const float);
-template void Field::update_fill_aware<CombineMode::Update,   float, int>(const Field&, const float, const float);
-template void Field::update_fill_aware<CombineMode::Multiply, float, int>(const Field&, const float, const float);
-template void Field::update_fill_aware<CombineMode::Divide,   float, int>(const Field&, const float, const float);
-template void Field::update_fill_aware<CombineMode::Max,      float, int>(const Field&, const float, const float);
-template void Field::update_fill_aware<CombineMode::Min,      float, int>(const Field&, const float, const float);
+template void Field::update_fill_aware<CombineMode::Replace,  float, int>(const Field&, const float, const float, const float);
+template void Field::update_fill_aware<CombineMode::Update,   float, int>(const Field&, const float, const float, const float);
+template void Field::update_fill_aware<CombineMode::Multiply, float, int>(const Field&, const float, const float, const float);
+template void Field::update_fill_aware<CombineMode::Divide,   float, int>(const Field&, const float, const float, const float);
+template void Field::update_fill_aware<CombineMode::Max,      float, int>(const Field&, const float, const float, const float);
+template void Field::update_fill_aware<CombineMode::Min,      float, int>(const Field&, const float, const float, const float);
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_update_fill_aware_int_int.cpp
+++ b/components/eamxx/src/share/field/eti/field_update_fill_aware_int_int.cpp
@@ -3,11 +3,11 @@
 
 namespace scream {
 
-template void Field::update_fill_aware<CombineMode::Replace,  int, int>(const Field&, const int, const int);
-template void Field::update_fill_aware<CombineMode::Update,   int, int>(const Field&, const int, const int);
-template void Field::update_fill_aware<CombineMode::Multiply, int, int>(const Field&, const int, const int);
-template void Field::update_fill_aware<CombineMode::Divide,   int, int>(const Field&, const int, const int);
-template void Field::update_fill_aware<CombineMode::Max,      int, int>(const Field&, const int, const int);
-template void Field::update_fill_aware<CombineMode::Min,      int, int>(const Field&, const int, const int);
+template void Field::update_fill_aware<CombineMode::Replace,  int, int>(const Field&, const int, const int, const int);
+template void Field::update_fill_aware<CombineMode::Update,   int, int>(const Field&, const int, const int, const int);
+template void Field::update_fill_aware<CombineMode::Multiply, int, int>(const Field&, const int, const int, const int);
+template void Field::update_fill_aware<CombineMode::Divide,   int, int>(const Field&, const int, const int, const int);
+template void Field::update_fill_aware<CombineMode::Max,      int, int>(const Field&, const int, const int, const int);
+template void Field::update_fill_aware<CombineMode::Min,      int, int>(const Field&, const int, const int, const int);
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_update_impl_double_double.cpp
+++ b/components/eamxx/src/share/field/eti/field_update_impl_double_double.cpp
@@ -3,11 +3,11 @@
 
 namespace scream {
 
-template void Field::update_impl<CombineMode::Replace,  double, double>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Update,   double, double>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Multiply, double, double>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Divide,   double, double>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Max,      double, double>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Min,      double, double>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Replace,  double, double>(const Field&, const double, const double, const double);
+template void Field::update_impl<CombineMode::Update,   double, double>(const Field&, const double, const double, const double);
+template void Field::update_impl<CombineMode::Multiply, double, double>(const Field&, const double, const double, const double);
+template void Field::update_impl<CombineMode::Divide,   double, double>(const Field&, const double, const double, const double);
+template void Field::update_impl<CombineMode::Max,      double, double>(const Field&, const double, const double, const double);
+template void Field::update_impl<CombineMode::Min,      double, double>(const Field&, const double, const double, const double);
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_update_impl_double_float.cpp
+++ b/components/eamxx/src/share/field/eti/field_update_impl_double_float.cpp
@@ -3,11 +3,11 @@
 
 namespace scream {
 
-template void Field::update_impl<CombineMode::Replace,  double, float>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Update,   double, float>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Multiply, double, float>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Divide,   double, float>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Max,      double, float>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Min,      double, float>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Replace,  double, float>(const Field&, const double, const double, const double);
+template void Field::update_impl<CombineMode::Update,   double, float>(const Field&, const double, const double, const double);
+template void Field::update_impl<CombineMode::Multiply, double, float>(const Field&, const double, const double, const double);
+template void Field::update_impl<CombineMode::Divide,   double, float>(const Field&, const double, const double, const double);
+template void Field::update_impl<CombineMode::Max,      double, float>(const Field&, const double, const double, const double);
+template void Field::update_impl<CombineMode::Min,      double, float>(const Field&, const double, const double, const double);
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_update_impl_double_int.cpp
+++ b/components/eamxx/src/share/field/eti/field_update_impl_double_int.cpp
@@ -3,11 +3,11 @@
 
 namespace scream {
 
-template void Field::update_impl<CombineMode::Replace,  double, int>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Update,   double, int>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Multiply, double, int>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Divide,   double, int>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Max,      double, int>(const Field&, const double, const double);
-template void Field::update_impl<CombineMode::Min,      double, int>(const Field&, const double, const double);
+template void Field::update_impl<CombineMode::Replace,  double, int>(const Field&, const double, const double, const double);
+template void Field::update_impl<CombineMode::Update,   double, int>(const Field&, const double, const double, const double);
+template void Field::update_impl<CombineMode::Multiply, double, int>(const Field&, const double, const double, const double);
+template void Field::update_impl<CombineMode::Divide,   double, int>(const Field&, const double, const double, const double);
+template void Field::update_impl<CombineMode::Max,      double, int>(const Field&, const double, const double, const double);
+template void Field::update_impl<CombineMode::Min,      double, int>(const Field&, const double, const double, const double);
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_update_impl_float_float.cpp
+++ b/components/eamxx/src/share/field/eti/field_update_impl_float_float.cpp
@@ -3,11 +3,11 @@
 
 namespace scream {
 
-template void Field::update_impl<CombineMode::Replace,  float, float>(const Field&, const float, const float);
-template void Field::update_impl<CombineMode::Update,   float, float>(const Field&, const float, const float);
-template void Field::update_impl<CombineMode::Multiply, float, float>(const Field&, const float, const float);
-template void Field::update_impl<CombineMode::Divide,   float, float>(const Field&, const float, const float);
-template void Field::update_impl<CombineMode::Max,      float, float>(const Field&, const float, const float);
-template void Field::update_impl<CombineMode::Min,      float, float>(const Field&, const float, const float);
+template void Field::update_impl<CombineMode::Replace,  float, float>(const Field&, const float, const float, const float);
+template void Field::update_impl<CombineMode::Update,   float, float>(const Field&, const float, const float, const float);
+template void Field::update_impl<CombineMode::Multiply, float, float>(const Field&, const float, const float, const float);
+template void Field::update_impl<CombineMode::Divide,   float, float>(const Field&, const float, const float, const float);
+template void Field::update_impl<CombineMode::Max,      float, float>(const Field&, const float, const float, const float);
+template void Field::update_impl<CombineMode::Min,      float, float>(const Field&, const float, const float, const float);
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_update_impl_float_int.cpp
+++ b/components/eamxx/src/share/field/eti/field_update_impl_float_int.cpp
@@ -3,11 +3,11 @@
 
 namespace scream {
 
-template void Field::update_impl<CombineMode::Replace,  float, int>(const Field&, const float, const float);
-template void Field::update_impl<CombineMode::Update,   float, int>(const Field&, const float, const float);
-template void Field::update_impl<CombineMode::Multiply, float, int>(const Field&, const float, const float);
-template void Field::update_impl<CombineMode::Divide,   float, int>(const Field&, const float, const float);
-template void Field::update_impl<CombineMode::Max,      float, int>(const Field&, const float, const float);
-template void Field::update_impl<CombineMode::Min,      float, int>(const Field&, const float, const float);
+template void Field::update_impl<CombineMode::Replace,  float, int>(const Field&, const float, const float, const float);
+template void Field::update_impl<CombineMode::Update,   float, int>(const Field&, const float, const float, const float);
+template void Field::update_impl<CombineMode::Multiply, float, int>(const Field&, const float, const float, const float);
+template void Field::update_impl<CombineMode::Divide,   float, int>(const Field&, const float, const float, const float);
+template void Field::update_impl<CombineMode::Max,      float, int>(const Field&, const float, const float, const float);
+template void Field::update_impl<CombineMode::Min,      float, int>(const Field&, const float, const float, const float);
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_update_impl_int_int.cpp
+++ b/components/eamxx/src/share/field/eti/field_update_impl_int_int.cpp
@@ -3,11 +3,11 @@
 
 namespace scream {
 
-template void Field::update_impl<CombineMode::Replace,  int, int>(const Field&, const int, const int);
-template void Field::update_impl<CombineMode::Update,   int, int>(const Field&, const int, const int);
-template void Field::update_impl<CombineMode::Multiply, int, int>(const Field&, const int, const int);
-template void Field::update_impl<CombineMode::Divide,   int, int>(const Field&, const int, const int);
-template void Field::update_impl<CombineMode::Max,      int, int>(const Field&, const int, const int);
-template void Field::update_impl<CombineMode::Min,      int, int>(const Field&, const int, const int);
+template void Field::update_impl<CombineMode::Replace,  int, int>(const Field&, const int, const int, const int);
+template void Field::update_impl<CombineMode::Update,   int, int>(const Field&, const int, const int, const int);
+template void Field::update_impl<CombineMode::Multiply, int, int>(const Field&, const int, const int, const int);
+template void Field::update_impl<CombineMode::Divide,   int, int>(const Field&, const int, const int, const int);
+template void Field::update_impl<CombineMode::Max,      int, int>(const Field&, const int, const int, const int);
+template void Field::update_impl<CombineMode::Min,      int, int>(const Field&, const int, const int, const int);
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_update_masked_double_double.cpp
+++ b/components/eamxx/src/share/field/eti/field_update_masked_double_double.cpp
@@ -3,11 +3,11 @@
 
 namespace scream {
 
-template void Field::update_masked<CombineMode::Replace,  double, double>(const Field&, const double, const double, const Field&);
-template void Field::update_masked<CombineMode::Update,   double, double>(const Field&, const double, const double, const Field&);
-template void Field::update_masked<CombineMode::Multiply, double, double>(const Field&, const double, const double, const Field&);
-template void Field::update_masked<CombineMode::Divide,   double, double>(const Field&, const double, const double, const Field&);
-template void Field::update_masked<CombineMode::Max,      double, double>(const Field&, const double, const double, const Field&);
-template void Field::update_masked<CombineMode::Min,      double, double>(const Field&, const double, const double, const Field&);
+template void Field::update_masked<CombineMode::Replace,  double, double>(const Field&, const double, const double, const double, const Field&);
+template void Field::update_masked<CombineMode::Update,   double, double>(const Field&, const double, const double, const double, const Field&);
+template void Field::update_masked<CombineMode::Multiply, double, double>(const Field&, const double, const double, const double, const Field&);
+template void Field::update_masked<CombineMode::Divide,   double, double>(const Field&, const double, const double, const double, const Field&);
+template void Field::update_masked<CombineMode::Max,      double, double>(const Field&, const double, const double, const double, const Field&);
+template void Field::update_masked<CombineMode::Min,      double, double>(const Field&, const double, const double, const double, const Field&);
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_update_masked_double_float.cpp
+++ b/components/eamxx/src/share/field/eti/field_update_masked_double_float.cpp
@@ -3,11 +3,11 @@
 
 namespace scream {
 
-template void Field::update_masked<CombineMode::Replace,  double, float>(const Field&, const double, const double, const Field&);
-template void Field::update_masked<CombineMode::Update,   double, float>(const Field&, const double, const double, const Field&);
-template void Field::update_masked<CombineMode::Multiply, double, float>(const Field&, const double, const double, const Field&);
-template void Field::update_masked<CombineMode::Divide,   double, float>(const Field&, const double, const double, const Field&);
-template void Field::update_masked<CombineMode::Max,      double, float>(const Field&, const double, const double, const Field&);
-template void Field::update_masked<CombineMode::Min,      double, float>(const Field&, const double, const double, const Field&);
+template void Field::update_masked<CombineMode::Replace,  double, float>(const Field&, const double, const double, const double, const Field&);
+template void Field::update_masked<CombineMode::Update,   double, float>(const Field&, const double, const double, const double, const Field&);
+template void Field::update_masked<CombineMode::Multiply, double, float>(const Field&, const double, const double, const double, const Field&);
+template void Field::update_masked<CombineMode::Divide,   double, float>(const Field&, const double, const double, const double, const Field&);
+template void Field::update_masked<CombineMode::Max,      double, float>(const Field&, const double, const double, const double, const Field&);
+template void Field::update_masked<CombineMode::Min,      double, float>(const Field&, const double, const double, const double, const Field&);
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_update_masked_double_int.cpp
+++ b/components/eamxx/src/share/field/eti/field_update_masked_double_int.cpp
@@ -3,11 +3,11 @@
 
 namespace scream {
 
-template void Field::update_masked<CombineMode::Replace,  double, int>(const Field&, const double, const double, const Field&);
-template void Field::update_masked<CombineMode::Update,   double, int>(const Field&, const double, const double, const Field&);
-template void Field::update_masked<CombineMode::Multiply, double, int>(const Field&, const double, const double, const Field&);
-template void Field::update_masked<CombineMode::Divide,   double, int>(const Field&, const double, const double, const Field&);
-template void Field::update_masked<CombineMode::Max,      double, int>(const Field&, const double, const double, const Field&);
-template void Field::update_masked<CombineMode::Min,      double, int>(const Field&, const double, const double, const Field&);
+template void Field::update_masked<CombineMode::Replace,  double, int>(const Field&, const double, const double, const double, const Field&);
+template void Field::update_masked<CombineMode::Update,   double, int>(const Field&, const double, const double, const double, const Field&);
+template void Field::update_masked<CombineMode::Multiply, double, int>(const Field&, const double, const double, const double, const Field&);
+template void Field::update_masked<CombineMode::Divide,   double, int>(const Field&, const double, const double, const double, const Field&);
+template void Field::update_masked<CombineMode::Max,      double, int>(const Field&, const double, const double, const double, const Field&);
+template void Field::update_masked<CombineMode::Min,      double, int>(const Field&, const double, const double, const double, const Field&);
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_update_masked_float_float.cpp
+++ b/components/eamxx/src/share/field/eti/field_update_masked_float_float.cpp
@@ -3,11 +3,11 @@
 
 namespace scream {
 
-template void Field::update_masked<CombineMode::Replace,  float, float>(const Field&, const float, const float, const Field&);
-template void Field::update_masked<CombineMode::Update,   float, float>(const Field&, const float, const float, const Field&);
-template void Field::update_masked<CombineMode::Multiply, float, float>(const Field&, const float, const float, const Field&);
-template void Field::update_masked<CombineMode::Divide,   float, float>(const Field&, const float, const float, const Field&);
-template void Field::update_masked<CombineMode::Max,      float, float>(const Field&, const float, const float, const Field&);
-template void Field::update_masked<CombineMode::Min,      float, float>(const Field&, const float, const float, const Field&);
+template void Field::update_masked<CombineMode::Replace,  float, float>(const Field&, const float, const float, const float, const Field&);
+template void Field::update_masked<CombineMode::Update,   float, float>(const Field&, const float, const float, const float, const Field&);
+template void Field::update_masked<CombineMode::Multiply, float, float>(const Field&, const float, const float, const float, const Field&);
+template void Field::update_masked<CombineMode::Divide,   float, float>(const Field&, const float, const float, const float, const Field&);
+template void Field::update_masked<CombineMode::Max,      float, float>(const Field&, const float, const float, const float, const Field&);
+template void Field::update_masked<CombineMode::Min,      float, float>(const Field&, const float, const float, const float, const Field&);
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_update_masked_float_int.cpp
+++ b/components/eamxx/src/share/field/eti/field_update_masked_float_int.cpp
@@ -3,11 +3,11 @@
 
 namespace scream {
 
-template void Field::update_masked<CombineMode::Replace,  float, int>(const Field&, const float, const float, const Field&);
-template void Field::update_masked<CombineMode::Update,   float, int>(const Field&, const float, const float, const Field&);
-template void Field::update_masked<CombineMode::Multiply, float, int>(const Field&, const float, const float, const Field&);
-template void Field::update_masked<CombineMode::Divide,   float, int>(const Field&, const float, const float, const Field&);
-template void Field::update_masked<CombineMode::Max,      float, int>(const Field&, const float, const float, const Field&);
-template void Field::update_masked<CombineMode::Min,      float, int>(const Field&, const float, const float, const Field&);
+template void Field::update_masked<CombineMode::Replace,  float, int>(const Field&, const float, const float, const float, const Field&);
+template void Field::update_masked<CombineMode::Update,   float, int>(const Field&, const float, const float, const float, const Field&);
+template void Field::update_masked<CombineMode::Multiply, float, int>(const Field&, const float, const float, const float, const Field&);
+template void Field::update_masked<CombineMode::Divide,   float, int>(const Field&, const float, const float, const float, const Field&);
+template void Field::update_masked<CombineMode::Max,      float, int>(const Field&, const float, const float, const float, const Field&);
+template void Field::update_masked<CombineMode::Min,      float, int>(const Field&, const float, const float, const float, const Field&);
 
 } // namespace scream

--- a/components/eamxx/src/share/field/eti/field_update_masked_int_int.cpp
+++ b/components/eamxx/src/share/field/eti/field_update_masked_int_int.cpp
@@ -3,11 +3,11 @@
 
 namespace scream {
 
-template void Field::update_masked<CombineMode::Replace,  int, int>(const Field&, const int, const int, const Field&);
-template void Field::update_masked<CombineMode::Update,   int, int>(const Field&, const int, const int, const Field&);
-template void Field::update_masked<CombineMode::Multiply, int, int>(const Field&, const int, const int, const Field&);
-template void Field::update_masked<CombineMode::Divide,   int, int>(const Field&, const int, const int, const Field&);
-template void Field::update_masked<CombineMode::Max,      int, int>(const Field&, const int, const int, const Field&);
-template void Field::update_masked<CombineMode::Min,      int, int>(const Field&, const int, const int, const Field&);
+template void Field::update_masked<CombineMode::Replace,  int, int>(const Field&, const int, const int, const int, const Field&);
+template void Field::update_masked<CombineMode::Update,   int, int>(const Field&, const int, const int, const int, const Field&);
+template void Field::update_masked<CombineMode::Multiply, int, int>(const Field&, const int, const int, const int, const Field&);
+template void Field::update_masked<CombineMode::Divide,   int, int>(const Field&, const int, const int, const int, const Field&);
+template void Field::update_masked<CombineMode::Max,      int, int>(const Field&, const int, const int, const int, const Field&);
+template void Field::update_masked<CombineMode::Min,      int, int>(const Field&, const int, const int, const int, const Field&);
 
 } // namespace scream

--- a/components/eamxx/src/share/field/field.cpp
+++ b/components/eamxx/src/share/field/field.cpp
@@ -559,6 +559,16 @@ void Field::min (const Field& x, const Field& mask)
   update_cm<CM>("Field::min (masked)",x,1,1,0,mask);
 }
 
+void Field::add_scalar (const ScalarWrapper gamma)
+{
+  update(*this,0,1,gamma);
+}
+
+void Field::add_scalar (const ScalarWrapper gamma, const Field& mask)
+{
+  update(*this,0,1,gamma,mask);
+}
+
 void Field::
 update (const Field& x, const ScalarWrapper alpha, const ScalarWrapper beta, const ScalarWrapper gamma)
 {

--- a/components/eamxx/src/share/field/field.cpp
+++ b/components/eamxx/src/share/field/field.cpp
@@ -10,6 +10,7 @@ void update_checks (const std::string& caller,
                     const Field& y, const Field& x,
                     const ScalarWrapper& alpha,
                     const ScalarWrapper& beta,
+                    const ScalarWrapper gamma = 0,
                     const Field* mask = nullptr)
 {
   // Check output field is writable
@@ -21,6 +22,7 @@ void update_checks (const std::string& caller,
   const auto& x_dt = x.data_type();
   const auto& a_dt = alpha.type;
   const auto& b_dt = beta.type;
+  const auto& g_dt = gamma.type;
 
   // Ensure data types are not somehow invalid
   EKAT_REQUIRE_MSG (y_dt!=DataType::Invalid,
@@ -34,6 +36,9 @@ void update_checks (const std::string& caller,
       " - lhs name: " + y.name() + "\n");
   EKAT_REQUIRE_MSG (b_dt!=DataType::Invalid,
       "[" + caller + "] Error! Beta coeff data type is invalid.\n"
+      " - lhs name: " + y.name() + "\n");
+  EKAT_REQUIRE_MSG (g_dt!=DataType::Invalid,
+      "[" + caller + "] Error! Gamma coeff data type is invalid.\n"
       " - lhs name: " + y.name() + "\n");
 
   // If user passes, say, double alpha/beta for an int field, we should error out, warning about
@@ -58,6 +63,11 @@ void update_checks (const std::string& caller,
       " - lhs name: " + y.name() + "\n"
       " - lhs data type  : " + e2str(y_dt) + "\n"
       " - beta data type: " + e2str(b_dt) + "\n");
+  EKAT_REQUIRE_MSG (not is_narrowing_conversion(g_dt,y_dt),
+      "[" + caller + "] Error! Coefficient gamma may be narrowed when converted to lhs data type.\n"
+      " - lhs name: " + y.name() + "\n"
+      " - lhs data type  : " + e2str(y_dt) + "\n"
+      " - gamma data type: " + e2str(g_dt) + "\n");
 
   // Check x/y are allocated
   EKAT_REQUIRE_MSG (y.is_allocated(),
@@ -450,7 +460,7 @@ void Field::deep_copy (const ScalarWrapper value)
 
 void Field::deep_copy (const ScalarWrapper value, const Field& mask, const bool negate_mask)
 {
-  update_checks("Field::deep_copy (scalar, masked)",*this,*this,value,value,&mask);
+  update_checks("Field::deep_copy (scalar, masked)",*this,*this,value,value,0,&mask);
 
   const auto my_data_type = data_type();
   switch (my_data_type) {
@@ -477,7 +487,7 @@ void Field::deep_copy (const Field& x)
     return;
 
   constexpr auto CM = CombineMode::Replace;
-  update_cm<CM>("Field::deep_copy",x,1,0);
+  update_cm<CM>("Field::deep_copy",x,1,0,0);
 }
 
 void Field::deep_copy (const Field& x, const Field& mask)
@@ -486,138 +496,151 @@ void Field::deep_copy (const Field& x, const Field& mask)
     return;
 
   constexpr auto CM = CombineMode::Replace;
-  update_cm<CM>("Field::deep_copy (masked)",x,1,0,mask);
+  update_cm<CM>("Field::deep_copy (masked)",x,1,0,0,mask);
 }
 
 void Field::scale (const ScalarWrapper beta)
 {
   constexpr auto CM = CombineMode::Update;
-  update_cm<CM>("Field::scale (scalar)",*this,0,beta);
+  update_cm<CM>("Field::scale (scalar)",*this,0,beta,0);
 }
 
 void Field::scale (const ScalarWrapper beta, const Field& mask)
 {
   constexpr auto CM = CombineMode::Update;
-  update_cm<CM>("Field::scale (scalar, masked)",*this,0,beta,mask);
+  update_cm<CM>("Field::scale (scalar, masked)",*this,0,beta,0,mask);
 }
 
 void Field::scale (const Field& x)
 {
   constexpr auto CM = CombineMode::Multiply;
-  update_cm<CM>("Field::scale",x,1,1);
+  update_cm<CM>("Field::scale",x,1,1,0);
 }
 
 void Field::scale (const Field& x, const Field& mask)
 {
   constexpr auto CM = CombineMode::Multiply;
-  update_cm<CM>("Field::scale (masked)",x,1,1,mask);
+  update_cm<CM>("Field::scale (masked)",x,1,1,0,mask);
 }
 
 void Field::scale_inv (const Field& x)
 {
   constexpr auto CM = CombineMode::Divide;
-  update_cm<CM>("Field::scale_inv",x,1,1);
+  update_cm<CM>("Field::scale_inv",x,1,1,0);
 }
 
 void Field::scale_inv (const Field& x, const Field& mask)
 {
   constexpr auto CM = CombineMode::Divide;
-  update_cm<CM>("Field::scale_inv (masked)",x,1,1,mask);
+  update_cm<CM>("Field::scale_inv (masked)",x,1,1,0,mask);
 }
 
 void Field::max (const Field& x)
 {
   constexpr auto CM = CombineMode::Max;
-  update_cm<CM>("Field::max",x,1,1);
+  update_cm<CM>("Field::max",x,1,1,0);
 }
 
 void Field::max (const Field& x, const Field& mask)
 {
   constexpr auto CM = CombineMode::Max;
-  update_cm<CM>("Field::max (masked)",x,1,1,mask);
+  update_cm<CM>("Field::max (masked)",x,1,1,0,mask);
 }
 
 void Field::min (const Field& x)
 {
   constexpr auto CM = CombineMode::Min;
-  update_cm<CM>("Field::min",x,1,1);
+  update_cm<CM>("Field::min",x,1,1,0);
 }
 
 void Field::min (const Field& x, const Field& mask)
 {
   constexpr auto CM = CombineMode::Min;
-  update_cm<CM>("Field::min (masked)",x,1,1,mask);
+  update_cm<CM>("Field::min (masked)",x,1,1,0,mask);
 }
 
 void Field::
-update (const Field& x, const ScalarWrapper alpha, const ScalarWrapper beta)
+update (const Field& x, const ScalarWrapper alpha, const ScalarWrapper beta, const ScalarWrapper gamma)
 {
   constexpr auto CM = CombineMode::Update;
-  update_cm<CM>("Field::update",x,alpha,beta);
+  update_cm<CM>("Field::update",x,alpha,beta,gamma);
 }
 
 void Field::
 update (const Field& x, const ScalarWrapper alpha, const ScalarWrapper beta, const Field& mask)
 {
   constexpr auto CM = CombineMode::Update;
-  update_cm<CM>("Field::update (masked)",x,alpha,beta,mask);
+  update_cm<CM>("Field::update (masked)",x,alpha,beta,0,mask);
+}
+
+void Field::
+update (const Field& x, const ScalarWrapper alpha, const ScalarWrapper beta)
+{
+  constexpr auto CM = CombineMode::Update;
+  update_cm<CM>("Field::update",x,alpha,beta,0);
+}
+
+void Field::
+update (const Field& x, const ScalarWrapper alpha, const ScalarWrapper beta, const ScalarWrapper gamma, const Field& mask)
+{
+  constexpr auto CM = CombineMode::Update;
+  update_cm<CM>("Field::update (masked)",x,alpha,beta,gamma,mask);
 }
 
 template<CombineMode CM>
 void Field::
-update_cm (const std::string& caller, const Field& x, const ScalarWrapper alpha, const ScalarWrapper beta)
+update_cm (const std::string& caller, const Field& x, const ScalarWrapper alpha, const ScalarWrapper beta, const ScalarWrapper gamma)
 {
-  // Determine if the RHS can contain fill_value entries
   // Check consistency of inputs
-  update_checks(caller,*this,x,alpha,beta);
+  update_checks(caller,*this,x,alpha,beta,gamma);
 
+  // Determine if the RHS can contain fill_value entries
   bool fill_aware = x.get_header().may_be_filled();
 
   if (data_type()==DataType::IntType) {
-    return fill_aware ? update_fill_aware<CM,int,int>(x,alpha.as<int>(),beta.as<int>())
-                      : update_impl<CM,int,int>(x,alpha.as<int>(),beta.as<int>());
+    return fill_aware ? update_fill_aware<CM,int,int>(x,alpha.as<int>(),beta.as<int>(),gamma.as<int>())
+                      : update_impl<CM,int,int>(x,alpha.as<int>(),beta.as<int>(),gamma.as<int>());
   } else if (data_type()==DataType::FloatType) {
     if (x.data_type()==DataType::FloatType)
-      return fill_aware ? update_fill_aware<CM,float,float>(x,alpha.as<float>(),beta.as<float>())
-                        : update_impl<CM,float,float>(x,alpha.as<float>(),beta.as<float>());
+      return fill_aware ? update_fill_aware<CM,float,float>(x,alpha.as<float>(),beta.as<float>(),gamma.as<float>())
+                        : update_impl<CM,float,float>(x,alpha.as<float>(),beta.as<float>(),gamma.as<float>());
     else
-      return fill_aware ? update_fill_aware<CM,float,int>(x,alpha.as<float>(),beta.as<float>())
-                        : update_impl<CM,float,int>(x,alpha.as<float>(),beta.as<float>());
+      return fill_aware ? update_fill_aware<CM,float,int>(x,alpha.as<float>(),beta.as<float>(),gamma.as<float>())
+                        : update_impl<CM,float,int>(x,alpha.as<float>(),beta.as<float>(),gamma.as<float>());
   } else if (data_type()==DataType::DoubleType) {
     if (x.data_type()==DataType::DoubleType)
-      return fill_aware ? update_fill_aware<CM,double,double>(x,alpha.as<double>(),beta.as<double>())
-                        : update_impl<CM,double,double>(x,alpha.as<double>(),beta.as<double>());
+      return fill_aware ? update_fill_aware<CM,double,double>(x,alpha.as<double>(),beta.as<double>(),gamma.as<double>())
+                        : update_impl<CM,double,double>(x,alpha.as<double>(),beta.as<double>(),gamma.as<double>());
     else if (x.data_type()==DataType::FloatType)
-      return fill_aware ? update_fill_aware<CM,double,float>(x,alpha.as<double>(),beta.as<double>())
-                        : update_impl<CM,double,float>(x,alpha.as<double>(),beta.as<double>());
+      return fill_aware ? update_fill_aware<CM,double,float>(x,alpha.as<double>(),beta.as<double>(),gamma.as<double>())
+                        : update_impl<CM,double,float>(x,alpha.as<double>(),beta.as<double>(),gamma.as<double>());
     else
-      return fill_aware ? update_fill_aware<CM,double,int>(x,alpha.as<double>(),beta.as<double>())
-                        : update_impl<CM,double,int>(x,alpha.as<double>(),beta.as<double>());
+      return fill_aware ? update_fill_aware<CM,double,int>(x,alpha.as<double>(),beta.as<double>(),gamma.as<double>())
+                        : update_impl<CM,double,int>(x,alpha.as<double>(),beta.as<double>(),gamma.as<double>());
   }
 }
 
 template<CombineMode CM>
 void Field::
-update_cm (const std::string& caller, const Field& x, const ScalarWrapper alpha, const ScalarWrapper beta, const Field& mask)
+update_cm (const std::string& caller, const Field& x, const ScalarWrapper alpha, const ScalarWrapper beta, const ScalarWrapper gamma, const Field& mask)
 {
-  // Determine if the RHS can contain fill_value entries
   // Check consistency of inputs
-  update_checks(caller,*this,x,alpha,beta,&mask);
+  update_checks(caller,*this,x,alpha,beta,gamma,&mask);
 
   if (data_type()==DataType::IntType) {
-    return update_masked<CM,int,int>(x,alpha.as<int>(),beta.as<int>(),mask);
+    return update_masked<CM,int,int>(x,alpha.as<int>(),beta.as<int>(),gamma.as<int>(),mask);
   } else if (data_type()==DataType::FloatType) {
     if (x.data_type()==DataType::FloatType)
-      return update_masked<CM,float,float>(x,alpha.as<float>(),beta.as<float>(),mask);
+      return update_masked<CM,float,float>(x,alpha.as<float>(),beta.as<float>(),gamma.as<float>(),mask);
     else
-      return update_masked<CM,float,int>(x,alpha.as<float>(),beta.as<float>(),mask);
+      return update_masked<CM,float,int>(x,alpha.as<float>(),beta.as<float>(),gamma.as<float>(),mask);
   } else if (data_type()==DataType::DoubleType) {
     if (x.data_type()==DataType::DoubleType)
-      return update_masked<CM,double,double>(x,alpha.as<double>(),beta.as<double>(),mask);
+      return update_masked<CM,double,double>(x,alpha.as<double>(),beta.as<double>(),gamma.as<double>(),mask);
     else if (x.data_type()==DataType::FloatType)
-      return update_masked<CM,double,float>(x,alpha.as<double>(),beta.as<double>(),mask);
+      return update_masked<CM,double,float>(x,alpha.as<double>(),beta.as<double>(),gamma.as<double>(),mask);
     else
-      return update_masked<CM,double,int>(x,alpha.as<double>(),beta.as<double>(),mask);
+      return update_masked<CM,double,int>(x,alpha.as<double>(),beta.as<double>(),gamma.as<double>(),mask);
   }
 }
 

--- a/components/eamxx/src/share/field/field.cpp
+++ b/components/eamxx/src/share/field/field.cpp
@@ -473,12 +473,18 @@ void Field::deep_copy (const ScalarWrapper value, const Field& mask, const bool 
 
 void Field::deep_copy (const Field& x)
 {
+  if (&x==this)
+    return;
+
   constexpr auto CM = CombineMode::Replace;
   update_cm<CM>("Field::deep_copy",x,1,0);
 }
 
 void Field::deep_copy (const Field& x, const Field& mask)
 {
+  if (&x==this)
+    return;
+
   constexpr auto CM = CombineMode::Replace;
   update_cm<CM>("Field::deep_copy (masked)",x,1,0,mask);
 }

--- a/components/eamxx/src/share/field/field.hpp
+++ b/components/eamxx/src/share/field/field.hpp
@@ -243,6 +243,10 @@ public:
   void update (const Field& x, const ScalarWrapper alpha, const ScalarWrapper beta, const ScalarWrapper gamma);
   void update (const Field& x, const ScalarWrapper alpha, const ScalarWrapper beta, const ScalarWrapper gamma, const Field& mask);
 
+  // Short-hand to update with alpha=0,beta=1
+  void add_scalar (const ScalarWrapper gamma);
+  void add_scalar (const ScalarWrapper gamma, const Field& mask);
+
   // Special case of update for particular choices of the combine mode
   void scale (const ScalarWrapper beta);
   void scale (const ScalarWrapper beta, const Field& mask);

--- a/components/eamxx/src/share/field/field.hpp
+++ b/components/eamxx/src/share/field/field.hpp
@@ -239,6 +239,10 @@ public:
   void update (const Field& x, const ScalarWrapper alpha, const ScalarWrapper beta);
   void update (const Field& x, const ScalarWrapper alpha, const ScalarWrapper beta, const Field& mask);
 
+  // Same as the above, but adds the scalar value gamma as well (i.e., does an affine transformation)
+  void update (const Field& x, const ScalarWrapper alpha, const ScalarWrapper beta, const ScalarWrapper gamma);
+  void update (const Field& x, const ScalarWrapper alpha, const ScalarWrapper beta, const ScalarWrapper gamma, const Field& mask);
+
   // Special case of update for particular choices of the combine mode
   void scale (const ScalarWrapper beta);
   void scale (const ScalarWrapper beta, const Field& mask);
@@ -350,18 +354,18 @@ protected:
   void deep_copy_masked (const ST value, const Field& mask);
 
   template<CombineMode CM>
-  void update_cm (const std::string& caller, const Field& x, const ScalarWrapper alpha, const ScalarWrapper beta);
+  void update_cm (const std::string& caller, const Field& x, const ScalarWrapper alpha, const ScalarWrapper beta, const ScalarWrapper gamma);
   template<CombineMode CM>
-  void update_cm (const std::string& caller, const Field& x, const ScalarWrapper alpha, const ScalarWrapper beta, const Field& mask);
+  void update_cm (const std::string& caller, const Field& x, const ScalarWrapper alpha, const ScalarWrapper beta, const ScalarWrapper gamma, const Field& mask);
 
   template<CombineMode CM, typename ST, typename STX>
-  void update_impl (const Field& x, const ST alpha, const ST beta);
+  void update_impl (const Field& x, const ST alpha, const ST beta, const ST gamma);
 
   template<CombineMode CM, typename ST, typename STX>
-  void update_fill_aware (const Field& x, const ST alpha, const ST beta);
+  void update_fill_aware (const Field& x, const ST alpha, const ST beta, const ST gamma);
 
   template<CombineMode CM, typename ST, typename STX>
-  void update_masked (const Field& x, const ST alpha, const ST beta, const Field& mask);
+  void update_masked (const Field& x, const ST alpha, const ST beta, const ST gamma, const Field& mask);
 
   template<HostOrDevice HD>
   const get_view_type<char*,HD>&

--- a/components/eamxx/src/share/field/field_update_fill_aware.hpp
+++ b/components/eamxx/src/share/field/field_update_fill_aware.hpp
@@ -2,6 +2,7 @@
 #define SCREAM_FIELD_UPDATE_FILL_AWARE_HPP
 
 #include "share/field/field.hpp"
+#include "share/util/eamxx_universal_constants.hpp"
 
 namespace scream
 {
@@ -53,10 +54,14 @@ struct CombineViewsFillAwareHelper {
   void operator() (Args... indices) const {
     auto& lhs_val = lhs.access(indices...);
     combine_fill_aware<CM>(rhs.access(indices...),lhs_val,alpha,beta);
+    if constexpr (CM==CombineMode::Update)
+      if (gamma!=constants::fill_value<ST>)
+        lhs_val += gamma;
   }
 
   ST alpha;
   ST beta;
+  ST gamma;
   LhsView lhs;
   RhsView rhs;
 };
@@ -64,7 +69,7 @@ struct CombineViewsFillAwareHelper {
 template<CombineMode CM, typename LhsView, typename RhsView, typename ST>
 void
 cvfah (LhsView lhs, RhsView rhs,
-     ST alpha, ST beta,
+     ST alpha, ST beta, ST gamma,
      const std::vector<int>& dims)
 {
   CombineViewsFillAwareHelper <CM, LhsView, RhsView,  ST> helper;
@@ -72,6 +77,7 @@ cvfah (LhsView lhs, RhsView rhs,
   helper.rhs = rhs;
   helper.alpha = alpha;
   helper.beta = beta;
+  helper.gamma = gamma;
   helper.run(dims);
 }
 
@@ -79,7 +85,7 @@ cvfah (LhsView lhs, RhsView rhs,
 
 template<CombineMode CM, typename ST, typename XST>
 void Field::
-update_fill_aware (const Field& x, const ST alpha, const ST beta)
+update_fill_aware (const Field& x, const ST alpha, const ST beta, const ST gamma)
 {
   const auto& layout = x.get_header().get_identifier().get_layout();
   const auto& dims = layout.dims();
@@ -92,127 +98,127 @@ update_fill_aware (const Field& x, const ST alpha, const ST beta)
       if (x_lr_ok and y_lr_ok)
         details::cvfah<CM>(get_view<ST>(),
                            x.get_view<const XST>(),
-                           alpha,beta,dims);
+                           alpha,beta,gamma,dims);
       else if (x_lr_ok)
         details::cvfah<CM>(get_strided_view<ST>(),
                            x.get_view<const XST>(),
-                           alpha,beta,dims);
+                           alpha,beta,gamma,dims);
       else if (y_lr_ok)
         details::cvfah<CM>(get_view<ST>(),
                            x.get_strided_view<const XST>(),
-                           alpha,beta,dims);
+                           alpha,beta,gamma,dims);
       else
         details::cvfah<CM>(get_strided_view<ST>(),
                            x.get_strided_view<const XST>(),
-                           alpha,beta,dims);
+                           alpha,beta,gamma,dims);
       break;
     case 1:
       if (x_lr_ok and y_lr_ok)
         details::cvfah<CM>(get_view<ST*>(),
                            x.get_view<const XST*>(),
-                           alpha,beta,dims);
+                           alpha,beta,gamma,dims);
       else if (x_lr_ok)
         details::cvfah<CM>(get_strided_view<ST*>(),
                            x.get_view<const XST*>(),
-                           alpha,beta,dims);
+                           alpha,beta,gamma,dims);
       else if (y_lr_ok)
         details::cvfah<CM>(get_view<ST*>(),
                            x.get_strided_view<const XST*>(),
-                           alpha,beta,dims);
+                           alpha,beta,gamma,dims);
       else
         details::cvfah<CM>(get_strided_view<ST*>(),
                            x.get_strided_view<const XST*>(),
-                           alpha,beta,dims);
+                           alpha,beta,gamma,dims);
       break;
     case 2:
       if (x_lr_ok and y_lr_ok)
         details::cvfah<CM>(get_view<ST**>(),
                            x.get_view<const XST**>(),
-                           alpha,beta,dims);
+                           alpha,beta,gamma,dims);
       else if (x_lr_ok)
         details::cvfah<CM>(get_strided_view<ST**>(),
                            x.get_view<const XST**>(),
-                           alpha,beta,dims);
+                           alpha,beta,gamma,dims);
       else if (y_lr_ok)
         details::cvfah<CM>(get_view<ST**>(),
                            x.get_strided_view<const XST**>(),
-                           alpha,beta,dims);
+                           alpha,beta,gamma,dims);
       else
         details::cvfah<CM>(get_strided_view<ST**>(),
                            x.get_strided_view<const XST**>(),
-                           alpha,beta,dims);
+                           alpha,beta,gamma,dims);
       break;
     case 3:
       if (x_lr_ok and y_lr_ok)
         details::cvfah<CM>(get_view<ST***>(),
                            x.get_view<const XST***>(),
-                           alpha,beta,dims);
+                           alpha,beta,gamma,dims);
       else if (x_lr_ok)
         details::cvfah<CM>(get_strided_view<ST***>(),
                            x.get_view<const XST***>(),
-                           alpha,beta,dims);
+                           alpha,beta,gamma,dims);
       else if (y_lr_ok)
         details::cvfah<CM>(get_view<ST***>(),
                            x.get_strided_view<const XST***>(),
-                           alpha,beta,dims);
+                           alpha,beta,gamma,dims);
       else
         details::cvfah<CM>(get_strided_view<ST***>(),
                            x.get_strided_view<const XST***>(),
-                           alpha,beta,dims);
+                           alpha,beta,gamma,dims);
       break;
     case 4:
       if (x_lr_ok and y_lr_ok)
         details::cvfah<CM>(get_view<ST****>(),
                            x.get_view<const XST****>(),
-                           alpha,beta,dims);
+                           alpha,beta,gamma,dims);
       else if (x_lr_ok)
         details::cvfah<CM>(get_strided_view<ST****>(),
                            x.get_view<const XST****>(),
-                           alpha,beta,dims);
+                           alpha,beta,gamma,dims);
       else if (y_lr_ok)
         details::cvfah<CM>(get_view<ST****>(),
                            x.get_strided_view<const XST****>(),
-                           alpha,beta,dims);
+                           alpha,beta,gamma,dims);
       else
         details::cvfah<CM>(get_strided_view<ST****>(),
                            x.get_strided_view<const XST****>(),
-                           alpha,beta,dims);
+                           alpha,beta,gamma,dims);
       break;
     case 5:
       if (x_lr_ok and y_lr_ok)
         details::cvfah<CM>(get_view<ST*****>(),
                            x.get_view<const XST*****>(),
-                           alpha,beta,dims);
+                           alpha,beta,gamma,dims);
       else if (x_lr_ok)
         details::cvfah<CM>(get_strided_view<ST*****>(),
                            x.get_view<const XST*****>(),
-                           alpha,beta,dims);
+                           alpha,beta,gamma,dims);
       else if (y_lr_ok)
         details::cvfah<CM>(get_view<ST*****>(),
                            x.get_strided_view<const XST*****>(),
-                           alpha,beta,dims);
+                           alpha,beta,gamma,dims);
       else
         details::cvfah<CM>(get_strided_view<ST*****>(),
                            x.get_strided_view<const XST*****>(),
-                           alpha,beta,dims);
+                           alpha,beta,gamma,dims);
       break;
     case 6:
       if (x_lr_ok and y_lr_ok)
         details::cvfah<CM>(get_view<ST******>(),
                            x.get_view<const XST******>(),
-                           alpha,beta,dims);
+                           alpha,beta,gamma,dims);
       else if (x_lr_ok)
         details::cvfah<CM>(get_strided_view<ST******>(),
                            x.get_view<const XST******>(),
-                           alpha,beta,dims);
+                           alpha,beta,gamma,dims);
       else if (y_lr_ok)
         details::cvfah<CM>(get_view<ST******>(),
                            x.get_strided_view<const XST******>(),
-                           alpha,beta,dims);
+                           alpha,beta,gamma,dims);
       else
         details::cvfah<CM>(get_strided_view<ST******>(),
                            x.get_strided_view<const XST******>(),
-                           alpha,beta,dims);
+                           alpha,beta,gamma,dims);
       break;
     default:
       EKAT_ERROR_MSG ("Error! Rank not supported in update_field.\n"

--- a/components/eamxx/src/share/field/field_update_fill_aware.hpp
+++ b/components/eamxx/src/share/field/field_update_fill_aware.hpp
@@ -48,37 +48,11 @@ struct CombineViewsFillAwareHelper {
     }
   }
 
+  template<typename... Args>
   KOKKOS_INLINE_FUNCTION
-  void operator() (int i) const {
-    if constexpr (N==0)
-      combine_fill_aware<CM>(rhs(),lhs(),alpha,beta);
-    else
-      combine_fill_aware<CM>(rhs(i),lhs(i),alpha,beta);
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator() (int i, int j) const {
-    combine_fill_aware<CM>(rhs(i,j),lhs(i,j),alpha,beta);
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator() (int i, int j, int k) const {
-    combine_fill_aware<CM>(rhs(i,j,k),lhs(i,j,k),alpha,beta);
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator() (int i, int j, int k, int l) const {
-    combine_fill_aware<CM>(rhs(i,j,k,l),lhs(i,j,k,l),alpha,beta);
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator() (int i, int j, int k, int l, int m) const {
-    combine_fill_aware<CM>(rhs(i,j,k,l,m),lhs(i,j,k,l,m),alpha,beta);
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator() (int i, int j, int k, int l, int m, int n) const {
-    combine_fill_aware<CM>(rhs(i,j,k,l,m,n),lhs(i,j,k,l,m,n),alpha,beta);
+  void operator() (Args... indices) const {
+    auto& lhs_val = lhs.access(indices...);
+    combine_fill_aware<CM>(rhs.access(indices...),lhs_val,alpha,beta);
   }
 
   ST alpha;

--- a/components/eamxx/src/share/field/field_update_impl.hpp
+++ b/components/eamxx/src/share/field/field_update_impl.hpp
@@ -48,37 +48,11 @@ struct CombineViewsHelper {
     }
   }
 
+  template<typename... Args>
   KOKKOS_INLINE_FUNCTION
-  void operator() (int i) const {
-    if constexpr (N==0)
-      combine<CM>(rhs(),lhs(),alpha,beta);
-    else
-      combine<CM>(rhs(i),lhs(i),alpha,beta);
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator() (int i, int j) const {
-    combine<CM>(rhs(i,j),lhs(i,j),alpha,beta);
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator() (int i, int j, int k) const {
-    combine<CM>(rhs(i,j,k),lhs(i,j,k),alpha,beta);
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator() (int i, int j, int k, int l) const {
-    combine<CM>(rhs(i,j,k,l),lhs(i,j,k,l),alpha,beta);
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator() (int i, int j, int k, int l, int m) const {
-    combine<CM>(rhs(i,j,k,l,m),lhs(i,j,k,l,m),alpha,beta);
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator() (int i, int j, int k, int l, int m, int n) const {
-    combine<CM>(rhs(i,j,k,l,m,n),lhs(i,j,k,l,m,n),alpha,beta);
+  void operator() (Args... indices) const {
+    auto& lhs_val = lhs.access(indices...);
+    combine<CM>(rhs.access(indices...),lhs_val,alpha,beta);
   }
 
   ST alpha;

--- a/components/eamxx/src/share/field/field_update_impl.hpp
+++ b/components/eamxx/src/share/field/field_update_impl.hpp
@@ -53,10 +53,13 @@ struct CombineViewsHelper {
   void operator() (Args... indices) const {
     auto& lhs_val = lhs.access(indices...);
     combine<CM>(rhs.access(indices...),lhs_val,alpha,beta);
+    if constexpr (CM==CombineMode::Update)
+      lhs_val += gamma;
   }
 
   ST alpha;
   ST beta;
+  ST gamma;
   LhsView lhs;
   RhsView rhs;
 };
@@ -64,7 +67,7 @@ struct CombineViewsHelper {
 template<CombineMode CM, typename LhsView, typename RhsView, typename ST>
 void
 cvh (LhsView lhs, RhsView rhs,
-     ST alpha, ST beta,
+     ST alpha, ST beta, ST gamma,
      const std::vector<int>& dims)
 {
   CombineViewsHelper <CM, LhsView, RhsView,  ST> helper;
@@ -72,6 +75,7 @@ cvh (LhsView lhs, RhsView rhs,
   helper.rhs = rhs;
   helper.alpha = alpha;
   helper.beta = beta;
+  helper.gamma = gamma;
   helper.run(dims);
 }
 
@@ -79,7 +83,7 @@ cvh (LhsView lhs, RhsView rhs,
 
 template<CombineMode CM, typename ST, typename XST>
 void Field::
-update_impl (const Field& x, const ST alpha, const ST beta)
+update_impl (const Field& x, const ST alpha, const ST beta, const ST gamma)
 {
   const auto& layout = x.get_header().get_identifier().get_layout();
   const auto& dims = layout.dims();
@@ -92,127 +96,127 @@ update_impl (const Field& x, const ST alpha, const ST beta)
       if (x_lr_ok and y_lr_ok)
         details::cvh<CM>(get_view<ST>(),
                          x.get_view<const XST>(),
-                         alpha,beta,dims);
+                         alpha,beta,gamma,dims);
       else if (x_lr_ok)
         details::cvh<CM>(get_strided_view<ST>(),
                          x.get_view<const XST>(),
-                         alpha,beta,dims);
+                         alpha,beta,gamma,dims);
       else if (y_lr_ok)
         details::cvh<CM>(get_view<ST>(),
                          x.get_strided_view<const XST>(),
-                         alpha,beta,dims);
+                         alpha,beta,gamma,dims);
       else
         details::cvh<CM>(get_strided_view<ST>(),
                          x.get_strided_view<const XST>(),
-                         alpha,beta,dims);
+                         alpha,beta,gamma,dims);
       break;
     case 1:
       if (x_lr_ok and y_lr_ok)
         details::cvh<CM>(get_view<ST*>(),
                          x.get_view<const XST*>(),
-                         alpha,beta,dims);
+                         alpha,beta,gamma,dims);
       else if (x_lr_ok)
         details::cvh<CM>(get_strided_view<ST*>(),
                          x.get_view<const XST*>(),
-                         alpha,beta,dims);
+                         alpha,beta,gamma,dims);
       else if (y_lr_ok)
         details::cvh<CM>(get_view<ST*>(),
                          x.get_strided_view<const XST*>(),
-                         alpha,beta,dims);
+                         alpha,beta,gamma,dims);
       else
         details::cvh<CM>(get_strided_view<ST*>(),
                          x.get_strided_view<const XST*>(),
-                         alpha,beta,dims);
+                         alpha,beta,gamma,dims);
       break;
     case 2:
       if (x_lr_ok and y_lr_ok)
         details::cvh<CM>(get_view<ST**>(),
                          x.get_view<const XST**>(),
-                         alpha,beta,dims);
+                         alpha,beta,gamma,dims);
       else if (x_lr_ok)
         details::cvh<CM>(get_strided_view<ST**>(),
                          x.get_view<const XST**>(),
-                         alpha,beta,dims);
+                         alpha,beta,gamma,dims);
       else if (y_lr_ok)
         details::cvh<CM>(get_view<ST**>(),
                          x.get_strided_view<const XST**>(),
-                         alpha,beta,dims);
+                         alpha,beta,gamma,dims);
       else
         details::cvh<CM>(get_strided_view<ST**>(),
                          x.get_strided_view<const XST**>(),
-                         alpha,beta,dims);
+                         alpha,beta,gamma,dims);
       break;
     case 3:
       if (x_lr_ok and y_lr_ok)
         details::cvh<CM>(get_view<ST***>(),
                          x.get_view<const XST***>(),
-                         alpha,beta,dims);
+                         alpha,beta,gamma,dims);
       else if (x_lr_ok)
         details::cvh<CM>(get_strided_view<ST***>(),
                          x.get_view<const XST***>(),
-                         alpha,beta,dims);
+                         alpha,beta,gamma,dims);
       else if (y_lr_ok)
         details::cvh<CM>(get_view<ST***>(),
                          x.get_strided_view<const XST***>(),
-                         alpha,beta,dims);
+                         alpha,beta,gamma,dims);
       else
         details::cvh<CM>(get_strided_view<ST***>(),
                          x.get_strided_view<const XST***>(),
-                         alpha,beta,dims);
+                         alpha,beta,gamma,dims);
       break;
     case 4:
       if (x_lr_ok and y_lr_ok)
         details::cvh<CM>(get_view<ST****>(),
                          x.get_view<const XST****>(),
-                         alpha,beta,dims);
+                         alpha,beta,gamma,dims);
       else if (x_lr_ok)
         details::cvh<CM>(get_strided_view<ST****>(),
                          x.get_view<const XST****>(),
-                         alpha,beta,dims);
+                         alpha,beta,gamma,dims);
       else if (y_lr_ok)
         details::cvh<CM>(get_view<ST****>(),
                          x.get_strided_view<const XST****>(),
-                         alpha,beta,dims);
+                         alpha,beta,gamma,dims);
       else
         details::cvh<CM>(get_strided_view<ST****>(),
                          x.get_strided_view<const XST****>(),
-                         alpha,beta,dims);
+                         alpha,beta,gamma,dims);
       break;
     case 5:
       if (x_lr_ok and y_lr_ok)
         details::cvh<CM>(get_view<ST*****>(),
                          x.get_view<const XST*****>(),
-                         alpha,beta,dims);
+                         alpha,beta,gamma,dims);
       else if (x_lr_ok)
         details::cvh<CM>(get_strided_view<ST*****>(),
                          x.get_view<const XST*****>(),
-                         alpha,beta,dims);
+                         alpha,beta,gamma,dims);
       else if (y_lr_ok)
         details::cvh<CM>(get_view<ST*****>(),
                          x.get_strided_view<const XST*****>(),
-                         alpha,beta,dims);
+                         alpha,beta,gamma,dims);
       else
         details::cvh<CM>(get_strided_view<ST*****>(),
                          x.get_strided_view<const XST*****>(),
-                         alpha,beta,dims);
+                         alpha,beta,gamma,dims);
       break;
     case 6:
       if (x_lr_ok and y_lr_ok)
         details::cvh<CM>(get_view<ST******>(),
                          x.get_view<const XST******>(),
-                         alpha,beta,dims);
+                         alpha,beta,gamma,dims);
       else if (x_lr_ok)
         details::cvh<CM>(get_strided_view<ST******>(),
                          x.get_view<const XST******>(),
-                         alpha,beta,dims);
+                         alpha,beta,gamma,dims);
       else if (y_lr_ok)
         details::cvh<CM>(get_view<ST******>(),
                          x.get_strided_view<const XST******>(),
-                         alpha,beta,dims);
+                         alpha,beta,gamma,dims);
       else
         details::cvh<CM>(get_strided_view<ST******>(),
                          x.get_strided_view<const XST******>(),
-                         alpha,beta,dims);
+                         alpha,beta,gamma,dims);
       break;
     default:
       EKAT_ERROR_MSG ("Error! Rank not supported in update_field.\n"

--- a/components/eamxx/src/share/field/field_update_masked.hpp
+++ b/components/eamxx/src/share/field/field_update_masked.hpp
@@ -49,45 +49,13 @@ struct CombineViewsMaskedHelper {
     }
   }
 
+  template<typename... Args>
   KOKKOS_INLINE_FUNCTION
-  void operator() (int i) const {
-    if constexpr (N==0) {
-      if (mask())
-        combine<CM>(rhs(),lhs(),alpha,beta);
-    } else {
-      if (mask(i))
-        combine<CM>(rhs(i),lhs(i),alpha,beta);
+  void operator() (Args... indices) const {
+    if (mask.access(indices...)) {
+      auto& lhs_val = lhs.access(indices...);
+      combine<CM>(rhs.access(indices...),lhs_val,alpha,beta);
     }
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator() (int i, int j) const {
-    if (mask(i,j))
-      combine<CM>(rhs(i,j),lhs(i,j),alpha,beta);
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator() (int i, int j, int k) const {
-    if (mask(i,j,k))
-      combine<CM>(rhs(i,j,k),lhs(i,j,k),alpha,beta);
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator() (int i, int j, int k, int l) const {
-    if (mask(i,j,k,l))
-      combine<CM>(rhs(i,j,k,l),lhs(i,j,k,l),alpha,beta);
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator() (int i, int j, int k, int l, int m) const {
-    if (mask(i,j,k,l,m))
-      combine<CM>(rhs(i,j,k,l,m),lhs(i,j,k,l,m),alpha,beta);
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator() (int i, int j, int k, int l, int m, int n) const {
-    if (mask(i,j,k,l,m,n))
-      combine<CM>(rhs(i,j,k,l,m,n),lhs(i,j,k,l,m,n),alpha,beta);
   }
 
   MaskView mask; 
@@ -155,45 +123,12 @@ struct SetValueMasked
     }
   }
 
+  template<typename... Args>
   KOKKOS_INLINE_FUNCTION
-  void operator() (int i) const {
-    if constexpr (N==0) {
-      if ((mask()!=0) != negate_mask)
-        lhs() = value;
-    } else {
-      if ((mask(i)!=0) != negate_mask)
-        lhs(i) = value;
-    }
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator() (int i, int j) const {
-    if ((mask(i,j)!=0) != negate_mask)
-      lhs(i,j) = value;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator() (int i, int j, int k) const {
-    if ((mask(i,j,k)!=0) != negate_mask)
-      lhs(i,j,k) = value;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator() (int i, int j, int k, int l) const {
-    if ((mask(i,j,k,l)!=0) != negate_mask)
-      lhs(i,j,k,l) = value;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator() (int i, int j, int k, int l, int m) const {
-    if ((mask(i,j,k,l,m)!=0) != negate_mask)
-      lhs(i,j,k,l,m) = value;
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  void operator() (int i, int j, int k, int l, int m, int n) const {
-    if ((mask(i,j,k,l,m,n)!=0) != negate_mask)
-      lhs(i,j,k,l,m,n) = value;
+  void operator() (Args... indices) const {
+    // Execute block if mask=0 and negate_mask=true or mask=1 and negate_mask=false
+    if ( (mask.access(indices...)!=0) != negate_mask )
+      lhs.access(indices...) = value;
   }
 
   ST value;

--- a/components/eamxx/src/share/field/field_update_masked.hpp
+++ b/components/eamxx/src/share/field/field_update_masked.hpp
@@ -55,12 +55,15 @@ struct CombineViewsMaskedHelper {
     if (mask.access(indices...)) {
       auto& lhs_val = lhs.access(indices...);
       combine<CM>(rhs.access(indices...),lhs_val,alpha,beta);
+      if constexpr (CM==CombineMode::Update)
+        lhs_val += gamma;
     }
   }
 
   MaskView mask; 
   ST alpha;
   ST beta;
+  ST gamma;
   LhsView lhs;
   RhsView rhs;
 };
@@ -68,7 +71,7 @@ struct CombineViewsMaskedHelper {
 template<CombineMode CM, typename LhsView, typename RhsView, typename MaskView, typename ST>
 void
 cvmh (LhsView lhs, RhsView rhs,
-      ST alpha, ST beta,
+      ST alpha, ST beta, ST gamma,
       const std::vector<int>& dims,
       MaskView mask)
 {
@@ -77,6 +80,7 @@ cvmh (LhsView lhs, RhsView rhs,
   helper.rhs = rhs;
   helper.alpha = alpha;
   helper.beta = beta;
+  helper.gamma = gamma;
   helper.mask = mask;
   helper.run(dims);
 }
@@ -158,7 +162,7 @@ svm (LhsView lhs,
 
 template<CombineMode CM, typename ST, typename XST>
 void Field::
-update_masked (const Field& x, const ST alpha, const ST beta, const Field& mask)
+update_masked (const Field& x, const ST alpha, const ST beta, const ST gamma, const Field& mask)
 {
   const auto& layout = x.get_header().get_identifier().get_layout();
   const auto& dims = layout.dims();
@@ -171,156 +175,156 @@ update_masked (const Field& x, const ST alpha, const ST beta, const Field& mask)
     case 0:
       if (x_lr_ok and y_lr_ok)
         m_lr_ok ? details::cvmh<CM>(get_view<ST>(),x.get_view<const XST>(),
-                                    alpha,beta,dims,mask.get_view<const int>())
+                                    alpha,beta,gamma,dims,mask.get_view<const int>())
                 : details::cvmh<CM>(get_view<ST>(),x.get_view<const XST>(),
-                                    alpha,beta,dims,mask.get_strided_view<const int>());
+                                    alpha,beta,gamma,dims,mask.get_strided_view<const int>());
       else if (x_lr_ok)
         m_lr_ok ? details::cvmh<CM>(get_strided_view<ST>(),x.get_view<const XST>(),
-                                    alpha,beta,dims,mask.get_view<const int>())
+                                    alpha,beta,gamma,dims,mask.get_view<const int>())
                 : details::cvmh<CM>(get_strided_view<ST>(),x.get_view<const XST>(),
-                                    alpha,beta,dims,mask.get_strided_view<const int>());
+                                    alpha,beta,gamma,dims,mask.get_strided_view<const int>());
       else if (y_lr_ok)
         m_lr_ok ? details::cvmh<CM>(get_view<ST>(),x.get_strided_view<const XST>(),
-                                    alpha,beta,dims,mask.get_view<const int>())
+                                    alpha,beta,gamma,dims,mask.get_view<const int>())
                 : details::cvmh<CM>(get_view<ST>(),x.get_strided_view<const XST>(),
-                                    alpha,beta,dims,mask.get_strided_view<const int>());
+                                    alpha,beta,gamma,dims,mask.get_strided_view<const int>());
       else
         m_lr_ok ? details::cvmh<CM>(get_strided_view<ST>(),x.get_strided_view<const XST>(),
-                                    alpha,beta,dims,mask.get_view<const int>())
+                                    alpha,beta,gamma,dims,mask.get_view<const int>())
                 : details::cvmh<CM>(get_strided_view<ST>(),x.get_strided_view<const XST>(),
-                                    alpha,beta,dims,mask.get_strided_view<const int>());
+                                    alpha,beta,gamma,dims,mask.get_strided_view<const int>());
       break;
     case 1:
       if (x_lr_ok and y_lr_ok)
         m_lr_ok ? details::cvmh<CM>(get_view<ST*>(),x.get_view<const XST*>(),
-                                    alpha,beta,dims,mask.get_view<const int*>())
+                                    alpha,beta,gamma,dims,mask.get_view<const int*>())
                 : details::cvmh<CM>(get_view<ST*>(),x.get_view<const XST*>(),
-                                    alpha,beta,dims,mask.get_strided_view<const int*>());
+                                    alpha,beta,gamma,dims,mask.get_strided_view<const int*>());
       else if (x_lr_ok)
         m_lr_ok ? details::cvmh<CM>(get_strided_view<ST*>(),x.get_view<const XST*>(),
-                                    alpha,beta,dims,mask.get_view<const int*>())
+                                    alpha,beta,gamma,dims,mask.get_view<const int*>())
                 : details::cvmh<CM>(get_strided_view<ST*>(),x.get_view<const XST*>(),
-                                    alpha,beta,dims,mask.get_strided_view<const int*>());
+                                    alpha,beta,gamma,dims,mask.get_strided_view<const int*>());
       else if (y_lr_ok)
         m_lr_ok ? details::cvmh<CM>(get_view<ST*>(),x.get_strided_view<const XST*>(),
-                                    alpha,beta,dims,mask.get_view<const int*>())
+                                    alpha,beta,gamma,dims,mask.get_view<const int*>())
                 : details::cvmh<CM>(get_view<ST*>(),x.get_strided_view<const XST*>(),
-                                    alpha,beta,dims,mask.get_strided_view<const int*>());
+                                    alpha,beta,gamma,dims,mask.get_strided_view<const int*>());
       else
         m_lr_ok ? details::cvmh<CM>(get_strided_view<ST*>(),x.get_strided_view<const XST*>(),
-                                    alpha,beta,dims,mask.get_view<const int*>())
+                                    alpha,beta,gamma,dims,mask.get_view<const int*>())
                 : details::cvmh<CM>(get_strided_view<ST*>(),x.get_strided_view<const XST*>(),
-                                    alpha,beta,dims,mask.get_strided_view<const int*>());
+                                    alpha,beta,gamma,dims,mask.get_strided_view<const int*>());
       break;
     case 2:
       if (x_lr_ok and y_lr_ok)
         m_lr_ok ? details::cvmh<CM>(get_view<ST**>(),x.get_view<const XST**>(),
-                                    alpha,beta,dims,mask.get_view<const int**>())
+                                    alpha,beta,gamma,dims,mask.get_view<const int**>())
                 : details::cvmh<CM>(get_view<ST**>(),x.get_view<const XST**>(),
-                                    alpha,beta,dims,mask.get_strided_view<const int**>());
+                                    alpha,beta,gamma,dims,mask.get_strided_view<const int**>());
       else if (x_lr_ok)
         m_lr_ok ? details::cvmh<CM>(get_strided_view<ST**>(),x.get_view<const XST**>(),
-                                    alpha,beta,dims,mask.get_view<const int**>())
+                                    alpha,beta,gamma,dims,mask.get_view<const int**>())
                 : details::cvmh<CM>(get_strided_view<ST**>(),x.get_view<const XST**>(),
-                                    alpha,beta,dims,mask.get_strided_view<const int**>());
+                                    alpha,beta,gamma,dims,mask.get_strided_view<const int**>());
       else if (y_lr_ok)
         m_lr_ok ? details::cvmh<CM>(get_view<ST**>(),x.get_strided_view<const XST**>(),
-                                    alpha,beta,dims,mask.get_view<const int**>())
+                                    alpha,beta,gamma,dims,mask.get_view<const int**>())
                 : details::cvmh<CM>(get_view<ST**>(),x.get_strided_view<const XST**>(),
-                                    alpha,beta,dims,mask.get_strided_view<const int**>());
+                                    alpha,beta,gamma,dims,mask.get_strided_view<const int**>());
       else
         m_lr_ok ? details::cvmh<CM>(get_strided_view<ST**>(),x.get_strided_view<const XST**>(),
-                                    alpha,beta,dims,mask.get_view<const int**>())
+                                    alpha,beta,gamma,dims,mask.get_view<const int**>())
                 : details::cvmh<CM>(get_strided_view<ST**>(),x.get_strided_view<const XST**>(),
-                                    alpha,beta,dims,mask.get_strided_view<const int**>());
+                                    alpha,beta,gamma,dims,mask.get_strided_view<const int**>());
       break;
     case 3:
       if (x_lr_ok and y_lr_ok)
         m_lr_ok ? details::cvmh<CM>(get_view<ST***>(),x.get_view<const XST***>(),
-                                    alpha,beta,dims,mask.get_view<const int***>())
+                                    alpha,beta,gamma,dims,mask.get_view<const int***>())
                 : details::cvmh<CM>(get_view<ST***>(),x.get_view<const XST***>(),
-                                    alpha,beta,dims,mask.get_strided_view<const int***>());
+                                    alpha,beta,gamma,dims,mask.get_strided_view<const int***>());
       else if (x_lr_ok)
         m_lr_ok ? details::cvmh<CM>(get_strided_view<ST***>(),x.get_view<const XST***>(),
-                                    alpha,beta,dims,mask.get_view<const int***>())
+                                    alpha,beta,gamma,dims,mask.get_view<const int***>())
                 : details::cvmh<CM>(get_strided_view<ST***>(),x.get_view<const XST***>(),
-                                    alpha,beta,dims,mask.get_strided_view<const int***>());
+                                    alpha,beta,gamma,dims,mask.get_strided_view<const int***>());
       else if (y_lr_ok)
         m_lr_ok ? details::cvmh<CM>(get_view<ST***>(),x.get_strided_view<const XST***>(),
-                                    alpha,beta,dims,mask.get_view<const int***>())
+                                    alpha,beta,gamma,dims,mask.get_view<const int***>())
                 : details::cvmh<CM>(get_view<ST***>(),x.get_strided_view<const XST***>(),
-                                    alpha,beta,dims,mask.get_strided_view<const int***>());
+                                    alpha,beta,gamma,dims,mask.get_strided_view<const int***>());
       else
         m_lr_ok ? details::cvmh<CM>(get_strided_view<ST***>(),x.get_strided_view<const XST***>(),
-                                    alpha,beta,dims,mask.get_view<const int***>())
+                                    alpha,beta,gamma,dims,mask.get_view<const int***>())
                 : details::cvmh<CM>(get_strided_view<ST***>(),x.get_strided_view<const XST***>(),
-                                    alpha,beta,dims,mask.get_strided_view<const int***>());
+                                    alpha,beta,gamma,dims,mask.get_strided_view<const int***>());
       break;
     case 4:
       if (x_lr_ok and y_lr_ok)
         m_lr_ok ? details::cvmh<CM>(get_view<ST****>(),x.get_view<const XST****>(),
-                                    alpha,beta,dims,mask.get_view<const int****>())
+                                    alpha,beta,gamma,dims,mask.get_view<const int****>())
                 : details::cvmh<CM>(get_view<ST****>(),x.get_view<const XST****>(),
-                                    alpha,beta,dims,mask.get_strided_view<const int****>());
+                                    alpha,beta,gamma,dims,mask.get_strided_view<const int****>());
       else if (x_lr_ok)
         m_lr_ok ? details::cvmh<CM>(get_strided_view<ST****>(),x.get_view<const XST****>(),
-                                    alpha,beta,dims,mask.get_view<const int****>())
+                                    alpha,beta,gamma,dims,mask.get_view<const int****>())
                 : details::cvmh<CM>(get_strided_view<ST****>(),x.get_view<const XST****>(),
-                                    alpha,beta,dims,mask.get_strided_view<const int****>());
+                                    alpha,beta,gamma,dims,mask.get_strided_view<const int****>());
       else if (y_lr_ok)
         m_lr_ok ? details::cvmh<CM>(get_view<ST****>(),x.get_strided_view<const XST****>(),
-                                    alpha,beta,dims,mask.get_view<const int****>())
+                                    alpha,beta,gamma,dims,mask.get_view<const int****>())
                 : details::cvmh<CM>(get_view<ST****>(),x.get_strided_view<const XST****>(),
-                                    alpha,beta,dims,mask.get_strided_view<const int****>());
+                                    alpha,beta,gamma,dims,mask.get_strided_view<const int****>());
       else
         m_lr_ok ? details::cvmh<CM>(get_strided_view<ST****>(),x.get_strided_view<const XST****>(),
-                                    alpha,beta,dims,mask.get_view<const int****>())
+                                    alpha,beta,gamma,dims,mask.get_view<const int****>())
                 : details::cvmh<CM>(get_strided_view<ST****>(),x.get_strided_view<const XST****>(),
-                                    alpha,beta,dims,mask.get_strided_view<const int****>());
+                                    alpha,beta,gamma,dims,mask.get_strided_view<const int****>());
       break;
     case 5:
       if (x_lr_ok and y_lr_ok)
         m_lr_ok ? details::cvmh<CM>(get_view<ST*****>(),x.get_view<const XST*****>(),
-                                    alpha,beta,dims,mask.get_view<const int*****>())
+                                    alpha,beta,gamma,dims,mask.get_view<const int*****>())
                 : details::cvmh<CM>(get_view<ST*****>(),x.get_view<const XST*****>(),
-                                    alpha,beta,dims,mask.get_strided_view<const int*****>());
+                                    alpha,beta,gamma,dims,mask.get_strided_view<const int*****>());
       else if (x_lr_ok)
         m_lr_ok ? details::cvmh<CM>(get_strided_view<ST*****>(),x.get_view<const XST*****>(),
-                                    alpha,beta,dims,mask.get_view<const int*****>())
+                                    alpha,beta,gamma,dims,mask.get_view<const int*****>())
                 : details::cvmh<CM>(get_strided_view<ST*****>(),x.get_view<const XST*****>(),
-                                    alpha,beta,dims,mask.get_strided_view<const int*****>());
+                                    alpha,beta,gamma,dims,mask.get_strided_view<const int*****>());
       else if (y_lr_ok)
         m_lr_ok ? details::cvmh<CM>(get_view<ST*****>(),x.get_strided_view<const XST*****>(),
-                                    alpha,beta,dims,mask.get_view<const int*****>())
+                                    alpha,beta,gamma,dims,mask.get_view<const int*****>())
                 : details::cvmh<CM>(get_view<ST*****>(),x.get_strided_view<const XST*****>(),
-                                    alpha,beta,dims,mask.get_strided_view<const int*****>());
+                                    alpha,beta,gamma,dims,mask.get_strided_view<const int*****>());
       else
         m_lr_ok ? details::cvmh<CM>(get_strided_view<ST*****>(),x.get_strided_view<const XST*****>(),
-                                    alpha,beta,dims,mask.get_view<const int*****>())
+                                    alpha,beta,gamma,dims,mask.get_view<const int*****>())
                 : details::cvmh<CM>(get_strided_view<ST*****>(),x.get_strided_view<const XST*****>(),
-                                    alpha,beta,dims,mask.get_strided_view<const int*****>());
+                                    alpha,beta,gamma,dims,mask.get_strided_view<const int*****>());
       break;
     case 6:
       if (x_lr_ok and y_lr_ok)
         m_lr_ok ? details::cvmh<CM>(get_view<ST******>(),x.get_view<const XST******>(),
-                                    alpha,beta,dims,mask.get_view<const int******>())
+                                    alpha,beta,gamma,dims,mask.get_view<const int******>())
                 : details::cvmh<CM>(get_view<ST******>(),x.get_view<const XST******>(),
-                                    alpha,beta,dims,mask.get_strided_view<const int******>());
+                                    alpha,beta,gamma,dims,mask.get_strided_view<const int******>());
       else if (x_lr_ok)
         m_lr_ok ? details::cvmh<CM>(get_strided_view<ST******>(),x.get_view<const XST******>(),
-                                    alpha,beta,dims,mask.get_view<const int******>())
+                                    alpha,beta,gamma,dims,mask.get_view<const int******>())
                 : details::cvmh<CM>(get_strided_view<ST******>(),x.get_view<const XST******>(),
-                                    alpha,beta,dims,mask.get_strided_view<const int******>());
+                                    alpha,beta,gamma,dims,mask.get_strided_view<const int******>());
       else if (y_lr_ok)
         m_lr_ok ? details::cvmh<CM>(get_view<ST******>(),x.get_strided_view<const XST******>(),
-                                    alpha,beta,dims,mask.get_view<const int******>())
+                                    alpha,beta,gamma,dims,mask.get_view<const int******>())
                 : details::cvmh<CM>(get_view<ST******>(),x.get_strided_view<const XST******>(),
-                                    alpha,beta,dims,mask.get_strided_view<const int******>());
+                                    alpha,beta,gamma,dims,mask.get_strided_view<const int******>());
       else
         m_lr_ok ? details::cvmh<CM>(get_strided_view<ST******>(),x.get_strided_view<const XST******>(),
-                                    alpha,beta,dims,mask.get_view<const int******>())
+                                    alpha,beta,gamma,dims,mask.get_view<const int******>())
                 : details::cvmh<CM>(get_strided_view<ST******>(),x.get_strided_view<const XST******>(),
-                                    alpha,beta,dims,mask.get_strided_view<const int******>());
+                                    alpha,beta,gamma,dims,mask.get_strided_view<const int******>());
       break;
     default:
       EKAT_ERROR_MSG ("Error! Rank not supported in update_masked.\n"

--- a/components/eamxx/src/share/field/tests/field_update_tests.cpp
+++ b/components/eamxx/src/share/field/tests/field_update_tests.cpp
@@ -190,10 +190,13 @@ TEST_CASE ("update") {
       f3.get_header().set_may_be_filled(true);
       f2.deep_copy(1.0);
       f2.update(f3,1,1);
-      if (not views_are_equal(f2,one)) {
-        print_field_hyperslab(f2);
-      }
       REQUIRE (views_are_equal(f2,one));
+
+      // Check handling of additive scalar
+      f3.deep_copy(-2);
+      f2.deep_copy(2);
+      f3.update(f2,0,0,1);
+      REQUIRE (views_are_equal(f3,one));
     }
 
     SECTION ("int") {
@@ -223,6 +226,12 @@ TEST_CASE ("update") {
       f2.deep_copy(1);
       f2.update(f3,1,1);
       REQUIRE (views_are_equal(f2,one));
+
+      // Check handling of additive scalar
+      f3.deep_copy(-2);
+      f2.deep_copy(2);
+      f3.update(f2,0,0,1);
+      REQUIRE (views_are_equal(f3,one));
     }
   }
 }


### PR DESCRIPTION
Generalize the impl of Field::update to a (possibly masked) affine transformation `a*x+b*y+c`.

[BFB]

---

I was adding this to another PR, but then decided to factor it out, for ease of testing and review. In that PR, the goal was to "add 1" to all entries of a field, but the current update methods do not allow it. My first thought was to implement `Field::add(scalar)` as a separate function, to avoid hindering perf of `Field::update`. But then I decided that the "penalty" of the extra scalar is most likely negligible, so I went with adding the extra additive scalar to update.

I also simplified a bit the API of the helper functor for combining views. Of course, for the compiler it's the same (there are still 7 instantiations of that function), but it is visually much simpler to parse.