### PR TITLE
EAMxx: tom_sponge_start

### DIFF
--- a/components/homme/src/share/cxx/SimulationParams.hpp
+++ b/components/homme/src/share/cxx/SimulationParams.hpp
@@ -45,6 +45,8 @@ struct SimulationParams
   bool      theta_hydrostatic_mode;   // Only for theta model
   bool      do_3d_turbulence;
 
+  double    tom_sponge_start = 0.0;   // start of TOM sponge layer, in hPa (0 = use ptop)
+
   double    dcmip16_mu;               // Only for theta model
   double    nu;
   double    nu_p;
@@ -108,6 +110,7 @@ inline void SimulationParams::print (std::ostream& out) {
   out << "   disable_diagnostics: " << (disable_diagnostics ? "yes" : "no") << "\n";
   out << "   theta_hydrostatic_mode: " << (theta_hydrostatic_mode ? "yes" : "no") << "\n";
   out << "   do_3d_turbulence: " << (do_3d_turbulence ? "yes" : "no") << "\n";
+  out << "   tom_sponge_start: " << tom_sponge_start << "\n";
   out << "   prescribed_wind: " << (prescribed_wind ? "yes" : "no") << "\n";
   out << "   nsplit: " << nsplit << "\n";
   out << "   scale_factor: " << scale_factor << "\n";

--- a/components/homme/src/theta-l_kokkos/cxx/HyperviscosityFunctorImpl.cpp
+++ b/components/homme/src/theta-l_kokkos/cxx/HyperviscosityFunctorImpl.cpp
@@ -78,6 +78,9 @@ void HyperviscosityFunctorImpl::init_params(const SimulationParams& params)
     m_nu_scale_top = ExecViewManaged<Scalar[NUM_LEV]>("nu_scale_top");
     ExecViewManaged<Scalar[NUM_LEV]>::HostMirror h_nu_scale_top;
     h_nu_scale_top = Kokkos::create_mirror_view(m_nu_scale_top);
+    
+    printf("params.tom_sponge_start = %f\n", params.tom_sponge_start);
+
 
     const auto etai_h = Kokkos::create_mirror_view(m_hvcoord.etai);
     const auto etam_h = Kokkos::create_mirror_view(m_hvcoord.etam);
@@ -103,9 +106,17 @@ void HyperviscosityFunctorImpl::init_params(const SimulationParams& params)
       }else{
           ptop_over_press = 0.0;
       }
-
-      auto val = 16.0*ptop_over_press*ptop_over_press / (ptop_over_press*ptop_over_press + 1);
+      Real val;
+      if (params.tom_sponge_start == 0.0) {
+        val = 16.0*ptop_over_press*ptop_over_press / (ptop_over_press*ptop_over_press + 1);
+      } else if (phys_lev < NUM_PHYSICAL_LEV) {
+        const Real r = (params.tom_sponge_start / 1000.0) / etam_h(ilev)[ivec];
+        val = 0.15 * r * r;
+      } else {
+        val = 0.0;
+      }
       if ( val < 0.15 ) val = 0.0;
+      if ( val > 8.0  ) val = 8.0;
       h_nu_scale_top(ilev)[ivec] = val;
 
       // This is the equivalent of nlev_tom in the F90 code.

--- a/components/homme/src/theta-l_kokkos/cxx/cxx_f90_interface_theta.cpp
+++ b/components/homme/src/theta-l_kokkos/cxx/cxx_f90_interface_theta.cpp
@@ -48,7 +48,7 @@ void init_simulation_params_c (const int& remap_alg, const int& limiter_option, 
                                const int& dt_remap_factor, const int& dt_tracer_factor,
                                const double& scale_factor, const double& laplacian_rigid_factor, const int& nsplit, const int& pgrad_correction,
                                const double& dp3d_thresh, const double& vtheta_thresh, const int& internal_diagnostics_level,
-                               const int& do_3d_turbulence)
+                               const int& do_3d_turbulence, const Real& tom_sponge_start)
 {
 
   // Check that the simulation options are supported. This helps us in the future, since we
@@ -127,6 +127,7 @@ void init_simulation_params_c (const int& remap_alg, const int& limiter_option, 
   params.vtheta_thresh                 = vtheta_thresh;
   params.internal_diagnostics_level    = internal_diagnostics_level;
   params.do_3d_turbulence              = (bool)do_3d_turbulence;
+  params.tom_sponge_start              = tom_sponge_start;
 
   if (time_step_type==5) {
     //5 stage, 3rd order, explicit

--- a/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
+++ b/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
@@ -91,7 +91,8 @@ contains
                               dcmip16_mu, theta_advect_form, test_case,                &
                               MAX_STRING_LEN, dt_remap_factor, dt_tracer_factor,       &
                               pgrad_correction, dp3d_thresh, vtheta_thresh,            &
-                              internal_diagnostics_level, do_3d_turbulence
+                              internal_diagnostics_level, do_3d_turbulence, &
+                              tom_sponge_start
     !
     ! Input(s)
     !
@@ -141,7 +142,8 @@ contains
                                    nsplit,                                                        &
                                    pgrad_correction,                                              &
                                    dp3d_thresh, vtheta_thresh, internal_diagnostics_level,        &
-                                   do_3d_turbulence_int)
+                                   do_3d_turbulence_int, &
+                                   tom_sponge_start)
 
     ! Initialize time level structure in C++
     call init_time_level_c(tl%nm1, tl%n0, tl%np1, tl%nstep, tl%nstep0)

--- a/components/homme/src/theta-l_kokkos/theta_f2c_mod.F90
+++ b/components/homme/src/theta-l_kokkos/theta_f2c_mod.F90
@@ -16,7 +16,8 @@ interface
                                        theta_hydrostatic_mode, test_case_name, dt_remap_factor,      &
                                        dt_tracer_factor, scale_factor, laplacian_rigid_factor,       &
                                        nsplit, pgrad_correction, dp3d_thresh, vtheta_thresh,         &
-                                       internal_diagnostics_level, do_3d_turbulence) bind(c)
+                                       internal_diagnostics_level, do_3d_turbulence, &
+                                       tom_sponge_start) bind(c)
 
     use iso_c_binding, only: c_int, c_double, c_ptr
     !
@@ -31,6 +32,7 @@ interface
     integer(kind=c_int),  intent(in) :: ftype, theta_adv_form
     integer(kind=c_int),  intent(in) :: prescribed_wind, use_moisture, disable_diagnostics, use_cpstar
     integer(kind=c_int),  intent(in) :: theta_hydrostatic_mode, pgrad_correction, do_3d_turbulence
+    real(kind=c_double),  intent(in) :: tom_sponge_start
     type(c_ptr), intent(in) :: test_case_name
   end subroutine init_simulation_params_c
 


### PR DESCRIPTION
PR #8224 added the namelist parameter tom_sponge_start. However, a component involving this parameter was missing. This PR adds the missing equation for tom_sponge_start, based on PR #4723.

While running the ne30 case with L72, we observed that the simulation crashed with an error indicating velocities greater than 400 at the top of the model. Removing the velocity interval check allowed the simulation to run longer; however, it eventually crashed with the error:

```
label: CaarFunctorImpl::run TagPreExchange
time-level 0
lat 1.054217737593061e+00 lon 1.861061130185492e-01
ie 10 igll 1 jgll 3 lev 0: bad dphi
level          dphi          dp3d       vtheta_dp
```
As recommended by @mt5555, using `tom_sponge_start=2.0` makes the simulation stable and resolves this issue.