### PR TITLE
EAMxx: support mask fields in all composable diagnostics

### DIFF
--- a/components/eamxx/src/share/diagnostics/binary_ops.cpp
+++ b/components/eamxx/src/share/diagnostics/binary_ops.cpp
@@ -37,63 +37,113 @@ ekat::units::Units apply_binary_op(const ekat::units::Units& a, const ekat::unit
 }
 // apply binary operation on two input fields
 void apply_binary_op(Field& d, const Field& a, const Real b, const int op_code){
+  bool masked = d.has_valid_mask();
   switch (op_code) {
     case OP_PLUS:
-      d.deep_copy(b);
-      d.update(a,1,1);
+      if (masked) {
+        d.update(a,1,0,b,d.get_valid_mask());
+      } else {
+        d.update(a,1,0,b);
+      }
       break;
     case OP_MINUS:
-      d.deep_copy(b);
-      d.update(a,1,-1);
+      if (masked) {
+        d.update(a,1,0,-b,d.get_valid_mask());
+      } else {
+        d.update(a,1,0,-b);
+      }
       break;
     case OP_TIMES:
-      d.deep_copy(a);
-      d.scale(b);
+      if (masked) {
+        d.update(a,b,0,0,d.get_valid_mask());
+      } else {
+        d.update(a,b,0,0);
+      }
       break;
     case OP_OVER:
-      d.deep_copy(a);
-      d.scale(1 / b);
+      if (masked) {
+        d.update(a,1/b,0,0,d.get_valid_mask());
+      } else {
+        d.update(a,1/b,0,0);
+      }
       break;
     default:
       EKAT_ERROR_MSG("Error! Unrecognized/unsupported binary op code (" + std::to_string(op_code) + ")\n");
   }
 }
-void apply_binary_op(Field& d, const Real a, const Field& b, const int op_code){
+
+void apply_binary_op(Field& d, const Real a, const Field& b, const int op_code)
+{
+  bool masked = d.has_valid_mask();
   switch (op_code) {
     case OP_PLUS:
-      d.deep_copy(a);
-      d.update(b,1,1);
+      if (masked) {
+        d.update(b,1,0,a,d.get_valid_mask());
+      } else {
+        d.update(b,1,0,a);
+      }
       break;
     case OP_MINUS:
-      d.deep_copy(a);
-      d.update(b,-1,1);
+      if (masked) {
+        d.update(b,-1,0,a,d.get_valid_mask());
+      } else {
+        d.update(b,-1,0,a);
+      }
       break;
     case OP_TIMES:
-      d.deep_copy(a);
-      d.scale(b);
+      if (masked) {
+        d.update(b,a,0,0,d.get_valid_mask());
+      } else {
+        d.update(b,a,0,0);
+      }
       break;
     case OP_OVER:
-      d.deep_copy(a);
-      d.scale_inv(b);
+      if (masked) {
+        auto mask = d.get_valid_mask();
+        d.deep_copy(a,mask);
+        d.scale_inv(b,mask);
+      } else {
+        d.deep_copy(a);
+        d.scale_inv(b);
+      }
       break;
     default:
       EKAT_ERROR_MSG("Error! Unrecognized/unsupported binary op code (" + std::to_string(op_code) + ")\n");
   }
 }
-void apply_binary_op(Field& d, const Field& a, const Field& b, const int op_code){
-  d.deep_copy(a);
+
+void apply_binary_op(Field& d, const Field& a, const Field& b, const int op_code)
+{
+  bool masked = d.has_valid_mask();
+  if (masked)
+    d.deep_copy(a,d.get_valid_mask());
+  else
+    d.deep_copy(a);
+
   switch (op_code) {
     case OP_PLUS:
-      d.update(b, 1, 1); // addition
+      if (masked)
+        d.update(b, 1, 1, d.get_valid_mask());
+      else
+        d.update(b, 1, 1);
       break;
     case OP_MINUS:
-      d.update(b, -1, 1); // subtraction
+      if (masked)
+        d.update(b, -1, 1, d.get_valid_mask());
+      else
+        d.update(b, -1, 1);
       break;
     case OP_TIMES:
-      d.scale(b); // multiplication
+      if (masked)
+        d.scale(b, d.get_valid_mask());
+      else
+        d.scale(b);
       break;
     case OP_OVER:
-      d.scale_inv(b); // division
+      if (masked)
+        d.scale_inv(b, d.get_valid_mask());
+      else
+        d.scale_inv(b);
       break;
     default:
       EKAT_ERROR_MSG("Error! Unrecognized/unsupported binary op code (" + std::to_string(op_code) + ")\n");
@@ -196,11 +246,27 @@ void BinaryOpsDiag::initialize_impl(const RunType /*run_type*/)
     // We can pre-compute the diag now
     compute_diagnostic_impl();
     m_diagnostic_output.get_header().get_tracking().update_time_stamp(start_of_step_ts());
+  } else {
+    m_arg1_has_mask = m_arg1_is_field and get_field_in(m_arg1_name).has_valid_mask();
+    m_arg2_has_mask = m_arg2_is_field and get_field_in(m_arg2_name).has_valid_mask();
+    if (m_arg1_has_mask or m_arg2_has_mask) {
+      m_diagnostic_output.create_valid_mask();
+      m_diagnostic_output.get_header().set_may_be_filled(true);
+    }
   }
 }
 
 void BinaryOpsDiag::compute_diagnostic_impl()
 {
+  // First, if one (or both) the args are masked, compute the diag mask
+  if (m_arg1_has_mask) {
+    m_diagnostic_output.get_valid_mask().deep_copy(get_field_in(m_arg1_name).get_valid_mask());
+    if (m_arg2_has_mask)
+      m_diagnostic_output.get_valid_mask().scale(get_field_in(m_arg2_name).get_valid_mask());
+  } else if (m_arg2_has_mask) {
+    m_diagnostic_output.get_valid_mask().deep_copy(get_field_in(m_arg2_name).get_valid_mask());
+  }
+
   const auto& dict = physics::Constants<Real>::dictionary();
   if (m_arg1_is_field and m_arg2_is_field) {
     const auto& f1 = get_field_in(m_arg1_name);
@@ -219,6 +285,12 @@ void BinaryOpsDiag::compute_diagnostic_impl()
     const auto  c1 = dict.at(m_arg1_name).value;
     const auto  c2 = dict.at(m_arg2_name).value;
     apply_binary_op(m_diagnostic_output, c1, c2, m_binary_op_code);
+  }
+
+  // Until IO is ready to fully rely on valid_mask fields, we must set diag=fill_value where invalid
+  if (m_diagnostic_output.has_valid_mask()) {
+    constexpr auto fv = constants::fill_value<Real>;
+    m_diagnostic_output.deep_copy(fv,m_diagnostic_output.get_valid_mask(),true);
   }
 }
 

--- a/components/eamxx/src/share/diagnostics/binary_ops.hpp
+++ b/components/eamxx/src/share/diagnostics/binary_ops.hpp
@@ -33,6 +33,8 @@ class BinaryOpsDiag : public AtmosphereDiagnostic {
 
   bool m_arg1_is_field;
   bool m_arg2_is_field;
+  bool m_arg1_has_mask = false;
+  bool m_arg2_has_mask = false;
 };  // class BinaryOpsDiag
 
 }  // namespace scream

--- a/components/eamxx/src/share/diagnostics/conditional_sampling.cpp
+++ b/components/eamxx/src/share/diagnostics/conditional_sampling.cpp
@@ -170,7 +170,7 @@ void ConditionalSampling::initialize_impl(const RunType /*run_type*/)
   }
 
   // If lhs is "lev" but diag is not "mask", we can still precompute the diag mask by
-  // broadcsting m_lev_mask
+  // broadcasting m_lev_mask
   if (m_lhs_is_lev and not m_diag_is_mask) {
     auto mask = m_diagnostic_output.get_valid_mask();
     const auto& dims = mask.get_header().get_identifier().get_layout().dims();

--- a/components/eamxx/src/share/diagnostics/field_at_height.cpp
+++ b/components/eamxx/src/share/diagnostics/field_at_height.cpp
@@ -98,8 +98,12 @@ initialize_impl (const RunType /*run_type*/)
 
   // All good, create the diag output
   auto d_fid = fid.clone(m_diag_name).reset_layout(layout.clone().strip_dim(tag));
-  m_diagnostic_output = Field(d_fid);
-  m_diagnostic_output.allocate_view();
+  m_diagnostic_output = Field(d_fid,true);
+
+  if (f.has_valid_mask()) {
+    m_diagnostic_output.create_valid_mask();
+    m_diagnostic_output.get_header().set_may_be_filled(true);
+  }
 
   using stratts_t = std::map<std::string,std::string>;
 
@@ -120,12 +124,20 @@ void FieldAtHeight::compute_diagnostic_impl()
   const auto& fl = f.get_header().get_identifier().get_layout();
 
   using RangePolicy = typename KokkosTypes<DefaultDevice>::RangePolicy;
+  using mask1d_t = Field::view_dev_t<int*>;
+  using mask2d_t = Field::view_dev_t<int**>;
+  using cmask2d_t = Field::view_dev_t<const int**>;
+  using cmask3d_t = Field::view_dev_t<const int***>;
 
   auto z_tgt = m_z;
   auto nlevs = fl.dims().back();
+  bool masked = m_diagnostic_output.has_valid_mask();
   if (fl.rank()==2) {
     const auto f_view = f.get_view<const Real**>();
     const auto d_view = m_diagnostic_output.get_view<Real*>();
+
+    const auto f_mask = masked ? f.get_valid_mask().get_view<const int**>() : cmask2d_t{};
+    const auto d_mask = masked ? m_diagnostic_output.get_valid_mask().get_view<int*>() : mask1d_t{};
 
     RangePolicy policy (0,fl.dims()[0]);
     Kokkos::parallel_for(policy,
@@ -137,24 +149,46 @@ void FieldAtHeight::compute_diagnostic_impl()
         auto end = beg+nlevs;
         auto it = find_first_smaller_z(beg,end,z_tgt);
         if (it==beg) {
-          // We just extapolate with first entry
-          d_view(i) = f_i(0);
+          if (not masked or f_mask(i,0)!=0) {
+            // We just extapolate with first entry
+            d_view(i) = f_i(0);
+            if (masked)
+              d_mask(i) = 1;
+          } else {
+            d_mask(i) = 0;
+          }
         } else if (it==end) {
-          // We just extapolate with last entry
-          d_view(i) = f_i(nlevs-1);
+          if (not masked or f_mask(i,nlevs-1)!=0) {
+            // We just extapolate with last entry
+            d_view(i) = f_i(nlevs-1);
+            if (masked)
+              d_mask(i) = 1;
+          } else {
+            d_mask(i) = 0;
+          }
         } else {
           auto pos = it-beg;
-          auto z0 = z_i(pos-1);
-          auto z1 = z_i(pos);
-          auto f0 = f_i(pos-1);
-          auto f1 = f_i(pos);
+          if (not masked or 
+              (f_mask(i,pos)!=0 and f_mask(i,pos-1)!=0)) {
+            auto z0 = z_i(pos-1);
+            auto z1 = z_i(pos);
+            auto f0 = f_i(pos-1);
+            auto f1 = f_i(pos);
 
-          d_view(i) = ( (z_tgt-z0)*f1 + (z1-z_tgt)*f0 ) / (z1-z0);
+            d_view(i) = ( (z_tgt-z0)*f1 + (z1-z_tgt)*f0 ) / (z1-z0);
+            if (masked)
+              d_mask(i) = 1;
+          } else {
+            d_mask(i) = 0;
+          }
         }
     });
   } else {
     const auto f_view = f.get_view<const Real***>();
     const auto d_view = m_diagnostic_output.get_view<Real**>();
+
+    const auto f_mask = masked ? f.get_valid_mask().get_view<const int***>() : cmask3d_t{};
+    const auto d_mask = masked ? m_diagnostic_output.get_valid_mask().get_view<int**>() : mask2d_t{};
 
     const auto dim0 = fl.dims()[0];
     const auto dim1 = fl.dims()[1];
@@ -170,21 +204,46 @@ void FieldAtHeight::compute_diagnostic_impl()
         auto end = beg+nlevs;
         auto it = find_first_smaller_z(beg,end,z_tgt);
         if (it==beg) {
-          // We just extapolate with first entry
-          d_view(i,j) = f_ij(0);
+          if (not masked or f_mask(i,j,0)!=0) {
+            // We just extapolate with first entry
+            d_view(i,j) = f_ij(0);
+            if (masked)
+              d_mask(i,j) = 1;
+          } else {
+            d_mask(i,j) = 0;
+          }
         } else if (it==end) {
-          // We just extapolate with last entry
-          d_view(i,j) = f_ij(nlevs-1);
+          if (not masked or f_mask(i,j,nlevs-1)!=0) {
+            // We just extapolate with last entry
+            d_view(i,j) = f_ij(nlevs-1);
+            if (masked)
+              d_mask(i,j) = 1;
+          } else {
+            d_mask(i,j) = 0;
+          }
         } else {
           auto pos = it-beg;
-          auto z0 = z_i(pos-1);
-          auto z1 = z_i(pos);
-          auto f0 = f_ij(pos-1);
-          auto f1 = f_ij(pos);
+          if (not masked or 
+              (f_mask(i,j,pos)!=0 and f_mask(i,j,pos-1)!=0)) {
+            auto z0 = z_i(pos-1);
+            auto z1 = z_i(pos);
+            auto f0 = f_ij(pos-1);
+            auto f1 = f_ij(pos);
 
-          d_view(i,j) = ( (z_tgt-z0)*f1 + (z1-z_tgt)*f0 ) / (z1-z0);
+            d_view(i,j) = ( (z_tgt-z0)*f1 + (z1-z_tgt)*f0 ) / (z1-z0);
+            if (masked)
+              d_mask(i,j) = 1;
+          } else {
+            d_mask(i,j) = 0;
+          }
         }
     });
+  }
+
+  // TODO: remove when IO stops relying on mask=0 entries being already set to FillValue
+  if (masked) {
+    auto& mask = m_diagnostic_output.get_valid_mask();
+    m_diagnostic_output.deep_copy(constants::fill_value<Real>,mask,true);
   }
 }
 

--- a/components/eamxx/src/share/diagnostics/field_at_level.cpp
+++ b/components/eamxx/src/share/diagnostics/field_at_level.cpp
@@ -1,5 +1,7 @@
 #include "field_at_level.hpp"
 
+#include "share/util/eamxx_universal_constants.hpp"
+
 #include <ekat_std_utils.hpp>
 
 namespace scream
@@ -26,6 +28,11 @@ void FieldAtLevel::
 initialize_impl (const RunType /*run_type*/)
 {
   const auto& f   = get_fields_in().front();
+  EKAT_REQUIRE_MSG (f.data_type()==DataType::IntType or f.data_type()==DataType::RealType,
+      "[FieldAtLevel] Error! Unsupported field data type.\n"
+      " - field name: " + f.name() + "\n"
+      " - data type : " + e2str(f.data_type()) + "\n");
+
   // Sanity checks
   using namespace ShortFieldTagsNames;
   const auto& fid    = f.get_header().get_identifier();
@@ -68,8 +75,11 @@ initialize_impl (const RunType /*run_type*/)
 
   // All good, create the diag output
   auto d_fid = fid.clone(m_diag_name).reset_layout(layout.clone().strip_dim(tag));
-  m_diagnostic_output = Field(d_fid);
-  m_diagnostic_output.allocate_view();
+  m_diagnostic_output = Field(d_fid,true);
+  if (f.has_valid_mask()) {
+    m_diagnostic_output.create_valid_mask();
+    m_diagnostic_output.get_header().set_may_be_filled(true);
+  }
 
   using stratts_t = std::map<std::string,std::string>;
 
@@ -86,82 +96,131 @@ initialize_impl (const RunType /*run_type*/)
 void FieldAtLevel::compute_diagnostic_impl()
 {
   const auto& f = get_fields_in().front();
-  const auto& diag_layout = m_diagnostic_output.get_header().get_identifier().get_layout();
-  using RangePolicy = Kokkos::RangePolicy<Field::device_t::execution_space>;
-  RangePolicy policy(0,diag_layout.size());
-  auto level  = m_field_level;
-  switch (diag_layout.rank()) {
+
+  auto ALL = Kokkos::ALL;
+  bool masked = m_diagnostic_output.has_valid_mask();
+  switch (f.rank()) {
     case 1:
       {
-        auto f_view = f.get_view<const Real**>();
-        auto d_view = m_diagnostic_output.get_view<      Real*>();
-        Kokkos::parallel_for(m_diagnostic_output.name(),policy,KOKKOS_LAMBDA(const int idx) {
-            d_view(idx) = f_view(idx,level);
-        });
-      }
-      break;
+        if (f.data_type()==DataType::IntType) {
+          auto fv = f.get_view<const int*>();
+          auto dv = m_diagnostic_output.get_view<int>();
+          Kokkos::deep_copy(dv,Kokkos::subview(fv,m_field_level));
+        } else if (f.data_type()==DataType::RealType) {
+          auto fv = f.get_view<const Real*>();
+          auto dv = m_diagnostic_output.get_view<Real>();
+          Kokkos::deep_copy(dv,Kokkos::subview(fv,m_field_level));
+        }
+
+        if (masked) {
+          auto fmv = f.get_valid_mask().get_view<const int*>();
+          auto dmv = m_diagnostic_output.get_valid_mask().get_view<int>();
+          Kokkos::deep_copy(dmv,Kokkos::subview(fmv,m_field_level));
+        }
+      } break;
     case 2:
       {
-        auto f_view = f.get_view<const Real***>();
-        auto d_view = m_diagnostic_output.get_view<      Real**>();
-        const int dim1 = diag_layout.dims()[1];
-        Kokkos::parallel_for(m_diagnostic_output.name(),policy,KOKKOS_LAMBDA(const int idx) {
-            const int i = idx / dim1;
-            const int j = idx % dim1;
-            d_view(i,j) = f_view(i,j,level);
-        });
-      }
-      break;
+        if (f.data_type()==DataType::IntType) {
+          auto fv = f.get_view<const int**>();
+          auto dv = m_diagnostic_output.get_view<int*>();
+          Kokkos::deep_copy(dv,Kokkos::subview(fv,ALL,m_field_level));
+        } else if (f.data_type()==DataType::RealType) {
+          auto fv = f.get_view<const Real**>();
+          auto dv = m_diagnostic_output.get_view<Real*>();
+          Kokkos::deep_copy(dv,Kokkos::subview(fv,ALL,m_field_level));
+        }
+
+        if (masked) {
+          auto fmv = f.get_valid_mask().get_view<const int**>();
+          auto dmv = m_diagnostic_output.get_valid_mask().get_view<int*>();
+          Kokkos::deep_copy(dmv,Kokkos::subview(fmv,ALL,m_field_level));
+        }
+      } break;
     case 3:
       {
-        auto f_view = f.get_view<const Real****>();
-        auto d_view = m_diagnostic_output.get_view<      Real***>();
-        const int dim1 = diag_layout.dims()[1];
-        const int dim2 = diag_layout.dims()[2];
-        Kokkos::parallel_for(m_diagnostic_output.name(),policy,KOKKOS_LAMBDA(const int idx) {
-            const int i = (idx / dim2) / dim1;
-            const int j = (idx / dim2) % dim1;
-            const int k =  idx % dim2;
-            d_view(i,j,k) = f_view(i,j,k,level);
-        });
-      }
-      break;
+        if (f.data_type()==DataType::IntType) {
+          auto fv = f.get_view<const int***>();
+          auto dv = m_diagnostic_output.get_view<int**>();
+          Kokkos::deep_copy(dv,Kokkos::subview(fv,ALL,ALL,m_field_level));
+        } else if (f.data_type()==DataType::RealType) {
+          auto fv = f.get_view<const Real***>();
+          auto dv = m_diagnostic_output.get_view<Real**>();
+          Kokkos::deep_copy(dv,Kokkos::subview(fv,ALL,ALL,m_field_level));
+        }
+
+        if (masked) {
+          auto fmv = f.get_valid_mask().get_view<const int***>();
+          auto dmv = m_diagnostic_output.get_valid_mask().get_view<int**>();
+          Kokkos::deep_copy(dmv,Kokkos::subview(fmv,ALL,ALL,m_field_level));
+        }
+      } break;
     case 4:
       {
-        auto f_view = f.get_view<const Real*****>();
-        auto d_view = m_diagnostic_output.get_view<      Real****>();
-        const int dim1 = diag_layout.dims()[1];
-        const int dim2 = diag_layout.dims()[2];
-        const int dim3 = diag_layout.dims()[3];
-        Kokkos::parallel_for(m_diagnostic_output.name(),policy,KOKKOS_LAMBDA(const int idx) {
-            const int i = ((idx / dim3) / dim2) / dim1;
-            const int j = ((idx / dim3) / dim2) % dim1;
-            const int k =  (idx / dim3) % dim2;
-            const int l =   idx % dim3;
-            d_view(i,j,k,l) = f_view(i,j,k,l,level);
-        });
-      }
-      break;
+        if (f.data_type()==DataType::IntType) {
+          auto fv = f.get_view<const int****>();
+          auto dv = m_diagnostic_output.get_view<int***>();
+          Kokkos::deep_copy(dv,Kokkos::subview(fv,ALL,ALL,ALL,m_field_level));
+        } else if (f.data_type()==DataType::RealType) {
+          auto fv = f.get_view<const Real****>();
+          auto dv = m_diagnostic_output.get_view<Real***>();
+          Kokkos::deep_copy(dv,Kokkos::subview(fv,ALL,ALL,ALL,m_field_level));
+        }
+
+        if (masked) {
+          auto fmv = f.get_valid_mask().get_view<const int****>();
+          auto dmv = m_diagnostic_output.get_valid_mask().get_view<int***>();
+          Kokkos::deep_copy(dmv,Kokkos::subview(fmv,ALL,ALL,ALL,m_field_level));
+        }
+      } break;
     case 5:
       {
-        auto f_view = f.get_view<const Real******>();
-        auto d_view = m_diagnostic_output.get_view<      Real*****>();
-        const int dim1 = diag_layout.dims()[1];
-        const int dim2 = diag_layout.dims()[2];
-        const int dim3 = diag_layout.dims()[3];
-        const int dim4 = diag_layout.dims()[4];
-        Kokkos::parallel_for(m_diagnostic_output.name(),policy,KOKKOS_LAMBDA(const int idx) {
-            const int i = (((idx / dim4) / dim3) / dim2) / dim1;
-            const int j = (((idx / dim4) / dim3) / dim2) % dim1;
-            const int k =  ((idx / dim4) / dim3) % dim2;
-            const int l =   (idx / dim4) % dim3;
-            const int m =    idx / dim4;
-            d_view(i,j,k,l,m) = f_view(i,j,k,l,m,level);
-        });
-      }
-      break;
+        if (f.data_type()==DataType::IntType) {
+          auto fv = f.get_view<const int*****>();
+          auto dv = m_diagnostic_output.get_view<int****>();
+          Kokkos::deep_copy(dv,Kokkos::subview(fv,ALL,ALL,ALL,ALL,m_field_level));
+        } else if (f.data_type()==DataType::RealType) {
+          auto fv = f.get_view<const Real*****>();
+          auto dv = m_diagnostic_output.get_view<Real****>();
+          Kokkos::deep_copy(dv,Kokkos::subview(fv,ALL,ALL,ALL,ALL,m_field_level));
+        }
+
+        if (masked) {
+          auto fmv = f.get_valid_mask().get_view<const int*****>();
+          auto dmv = m_diagnostic_output.get_valid_mask().get_view<int****>();
+          Kokkos::deep_copy(dmv,Kokkos::subview(fmv,ALL,ALL,ALL,ALL,m_field_level));
+        }
+      } break;
+    case 6:
+      {
+        if (f.data_type()==DataType::IntType) {
+          auto fv = f.get_view<const int******>();
+          auto dv = m_diagnostic_output.get_view<int*****>();
+          Kokkos::deep_copy(dv,Kokkos::subview(fv,ALL,ALL,ALL,ALL,ALL,m_field_level));
+        } else if (f.data_type()==DataType::RealType) {
+          auto fv = f.get_view<const Real******>();
+          auto dv = m_diagnostic_output.get_view<Real*****>();
+          Kokkos::deep_copy(dv,Kokkos::subview(fv,ALL,ALL,ALL,ALL,ALL,m_field_level));
+        }
+
+        if (masked) {
+          auto fmv = f.get_valid_mask().get_view<const int******>();
+          auto dmv = m_diagnostic_output.get_valid_mask().get_view<int*****>();
+          Kokkos::deep_copy(dmv,Kokkos::subview(fmv,ALL,ALL,ALL,ALL,ALL,m_field_level));
+        }
+      } break;
+    default:
+      EKAT_ERROR_MSG (
+          "[FieldAtLevel] Unexpected field rank. You should have gotten an error before though.\n"
+          " - field name: " + f.name() + "\n"
+          " - field rank: " + std::to_string(f.rank()) + "\n");
   }
-  Kokkos::fence();
+
+  // TODO: remove when IO stops relying on mask=0 entries being already set to FillValue
+  if (masked) {
+    const auto fv = f.data_type()==DataType::RealType ? constants::fill_value<Real>
+                                                      : constants::fill_value<int>;
+    m_diagnostic_output.deep_copy(fv,m_diagnostic_output.get_valid_mask(),true);
+  }
 }
 
 } //namespace scream

--- a/components/eamxx/src/share/diagnostics/field_at_pressure_level.cpp
+++ b/components/eamxx/src/share/diagnostics/field_at_pressure_level.cpp
@@ -67,8 +67,7 @@ initialize_impl (const RunType /*run_type*/)
 
   // All good, create the diag output
   auto d_fid = fid.clone(m_diag_name).reset_layout(layout.clone().strip_dim(tag));
-  m_diagnostic_output = Field(d_fid);
-  m_diagnostic_output.allocate_view();
+  m_diagnostic_output = Field(d_fid,true);
 
   m_pressure_name = tag==LEV ? "p_mid" : "p_int";
 
@@ -92,6 +91,8 @@ void FieldAtPressureLevel::compute_diagnostic_impl()
 {
   using KT = KokkosTypes<DefaultDevice>;
   using MemberType = typename KT::MemberType;
+  using cmask2d_t = Field::view_dev_t<const int**>;
+  using cmask3d_t = Field::view_dev_t<const int***>;
 
   //This is 2D source pressure
   const Field& p_src = get_field_in(m_pressure_name);
@@ -107,10 +108,12 @@ void FieldAtPressureLevel::compute_diagnostic_impl()
 
   auto p_tgt = m_pressure_level;
   constexpr auto fval = constants::fill_value<Real>;
+  bool masked = f.has_valid_mask();
   if (rank==2) {
     auto policy = KT::RangePolicy(0,ncols);
     auto diag = m_diagnostic_output.get_view<Real*>();
-    auto mask = m_diagnostic_output.get_valid_mask().get_view<int*>();
+    auto dmask = m_diagnostic_output.get_valid_mask().get_view<int*>();
+    auto fmask = masked ? f.get_valid_mask().get_view<const int**>() : cmask2d_t{};
     auto f_v  = f.get_view<const Real**>();
     Kokkos::parallel_for(policy,KOKKOS_LAMBDA(const int icol) {
       auto x1 = ekat::subview(p_src_v,icol);
@@ -120,28 +123,44 @@ void FieldAtPressureLevel::compute_diagnostic_impl()
       auto last = beg + (nlevs-1);
       if (p_tgt<*beg or p_tgt>*last) {
         diag(icol) = fval;
-        mask(icol) = 0;
+        dmask(icol) = 0;
       } else {
         auto ub = ekat::upper_bound(beg,end,p_tgt);     
         auto k1 = ub - beg;
         if (k1==0) {
-          // Corner case: p_tgt==y1(0)
-          diag(icol) = y1(0);
+          if (not masked or fmask(icol,0)!=0) {
+            // Corner case: p_tgt==y1(0)
+            diag(icol) = y1(0);
+            dmask(icol) = 1;
+          } else {
+            dmask(icol) = 0;
+          }
         } else if (k1==nlevs) {
-          // Corner case: p_tgt==y1(nlevs-1)
-          diag(icol) = y1(nlevs-1);
+          if (not masked or fmask(icol,nlevs-1)!=0) {
+            // Corner case: p_tgt==y1(nlevs-1)
+            diag(icol) = y1(nlevs-1);
+            dmask(icol) = 1;
+          } else {
+            dmask(icol) = 0;
+          }
         } else {
-          // General case: interpolate between k1 and k1-1
-          diag(icol) = y1(k1-1) + (y1(k1)-y1(k1-1))/(x1(k1) - x1(k1-1)) * (p_tgt-x1(k1-1));
+          if (not masked or
+              (fmask(icol,k1)!=0 and fmask(icol,k1-1)!=0)) {
+            // General case: interpolate between k1 and k1-1
+            diag(icol) = y1(k1-1) + (y1(k1)-y1(k1-1))/(x1(k1) - x1(k1-1)) * (p_tgt-x1(k1-1));
+            dmask(icol) = 1;
+          } else {
+            dmask(icol) = 0;
+          }
         }
-        mask(icol) = 1;
       }
     });
   } else if (rank==3) {
     const int ndims = f.get_header().get_identifier().get_layout().get_vector_dim();
     auto policy = KT::TeamPolicy(ncols,ndims);
     auto diag = m_diagnostic_output.get_view<Real**>();
-    auto mask = m_diagnostic_output.get_valid_mask().get_view<int**>();
+    auto dmask = m_diagnostic_output.get_valid_mask().get_view<int**>();
+    auto fmask = masked ? f.get_valid_mask().get_view<const int***>() : cmask3d_t{};
     auto f_v  = f.get_view<const Real***>();
     Kokkos::parallel_for(policy,KOKKOS_LAMBDA(const MemberType& team) {
       int icol = team.league_rank();
@@ -152,28 +171,47 @@ void FieldAtPressureLevel::compute_diagnostic_impl()
       Kokkos::parallel_for(Kokkos::TeamVectorRange(team,ndims),[&](const int idim) {
         if (p_tgt<*beg or p_tgt>*last) {
           diag(icol,idim) = fval; // TODO: don't bother setting an arbitrary value
-          mask(icol,idim) = 0;
+          dmask(icol,idim) = 0;
         } else {
           auto y1 = ekat::subview(f_v,icol,idim);
           auto ub = ekat::upper_bound(beg,end,p_tgt);     
           auto k1 = ub - beg;
           if (k1==0) {
-            // Corner case: p_tgt==y1(0)
-            diag(icol,idim) = y1(0);
+            if (not masked or fmask(icol,idim,0)!=0) {
+              // Corner case: p_tgt==y1(0)
+              diag(icol,idim) = y1(0);
+              dmask(icol,idim) = 1;
+            } else {
+              dmask(icol,idim) = 0;
+            }
           } else if (k1==nlevs) {
-            // Corner case: p_tgt==y1(nlevs-1)
-            diag(icol,idim) = y1(nlevs-1);
+            if (not masked or fmask(icol,idim,nlevs-1)!=0) {
+              // Corner case: p_tgt==y1(nlevs-1)
+              diag(icol,idim) = y1(nlevs-1);
+              dmask(icol,idim) = 1;
+            } else {
+              dmask(icol,idim) = 0;
+            }
           } else {
-            // General case: interpolate between k1 and k1-1
-            diag(icol,idim) = y1(k1-1) + (y1(k1)-y1(k1-1))/(x1(k1) - x1(k1-1)) * (p_tgt-x1(k1-1));
+            if (not masked or
+                (fmask(icol,idim,k1)!=0 and fmask(icol,idim,k1-1)!=0)) {
+              // General case: interpolate between k1 and k1-1
+              diag(icol,idim) = y1(k1-1) + (y1(k1)-y1(k1-1))/(x1(k1) - x1(k1-1)) * (p_tgt-x1(k1-1));
+              dmask(icol,idim) = 1;
+            } else {
+              dmask(icol,idim) = 0;
+            }
           }
-          mask(icol,idim) = 1;
         }
       });
     });
   } else {
     EKAT_ERROR_MSG("Error! field at pressure level only supports fields ranks 2 and 3 \n");
   }
+
+  // TODO: remove when IO stops relying on mask=0 entries being already set to FillValue
+  auto& mask = m_diagnostic_output.get_valid_mask();
+  m_diagnostic_output.deep_copy(constants::fill_value<Real>,mask,true);
 
 }
 

--- a/components/eamxx/src/share/diagnostics/field_over_dt.cpp
+++ b/components/eamxx/src/share/diagnostics/field_over_dt.cpp
@@ -1,7 +1,5 @@
 #include "field_over_dt.hpp"
 
-#include "share/util/eamxx_universal_constants.hpp"
-
 namespace scream {
 
 FieldOverDtDiag::
@@ -40,25 +38,30 @@ void FieldOverDtDiag::initialize_impl(const RunType /*run_type*/) {
   auto diag_units = fid.get_units() / s;
 
   FieldIdentifier d_fid(m_name + "_over_dt", layout.clone(), diag_units, gn);
-  m_diagnostic_output = Field(d_fid);
-  m_diagnostic_output.allocate_view();
+  m_diagnostic_output = Field(d_fid,true);
+  if (f.has_valid_mask()) {
+    m_diagnostic_output.set_valid_mask(f.get_valid_mask());
+    m_diagnostic_output.get_header().set_may_be_filled(true);
+  }
 }
 
 void FieldOverDtDiag::init_timestep(const util::TimeStamp &start_of_step) {
   m_start_ts = start_of_step;
+  EKAT_REQUIRE_MSG (m_start_ts.is_valid(),
+      "Error! Initializing FieldOverDtDiag timestep with an invalid time stamp.\n"
+      " - diag field name: " + m_diagnostic_output.name() + "\n");
 }
 
-void FieldOverDtDiag::compute_diagnostic_impl() {
+void FieldOverDtDiag::compute_diagnostic_impl()
+{
   const auto &f = get_field_in(m_name);
 
-  if (!m_start_ts.is_valid()) {
-    // init_timestep has not been called yet; fill with invalid sentinel
-    m_diagnostic_output.deep_copy(constants::fill_value<Real>);
-    return;
-  }
-
   const auto &curr_ts = f.get_header().get_tracking().get_time_stamp();
-  const std::int64_t dt = curr_ts - m_start_ts;
+  EKAT_REQUIRE_MSG (curr_ts.is_valid() and m_start_ts.is_valid(),
+      "Error! FieldOverDtDiag does not work if you don't call init_timestep first.\n"
+      " - diag field name: " + m_diagnostic_output.name() + "\n");
+
+  const std::int64_t dt = curr_ts.seconds_from(m_start_ts);
 
   EKAT_REQUIRE_MSG(dt > 0,
       "Error! FieldOverDtDiag: dt must be positive.\n"
@@ -66,8 +69,15 @@ void FieldOverDtDiag::compute_diagnostic_impl() {
       " - start timestamp: " + m_start_ts.to_string() + "\n"
       " - curr timestamp:  " + curr_ts.to_string() + "\n");
 
-  m_diagnostic_output.deep_copy(f);
-  m_diagnostic_output.scale(1.0 / dt);
+  // diag = 0*diag + 1/dt*f
+  const auto dt_inv = 1 / static_cast<Real>(dt);
+  if (f.has_valid_mask()) {
+    m_diagnostic_output.update(f,dt_inv,0,f.get_valid_mask());
+    // TODO: remove when IO handles fill value internally
+    m_diagnostic_output.deep_copy(constants::fill_value<Real>,f.get_valid_mask(),true);
+  } else {
+    m_diagnostic_output.update(f,dt_inv,0);
+  }
 }
 
 }  // namespace scream

--- a/components/eamxx/src/share/diagnostics/field_prev.cpp
+++ b/components/eamxx/src/share/diagnostics/field_prev.cpp
@@ -41,50 +41,40 @@ void FieldPrevDiag::initialize_impl(const RunType /*run_type*/) {
 
   // Output has the same layout and units as the input field
   FieldIdentifier d_fid(m_name + "_prev", layout.clone(), fid.get_units(), gn);
-  m_diagnostic_output = Field(d_fid);
-  m_diagnostic_output.allocate_view();
+  m_diagnostic_output = Field(d_fid,true);
 
-  // Storage for the field value at the start of the timestep
-  FieldIdentifier prev_fid(m_name + "_prev_store", layout.clone(), fid.get_units(), gn);
-  m_f_prev = Field(prev_fid);
-  m_f_prev.allocate_view();
+  // NOTE: even if the input field is masked, we must use a different one, since
+  // at the first timestep, the field may have not been computed yet (but it's not masked per se)
+  auto mask = m_diagnostic_output.create_valid_mask();
+  m_diagnostic_output.get_header().set_may_be_filled(true);
+  mask.deep_copy(0);
+
+  // TODO: remove when IO stops relying on mask=0 entries being already set to FillValue
+  m_diagnostic_output.deep_copy(constants::fill_value<Real>);
 }
 
-void FieldPrevDiag::init_timestep(const util::TimeStamp &start_of_step) {
-  const auto &f_curr = get_field_in(m_name);
-  const auto &f_curr_ts = f_curr.get_header().get_tracking().get_time_stamp();
+void FieldPrevDiag::init_timestep(const util::TimeStamp &start_of_step)
+{
+  // At the timestep begin, the field is at the "prev" timestep.
+  const auto& f_prev = get_field_in(m_name);
+  const auto& prev_ts = f_prev.get_header().get_tracking().get_time_stamp();
 
-  // Only capture f_curr if it has been initialized (valid timestamp).
-  // If the source is a computed diagnostic that has not been evaluated yet
-  // (e.g., on the very first timestep before any computation has run),
-  // its data is Kokkos-zero-initialized — not a meaningful "t=0" value.
-  // Leaving m_f_prev with an invalid timestamp causes compute_diagnostic_impl
-  // to return fill_value, which is safer than silently propagating zeros into
-  // downstream arithmetic (e.g., X_minus_X_prev_times_something can overflow
-  // if X_prev is zero and X is fill_value from another uninitialized diag).
-  if (f_curr_ts.is_valid()) {
-    m_f_prev.deep_copy(f_curr);
-    m_f_prev.get_header().get_tracking().update_time_stamp(start_of_step);
+  if (prev_ts.is_valid()) {
+    // Field was inited/computed at least once, so it makes sense to copy it
+    if (f_prev.has_valid_mask()) {
+      m_diagnostic_output.deep_copy(f_prev,f_prev.get_valid_mask());
+      m_diagnostic_output.get_valid_mask().deep_copy(f_prev.get_valid_mask());
+    } else {
+      m_diagnostic_output.deep_copy(f_prev);
+      m_diagnostic_output.get_valid_mask().deep_copy(1);
+    }
+  } else {
+    m_diagnostic_output.get_valid_mask().deep_copy(0);
   }
 }
 
 void FieldPrevDiag::compute_diagnostic_impl() {
-  const auto &prev_ts = m_f_prev.get_header().get_tracking().get_time_stamp();
-
-  if (prev_ts.is_valid()) {
-    // Normal case: return the value captured at the start of this timestep.
-    m_diagnostic_output.deep_copy(m_f_prev);
-  } else {
-    // m_f_prev was never captured because the source field had no valid
-    // timestamp when init_timestep ran (e.g., a derived diagnostic on the
-    // very first step).  By the time compute_diagnostic_impl is called the
-    // source has always been computed (the base-class timestamp guard
-    // ensures this), so we use the current source value as a stand-in for
-    // "X at t=0".  This gives X − X_prev = 0 on the first step and avoids
-    // fill_value propagation into downstream arithmetic that could overflow
-    // (fill_value × fill_value → Inf).
-    m_diagnostic_output.deep_copy(get_field_in(m_name));
-  }
+  // Nothing to do here
 }
 
 }  // namespace scream

--- a/components/eamxx/src/share/diagnostics/field_prev.hpp
+++ b/components/eamxx/src/share/diagnostics/field_prev.hpp
@@ -2,14 +2,14 @@
 #define EAMXX_FIELD_PREV_DIAG_HPP
 
 #include "share/atm_process/atmosphere_diagnostic.hpp"
-#include "share/util/eamxx_time_stamp.hpp"
 
 namespace scream {
 
 /*
  * This diagnostic stores the value of a given field at the beginning
- * of the previous timestep. Users can request X_prev for any field X
- * to capture the prior start-of-timestep value before model updates occur.
+ * of the current timestep (i.e., at the end of the previous timestep).
+ * Users can request X_prev for any field X to capture the start-of-timestep
+ * value before model updates occur.
  */
 
 class FieldPrevDiag : public AtmosphereDiagnostic {
@@ -18,16 +18,16 @@ class FieldPrevDiag : public AtmosphereDiagnostic {
   FieldPrevDiag(const ekat::Comm &comm, const ekat::ParameterList &params);
 
   // The name of the diagnostic CLASS (not the computed field)
-  std::string name() const { return "FieldPrevDiag"; }
+  std::string name() const override { return "FieldPrevDiag"; }
 
   // Set the grid
-  void create_requests();
+  void create_requests() override;
 
  protected:
 #ifdef KOKKOS_ENABLE_CUDA
  public:
 #endif
-  void compute_diagnostic_impl();
+  void compute_diagnostic_impl() override;
 
   // Store the field at the start of each timestep
   void init_timestep(const util::TimeStamp &start_of_step) override;
@@ -37,9 +37,6 @@ class FieldPrevDiag : public AtmosphereDiagnostic {
 
   // The name of the field to track
   std::string m_name;
-
-  // Store the field value from the beginning of the timestep
-  Field m_f_prev;
 
 };  // class FieldPrevDiag
 

--- a/components/eamxx/src/share/diagnostics/histogram.cpp
+++ b/components/eamxx/src/share/diagnostics/histogram.cpp
@@ -53,8 +53,7 @@ void HistogramDiag::initialize_impl(const RunType /*run_type*/) {
   FieldLayout diagnostic_layout({CMP}, {num_bins}, {"bin"});
   FieldIdentifier diagnostic_id(m_diag_name, diagnostic_layout,
                                 ekat::units::none, field_id.get_grid_name());
-  m_diagnostic_output = Field(diagnostic_id);
-  m_diagnostic_output.allocate_view();
+  m_diagnostic_output = Field(diagnostic_id,true);
 
   // allocate field for bin values
   FieldLayout bin_values_layout({CMP}, {num_bins+1}, {"bin"});
@@ -82,12 +81,18 @@ void HistogramDiag::compute_diagnostic_impl() {
   using TeamPolicy = Kokkos::TeamPolicy<Field::device_t::execution_space>;
   using TeamMember = typename TeamPolicy::member_type;
   using TPF        = ekat::TeamPolicyFactory<typename KT::ExeSpace>;
+  using cmask1d_t = Field::view_dev_t<const int*>;
+  using cmask2d_t = Field::view_dev_t<const int**>;
+  using cmask3d_t = Field::view_dev_t<const int***>;
+
+  bool masked = field.has_valid_mask();
   switch (field_layout.rank())
   {
     case 1: {
       const int d1 = field_layout.dim(0);
       auto field_view = field.get_view<const Real *>();
       TeamPolicy team_policy = TPF::get_default_team_policy(num_bins, d1);
+      auto mask_view = masked ? field.get_valid_mask().get_view<const int*>() : cmask1d_t{};
       Kokkos::parallel_for("compute_histogram_" + field.name(), team_policy,
           KOKKOS_LAMBDA(const TeamMember &tm) {
             const int bin_i = tm.league_rank();
@@ -95,7 +100,8 @@ void HistogramDiag::compute_diagnostic_impl() {
             const Real bin_upper = bin_values_view(bin_i+1);
             Kokkos::parallel_reduce(Kokkos::TeamVectorRange(tm, d1),
                 [&](int i, Real &val) {
-                  if ((bin_lower <= field_view(i)) && (field_view(i) < bin_upper))
+                  if ((not masked or mask_view(i)!=0) and
+                      (bin_lower <= field_view(i)) && (field_view(i) < bin_upper))
                     val += sp(1.0);
                 },
                 histogram_view(bin_i));
@@ -106,6 +112,7 @@ void HistogramDiag::compute_diagnostic_impl() {
       const int d2 = field_layout.dim(1);
       auto field_view = field.get_view<const Real **>();
       TeamPolicy team_policy = TPF::get_default_team_policy(num_bins, d1*d2);
+      auto mask_view = masked ? field.get_valid_mask().get_view<const int**>() : cmask2d_t{};
       Kokkos::parallel_for("compute_histogram_" + field.name(), team_policy,
           KOKKOS_LAMBDA(const TeamMember &tm) {
             const int bin_i = tm.league_rank();
@@ -115,7 +122,8 @@ void HistogramDiag::compute_diagnostic_impl() {
                 [&](int ind, Real &val) {
                   const int i1 = ind / d2;
                   const int i2 = ind % d2;
-                  if ((bin_lower <= field_view(i1,i2)) && (field_view(i1,i2) < bin_upper))
+                  if ((not masked or mask_view(i1,i2)!=0) and
+                      (bin_lower <= field_view(i1,i2)) && (field_view(i1,i2) < bin_upper))
                     val += sp(1.0);
                 },
                 histogram_view(bin_i));
@@ -127,6 +135,7 @@ void HistogramDiag::compute_diagnostic_impl() {
       const int d3 = field_layout.dim(2);
       auto field_view = field.get_view<const Real ***>();
       TeamPolicy team_policy = TPF::get_default_team_policy(num_bins, d1*d2*d3);
+      auto mask_view = masked ? field.get_valid_mask().get_view<const int***>() : cmask3d_t{};
       Kokkos::parallel_for("compute_histogram_" + field.name(), team_policy,
           KOKKOS_LAMBDA(const TeamMember &tm) {
             const int bin_i = tm.league_rank();
@@ -138,7 +147,8 @@ void HistogramDiag::compute_diagnostic_impl() {
                   const int ind2 = ind % (d2*d3);
                   const int i2 = ind2 / d3;
                   const int i3 = ind2 % d3;
-                  if ((bin_lower <= field_view(i1,i2,i3)) && (field_view(i1,i2,i3) < bin_upper))
+                  if ((not masked or mask_view(i1,i2,i3)!=0) and
+                      (bin_lower <= field_view(i1,i2,i3)) && (field_view(i1,i2,i3) < bin_upper))
                     val += sp(1.0);
                 },
                 histogram_view(bin_i));

--- a/components/eamxx/src/share/diagnostics/tests/atm_backtend_test.cpp
+++ b/components/eamxx/src/share/diagnostics/tests/atm_backtend_test.cpp
@@ -40,7 +40,7 @@ TEST_CASE("atm_backtend") {
 
   ekat::Comm comm(MPI_COMM_WORLD);
 
-  util::TimeStamp t0({2024, 1, 1}, {0, 0, 0});
+  util::TimeStamp ts({2024, 1, 1}, {0, 0, 0});
 
   constexpr int nlevs = 7;
   const int ngcols    = 2 * comm.size();
@@ -60,7 +60,7 @@ TEST_CASE("atm_backtend") {
   register_diagnostics();
 
   // Set time for qc and randomize its values
-  qc.get_header().get_tracking().update_time_stamp(t0);
+  qc.get_header().get_tracking().update_time_stamp(ts);
   randomize_uniform(qc, seed++, 0, 200);
   qc.sync_to_dev();
 
@@ -72,7 +72,7 @@ TEST_CASE("atm_backtend") {
   auto prev_diag = diag_factory.create("FieldPrevDiag", comm, prev_params);
   prev_diag->set_grids(gm);
   prev_diag->set_required_field(qc);
-  prev_diag->initialize(t0, RunType::Initial);
+  prev_diag->initialize(ts, RunType::Initial);
 
   // The output of FieldPrevDiag is "qc_prev"
   auto qc_prev_field = prev_diag->get_diagnostic();
@@ -87,7 +87,7 @@ TEST_CASE("atm_backtend") {
   minus_diag->set_grids(gm);
   minus_diag->set_required_field(qc);
   minus_diag->set_required_field(qc_prev_field);
-  minus_diag->initialize(t0, RunType::Initial);
+  minus_diag->initialize(ts, RunType::Initial);
 
   auto qc_minus_qc_prev_field = minus_diag->get_diagnostic();
 
@@ -98,27 +98,19 @@ TEST_CASE("atm_backtend") {
   auto over_dt_diag = diag_factory.create("FieldOverDtDiag", comm, over_dt_params);
   over_dt_diag->set_grids(gm);
   over_dt_diag->set_required_field(qc_minus_qc_prev_field);
-  over_dt_diag->initialize(t0, RunType::Initial);
+  over_dt_diag->initialize(ts, RunType::Initial);
 
-  // First evaluation (before any init_timestep): result should be fill_value
-  prev_diag->compute_diagnostic();
-  minus_diag->compute_diagnostic();
-  over_dt_diag->compute_diagnostic();
+  // First evaluation (before any init_timestep): should throw
+  REQUIRE_THROWS(over_dt_diag->compute_diagnostic());
 
   auto result = over_dt_diag->get_diagnostic();
-  result.sync_to_host();
-  {
-    auto v = result.get_view<Real**, Host>();
-    const Real fill_val = constants::fill_value<Real>;
-    for (int icol = 0; icol < ngcols; ++icol)
-      for (int ilev = 0; ilev < nlevs; ++ilev)
-        REQUIRE(v(icol, ilev) == fill_val);
-  }
 
   const Real a_day = 24.0 * 60.0 * 60.0;  // seconds
 
   constexpr int ntests = 10;
+  constexpr auto tol = std::numeric_limits<Real>::epsilon()*100;
 
+  qc.get_header().get_tracking().update_time_stamp(ts);
   for (int itest = 2; itest < ntests; itest++) {
     // Save current qc before advancing
     auto qc_old = qc.clone();
@@ -126,12 +118,12 @@ TEST_CASE("atm_backtend") {
     qc_old.sync_to_host();
 
     // init_timestep: FieldPrevDiag stores current qc; FieldOverDtDiag saves start ts
-    prev_diag->init_timestep(t0);
-    over_dt_diag->init_timestep(t0);
+    prev_diag->init_timestep(ts);
+    over_dt_diag->init_timestep(ts);
 
     // Advance time by one day and update qc
-    util::TimeStamp t1({2024, 1, itest}, {0, 0, 0});
-    qc.get_header().get_tracking().update_time_stamp(t1);
+    ts += 86400;
+    qc.get_header().get_tracking().update_time_stamp(ts);
     randomize_uniform(qc, seed++, 0, 200);
     qc.sync_to_dev();
 
@@ -146,12 +138,13 @@ TEST_CASE("atm_backtend") {
     auto qc_old_v = qc_old.get_view<Real**, Host>();
     auto res_v    = result.get_view<Real**, Host>();
 
-    for (int icol = 0; icol < ngcols; ++icol)
-      for (int ilev = 0; ilev < nlevs; ++ilev)
-        REQUIRE(res_v(icol, ilev) ==
-                Approx((qc_new_v(icol, ilev) - qc_old_v(icol, ilev)) / a_day));
+    auto manual = qc.clone();
+    manual.update(qc_old,-1,1);
+    manual.scale(1/a_day);
 
-    t0 = t1;
+    auto diff = result.clone();
+    diff.update(manual,-1,1);
+    REQUIRE_THAT (inf_norm(diff).as<Real>(), Catch::WithinAbs(0,tol));
   }
 }
 

--- a/components/eamxx/src/share/diagnostics/tests/binary_ops_test.cpp
+++ b/components/eamxx/src/share/diagnostics/tests/binary_ops_test.cpp
@@ -75,6 +75,12 @@ TEST_CASE("binary_ops") {
   randomize_uniform(qv, seed++, 0, 200);
   randomize_uniform(m,  seed++, 0, 200);
 
+  // Create random mask fields for qc/qv
+  qc.create_valid_mask();
+  qv.create_valid_mask();
+  randomize_uniform(qc.get_valid_mask(),seed++);
+  randomize_uniform(qv.get_valid_mask(),seed++);
+
   // Create and set up the diagnostic
   params_plus.set("grid_name", grid->name());
   params_plus.set<std::string>("arg1", "qc");
@@ -118,23 +124,26 @@ TEST_CASE("binary_ops") {
   auto rgas_diag_f = prod_scl_scl->get_diagnostic(); rgas_diag_f.sync_to_host();
 
   // Check that the output fields have the right values
-  const auto &plus_v = plus_diag_f.get_view<Real**, Host>();
-  const auto &prod_v = prod_diag_f.get_view<Real**, Host>();
-  const auto &rgas_v = rgas_diag_f.get_view<Real, Host>();
-  const auto &qc_v   = qc.get_view<Real**, Host>();
-  const auto &qv_v   = qv.get_view<Real**, Host>();
-  const auto &m_v    = m.get_view<Real**, Host>();
   const auto g = physics::Constants<Real>::gravit.value;
-  for (int icol = 0; icol < ngcols; ++icol) {
-    for (int ilev = 0; ilev < nlevs; ++ilev) {
-      // Check plus
-      REQUIRE(plus_v(icol, ilev) == qc_v(icol, ilev) + qv_v(icol, ilev));
-      // Check product
-      REQUIRE(prod_v(icol, ilev) == (m_v(icol,ilev)*g));
-    }
-  }
-  // The diag_scl_scl shoould compute the prod of avogadro's number and boltzman's constant, which is Rgas
-  REQUIRE (rgas_v()==physics::Constants<Real>::dictionary().at("Rgas").value);
+
+  // field*constant diag
+  m.scale(g);
+  REQUIRE (not prod_diag_f.has_valid_mask());
+  REQUIRE (views_are_equal(prod_diag_f,m));
+
+  // field+field diag
+  REQUIRE (plus_diag_f.has_valid_mask());
+  auto tgt_mask = qc.get_valid_mask().clone();
+  tgt_mask.scale(qv.get_valid_mask());
+  REQUIRE (views_are_equal(tgt_mask,plus_diag_f.get_valid_mask()));
+
+  qv.update(qc,1,1,tgt_mask);
+  qv.deep_copy(0,tgt_mask,true);
+  plus_diag_f.deep_copy(0,tgt_mask,true);
+  REQUIRE (views_are_equal(plus_diag_f,qv));
+
+  // constant*constant diag
+  REQUIRE (rgas_diag_f.get_view<Real,Host>()()==physics::Constants<Real>::dictionary().at("Rgas").value);
 
   // redundant, why not
   qc.update(qv, 1, 1);

--- a/components/eamxx/src/share/diagnostics/tests/conditional_sampling_test.cpp
+++ b/components/eamxx/src/share/diagnostics/tests/conditional_sampling_test.cpp
@@ -210,12 +210,6 @@ TEST_CASE("conditional_sampling") {
           iota_z<int>(lev);
           auto cmp = cmp_s=="ge" ? Comparison::GE : Comparison::LE;
           compute_mask(lev,val,cmp,mask);
-          if (not views_are_equal(d.get_valid_mask(),mask))
-          {
-            print_field_hyperslab(lev.alias("lev"));
-            print_field_hyperslab(mask.alias("manual"));
-            print_field_hyperslab(d.get_valid_mask().alias("computed"));
-          }
           REQUIRE (views_are_equal(d.get_valid_mask(),mask));
 
           x.deep_copy(fv,mask,true);

--- a/components/eamxx/src/share/diagnostics/tests/field_over_dt_test.cpp
+++ b/components/eamxx/src/share/diagnostics/tests/field_over_dt_test.cpp
@@ -4,7 +4,6 @@
 #include "share/field/field_utils.hpp"
 #include "share/data_managers/mesh_free_grids_manager.hpp"
 #include "share/core/eamxx_setup_random_test.hpp"
-#include "share/util/eamxx_universal_constants.hpp"
 
 namespace scream {
 
@@ -68,25 +67,10 @@ TEST_CASE("field_over_dt") {
   diag->set_required_field(qc);
   diag->initialize(t0, RunType::Initial);
 
-  // Run diag before any init_timestep call: should return fill_value
-  diag->compute_diagnostic();
-  auto diag_f = diag->get_diagnostic();
-  diag_f.sync_to_host();
-
-  auto fill_field = qc.clone();
-  fill_field.deep_copy(constants::fill_value<Real>);
-  // Units differ (kg/kg/s vs kg/kg) so compare values directly
-  {
-    auto diag_host = diag_f.get_view<Real**, Host>();
-    const Real fill_val = constants::fill_value<Real>;
-    for (int icol = 0; icol < ngcols; ++icol)
-      for (int ilev = 0; ilev < nlevs; ++ilev)
-        REQUIRE(diag_host(icol, ilev) == fill_val);
-  }
-
   constexpr int ntests = 10;
   const Real a_day = 24.0 * 60.0 * 60.0;  // seconds
 
+  auto diag_f = diag->get_diagnostic();
   for (int itest = 2; itest < ntests; itest++) {
     // Save qc before advancing
     auto qc_prev = qc.clone();

--- a/components/eamxx/src/share/diagnostics/tests/field_prev_test.cpp
+++ b/components/eamxx/src/share/diagnostics/tests/field_prev_test.cpp
@@ -4,7 +4,6 @@
 #include "share/field/field_utils.hpp"
 #include "share/data_managers/mesh_free_grids_manager.hpp"
 #include "share/core/eamxx_setup_random_test.hpp"
-#include "share/util/eamxx_universal_constants.hpp"
 
 namespace scream {
 
@@ -35,7 +34,7 @@ TEST_CASE("field_prev") {
   ekat::Comm comm(MPI_COMM_WORLD);
 
   // A time stamp
-  util::TimeStamp t0({2024, 1, 1}, {0, 0, 0});
+  util::TimeStamp ts({2024, 1, 1}, {0, 0, 0});
 
   // Create a grids manager
   constexpr int nlevs = 7;
@@ -66,7 +65,6 @@ TEST_CASE("field_prev") {
   REQUIRE_THROWS(diag_factory.create("FieldPrevDiag", comm, params)); // Still no field_name
 
   // Set time for qc and randomize its values
-  qc.get_header().get_tracking().update_time_stamp(t0);
   randomize_uniform(qc, seed++, 0, 200);
 
   // Create and set up the diagnostic
@@ -74,67 +72,46 @@ TEST_CASE("field_prev") {
   auto diag = diag_factory.create("FieldPrevDiag", comm, params);
   diag->set_grids(gm);
   diag->set_required_field(qc);
-  diag->initialize(t0, RunType::Initial);
+  diag->initialize(ts, RunType::Initial);
 
-  // Run diag before any init_timestep call: qc already has a valid t0
-  // timestamp, so the fallback path returns X(t=0) = qc rather than fill_value.
-  diag->compute_diagnostic();
-  auto diag_f = diag->get_diagnostic();
-  REQUIRE(views_are_equal(diag_f, qc));
+  REQUIRE (diag->get_diagnostic().has_valid_mask());
 
   // Simulate a derived diagnostic whose source has no valid timestamp at
   // init_timestep time (i.e. it hasn't been computed yet on step 1).
-  // After init_timestep the source is computed and gets a valid timestamp;
-  // the diagnostic should then return the current source value (X_prev = X(t=0))
-  // rather than fill_value or stale zeros — this is the key test for the
-  // "first step of a derived _prev field" correctness.
-  {
-    FieldIdentifier qc_uninit_fid("qc_uninit", scalar2d_layout, kg / kg, grid->name());
-    Field qc_uninit(qc_uninit_fid);
-    qc_uninit.allocate_view();  // zero-initialized, no valid timestamp
+  diag->init_timestep(ts);
 
-    ekat::ParameterList p2;
-    p2.set("grid_name", grid->name());
-    p2.set<std::string>("field_name", "qc_uninit");
-    auto diag2 = diag_factory.create("FieldPrevDiag", comm, p2);
-    diag2->set_grids(gm);
-    diag2->set_required_field(qc_uninit);
-    diag2->initialize(t0, RunType::Initial);
+  // Source is now "computed" (gets a valid timestamp and random values), but it's too late...
+  qc.get_header().get_tracking().update_time_stamp(ts);
+  randomize_uniform(qc, seed++, 0, 200);
+  diag->compute_diagnostic();
+  auto diag_mask = diag->get_diagnostic().get_valid_mask();
 
-    // init_timestep: source has no valid timestamp → no capture
-    diag2->init_timestep(t0);
+  auto tgt_mask = diag_mask.clone();
+  tgt_mask.deep_copy(0);
 
-    // Source is now "computed" (gets a valid timestamp and random values),
-    // simulating what the output manager does before calling this diagnostic.
-    qc_uninit.get_header().get_tracking().update_time_stamp(t0);
-    randomize_uniform(qc_uninit, seed++, 0, 200);
-
-    // Fallback: m_f_prev invalid, source now valid → returns current source value
-    diag2->compute_diagnostic();
-    auto diag2_f = diag2->get_diagnostic();
-    REQUIRE(views_are_equal(diag2_f, qc_uninit));
-  }
+  REQUIRE(views_are_equal(diag_mask,tgt_mask));
 
   constexpr int ntests = 10;
-
+  tgt_mask.deep_copy(1);
   for (int itest = 2; itest < ntests; itest++) {
     // Save current qc before we advance
     auto qc_prev = qc.clone();
     qc_prev.deep_copy(qc);
 
     // init_timestep stores the current qc as the "previous" value
-    diag->init_timestep(t0);
+    diag->init_timestep(ts);
 
     // Advance time and update qc
-    util::TimeStamp t1({2024, 1, itest}, {0, 0, 0});
-    qc.get_header().get_tracking().update_time_stamp(t1);
+    ts += 300;
+    qc.get_header().get_tracking().update_time_stamp(ts);
     randomize_uniform(qc, seed++, 0, 200);
 
     // Diagnostic should return the value stored at init_timestep (qc_prev)
     diag->compute_diagnostic();
+    auto diag_f = diag->get_diagnostic();
     REQUIRE(views_are_equal(diag_f, qc_prev));
 
-    t0 = t1;
+    REQUIRE(views_are_equal(diag_mask,tgt_mask));
   }
 }
 

--- a/components/eamxx/src/share/diagnostics/tests/vert_derivative_test.cpp
+++ b/components/eamxx/src/share/diagnostics/tests/vert_derivative_test.cpp
@@ -158,6 +158,62 @@ TEST_CASE("vert_derivative") {
     }
   }
 
+  SECTION("dp_vert_derivative_masked") {
+    // calculate dp_vert_div manually
+    fin2.create_valid_mask();
+    randomize_uniform(fin2.get_valid_mask(),seed++);
+    dp.sync_to_host();
+    fin2.sync_to_host();
+    diag1_m.sync_to_host();
+
+    auto dp_v      = dp.get_view<const Real **, Host>();
+    auto fin2_v    = fin2.get_view<const Real **, Host>();
+    auto fin2_m    = fin2.get_valid_mask().get_view<const int**, Host>();
+    auto diag1_m_v = diag1_m.get_view<Real **, Host>();
+    auto diag1_m_mask = diag1_m.create_valid_mask();
+    auto diag1_m_mask_v = diag1_m.get_valid_mask().get_view<int**,Host>();
+    int last_lev = nlevs-1;
+    for (int icol = 0; icol < ngcols; ++icol) {
+      for (int ilev = 0; ilev < nlevs; ++ilev) {
+        if (fin2_m(icol,ilev)==0 or
+            (ilev>0 and fin2_m(icol,ilev-1)==0) or
+            (ilev<last_lev and fin2_m(icol,ilev+1)==0)) {
+          diag1_m_mask_v(icol,ilev)=0;
+          continue;
+        }
+        diag1_m_mask_v(icol,ilev)=1;
+        auto fa1 = (ilev < nlevs - 1) ? (fin2_v(icol, ilev + 1) * dp_v(icol, ilev) +
+                    fin2_v(icol, ilev) * dp_v(icol, ilev + 1)) /
+                   (dp_v(icol, ilev) + dp_v(icol, ilev + 1)) : fin2_v(icol, nlevs-1);
+        auto fa0 = (ilev > 0 ) ? (fin2_v(icol, ilev) * dp_v(icol, ilev - 1) +
+                    fin2_v(icol, ilev - 1) * dp_v(icol, ilev)) /
+                   (dp_v(icol, ilev - 1) + dp_v(icol, ilev)) : fin2_v(icol, 0);
+        diag1_m_v(icol, ilev) = (fa1 - fa0) / dp_v(icol, ilev);
+      }
+    }
+    diag1_m.sync_to_dev();
+    diag1_m.get_valid_mask().sync_to_dev();
+
+    // Calculate weighted avg through diagnostics
+    dp_vert_derivative->set_required_field(fin2);
+    dp_vert_derivative->set_required_field(dp);
+    dp_vert_derivative->initialize(t0, RunType::Initial);
+    dp_vert_derivative->compute_diagnostic();
+    auto dp_vert_derivative_f = dp_vert_derivative->get_diagnostic();
+
+    // Check diag mask field
+    REQUIRE (dp_vert_derivative_f.has_valid_mask());
+    REQUIRE (views_are_equal(dp_vert_derivative_f.get_valid_mask(),diag1_m_mask));
+
+    // Set diag and manual diag to 0 where mask=0, then compute diff norm
+    dp_vert_derivative_f.deep_copy(0,diag1_m_mask,true);
+    diag1_m.deep_copy(0,diag1_m_mask,true);
+    diag1_m.update(dp_vert_derivative_f,1,-1,diag1_m_mask);
+
+    constexpr auto tol = std::numeric_limits<Real>::epsilon()*1000;
+    REQUIRE_THAT (inf_norm(diag1_m).as<Real>(),Catch::WithinAbs(0,tol));
+  }
+
   // TODO: add SECTION("dz_vert_derivative")
 }
 

--- a/components/eamxx/src/share/diagnostics/vert_derivative.cpp
+++ b/components/eamxx/src/share/diagnostics/vert_derivative.cpp
@@ -64,6 +64,11 @@ void VertDerivativeDiag::initialize_impl(const RunType /*run_type*/) {
   auto d_fid = fid.clone(m_diag_name).reset_units(diag_units);
   m_diagnostic_output = Field(d_fid);
   m_diagnostic_output.allocate_view();
+
+  if (f.has_valid_mask()) {
+    m_diagnostic_output.create_valid_mask();
+    m_diagnostic_output.get_header().set_may_be_filled(true);
+  }
 }
 
 void VertDerivativeDiag::compute_diagnostic_impl() {
@@ -82,14 +87,20 @@ void VertDerivativeDiag::compute_diagnostic_impl() {
   using KT          = KokkosTypes<DefaultDevice>;
   using MT          = typename KT::MemberType;
   using TPF         = ekat::TeamPolicyFactory<typename KT::ExeSpace>;
+  using mview_t     = Field::view_dev_t<int**>;
+  using cmview_t    = Field::view_dev_t<const int**>;
   const int ncols   = f.get_header().get_identifier().get_layout().dim(0);
   const int nlevs   = f.get_header().get_identifier().get_layout().dim(1);
   const auto policy = TPF::get_default_team_policy(ncols, nlevs);
 
   auto d_v = (m_derivative_method == "z") ? get_field_in("dz").get_view<Real **>() : dp2d;
 
-  Kokkos::parallel_for(
-      "Compute df / denominator for " + m_diagnostic_output.name(), policy,
+  bool masked = m_diagnostic_output.has_valid_mask();
+  auto d_mask = masked ? m_diagnostic_output.get_valid_mask().get_view<int**>() : mview_t{};
+  auto f_mask = masked ? f.get_valid_mask().get_view<const int**>() : cmview_t{};
+  int last_lev = nlevs-1;
+  constexpr auto fv = constants::fill_value<Real>;
+  Kokkos::parallel_for("Compute df / denominator for " + m_diagnostic_output.name(),policy,
       KOKKOS_LAMBDA(const MT &team) {
         const int icol = team.league_rank();
         auto f_icol    = ekat::subview(f2d, icol); // field at midpoint
@@ -103,19 +114,30 @@ void VertDerivativeDiag::compute_diagnostic_impl() {
           // if dp(k) << dp(k+1), the interface is closer to fm(k) than fm(k+1)
           // boundary points: assume constant extrapolation (i.e., f_int(0)=f_mid(0))
 
-          auto f_int_kp1 =
-              (ilev < nlevs - 1)
-                  ? (f_icol(ilev + 1) * dpicol(ilev) + f_icol(ilev) * dpicol(ilev + 1)) /
-                        (dpicol(ilev) + dpicol(ilev + 1))
-                  : f_icol(nlevs - 1);
+          if (masked) {
+            d_mask(icol,ilev) = f_mask(icol,ilev) *
+                                (ilev<last_lev ? f_mask(icol,ilev+1) : 1) *
+                                (ilev>0 ? f_mask(icol,ilev-1) : 1);
+          }
 
-          auto f_int_kp0 =
-              (ilev > 0) 
-                  ? (f_icol(ilev) * dpicol(ilev - 1) + f_icol(ilev - 1) * dpicol(ilev)) /
-                         (dpicol(ilev - 1) + dpicol(ilev))
-                  : f_icol(0);
+          if (not masked or d_mask(icol,ilev)!=0) {
+            auto f_int_kp1 =
+                (ilev < nlevs - 1)
+                    ? (f_icol(ilev + 1) * dpicol(ilev) + f_icol(ilev) * dpicol(ilev + 1)) /
+                          (dpicol(ilev) + dpicol(ilev + 1))
+                    : f_icol(nlevs - 1);
 
-          o_icol(ilev) = (f_int_kp1 - f_int_kp0) / d_icol(ilev);
+            auto f_int_kp0 =
+                (ilev > 0) 
+                    ? (f_icol(ilev) * dpicol(ilev - 1) + f_icol(ilev - 1) * dpicol(ilev)) /
+                           (dpicol(ilev - 1) + dpicol(ilev))
+                    : f_icol(0);
+
+            o_icol(ilev) = (f_int_kp1 - f_int_kp0) / d_icol(ilev);
+          } else {
+            // Remove this when IO solely relies on mask fields
+            o_icol(ilev) = fv;
+          }
         });
       });
 }

--- a/components/eamxx/src/share/diagnostics/zonal_avg.cpp
+++ b/components/eamxx/src/share/diagnostics/zonal_avg.cpp
@@ -1,4 +1,7 @@
 #include "zonal_avg.hpp"
+
+#include "share/field/field_utils.hpp"
+
 #include <ekat_math_utils.hpp>
 #include <ekat_team_policy_utils.hpp>
 
@@ -13,7 +16,8 @@ namespace scream {
 // - the first dimension for result and bin_to_cols is for the zonal bins (CMP,"bin")
 // - field and result must be the same dimension, up to 3
 void compute_zonal_sum(const Field &result, const Field &field, const Field &weight,
-                        const Field &bin_to_cols, const ekat::Comm *comm) {
+                       const Field &bin_to_cols, const ekat::Comm *comm)
+{
   auto result_layout = result.get_header().get_identifier().get_layout();
   auto bin_to_cols_layout = bin_to_cols.get_header().get_identifier().get_layout();
   const int num_zonal_bins = bin_to_cols_layout.dim(0);
@@ -25,11 +29,17 @@ void compute_zonal_sum(const Field &result, const Field &field, const Field &wei
   using TeamPolicy = Kokkos::TeamPolicy<Field::device_t::execution_space>;
   using TeamMember = typename TeamPolicy::member_type;
   using TPF        = ekat::TeamPolicyFactory<typename KT::ExeSpace>;
+  using cmask1d_t = Field::view_dev_t<const int*>;
+  using cmask2d_t = Field::view_dev_t<const int**>;
+  using cmask3d_t = Field::view_dev_t<const int***>;
+
+  bool masked = field.has_valid_mask();
   switch (result_layout.rank()) {
   case 1: {
     auto field_view        = field.get_view<const Real *>();
     auto result_view       = result.get_view<Real *>();
     TeamPolicy team_policy = TPF::get_default_team_policy(num_zonal_bins, max_ncols_per_bin);
+    auto mask_view = masked ? field.get_valid_mask().get_view<const int*>() : cmask1d_t{};
     Kokkos::parallel_for(
         "compute_zonal_sum_" + field.name(), team_policy,
         KOKKOS_LAMBDA(const TeamMember &tm) {
@@ -38,7 +48,8 @@ void compute_zonal_sum(const Field &result, const Field &field, const Field &wei
               Kokkos::TeamVectorRange(tm, 1, 1+bin_to_cols_view(bin_i,0)),
               [&](int lcol_j, Real &val) {
                 const int col_i = bin_to_cols_view(bin_i, lcol_j);
-                val += weight_view(col_i) * field_view(col_i);
+                if (not masked or mask_view(col_i)!=0)
+                  val += weight_view(col_i) * field_view(col_i);
               },
               result_view(bin_i));
         });
@@ -48,6 +59,7 @@ void compute_zonal_sum(const Field &result, const Field &field, const Field &wei
     auto field_view        = field.get_view<const Real **>();
     auto result_view       = result.get_view<Real **>();
     TeamPolicy team_policy = TPF::get_default_team_policy(num_zonal_bins * d1, max_ncols_per_bin);
+    auto mask_view = masked ? field.get_valid_mask().get_view<const int**>() : cmask2d_t{};
     Kokkos::parallel_for(
         "compute_zonal_sum_" + field.name(), team_policy,
         KOKKOS_LAMBDA(const TeamMember &tm) {
@@ -58,7 +70,8 @@ void compute_zonal_sum(const Field &result, const Field &field, const Field &wei
               Kokkos::TeamVectorRange(tm, 1, 1+bin_to_cols_view(bin_i,0)),
               [&](int lcol_j, Real &val) {
                 const int col_i = bin_to_cols_view(bin_i, lcol_j);
-                val += weight_view(col_i) * field_view(col_i, d1_i);
+                if (not masked or mask_view(col_i,d1_i)!=0)
+                  val += weight_view(col_i) * field_view(col_i, d1_i);
               },
               result_view(bin_i, d1_i));
         });
@@ -69,6 +82,7 @@ void compute_zonal_sum(const Field &result, const Field &field, const Field &wei
     auto field_view        = field.get_view<const Real ***>();
     auto result_view       = result.get_view<Real ***>();
     TeamPolicy team_policy = TPF::get_default_team_policy(num_zonal_bins * d1 * d2, max_ncols_per_bin);
+    auto mask_view = masked ? field.get_valid_mask().get_view<const int***>() : cmask3d_t{};
     Kokkos::parallel_for(
         "compute_zonal_sum_" + field.name(), team_policy, KOKKOS_LAMBDA(const TeamMember &tm) {
           const int idx        = tm.league_rank();
@@ -80,7 +94,8 @@ void compute_zonal_sum(const Field &result, const Field &field, const Field &wei
               Kokkos::TeamVectorRange(tm, 1, 1+bin_to_cols_view(bin_i,0)),
               [&](int lcol_j, Real &val) {
                 const int col_i = bin_to_cols_view(bin_i, lcol_j);
-                val += weight_view(col_i) * field_view(col_i, d1_i, d2_i);
+                if (not masked or mask_view(col_i,d1_i, d2_i)!=0)
+                  val += weight_view(col_i) * field_view(col_i, d1_i, d2_i);
               },
               result_view(bin_i, d1_i, d2_i));
         });
@@ -116,17 +131,20 @@ void ZonalAvgDiag::create_requests() {
   add_field<Required>(field_name, grid_name);
   const GridsManager::grid_ptr_type grid = m_grids_manager->get_grid(grid_name);
   m_lat                                  = grid->get_geometry_data("lat");
-  // area will be scaled in initialize_impl
-  m_scaled_area = grid->get_geometry_data("area").clone();
+
+  // Area will be used as weight in the zonal sum
+  m_area = grid->get_geometry_data("area");
 }
 
-void ZonalAvgDiag::initialize_impl(const RunType /*run_type*/) {
+void ZonalAvgDiag::initialize_impl(const RunType /*run_type*/)
+{
   using FieldIdentifier = FieldHeader::identifier_type;
   using FieldLayout     = FieldIdentifier::layout_type;
   using ShortFieldTagsNames::COL, ShortFieldTagsNames::CMP, ShortFieldTagsNames::LEV;
   const Field &field              = get_fields_in().front();
   const FieldIdentifier &field_id = field.get_header().get_identifier();
   const FieldLayout &field_layout = field_id.get_layout();
+  const auto grid_name = field_id.get_grid_name();
 
   EKAT_REQUIRE_MSG(field_layout.rank() >= 1 && field_layout.rank() <= 3,
                    "Error! Field rank not supported by ZonalAvgDiag.\n"
@@ -144,17 +162,11 @@ void ZonalAvgDiag::initialize_impl(const RunType /*run_type*/) {
                        " - field layout: " +
                        field_layout.to_string() + "\n");
 
-  FieldLayout diagnostic_layout =
-      field_layout.clone().strip_dim(COL).prepend_dim(CMP, m_num_zonal_bins, "bin");
-  auto diagnostic_id = field_id.clone(m_diag_name).reset_layout(diagnostic_layout);
-  m_diagnostic_output = Field(diagnostic_id);
-  m_diagnostic_output.allocate_view();
+  FieldLayout bins_layout({CMP}, {m_num_zonal_bins}, {"bin"});
 
   // allocate column counter
-  FieldLayout ncols_per_bin_layout({CMP}, {m_num_zonal_bins}, {"bin"});
   FieldIdentifier ncols_per_bin_id("number of columns per bin",
-    ncols_per_bin_layout, ekat::units::none,
-    field_id.get_grid_name(), DataType::IntType);
+      bins_layout, ekat::units::none, grid_name, DataType::IntType);
   Field ncols_per_bin(ncols_per_bin_id);
   ncols_per_bin.allocate_view();
   ncols_per_bin.deep_copy(0);
@@ -192,10 +204,9 @@ void ZonalAvgDiag::initialize_impl(const RunType /*run_type*/) {
         val = ncols_per_bin_view(bin_i) > val ? ncols_per_bin_view(bin_i) : val;
       },
       Kokkos::Max<Int>(max_ncols_per_bin));
-  FieldLayout bin_to_cols_layout = ncols_per_bin_layout.append_dim(COL, 1+max_ncols_per_bin);
+  FieldLayout bin_to_cols_layout = bins_layout.clone().append_dim(COL, 1+max_ncols_per_bin);
   FieldIdentifier bin_to_cols_id("columns in each zonal bin",
-    bin_to_cols_layout, ekat::units::none,
-    field_id.get_grid_name(), DataType::IntType);
+    bin_to_cols_layout, ekat::units::none, grid_name , DataType::IntType);
   m_bin_to_cols = Field(bin_to_cols_id);
   m_bin_to_cols.allocate_view();
 
@@ -219,36 +230,62 @@ void ZonalAvgDiag::initialize_impl(const RunType /*run_type*/) {
         }
       });
 
-  // allocate zonal area
-  const FieldIdentifier &area_id = m_scaled_area.get_header().get_identifier();
-  FieldLayout zonal_area_layout({CMP}, {m_num_zonal_bins}, {"bin"});
-  auto zonal_area_id = area_id.clone("zonal area").reset_layout(zonal_area_layout);
-  Field zonal_area(zonal_area_id);
-  zonal_area.allocate_view();
+  // Create the diagnostic
+  auto diagnostic_layout = field_layout.clone().strip_dim(COL).prepend_dim(CMP, m_num_zonal_bins, "bin");
+  auto diagnostic_id = field_id.clone(m_diag_name).reset_layout(diagnostic_layout);
+  m_diagnostic_output = Field(diagnostic_id,true);
 
-  // compute zonal area
-  auto ones = m_scaled_area.clone("ones");
-  ones.deep_copy(1.0);
-  compute_zonal_sum(zonal_area, m_scaled_area, ones, m_bin_to_cols, &m_comm);
+  if (not field.has_valid_mask()) {
+    m_ones = m_area.clone("ones");
+    m_ones.deep_copy(1);
+    // It's not nondimensional, but we're just using it as a scaling factor field
+    FieldIdentifier zonal_area_fid ("zonal area",bins_layout,ekat::units::none,grid_name);
+    m_zonal_area = Field(zonal_area_fid,true);
+    compute_zonal_sum(m_zonal_area,m_ones,m_area,m_bin_to_cols,&m_comm);
 
-  // scale area by 1 / zonal area
-  auto zonal_area_view  = zonal_area.get_view<const Real *>();
-  auto scaled_area_view = m_scaled_area.get_view<Real *>();
-  Kokkos::parallel_for("scale_area_by_zonal_area_" + field.name(),
-      team_policy, KOKKOS_LAMBDA(const TeamMember &tm) {
-        const int bin_i = tm.league_rank();
-        Kokkos::parallel_for(
-          Kokkos::TeamVectorRange(tm, 1, 1+bin_to_cols_view(bin_i,0)),
-            [&](int lcol_j) {
-              const int col_i = bin_to_cols_view(bin_i, lcol_j);
-              scaled_area_view(col_i) /= zonal_area_view(bin_i);
-            });
-      });
+    // Create a copy of area which is scaled by 1 / zonal area
+    m_scaled_area = m_area.clone("scaled_area");
+    auto zonal_area_view  = m_zonal_area.get_view<const Real *>();
+    auto scaled_area_view = m_scaled_area.get_view<Real *>();
+    Kokkos::parallel_for("scale_area_by_zonal_area_" + field.name(),
+        team_policy, KOKKOS_LAMBDA(const TeamMember &tm) {
+          const int bin_i = tm.league_rank();
+          Kokkos::parallel_for(
+            Kokkos::TeamVectorRange(tm, 1, 1+bin_to_cols_view(bin_i,0)),
+              [&](int lcol_j) {
+                const int col_i = bin_to_cols_view(bin_i, lcol_j);
+                scaled_area_view(col_i) /= zonal_area_view(bin_i);
+              });
+        });
+  } else {
+    m_ones = field.clone("ones");
+    m_ones.deep_copy(1);
+    m_ones.set_valid_mask(field.get_valid_mask());
+    m_zonal_area = m_diagnostic_output.clone("zonal_area");
+    m_diagnostic_output.create_valid_mask();
+    m_diagnostic_output.get_header().set_may_be_filled(true);
+  }
 }
 
-void ZonalAvgDiag::compute_diagnostic_impl() {
+void ZonalAvgDiag::compute_diagnostic_impl()
+{
   const auto &field = get_fields_in().front();
-  compute_zonal_sum(m_diagnostic_output, field, m_scaled_area, m_bin_to_cols, &m_comm);
+
+  if (field.has_valid_mask()) {
+    // Compute masked field zonal sum, masked area zonal sum, and divide
+    compute_zonal_sum(m_diagnostic_output, field, m_area, m_bin_to_cols, &m_comm);
+    compute_zonal_sum(m_zonal_area,m_ones,m_area,m_bin_to_cols,&m_comm);
+
+    auto& dmask = m_diagnostic_output.get_valid_mask();
+    compute_mask(m_zonal_area,0,Comparison::NE,dmask);
+    m_diagnostic_output.scale_inv(m_zonal_area,dmask);
+
+    // TODO: remove when IO stops relying on mask=0 entries being already set to FillValue
+    m_diagnostic_output.deep_copy(constants::fill_value<Real>,dmask,true);
+  } else {
+    // Compute field zonal sum using scaled area as weight
+    compute_zonal_sum(m_diagnostic_output, field, m_scaled_area, m_bin_to_cols, &m_comm);
+  }
 }
 
 } // namespace scream

--- a/components/eamxx/src/share/diagnostics/zonal_avg.hpp
+++ b/components/eamxx/src/share/diagnostics/zonal_avg.hpp
@@ -38,9 +38,17 @@ protected:
   int m_num_zonal_bins;
 
   Field m_lat;
-  Field m_scaled_area;
   Field m_bin_to_cols;
 
+  // Weight field if input is NOT masked
+  Field m_scaled_area;
+
+  // Weight field if input IS masked
+  Field m_area;
+
+  // Fields used to compute masked area zonal sum at runtime if field is masked
+  Field m_zonal_area;
+  Field m_ones;
 };
 
 } // namespace scream

--- a/components/eamxx/src/share/remap/vertical_remapper.cpp
+++ b/components/eamxx/src/share/remap/vertical_remapper.cpp
@@ -223,16 +223,18 @@ registration_ends_impl ()
       }
     } else {
       // If a field does not have any vertical tag (LEV, ILEV, or LEVP) it may still have
-      // fill_value tracking assigned from somewhere else.
+      // a mask assigned from somewhere else.
       // For instance, this could be a 2d field computed by FieldAtPressureLevel diagnostic.
-      // In those cases we want to copy that fill_value tracking to the target field.
+      // In those cases we want to copy that mask to the target field.
       if (src.has_valid_mask()) {
         EKAT_REQUIRE_MSG(not tgt.has_valid_mask(),
             "[VerticalRemapper::registration_ends_impl] Error! Target field already has mask data assigned.\n"
             " - tgt field name: " + tgt.name() + "\n");
         auto src_mask = src.get_valid_mask();
-        tgt.set_valid_mask(src_mask);
+        tgt.set_valid_mask(src_mask.alias(src_mask.name(),m_tgt_grid->name()));
       }
+
+      // TODO: remove when we get rid of fill-aware Field manipulation methods
       if (src.get_header().may_be_filled()) {
         tgt.get_header().set_may_be_filled(true);
       }


### PR DESCRIPTION
Propagate mask fields to all generic diagnostics.

[BFB]

---

Notes:
- by "generic", here I mean diagnostics that accept a generic field as input (such as contractions, FieldAt<Level|Height|PressureLevel> etc).
- I still need to add unit tests for some of the diags (I will ask Claudio to do it).
- I modified a bit FieldPrevDiag: all calculations are done during `init_timestep` (the method `compute_diagnostic` is empty). Hence, also the member `m_f_prev` becomes pointless.
- this PR needs to wait for #8302 to be merged (it uses the additive scalar feature to simplify a tiny bit the bin ops diag). I cherry picked the commits in that PR just to get the code to compile, I will rebase when it's merged to keep the history clean.
- I am not sure how to propagate the mask in the Histogram/ZonalAvg diagnostics. We should prob have a threshold (like we do in avg cnt in IO) that sets an entry to invalid if not enough valid values were used in the histogram or average. But there's no way to request that via the simple `my_field_zonal_avg` string-based way we use in our yaml files. We may consider removing mask handling and simply error out if the input has a valid mask field, to prevent getting unexpected results.

I'm not sure if this would close #8161, but I'm going to at least tag it for xref...

