### PR TITLE
Fix the bug in Nr conservation subroutine in EAMxx

### DIFF
--- a/components/eamxx/src/physics/p3/impl/p3_back_to_cell_average_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_back_to_cell_average_impl.hpp
@@ -18,10 +18,7 @@ void Functions<S,D>
   const Pack& cld_frac_l, const Pack& cld_frac_r,
   const Pack& cld_frac_i, Pack& qc2qr_accret_tend, Pack& qr2qv_evap_tend,
   Pack& qc2qr_autoconv_tend, Pack& nc_accret_tend, Pack& nc_selfcollect_tend,
-//[shanyp 20260220
-//  Pack& nc2nr_autoconv_tend, Pack& nr_selfcollect_tend, Pack& nr_evap_tend,
   Pack& nc2nr_autoconv_tend, Pack& nr_selfcollect_tend, Pack& nr_breakup_tend, Pack& nr_evap_tend,
-//shanyp 20260220]
   Pack& ncautr,
   Pack& qi2qv_sublim_tend, Pack& nr_ice_shed_tend, Pack& qc2qi_hetero_freeze_tend,
   Pack& qr2qi_collect_tend, Pack& qc2qr_ice_shed_tend, Pack& qi2qr_melt_tend,
@@ -52,9 +49,7 @@ void Functions<S,D>
   nc_selfcollect_tend.set(context, nc_selfcollect_tend * cld_frac_l);    // Self collection occurs locally in liq. cloud
   nc2nr_autoconv_tend.set(context, nc2nr_autoconv_tend * cld_frac_l);   // Impact of autoconversion on number
   nr_selfcollect_tend.set(context, nr_selfcollect_tend * cld_frac_r);    // Self collection occurs locally in rain cloud
-//[shanyp 20260220
   nr_breakup_tend.set(context, nr_breakup_tend * cld_frac_r);    // Breakup occurs locally in rain cloud
-//shanyp 20260220]
   nr_evap_tend.set(context, nr_evap_tend * cld_frac_r);    // Change in rain number due to evaporation
   ncautr.set(context, ncautr * lr_cldm); // Autoconversion of rain drops within rain/liq cloud
 

--- a/components/eamxx/src/physics/p3/impl/p3_back_to_cell_average_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_back_to_cell_average_impl.hpp
@@ -18,7 +18,10 @@ void Functions<S,D>
   const Pack& cld_frac_l, const Pack& cld_frac_r,
   const Pack& cld_frac_i, Pack& qc2qr_accret_tend, Pack& qr2qv_evap_tend,
   Pack& qc2qr_autoconv_tend, Pack& nc_accret_tend, Pack& nc_selfcollect_tend,
-  Pack& nc2nr_autoconv_tend, Pack& nr_selfcollect_tend, Pack& nr_evap_tend,
+//[shanyp 20260220
+//  Pack& nc2nr_autoconv_tend, Pack& nr_selfcollect_tend, Pack& nr_evap_tend,
+  Pack& nc2nr_autoconv_tend, Pack& nr_selfcollect_tend, Pack& nr_breakup_tend, Pack& nr_evap_tend,
+//shanyp 20260220]
   Pack& ncautr,
   Pack& qi2qv_sublim_tend, Pack& nr_ice_shed_tend, Pack& qc2qi_hetero_freeze_tend,
   Pack& qr2qi_collect_tend, Pack& qc2qr_ice_shed_tend, Pack& qi2qr_melt_tend,
@@ -49,6 +52,9 @@ void Functions<S,D>
   nc_selfcollect_tend.set(context, nc_selfcollect_tend * cld_frac_l);    // Self collection occurs locally in liq. cloud
   nc2nr_autoconv_tend.set(context, nc2nr_autoconv_tend * cld_frac_l);   // Impact of autoconversion on number
   nr_selfcollect_tend.set(context, nr_selfcollect_tend * cld_frac_r);    // Self collection occurs locally in rain cloud
+//[shanyp 20260220
+  nr_breakup_tend.set(context, nr_breakup_tend * cld_frac_r);    // Breakup occurs locally in rain cloud
+//shanyp 20260220]
   nr_evap_tend.set(context, nr_evap_tend * cld_frac_r);    // Change in rain number due to evaporation
   ncautr.set(context, ncautr * lr_cldm); // Autoconversion of rain drops within rain/liq cloud
 

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl_part2.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl_part2.hpp
@@ -156,6 +156,9 @@ void Functions<S,D>
       nc_selfcollect_tend   (0), // change in cloud droplet number from self-collection  (Not in paper?)
       nc2nr_autoconv_tend  (0), // change in cloud droplet number from autoconversion
       nr_selfcollect_tend   (0), // change in rain number from self-collection  (Not in paper?)
+//[shanyp 20260220
+      nr_breakup_tend (0), // change in rain number from breakup  (Not in paper?)
+//shanyp 20260220]
       nr_evap_tend   (0), // change in rain number from evaporation
       ncautr  (0), // change in rain number from autoconversion of cloud water
 
@@ -422,13 +425,19 @@ void Functions<S,D>
     // (breakup following modified Verlinde and Cotton scheme)
     rain_self_collection(
       rho(k), qr_incld(k), nr_incld(k),
-      nr_selfcollect_tend, runtime_options, not_skip_all);
+//[shanyp 20260220
+//      nr_selfcollect_tend, runtime_options, not_skip_all);
+      nr_selfcollect_tend, nr_breakup_tend, runtime_options, not_skip_all);
+//shanyp 20260220]
 
     // Here we map the microphysics tendency rates back to CELL-AVERAGE quantities for updating
     // cell-average quantities.
     back_to_cell_average(
       cld_frac_l(k), cld_frac_r(k), cld_frac_i(k), qc2qr_accret_tend, qr2qv_evap_tend, qc2qr_autoconv_tend,
-      nc_accret_tend, nc_selfcollect_tend, nc2nr_autoconv_tend, nr_selfcollect_tend, nr_evap_tend, ncautr, qi2qv_sublim_tend, nr_ice_shed_tend, qc2qi_hetero_freeze_tend,
+//[shanyp 20260220
+//      nc_accret_tend, nc_selfcollect_tend, nc2nr_autoconv_tend, nr_selfcollect_tend, nr_evap_tend, ncautr, qi2qv_sublim_tend, nr_ice_shed_tend, qc2qi_hetero_freeze_tend,
+      nc_accret_tend, nc_selfcollect_tend, nc2nr_autoconv_tend, nr_selfcollect_tend, nr_breakup_tend, nr_evap_tend, ncautr, qi2qv_sublim_tend, nr_ice_shed_tend, qc2qi_hetero_freeze_tend,
+//shanyp 20260220]
       qr2qi_collect_tend, qc2qr_ice_shed_tend, qi2qr_melt_tend, qc2qi_collect_tend, qr2qi_immers_freeze_tend, ni2nr_melt_tend, nc_collect_tend,
       ncshdc, nc2ni_immers_freeze_tend, nr_collect_tend, ni_selfcollect_tend,
       qv2qi_vapdep_tend, nr2ni_immers_freeze_tend, ni_sublim_tend, qv2qi_nucleat_tend, ni_nucleat_tend, qc2qi_berg_tend, 
@@ -471,7 +480,10 @@ void Functions<S,D>
     nc_conservation(nc(k), nc_selfcollect_tend, dt, nc_collect_tend, nc2ni_immers_freeze_tend,
                     nc_accret_tend, nc2nr_autoconv_tend, ncheti_cnt, nicnt, use_hetfrz_classnuc, not_skip_all);
     nr_conservation(nr(k),ni2nr_melt_tend,nr_ice_shed_tend,ncshdc,nc2nr_autoconv_tend,dt,nmltratio,nr_collect_tend,
-                    nr2ni_immers_freeze_tend,nr_selfcollect_tend,nr_evap_tend, not_skip_all);
+//[shanyp 20260401
+//		    nr2ni_immers_freeze_tend,nr_selfcollect_tend,nr_evap_tend, not_skip_all);
+                  nr2ni_immers_freeze_tend,nr_selfcollect_tend,nr_breakup_tend,nr_evap_tend, not_skip_all);
+//shanyp 20260401]
     ni_conservation(ni(k),ni_nucleat_tend,nr2ni_immers_freeze_tend,nc2ni_immers_freeze_tend, ncheti_cnt, nicnt, ninuc_cnt, dt,ni2nr_melt_tend,
                     ni_sublim_tend,ni_selfcollect_tend, use_hetfrz_classnuc, not_skip_all);
 
@@ -497,7 +509,10 @@ void Functions<S,D>
 
     //-- warm-phase only processes:
     update_prognostic_liquid(
-      qc2qr_accret_tend, nc_accret_tend, qc2qr_autoconv_tend, nc2nr_autoconv_tend, ncautr, nc_selfcollect_tend, qr2qv_evap_tend, nr_evap_tend, nr_selfcollect_tend,
+//[shanyp 20260401
+//      qc2qr_accret_tend, nc_accret_tend, qc2qr_autoconv_tend, nc2nr_autoconv_tend, ncautr, nc_selfcollect_tend, qr2qv_evap_tend, nr_evap_tend, nr_selfcollect_tend,
+      qc2qr_accret_tend, nc_accret_tend, qc2qr_autoconv_tend, nc2nr_autoconv_tend, ncautr, nc_selfcollect_tend, qr2qv_evap_tend, nr_evap_tend, nr_selfcollect_tend, nr_breakup_tend,
+//shanyp 20260401]
       predictNc, do_prescribed_CCN, inv_rho(k), inv_exner(k), dt, th_atm(k), qv(k), qc(k), nc(k),
       qr(k), nr(k), not_skip_all);
 

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl_part2.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl_part2.hpp
@@ -156,9 +156,7 @@ void Functions<S,D>
       nc_selfcollect_tend   (0), // change in cloud droplet number from self-collection  (Not in paper?)
       nc2nr_autoconv_tend  (0), // change in cloud droplet number from autoconversion
       nr_selfcollect_tend   (0), // change in rain number from self-collection  (Not in paper?)
-//[shanyp 20260220
       nr_breakup_tend (0), // change in rain number from breakup  (Not in paper?)
-//shanyp 20260220]
       nr_evap_tend   (0), // change in rain number from evaporation
       ncautr  (0), // change in rain number from autoconversion of cloud water
 
@@ -425,19 +423,13 @@ void Functions<S,D>
     // (breakup following modified Verlinde and Cotton scheme)
     rain_self_collection(
       rho(k), qr_incld(k), nr_incld(k),
-//[shanyp 20260220
-//      nr_selfcollect_tend, runtime_options, not_skip_all);
       nr_selfcollect_tend, nr_breakup_tend, runtime_options, not_skip_all);
-//shanyp 20260220]
 
     // Here we map the microphysics tendency rates back to CELL-AVERAGE quantities for updating
     // cell-average quantities.
     back_to_cell_average(
       cld_frac_l(k), cld_frac_r(k), cld_frac_i(k), qc2qr_accret_tend, qr2qv_evap_tend, qc2qr_autoconv_tend,
-//[shanyp 20260220
-//      nc_accret_tend, nc_selfcollect_tend, nc2nr_autoconv_tend, nr_selfcollect_tend, nr_evap_tend, ncautr, qi2qv_sublim_tend, nr_ice_shed_tend, qc2qi_hetero_freeze_tend,
       nc_accret_tend, nc_selfcollect_tend, nc2nr_autoconv_tend, nr_selfcollect_tend, nr_breakup_tend, nr_evap_tend, ncautr, qi2qv_sublim_tend, nr_ice_shed_tend, qc2qi_hetero_freeze_tend,
-//shanyp 20260220]
       qr2qi_collect_tend, qc2qr_ice_shed_tend, qi2qr_melt_tend, qc2qi_collect_tend, qr2qi_immers_freeze_tend, ni2nr_melt_tend, nc_collect_tend,
       ncshdc, nc2ni_immers_freeze_tend, nr_collect_tend, ni_selfcollect_tend,
       qv2qi_vapdep_tend, nr2ni_immers_freeze_tend, ni_sublim_tend, qv2qi_nucleat_tend, ni_nucleat_tend, qc2qi_berg_tend, 
@@ -480,10 +472,7 @@ void Functions<S,D>
     nc_conservation(nc(k), nc_selfcollect_tend, dt, nc_collect_tend, nc2ni_immers_freeze_tend,
                     nc_accret_tend, nc2nr_autoconv_tend, ncheti_cnt, nicnt, use_hetfrz_classnuc, not_skip_all);
     nr_conservation(nr(k),ni2nr_melt_tend,nr_ice_shed_tend,ncshdc,nc2nr_autoconv_tend,dt,nmltratio,nr_collect_tend,
-//[shanyp 20260401
-//		    nr2ni_immers_freeze_tend,nr_selfcollect_tend,nr_evap_tend, not_skip_all);
                   nr2ni_immers_freeze_tend,nr_selfcollect_tend,nr_breakup_tend,nr_evap_tend, not_skip_all);
-//shanyp 20260401]
     ni_conservation(ni(k),ni_nucleat_tend,nr2ni_immers_freeze_tend,nc2ni_immers_freeze_tend, ncheti_cnt, nicnt, ninuc_cnt, dt,ni2nr_melt_tend,
                     ni_sublim_tend,ni_selfcollect_tend, use_hetfrz_classnuc, not_skip_all);
 
@@ -509,10 +498,7 @@ void Functions<S,D>
 
     //-- warm-phase only processes:
     update_prognostic_liquid(
-//[shanyp 20260401
-//      qc2qr_accret_tend, nc_accret_tend, qc2qr_autoconv_tend, nc2nr_autoconv_tend, ncautr, nc_selfcollect_tend, qr2qv_evap_tend, nr_evap_tend, nr_selfcollect_tend,
       qc2qr_accret_tend, nc_accret_tend, qc2qr_autoconv_tend, nc2nr_autoconv_tend, ncautr, nc_selfcollect_tend, qr2qv_evap_tend, nr_evap_tend, nr_selfcollect_tend, nr_breakup_tend,
-//shanyp 20260401]
       predictNc, do_prescribed_CCN, inv_rho(k), inv_exner(k), dt, th_atm(k), qv(k), qc(k), nc(k),
       qr(k), nr(k), not_skip_all);
 

--- a/components/eamxx/src/physics/p3/impl/p3_nr_conservation_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_nr_conservation_impl.hpp
@@ -13,10 +13,16 @@ namespace p3 {
 
 template<typename S, typename D>
 KOKKOS_FUNCTION
-void Functions<S,D>::nr_conservation(const Pack& nr, const Pack& ni2nr_melt_tend, const Pack& nr_ice_shed_tend, const Pack& ncshdc, const Pack& nc2nr_autoconv_tend, const Real& dt, const Real& nmltratio, Pack& nr_collect_tend, Pack& nr2ni_immers_freeze_tend, Pack& nr_selfcollect_tend, Pack& nr_evap_tend, const Mask& context)
+//void Functions<S,D>::nr_conservation(const Pack& nr, const Pack& ni2nr_melt_tend, const Pack& nr_ice_shed_tend, const Pack& ncshdc, const Pack& nc2nr_autoconv_tend, const Real& dt, const Real& nmltratio, Pack& nr_collect_tend, Pack& nr2ni_immers_freeze_tend, Pack& nr_selfcollect_tend, Pack& nr_evap_tend, const Mask& context)
+//[shanyp 20260220
+void Functions<S,D>::nr_conservation(const Pack& nr, const Pack& ni2nr_melt_tend, const Pack& nr_ice_shed_tend, const Pack& ncshdc, const Pack& nc2nr_autoconv_tend, const Real& dt, const Real& nmltratio, Pack& nr_collect_tend, Pack& nr2ni_immers_freeze_tend, Pack& nr_selfcollect_tend, Pack& nr_breakup_tend, Pack& nr_evap_tend, const Mask& context)
+//shanyp 20260220]
 {
   const auto sink_nr = (nr_collect_tend + nr2ni_immers_freeze_tend + nr_selfcollect_tend + nr_evap_tend)*dt;
-  const auto source_nr = nr + (ni2nr_melt_tend*nmltratio + nr_ice_shed_tend + ncshdc + nc2nr_autoconv_tend)*dt;
+//  const auto source_nr = nr + (ni2nr_melt_tend*nmltratio + nr_ice_shed_tend + ncshdc + nc2nr_autoconv_tend)*dt;
+//[shanyp 20260220
+  const auto source_nr = nr + (ni2nr_melt_tend*nmltratio + nr_ice_shed_tend + ncshdc + nc2nr_autoconv_tend + nr_breakup_tend)*dt;
+//shanyp 20260220]
   const auto mask = sink_nr > source_nr && context;
   if (mask.any()) {
     const auto ratio = source_nr/sink_nr;

--- a/components/eamxx/src/physics/p3/impl/p3_nr_conservation_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_nr_conservation_impl.hpp
@@ -14,15 +14,11 @@ namespace p3 {
 template<typename S, typename D>
 KOKKOS_FUNCTION
 //void Functions<S,D>::nr_conservation(const Pack& nr, const Pack& ni2nr_melt_tend, const Pack& nr_ice_shed_tend, const Pack& ncshdc, const Pack& nc2nr_autoconv_tend, const Real& dt, const Real& nmltratio, Pack& nr_collect_tend, Pack& nr2ni_immers_freeze_tend, Pack& nr_selfcollect_tend, Pack& nr_evap_tend, const Mask& context)
-//[shanyp 20260220
 void Functions<S,D>::nr_conservation(const Pack& nr, const Pack& ni2nr_melt_tend, const Pack& nr_ice_shed_tend, const Pack& ncshdc, const Pack& nc2nr_autoconv_tend, const Real& dt, const Real& nmltratio, Pack& nr_collect_tend, Pack& nr2ni_immers_freeze_tend, Pack& nr_selfcollect_tend, Pack& nr_breakup_tend, Pack& nr_evap_tend, const Mask& context)
-//shanyp 20260220]
 {
   const auto sink_nr = (nr_collect_tend + nr2ni_immers_freeze_tend + nr_selfcollect_tend + nr_evap_tend)*dt;
 //  const auto source_nr = nr + (ni2nr_melt_tend*nmltratio + nr_ice_shed_tend + ncshdc + nc2nr_autoconv_tend)*dt;
-//[shanyp 20260220
   const auto source_nr = nr + (ni2nr_melt_tend*nmltratio + nr_ice_shed_tend + ncshdc + nc2nr_autoconv_tend + nr_breakup_tend)*dt;
-//shanyp 20260220]
   const auto mask = sink_nr > source_nr && context;
   if (mask.any()) {
     const auto ratio = source_nr/sink_nr;

--- a/components/eamxx/src/physics/p3/impl/p3_rain_self_collection_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_rain_self_collection_impl.hpp
@@ -11,9 +11,7 @@ KOKKOS_FUNCTION
 void Functions<S,D>
 ::rain_self_collection(
 //  const Pack& rho, const Pack& qr_incld, const Pack& nr_incld, Pack& nr_selfcollect_tend,
-//[shanyp 20260220
   const Pack& rho, const Pack& qr_incld, const Pack& nr_incld, Pack& nr_selfcollect_tend, Pack& nr_breakup_tend,
-//shanyp 20260220]
   const P3Runtime& runtime_options,
   const Mask& context)
 {
@@ -54,14 +52,12 @@ void Functions<S,D>
     nr_selfcollect_tend.set(
         qr_incld_not_small,
         dum * rain_selfcollection_prefactor * nr_incld * qr_incld * rho);
-//[shanyp 20260220
-   auto selfcoll = nr_selfcollect_tend >= 0.;
-   nr_breakup_tend.set(selfcoll, 0.);
+   auto selfcoll = nr_selfcollect_tend >= 0;
+   nr_breakup_tend.set(selfcoll, 0);
 
-   auto breakup = nr_selfcollect_tend < 0.;
-   nr_breakup_tend.set(breakup, nr_selfcollect_tend*(-1.));
-   nr_selfcollect_tend.set(breakup, 0.);
-//shanyp 20260220]
+   auto breakup = nr_selfcollect_tend < 0;
+   nr_breakup_tend.set(breakup, -nr_selfcollect_tend);
+   nr_selfcollect_tend.set(breakup, 0);
   }
 }
 

--- a/components/eamxx/src/physics/p3/impl/p3_rain_self_collection_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_rain_self_collection_impl.hpp
@@ -10,7 +10,10 @@ template<typename S, typename D>
 KOKKOS_FUNCTION
 void Functions<S,D>
 ::rain_self_collection(
-  const Pack& rho, const Pack& qr_incld, const Pack& nr_incld, Pack& nr_selfcollect_tend,
+//  const Pack& rho, const Pack& qr_incld, const Pack& nr_incld, Pack& nr_selfcollect_tend,
+//[shanyp 20260220
+  const Pack& rho, const Pack& qr_incld, const Pack& nr_incld, Pack& nr_selfcollect_tend, Pack& nr_breakup_tend,
+//shanyp 20260220]
   const P3Runtime& runtime_options,
   const Mask& context)
 {
@@ -51,6 +54,14 @@ void Functions<S,D>
     nr_selfcollect_tend.set(
         qr_incld_not_small,
         dum * rain_selfcollection_prefactor * nr_incld * qr_incld * rho);
+//[shanyp 20260220
+   auto selfcoll = nr_selfcollect_tend >= 0.;
+   nr_breakup_tend.set(selfcoll, 0.);
+
+   auto breakup = nr_selfcollect_tend < 0.;
+   nr_breakup_tend.set(breakup, nr_selfcollect_tend*(-1.));
+   nr_selfcollect_tend.set(breakup, 0.);
+//shanyp 20260220]
   }
 }
 

--- a/components/eamxx/src/physics/p3/impl/p3_update_prognostics_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_update_prognostics_impl.hpp
@@ -118,7 +118,10 @@ void Functions<S,D>
 ::update_prognostic_liquid(
   const Pack& qc2qr_accret_tend, const Pack& nc_accret_tend,
   const Pack& qc2qr_autoconv_tend,const Pack& nc2nr_autoconv_tend, const Pack& ncautr,
-  const Pack& nc_selfcollect_tend, const Pack& qr2qv_evap_tend, const Pack& nr_evap_tend, const Pack& nr_selfcollect_tend,
+//  const Pack& nc_selfcollect_tend, const Pack& qr2qv_evap_tend, const Pack& nr_evap_tend, const Pack& nr_selfcollect_tend,
+//[shanyp 20260220
+  const Pack& nc_selfcollect_tend, const Pack& qr2qv_evap_tend, const Pack& nr_evap_tend, const Pack& nr_selfcollect_tend, const Pack& nr_breakup_tend,
+//shanyp 20260220]
   const bool do_predict_nc, const bool do_prescribed_CCN, const Pack& inv_rho, const Pack& inv_exner,
   const Scalar dt, Pack& th_atm, Pack& qv, Pack& qc, Pack& nc, Pack& qr, Pack& nr,
   const Mask& context)
@@ -139,10 +142,16 @@ void Functions<S,D>
   }
 
   if (IPARAM == 1 || IPARAM == 2) {
-    nr.set(context, nr + (sp(0.5) * nc2nr_autoconv_tend - nr_selfcollect_tend - nr_evap_tend) * dt);
+//[shanyp 20260220
+//      nr.set(context, nr + (sp(0.5) * nc2nr_autoconv_tend - nr_selfcollect_tend                   - nr_evap_tend) * dt);
+        nr.set(context, nr + (sp(0.5) * nc2nr_autoconv_tend - nr_selfcollect_tend - nr_breakup_tend - nr_evap_tend) * dt);
+//shanyp 20260220]
   }
   else {
-    nr.set(context, nr + (ncautr - nr_selfcollect_tend - nr_evap_tend) * dt);
+//[shanyp 20260220
+//      nr.set(context, nr + (ncautr - nr_selfcollect_tend                   - nr_evap_tend) * dt);
+        nr.set(context, nr + (ncautr - nr_selfcollect_tend - nr_breakup_tend - nr_evap_tend) * dt);
+//shanyp 20260220]
   }
 
   qv.set(context, qv + qr2qv_evap_tend *dt);

--- a/components/eamxx/src/physics/p3/impl/p3_update_prognostics_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_update_prognostics_impl.hpp
@@ -119,9 +119,7 @@ void Functions<S,D>
   const Pack& qc2qr_accret_tend, const Pack& nc_accret_tend,
   const Pack& qc2qr_autoconv_tend,const Pack& nc2nr_autoconv_tend, const Pack& ncautr,
 //  const Pack& nc_selfcollect_tend, const Pack& qr2qv_evap_tend, const Pack& nr_evap_tend, const Pack& nr_selfcollect_tend,
-//[shanyp 20260220
   const Pack& nc_selfcollect_tend, const Pack& qr2qv_evap_tend, const Pack& nr_evap_tend, const Pack& nr_selfcollect_tend, const Pack& nr_breakup_tend,
-//shanyp 20260220]
   const bool do_predict_nc, const bool do_prescribed_CCN, const Pack& inv_rho, const Pack& inv_exner,
   const Scalar dt, Pack& th_atm, Pack& qv, Pack& qc, Pack& nc, Pack& qr, Pack& nr,
   const Mask& context)
@@ -142,16 +140,10 @@ void Functions<S,D>
   }
 
   if (IPARAM == 1 || IPARAM == 2) {
-//[shanyp 20260220
-//      nr.set(context, nr + (sp(0.5) * nc2nr_autoconv_tend - nr_selfcollect_tend                   - nr_evap_tend) * dt);
         nr.set(context, nr + (sp(0.5) * nc2nr_autoconv_tend - nr_selfcollect_tend - nr_breakup_tend - nr_evap_tend) * dt);
-//shanyp 20260220]
   }
   else {
-//[shanyp 20260220
-//      nr.set(context, nr + (ncautr - nr_selfcollect_tend                   - nr_evap_tend) * dt);
         nr.set(context, nr + (ncautr - nr_selfcollect_tend - nr_breakup_tend - nr_evap_tend) * dt);
-//shanyp 20260220]
   }
 
   qv.set(context, qv + qr2qv_evap_tend *dt);

--- a/components/eamxx/src/physics/p3/p3_functions.hpp
+++ b/components/eamxx/src/physics/p3/p3_functions.hpp
@@ -408,10 +408,7 @@ template <typename ScalarT, typename DeviceT> struct Functions {
       const Pack &cld_frac_l, const Pack &cld_frac_r, const Pack &cld_frac_i,
       Pack &qc2qr_accret_tend, Pack &qr2qv_evap_tend, Pack &qc2qr_autoconv_tend,
       Pack &nc_accret_tend, Pack &nc_selfcollect_tend, Pack &nc2nr_autoconv_tend,
-//[shanyp 20260220
-//      Pack &nr_selfcollect_tend, Pack &nr_evap_tend, Pack &ncautr, Pack &qi2qv_sublim_tend,
       Pack &nr_selfcollect_tend, Pack &nr_breakup_tend, Pack &nr_evap_tend, Pack &ncautr, Pack &qi2qv_sublim_tend,
-//shanyp 20260220]
       Pack &nr_ice_shed_tend, Pack &qc2qi_hetero_freeze_tend, Pack &qr2qi_collect_tend,
       Pack &qc2qr_ice_shed_tend, Pack &qi2qr_melt_tend, Pack &qc2qi_collect_tend,
       Pack &qr2qi_immers_freeze_tend, Pack &ni2nr_melt_tend, Pack &nc_collect_tend,
@@ -733,10 +730,7 @@ template <typename ScalarT, typename DeviceT> struct Functions {
   // Computes rain self collection process rate
   KOKKOS_FUNCTION
   static void rain_self_collection(const Pack &rho, const Pack &qr_incld, const Pack &nr_incld,
-//[shanyp 20260220
-//		  Pack &nr_selfcollect_tend, const P3Runtime &runtime_options,
 		Pack &nr_selfcollect_tend, Pack &nr_breakup_tend, const P3Runtime &runtime_options,
-//shanyp 20260220]
                                    const Mask &context = Mask(true));
 
   // Impose maximum ice number
@@ -859,10 +853,7 @@ template <typename ScalarT, typename DeviceT> struct Functions {
   static void update_prognostic_liquid(
       const Pack &qc2qr_accret_tend, const Pack &nc_accret_tend, const Pack &qc2qr_autoconv_tend,
       const Pack &nc2nr_autoconv_tend, const Pack &ncautr, const Pack &nc_selfcollect_tend,
-//[shanyp 20260220
-//      const Pack &qr2qv_evap_tend, const Pack &nr_evap_tend, const Pack &nr_selfcollect_tend,
       const Pack &qr2qv_evap_tend, const Pack &nr_evap_tend, const Pack &nr_selfcollect_tend, const Pack &nr_breakup_tend,
-//shanyp 20260220]
       const bool do_predict_nc, const bool do_prescribed_CCN, const Pack &inv_rho,
       const Pack &inv_exner, const Scalar dt, Pack &th_atm, Pack &qv, Pack &qc, Pack &nc,
       Pack &qr, Pack &nr, const Mask &context = Mask(true));
@@ -1210,10 +1201,7 @@ template <typename ScalarT, typename DeviceT> struct Functions {
                               const Pack &nr_ice_shed_tend, const Pack &ncshdc,
                               const Pack &nc2nr_autoconv_tend, const Real &dt,
                               const Real &nmltratio, Pack &nr_collect_tend,
-//[shanyp 20260220
-//			      Pack &nr2ni_immers_freeze_tend, Pack &nr_selfcollect_tend,
                               Pack &nr2ni_immers_freeze_tend, Pack &nr_selfcollect_tend, Pack &nr_breakup_tend,
-//shanyp 20260220]
                               Pack &nr_evap_tend, const Mask &context = Mask(true));
 
   KOKKOS_FUNCTION

--- a/components/eamxx/src/physics/p3/p3_functions.hpp
+++ b/components/eamxx/src/physics/p3/p3_functions.hpp
@@ -408,7 +408,10 @@ template <typename ScalarT, typename DeviceT> struct Functions {
       const Pack &cld_frac_l, const Pack &cld_frac_r, const Pack &cld_frac_i,
       Pack &qc2qr_accret_tend, Pack &qr2qv_evap_tend, Pack &qc2qr_autoconv_tend,
       Pack &nc_accret_tend, Pack &nc_selfcollect_tend, Pack &nc2nr_autoconv_tend,
-      Pack &nr_selfcollect_tend, Pack &nr_evap_tend, Pack &ncautr, Pack &qi2qv_sublim_tend,
+//[shanyp 20260220
+//      Pack &nr_selfcollect_tend, Pack &nr_evap_tend, Pack &ncautr, Pack &qi2qv_sublim_tend,
+      Pack &nr_selfcollect_tend, Pack &nr_breakup_tend, Pack &nr_evap_tend, Pack &ncautr, Pack &qi2qv_sublim_tend,
+//shanyp 20260220]
       Pack &nr_ice_shed_tend, Pack &qc2qi_hetero_freeze_tend, Pack &qr2qi_collect_tend,
       Pack &qc2qr_ice_shed_tend, Pack &qi2qr_melt_tend, Pack &qc2qi_collect_tend,
       Pack &qr2qi_immers_freeze_tend, Pack &ni2nr_melt_tend, Pack &nc_collect_tend,
@@ -730,7 +733,10 @@ template <typename ScalarT, typename DeviceT> struct Functions {
   // Computes rain self collection process rate
   KOKKOS_FUNCTION
   static void rain_self_collection(const Pack &rho, const Pack &qr_incld, const Pack &nr_incld,
-                                   Pack &nr_selfcollect_tend, const P3Runtime &runtime_options,
+//[shanyp 20260220
+//		  Pack &nr_selfcollect_tend, const P3Runtime &runtime_options,
+		Pack &nr_selfcollect_tend, Pack &nr_breakup_tend, const P3Runtime &runtime_options,
+//shanyp 20260220]
                                    const Mask &context = Mask(true));
 
   // Impose maximum ice number
@@ -853,7 +859,10 @@ template <typename ScalarT, typename DeviceT> struct Functions {
   static void update_prognostic_liquid(
       const Pack &qc2qr_accret_tend, const Pack &nc_accret_tend, const Pack &qc2qr_autoconv_tend,
       const Pack &nc2nr_autoconv_tend, const Pack &ncautr, const Pack &nc_selfcollect_tend,
-      const Pack &qr2qv_evap_tend, const Pack &nr_evap_tend, const Pack &nr_selfcollect_tend,
+//[shanyp 20260220
+//      const Pack &qr2qv_evap_tend, const Pack &nr_evap_tend, const Pack &nr_selfcollect_tend,
+      const Pack &qr2qv_evap_tend, const Pack &nr_evap_tend, const Pack &nr_selfcollect_tend, const Pack &nr_breakup_tend,
+//shanyp 20260220]
       const bool do_predict_nc, const bool do_prescribed_CCN, const Pack &inv_rho,
       const Pack &inv_exner, const Scalar dt, Pack &th_atm, Pack &qv, Pack &qc, Pack &nc,
       Pack &qr, Pack &nr, const Mask &context = Mask(true));
@@ -1201,7 +1210,10 @@ template <typename ScalarT, typename DeviceT> struct Functions {
                               const Pack &nr_ice_shed_tend, const Pack &ncshdc,
                               const Pack &nc2nr_autoconv_tend, const Real &dt,
                               const Real &nmltratio, Pack &nr_collect_tend,
-                              Pack &nr2ni_immers_freeze_tend, Pack &nr_selfcollect_tend,
+//[shanyp 20260220
+//			      Pack &nr2ni_immers_freeze_tend, Pack &nr_selfcollect_tend,
+                              Pack &nr2ni_immers_freeze_tend, Pack &nr_selfcollect_tend, Pack &nr_breakup_tend,
+//shanyp 20260220]
                               Pack &nr_evap_tend, const Mask &context = Mask(true));
 
   KOKKOS_FUNCTION


### PR DESCRIPTION
Nr bug fix for the P3 in E3SMv3 and EAMxx (identified by Hugh Morrison):
In the raindrop number concentration (Nr) conservation subroutine (this is to prevent negative Nr) :
    A bug was identified in Nr conservation subroutine,  the original term nr_selfcollect_tend represented  changes in Nr by both raindrop self-collection (negative) and breakup (positive). This term was treated as negative previously.
    The fix is that a new term for breakup is introduced so nr_selfcollect_tend only represents self-collection (negative term) only.

[NBFB]