### PR TITLE
EAMxx: clean up a few units-related issues

### DIFF
--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -1438,7 +1438,7 @@ void AtmosphereDriver::set_initial_conditions ()
 
     using namespace ShortFieldTagsNames;
     const auto& pmask_lt = gll_grid->get_vertical_layout(LEV);
-    const auto nondim = ekat::units::Units::nondimensional();
+    const auto nondim = ekat::units::none;
     FieldIdentifier pmask_fid("lev_mask",pmask_lt,nondim,gll_grid->name(),DataType::IntType);
     Field pressure_mask(pmask_fid,true);
     auto pmask_h = pressure_mask.get_view<int*,Host>();

--- a/components/eamxx/src/control/atmosphere_surface_coupling_exporter.cpp
+++ b/components/eamxx/src/control/atmosphere_surface_coupling_exporter.cpp
@@ -82,8 +82,7 @@ void SurfaceCouplingExporter::create_helper_field (const std::string& name,
                                                    const FieldLayout& layout,
                                                    const std::string& grid_name)
 {
-  using namespace ekat::units;
-  FieldIdentifier id(name,layout,Units::nondimensional(),grid_name);
+  FieldIdentifier id(name,layout,ekat::units::none,grid_name);
 
   // Create the field. Init with NaN's, so we spot instances of uninited memory usage
   Field f(id);

--- a/components/eamxx/src/control/atmosphere_surface_coupling_importer.cpp
+++ b/components/eamxx/src/control/atmosphere_surface_coupling_importer.cpp
@@ -26,9 +26,6 @@ void SurfaceCouplingImporter::create_requests()
 
   m_num_cols = m_grid->get_num_local_dofs();      // Number of columns on this rank
 
-  // The units of mixing ratio Q are technically non-dimensional.
-  // Nevertheless, for output reasons, we like to see 'kg/kg'.
-  constexpr auto nondim = Units::nondimensional();
   constexpr auto m2 = pow(m, 2);
 
   // Define the different field layouts that will be used for this process
@@ -38,10 +35,10 @@ void SurfaceCouplingImporter::create_requests()
   const FieldLayout vector2d = m_grid->get_2d_vector_layout(2);
   const FieldLayout vector4d = m_grid->get_2d_vector_layout(4);
 
-  add_field<Computed>("sfc_alb_dir_vis",  scalar2d, nondim,  grid_name);
-  add_field<Computed>("sfc_alb_dir_nir",  scalar2d, nondim,  grid_name);
-  add_field<Computed>("sfc_alb_dif_vis",  scalar2d, nondim,  grid_name);
-  add_field<Computed>("sfc_alb_dif_nir",  scalar2d, nondim,  grid_name);
+  add_field<Computed>("sfc_alb_dir_vis",  scalar2d, none,    grid_name);
+  add_field<Computed>("sfc_alb_dir_nir",  scalar2d, none,    grid_name);
+  add_field<Computed>("sfc_alb_dif_vis",  scalar2d, none,    grid_name);
+  add_field<Computed>("sfc_alb_dif_nir",  scalar2d, none,    grid_name);
   add_field<Computed>("surf_lw_flux_up",  scalar2d, W/m2,    grid_name);
   add_field<Computed>("surf_sens_flux",   scalar2d, W/m2,    grid_name);
   add_field<Computed>("surf_evap",        scalar2d, kg/m2/s, grid_name);
@@ -51,9 +48,9 @@ void SurfaceCouplingImporter::create_requests()
   add_field<Computed>("qv_2m",            scalar2d, kg/kg,   grid_name);
   add_field<Computed>("wind_speed_10m",   scalar2d, m/s,     grid_name);
   add_field<Computed>("snow_depth_land",  scalar2d, m,       grid_name);
-  add_field<Computed>("ocnfrac",          scalar2d, nondim,  grid_name);
-  add_field<Computed>("landfrac",         scalar2d, nondim,  grid_name);
-  add_field<Computed>("icefrac",          scalar2d, nondim,  grid_name);
+  add_field<Computed>("ocnfrac",          scalar2d, none,    grid_name);
+  add_field<Computed>("landfrac",         scalar2d, none,    grid_name);
+  add_field<Computed>("icefrac",          scalar2d, none,    grid_name);
   // Friction velocity [m/s]
   add_field<Computed>("fv",               scalar2d, m/s,     grid_name);
   // Aerodynamical resistance

--- a/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp
@@ -784,9 +784,9 @@ void HommeDynamics::
 create_helper_field (const std::string& name,
                      const std::vector<FieldTag>& tags,
                      const std::vector<int>& dims,
-                     const std::string& grid) {
-  using namespace ekat::units;
-  FieldIdentifier id(name,FieldLayout{tags,dims},Units::nondimensional(),grid);
+                     const std::string& grid)
+{
+  FieldIdentifier id(name,FieldLayout{tags,dims},ekat::units::none,grid);
 
   const auto lt = id.get_layout().type();
 

--- a/components/eamxx/src/dynamics/homme/homme_grids_manager.cpp
+++ b/components/eamxx/src/dynamics/homme/homme_grids_manager.cpp
@@ -155,7 +155,6 @@ void HommeGridsManager::build_dynamics_grid () {
   auto dyn_grid = std::make_shared<SEGrid>("dynamics",nlelem,HOMMEXX_NP,nlev,m_comm);
 
   const auto layout2d = dyn_grid->get_2d_scalar_layout();
-  const Units rad (Units::nondimensional(),"rad");
 
   // Filling the cg/dg gids, elgpgp, coords, lat/lon views
   auto dg_dofs = dyn_grid->get_dofs_gids();
@@ -225,12 +224,11 @@ build_physics_grid (const ci_string& type, const ci_string& rebalance) {
   using namespace ShortFieldTagsNames;
   using namespace ekat::units;
   const auto layout2d = phys_grid->get_2d_scalar_layout();
-  const Units rad (Units::nondimensional(),"rad");
 
   auto dofs = phys_grid->get_dofs_gids();
   auto lat  = phys_grid->create_geometry_data("lat",layout2d,rad);
   auto lon  = phys_grid->create_geometry_data("lon",layout2d,rad);
-  auto area = phys_grid->create_geometry_data("area",layout2d,rad*rad);
+  auto area = phys_grid->create_geometry_data("area",layout2d,sr);
 
   using gid_type = AbstractGrid::gid_type;
 
@@ -266,14 +264,12 @@ build_physics_grid (const ci_string& type, const ci_string& rebalance) {
   if (get_grid("dynamics")->has_geometry_data("hyam")) {
     auto layout_mid = phys_grid->get_vertical_layout(LEV);
     auto layout_int = phys_grid->get_vertical_layout(ILEV);
-    using namespace ekat::units;
-    Units nondim = Units::nondimensional();
-    Units mbar(bar/1000,"mb");
+    auto mbar = (bar/1000).rename("mb");
 
-    auto hyai = phys_grid->create_geometry_data("hyai",layout_int,nondim);
-    auto hybi = phys_grid->create_geometry_data("hybi",layout_int,nondim);
-    auto hyam = phys_grid->create_geometry_data("hyam",layout_mid,nondim);
-    auto hybm = phys_grid->create_geometry_data("hybm",layout_mid,nondim);
+    auto hyai = phys_grid->create_geometry_data("hyai",layout_int,none);
+    auto hybi = phys_grid->create_geometry_data("hybi",layout_int,none);
+    auto hyam = phys_grid->create_geometry_data("hyam",layout_mid,none);
+    auto hybm = phys_grid->create_geometry_data("hybm",layout_mid,none);
     auto lev  = phys_grid->create_geometry_data("lev", layout_mid,mbar);
     auto ilev = phys_grid->create_geometry_data("ilev",layout_int,mbar);
 
@@ -334,12 +330,11 @@ initialize_vertical_coordinates (const nonconstgrid_ptr_type& dyn_grid) {
   // Create vcoords fields
   auto layout_mid = dyn_grid->get_vertical_layout(LEV);
   auto layout_int = dyn_grid->get_vertical_layout(ILEV);
-  constexpr auto nondim = ekat::units::Units::nondimensional();
 
-  auto hyai = dyn_grid->create_geometry_data("hyai",layout_int,nondim);
-  auto hybi = dyn_grid->create_geometry_data("hybi",layout_int,nondim);
-  auto hyam = dyn_grid->create_geometry_data("hyam",layout_mid,nondim);
-  auto hybm = dyn_grid->create_geometry_data("hybm",layout_mid,nondim);
+  auto hyai = dyn_grid->create_geometry_data("hyai",layout_int,ekat::units::none);
+  auto hybi = dyn_grid->create_geometry_data("hybi",layout_int,ekat::units::none);
+  auto hyam = dyn_grid->create_geometry_data("hyam",layout_mid,ekat::units::none);
+  auto hybm = dyn_grid->create_geometry_data("hybm",layout_mid,ekat::units::none);
 
   std::vector<Field> fields = {hyai, hybi, hyam, hybm};
   AtmosphereInput vcoord_reader(filename,dyn_grid,fields);

--- a/components/eamxx/src/dynamics/homme/homme_grids_manager.cpp
+++ b/components/eamxx/src/dynamics/homme/homme_grids_manager.cpp
@@ -11,6 +11,7 @@
 #include "share/property_checks/field_within_interval_check.hpp"
 #endif
 
+#include "share/field/field_utils.hpp"
 #include "share/grid/point_grid.hpp"
 #include "share/remap/inverse_remapper.hpp"
 #include "share/grid/se_grid.hpp"
@@ -225,9 +226,11 @@ build_physics_grid (const ci_string& type, const ci_string& rebalance) {
   using namespace ekat::units;
   const auto layout2d = phys_grid->get_2d_scalar_layout();
 
+  auto degN = none.rename("degrees_north");
+  auto degE = none.rename("degrees_east");
   auto dofs = phys_grid->get_dofs_gids();
-  auto lat  = phys_grid->create_geometry_data("lat",layout2d,rad);
-  auto lon  = phys_grid->create_geometry_data("lon",layout2d,rad);
+  auto lat  = phys_grid->create_geometry_data("lat",layout2d,degN);
+  auto lon  = phys_grid->create_geometry_data("lon",layout2d,degE);
   auto area = phys_grid->create_geometry_data("area",layout2d,sr);
 
   using gid_type = AbstractGrid::gid_type;

--- a/components/eamxx/src/dynamics/homme/tests/dyn_grid_io.cpp
+++ b/components/eamxx/src/dynamics/homme/tests/dyn_grid_io.cpp
@@ -79,7 +79,7 @@ TEST_CASE("dyn_grid_io")
   auto phys_vector3d_mid = phys_grid->get_3d_vector_layout(LEV,2);
   auto phys_scalar2d     = phys_grid->get_2d_scalar_layout();
 
-  auto nondim = ekat::units::Units::nondimensional();
+  auto nondim = ekat::units::none;
   FieldIdentifier fid_dyn_1 ("field_1",dyn_scalar3d_mid,nondim,dyn_grid->name());
   FieldIdentifier fid_dyn_2 ("field_2",dyn_vector3d_mid,nondim,dyn_grid->name());
   FieldIdentifier fid_dyn_3 ("field_3",dyn_scalar2d    ,nondim,dyn_grid->name());

--- a/components/eamxx/src/physics/cld_fraction/cld_frac_net/eamxx_cld_frac_net_process_interface.cpp
+++ b/components/eamxx/src/physics/cld_fraction/cld_frac_net/eamxx_cld_frac_net_process_interface.cpp
@@ -32,18 +32,17 @@ void CldFracNet::create_requests()
   using namespace ekat::units;
   using namespace ShortFieldTagsNames;
 
-  const auto nondim = Units::nondimensional();
   const auto grid = m_grids_manager->get_grid("physics");
   const auto grid_name = grid->name();
   const auto layout = grid->get_3d_scalar_layout(LEV);
 
   // Input fields
   add_tracer<Required>("qi", grid, kg/kg);
-  add_field<Required>("cldfrac_liq", layout, nondim, grid_name);
+  add_field<Required>("cldfrac_liq", layout, none, grid_name);
 
   // Output fields
-  add_field<Computed>("cldfrac_tot", layout, nondim, grid_name);
-  add_field<Computed>("cldfrac_ice", layout, nondim, grid_name);
+  add_field<Computed>("cldfrac_tot", layout, none, grid_name);
+  add_field<Computed>("cldfrac_ice", layout, none, grid_name);
 }
 
 void CldFracNet::initialize_impl (const RunType /* run_type */)

--- a/components/eamxx/src/physics/cld_fraction/eamxx_cld_fraction_process_interface.cpp
+++ b/components/eamxx/src/physics/cld_fraction/eamxx_cld_fraction_process_interface.cpp
@@ -26,10 +26,6 @@ void CldFraction::create_requests()
   using CldFractionFunc = cld_fraction::CldFractionFunctions<Real, DefaultDevice>;
   using Pack           = CldFractionFunc::Pack;
 
-  // The units of mixing ratio Q are technically non-dimensional.
-  // Nevertheless, for output reasons, we like to see 'kg/kg'.
-  auto nondim = Units::nondimensional();
-
   m_grid = m_grids_manager->get_grid("physics");
   const auto& grid_name = m_grid->name();
   m_num_cols = m_grid->get_num_local_dofs(); // Number of columns on this rank
@@ -43,11 +39,11 @@ void CldFraction::create_requests()
   // Set of fields used strictly as input
   constexpr int ps = Pack::n;
   add_tracer<Required>("qi", m_grid, kg/kg, ps);
-  add_field<Required>("cldfrac_liq", scalar3d_layout_mid, nondim, grid_name,ps);
+  add_field<Required>("cldfrac_liq", scalar3d_layout_mid, none, grid_name,ps);
 
   // Set of fields used strictly as output
-  add_field<Computed>("cldfrac_tot", scalar3d_layout_mid, nondim, grid_name,ps);
-  add_field<Computed>("cldfrac_ice", scalar3d_layout_mid, nondim, grid_name,ps);
+  add_field<Computed>("cldfrac_tot", scalar3d_layout_mid, none, grid_name,ps);
+  add_field<Computed>("cldfrac_ice", scalar3d_layout_mid, none, grid_name,ps);
   // Note, we track two versions of the cloud fraction.  The versions below have "_for_analysis"
   // attached to the name because they're meant for use with fields that are exclusively
   // related to writing output.  This is an important distinction here because the internal ice
@@ -55,8 +51,8 @@ void CldFraction::create_requests()
   // for the model's ice processes to act on that cell). Folks evaluating cloud, on the other hand,
   // expect cloud fraction to represent cloud visible to the human eye (which corresponds to
   // ~1e-5 kg/kg).
-  add_field<Computed>("cldfrac_tot_for_analysis", scalar3d_layout_mid, nondim, grid_name,ps);
-  add_field<Computed>("cldfrac_ice_for_analysis", scalar3d_layout_mid, nondim, grid_name,ps);
+  add_field<Computed>("cldfrac_tot_for_analysis", scalar3d_layout_mid, none, grid_name,ps);
+  add_field<Computed>("cldfrac_ice_for_analysis", scalar3d_layout_mid, none, grid_name,ps);
 
   // Set of fields used as input and output
   // - There are no fields used as both input and output.

--- a/components/eamxx/src/physics/cosp/eamxx_cosp.cpp
+++ b/components/eamxx/src/physics/cosp/eamxx_cosp.cpp
@@ -37,8 +37,7 @@ void Cosp::create_requests()
 
   // The units of mixing ratio Q are technically non-dimensional.
   // Nevertheless, for output reasons, we like to see 'kg/kg'.
-  Units nondim = Units::nondimensional();
-  Units percent (nondim,"%");
+  auto percent = none.rename("%");
   auto micron = micro*m;
   auto m2 = pow(m, 2);
   auto s2 = pow(s, 2);
@@ -66,7 +65,7 @@ void Cosp::create_requests()
   add_field<Required>("surf_radiative_T", scalar2d    , K,      grid_name);
   //add_field<Required>("surfelev",    scalar2d    , m,      grid_name);
   //add_field<Required>("landmask",    scalar2d    , nondim, grid_name);
-  add_field<Required>(FieldIdentifier("sunlit_mask", scalar2d, nondim, grid_name, DataType::IntType));
+  add_field<Required>(FieldIdentifier("sunlit_mask", scalar2d, none, grid_name, DataType::IntType));
   add_field<Required>("p_mid",             scalar3d_mid, Pa,     grid_name);
   add_field<Required>("p_int",             scalar3d_int, Pa,     grid_name);
   //add_field<Required>("height_mid",  scalar3d_mid, m,      grid_name);
@@ -74,13 +73,13 @@ void Cosp::create_requests()
   add_field<Required>("T_mid",            scalar3d_mid, K,      grid_name);
   add_field<Required>("phis",             scalar2d    , m2/s2,  grid_name);
   add_field<Required>("pseudo_density",   scalar3d_mid, Pa,     grid_name);
-  add_field<Required>("cldfrac_rad",      scalar3d_mid, nondim, grid_name);
+  add_field<Required>("cldfrac_rad",      scalar3d_mid, none,   grid_name);
   add_tracer<Required>("qv", m_grid, kg/kg);
   add_tracer<Required>("qc", m_grid, kg/kg);
   add_tracer<Required>("qi", m_grid, kg/kg);
   // Optical properties, should be computed in radiation interface
-  add_field<Required>("dtau067",     scalar3d_mid, nondim, grid_name); // 0.67 micron optical depth
-  add_field<Required>("dtau105",     scalar3d_mid, nondim, grid_name); // 10.5 micron optical depth
+  add_field<Required>("dtau067",     scalar3d_mid, none, grid_name); // 0.67 micron optical depth
+  add_field<Required>("dtau105",     scalar3d_mid, none, grid_name); // 10.5 micron optical depth
   // Effective radii, should be computed in either microphysics or radiation interface
   // TODO: should these be meters or microns? Was meters before, but using "m" instead
   // of "micron" seemed to cause prim_model_finalize to throw error with the following:
@@ -98,7 +97,7 @@ void Cosp::create_requests()
   // We can allocate these now
   m_z_mid = Field(FieldIdentifier("z_mid",scalar3d_mid,m,grid_name),true);
   m_z_int = Field(FieldIdentifier("z_int",scalar3d_int,m,grid_name),true);
-  m_sunlit_real = Field(FieldIdentifier("sunlit_mask_real",scalar2d,nondim,grid_name),true);
+  m_sunlit_real = Field(FieldIdentifier("sunlit_mask_real",scalar2d,none,grid_name),true);
 }
 
 // =========================================================================================
@@ -108,6 +107,7 @@ void Cosp::initialize_impl (const RunType /* run_type */)
   CospFunc::initialize(m_num_cols, m_num_subcols, m_num_levs);
 
   using namespace ShortFieldTagsNames;
+  using namespace ekat::units;
 
   // Create the masks for the 4d fields
   FieldLayout scalar4d_ctptau ( {COL,CMP,CMP},
@@ -117,9 +117,8 @@ void Cosp::initialize_impl (const RunType /* run_type */)
                                 {m_num_cols,m_num_tau,m_num_cth},
                                 {e2str(COL), "cosp_tau", "cosp_cth"});
 
-  const auto nondim = ekat::units::Units::nondimensional();
-  FieldIdentifier mctp_fid ("sunlit_mask_ctptau", scalar4d_ctptau, nondim, m_grid->name(), DataType::IntType);
-  FieldIdentifier mcth_fid ("sunlit_mask_cthtau", scalar4d_cthtau, nondim, m_grid->name(), DataType::IntType);
+  FieldIdentifier mctp_fid ("sunlit_mask_ctptau", scalar4d_ctptau, none, m_grid->name(), DataType::IntType);
+  FieldIdentifier mcth_fid ("sunlit_mask_cthtau", scalar4d_cthtau, none, m_grid->name(), DataType::IntType);
   Field mctp(mctp_fid,true);
   Field mcth(mcth_fid,true);
   std::map<std::string,Field> masks = {
@@ -152,10 +151,10 @@ void Cosp::initialize_impl (const RunType /* run_type */)
   FieldLayout cosp_prs_bnds_layout ({CMP,CMP}, {m_num_ctp,2}, {"cosp_prs","nbnd"});
   FieldLayout cosp_cth_bnds_layout ({CMP,CMP}, {m_num_cth,2}, {"cosp_cth","nbnd"});
 
-  auto cosp_tau_f      = m_grid->create_geometry_data("cosp_tau",      cosp_tau_layout,     nondim);
+  auto cosp_tau_f      = m_grid->create_geometry_data("cosp_tau",      cosp_tau_layout,     none);
   auto cosp_prs_f      = m_grid->create_geometry_data("cosp_prs",      cosp_prs_layout,     Pa);
   auto cosp_cth_f      = m_grid->create_geometry_data("cosp_cth",      cosp_cth_layout,     m);
-  auto cosp_tau_bnds_f = m_grid->create_geometry_data("cosp_tau_bnds", cosp_tau_bnds_layout, nondim);
+  auto cosp_tau_bnds_f = m_grid->create_geometry_data("cosp_tau_bnds", cosp_tau_bnds_layout, none);
   auto cosp_prs_bnds_f = m_grid->create_geometry_data("cosp_prs_bnds", cosp_prs_bnds_layout, Pa);
   auto cosp_cth_bnds_f = m_grid->create_geometry_data("cosp_cth_bnds", cosp_cth_bnds_layout, m);
 

--- a/components/eamxx/src/physics/iop_forcing/eamxx_iop_forcing_process_interface.cpp
+++ b/components/eamxx/src/physics/iop_forcing/eamxx_iop_forcing_process_interface.cpp
@@ -113,8 +113,7 @@ void IOPForcing::create_helper_field (const std::string& name,
                                       const std::string& grid_name,
                                       const int          ps)
 {
-  using namespace ekat::units;
-  FieldIdentifier id(name,layout,Units::nondimensional(),grid_name);
+  FieldIdentifier id(name,layout,ekat::units::none,grid_name);
 
   // Create the field. Init with NaN's, so we spot instances of uninited memory usage
   Field f(id);

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
@@ -83,8 +83,6 @@ void MAMAci::create_requests() {
   using namespace ekat::units;
   constexpr auto n_unit = 1 / kg;  // units of number mixing ratios of tracers
 
-  constexpr auto nondim = ekat::units::Units::nondimensional();
-
   add_tracers_wet_atm();
   add_fields_dry_atm();
 
@@ -109,10 +107,10 @@ void MAMAci::create_requests() {
   // "shoc_cldfrac" and in the F90 code it is called "cloud_frac"
 
   // Liquid stratiform cloud fraction at midpoints
-  add_field<Required>("cldfrac_liq", scalar3d_mid, nondim, grid_name);
+  add_field<Required>("cldfrac_liq", scalar3d_mid, none, grid_name);
 
   // Previous value of liquid stratiform cloud fraction at midpoints
-  add_field<Required>("cldfrac_liq_prev", scalar3d_mid, nondim, grid_name);
+  add_field<Required>("cldfrac_liq_prev", scalar3d_mid, none, grid_name);
 
   // Eddy diffusivity for heat
   add_field<Required>("eddy_diff_heat", scalar3d_mid, m2 / s, grid_name);

--- a/components/eamxx/src/physics/mam/eamxx_mam_dry_deposition_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_dry_deposition_process_interface.cpp
@@ -64,7 +64,6 @@ void MAMDryDep::create_requests() {
       LEV, num_aero_modes, mam_coupling::num_modes_tag_name());
 
   using namespace ekat::units;
-  auto nondim = ekat::units::Units::nondimensional();
 
   auto m3 = m * m * m;  // meter cubed
 
@@ -88,7 +87,7 @@ void MAMDryDep::create_requests() {
   //----------- Variables from microphysics scheme -------------
 
   // Total cloud fraction [fraction] (Require only for building DS)
-  add_field<Required>("cldfrac_tot", scalar3d_mid, nondim, grid_name);
+  add_field<Required>("cldfrac_tot", scalar3d_mid, none, grid_name);
 
   //----------- Variables from coupler (land component)---------
   // Obukhov length [m]
@@ -98,7 +97,7 @@ void MAMDryDep::create_requests() {
   add_field<Required>("ustar", scalar2d, m / s, grid_name);
 
   // Land fraction [fraction]
-  add_field<Required>("landfrac", scalar2d, nondim, grid_name);
+  add_field<Required>("landfrac", scalar2d, none, grid_name);
 
   // Friction velocity from land model [m/s]
   add_field<Required>("fv", scalar2d, m / s, grid_name);
@@ -109,11 +108,11 @@ void MAMDryDep::create_requests() {
   //----------- Variables from coupler (ice component)---------
 
   // Ice fraction [unitless]
-  add_field<Required>("icefrac", scalar2d, nondim, grid_name);
+  add_field<Required>("icefrac", scalar2d, none, grid_name);
 
   //----------- Variables from coupler (ocean component)---------
   // Ocean fraction [unitless]
-  add_field<Required>("ocnfrac", scalar2d, nondim, grid_name);
+  add_field<Required>("ocnfrac", scalar2d, none, grid_name);
 
   //----------- Variables from other mam4xx processes ------------
   // Geometric mean wet diameter for number distribution [m]
@@ -147,7 +146,7 @@ void MAMDryDep::create_requests() {
                       vector2d_pcnst, 1 / m2 / s, grid_name);
 
   // Fractional land use [fraction]
-  add_field<Computed>("fraction_landuse", vector2d_class, nondim, grid_name);
+  add_field<Computed>("fraction_landuse", vector2d_class, none, grid_name);
   // -------------------------------------------------------------
   // setup to enable reading fractional land use file
   // -------------------------------------------------------------

--- a/components/eamxx/src/physics/mam/eamxx_mam_generic_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_generic_process_interface.cpp
@@ -407,7 +407,6 @@ void MAMGenericInterface::add_fields_dry_atm() {
   // layout for 2D (1d horiz X 1d vertical) variable
   FieldLayout scalar2d_layout_col{{COL}, {ncol}};
   using namespace ekat::units;
-  constexpr auto nondim = Units::nondimensional();
 
   // Temperature[K] at midpoints
   add_field<Required>("T_mid", scalar3d_mid, K, grid_name);
@@ -428,7 +427,7 @@ void MAMGenericInterface::add_fields_dry_atm() {
   add_field<Required>("pbl_height", scalar2d_layout_col, m, grid_name);
 
   // cloud fraction [nondimensional] computed by eamxx_cld_fraction_process
-  add_field<Required>("cldfrac_tot", scalar3d_mid, nondim, grid_name);
+  add_field<Required>("cldfrac_tot", scalar3d_mid, none, grid_name);
 
   // geopotential height above surface at interface levels (m)
   add_field<Updated>("z_mam4_int", scalar3d_int, m, grid_name);

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -127,9 +127,8 @@ MAMMicrophysics::create_requests()
   add_field<Required>("horiz_winds", vector3d, m / s, grid_name);
 
   //----------- Variables from microphysics scheme -------------
-  constexpr auto nondim = ekat::units::Units::nondimensional();
   // Total cloud fraction [fraction]
-  add_field<Required>("cldfrac_liq", scalar3d_mid, nondim, grid_name);
+  add_field<Required>("cldfrac_liq", scalar3d_mid, none, grid_name);
 
   // Evaporation from stratiform rain [kg/kg/s]
   add_field<Required>("nevapr", scalar3d_mid, kg / kg / s, grid_name);
@@ -165,11 +164,11 @@ MAMMicrophysics::create_requests()
       grid_->get_2d_vector_layout(mam4::mo_drydep::n_land_type, "class");
 
   // Fractional land use [fraction]
-  add_field<Required>("fraction_landuse", vector2d_class, nondim, grid_name);
+  add_field<Required>("fraction_landuse", vector2d_class, none, grid_name);
 
   //----------- Variables from the coupler ---------
   // surface albedo shortwave, direct
-  add_field<Required>("sfc_alb_dir_vis", scalar2d, nondim, grid_name);
+  add_field<Required>("sfc_alb_dir_vis", scalar2d, none, grid_name);
 
   // Surface temperature[K]
   add_field<Required>("surf_radiative_T", scalar2d, K, grid_name);
@@ -225,17 +224,17 @@ MAMMicrophysics::create_requests()
 
     // Diagnostics: tendencies due to gas phase chemistry [mixed units: kg/kg/s or #/kg/s]
     add_field<Computed>("mam4_microphysics_tendency_gas_phase_chemistry",
-                        vector3d_num_gas_aerosol_constituents, nondim, grid_name);
+                        vector3d_num_gas_aerosol_constituents, none, grid_name);
 
     // Diagnostics: tendencies due to aqueous chemistry [mixed units: kg/kg/s or #/kg/s]
     add_field<Computed>("mam4_microphysics_tendency_aqueous_chemistry",
-                        vector3d_num_gas_aerosol_constituents, nondim, grid_name);
+                        vector3d_num_gas_aerosol_constituents, none, grid_name);
 
     // Diagnostics: SO4 in-cloud tendencies [mixed units: kg/kg/s or #/kg/s]
-    add_field<Computed>("mam4_microphysics_tendency_aqso4", vector3d_mid_nmodes, nondim, grid_name);
+    add_field<Computed>("mam4_microphysics_tendency_aqso4", vector3d_mid_nmodes, none, grid_name);
 
     // Diagnostics: H2SO4 in-cloud tendencies [mixed units: kg/kg/s or #/kg/s]
-    add_field<Computed>("mam4_microphysics_tendency_aqh2so4", vector3d_mid_nmodes, nondim,
+    add_field<Computed>("mam4_microphysics_tendency_aqh2so4", vector3d_mid_nmodes, none,
                         grid_name);
 
     // Register computed diagnostic fields
@@ -249,15 +248,15 @@ MAMMicrophysics::create_requests()
     // Diagnostics: tendencies due to aerosol microphysics (gas aerosol exchange) [mixed units:
     // mol/mol/s or #/mol/s]
     add_field<Computed>("mam4_microphysics_tendency_condensation",
-                        vector3d_num_gas_aerosol_constituents, nondim, grid_name);
+                        vector3d_num_gas_aerosol_constituents, none, grid_name);
     add_field<Computed>("mam4_microphysics_tendency_renaming",
-                        vector3d_num_gas_aerosol_constituents, nondim, grid_name);
+                        vector3d_num_gas_aerosol_constituents, none, grid_name);
     add_field<Computed>("mam4_microphysics_tendency_nucleation",
-                        vector3d_num_gas_aerosol_constituents, nondim, grid_name);
+                        vector3d_num_gas_aerosol_constituents, none, grid_name);
     add_field<Computed>("mam4_microphysics_tendency_coagulation",
-                        vector3d_num_gas_aerosol_constituents, nondim, grid_name);
+                        vector3d_num_gas_aerosol_constituents, none, grid_name);
     add_field<Computed>("mam4_microphysics_tendency_renaming_cloud_borne",
-                        vector3d_num_gas_aerosol_constituents, nondim, grid_name);
+                        vector3d_num_gas_aerosol_constituents, none, grid_name);
     constexpr auto cm2 = m * m / 10000;
     add_field<Computed>("mam4_gas_dry_deposition_flux", vector2d_gas_pcnst, 1 / cm2 / s, grid_name);
   }
@@ -277,12 +276,12 @@ MAMMicrophysics::create_requests()
   if (config_.linoz.compute) {
     // The DataInterpolation class uses Field. We save these fields in FM.
     for(const auto &field_name : var_names_linoz_) {
-      add_field<Computed>(field_name, scalar3d_mid, nondim, grid_name);
+      add_field<Computed>(field_name, scalar3d_mid, none, grid_name);
     }
   }
   for(const auto &field_name : var_names_oxi_) {
     // Adding oxid_ to avoid conflicts with gases treated as tracers.
-    add_field<Computed>("oxid_"+field_name, scalar3d_mid, nondim, grid_name);
+    add_field<Computed>("oxid_"+field_name, scalar3d_mid, none, grid_name);
   }
 
   // list of species for elevated emissiones.
@@ -311,7 +310,7 @@ MAMMicrophysics::create_requests()
   for(const auto &pair : elevated_emis_var_names_) {
     const auto &var_name =pair.first;
     for(const auto &field_name : pair.second) {
-      add_field<Computed>(field_name+"_"+var_name, scalar3d_mid, nondim, grid_name);
+      add_field<Computed>(field_name+"_"+var_name, scalar3d_mid, none, grid_name);
     }
   }
 
@@ -545,7 +544,7 @@ void MAMMicrophysics::set_exo_coldens_reader()
   grid_exo_coldens->reset_vertical_configuration(1, AbstractGrid::VKind::Model);
   auto layout = grid_exo_coldens->get_3d_scalar_layout(LEV);
 
-  auto molec = Units::nondimensional();// example;
+  auto molec = none;// example;
   auto cm2 = pow(m / 100,2);
   auto molec_cm2 = Units(molec/cm2,"molecules/cm2");
   const std::string exo_coldens_name = "O3_column_density";

--- a/components/eamxx/src/physics/mam/eamxx_mam_optics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_optics_process_interface.cpp
@@ -39,7 +39,6 @@ void MAMOptics::create_requests() {
   // Define the different field layouts that will be used for this process
 
   // Define aerosol optics fields computed by this process.
-  auto nondim = Units::nondimensional();
   // 3D layout for short/longwave aerosol fields: columns, number of
   // short/longwave band, nlev
   FieldLayout scalar3d_swband =
@@ -65,18 +64,18 @@ void MAMOptics::create_requests() {
   add_field<Required>("phis", scalar2d, m2 / s2, grid_name);
 
   // shortwave aerosol scattering asymmetry parameter [unitless]
-  add_field<Computed>("aero_g_sw", scalar3d_swband, nondim, grid_name);
+  add_field<Computed>("aero_g_sw", scalar3d_swband, none, grid_name);
 
   // shortwave aerosol single-scattering albedo [unitless]
-  add_field<Computed>("aero_ssa_sw", scalar3d_swband, nondim, grid_name);
+  add_field<Computed>("aero_ssa_sw", scalar3d_swband, none, grid_name);
 
   // shortwave aerosol extinction optical depth
-  add_field<Computed>("aero_tau_sw", scalar3d_swband, nondim, grid_name);
+  add_field<Computed>("aero_tau_sw", scalar3d_swband, none, grid_name);
 
   // longwave aerosol extinction optical depth [unitless]
-  add_field<Computed>("aero_tau_lw", scalar3d_lwband, nondim, grid_name);
+  add_field<Computed>("aero_tau_lw", scalar3d_lwband, none, grid_name);
 
-  add_field<Computed>("aodvis", scalar2d, nondim, grid_name);
+  add_field<Computed>("aodvis", scalar2d, none, grid_name);
 
   // (interstitial) aerosol tracers of interest: mass (q) and number (n) mixing
   // ratios

--- a/components/eamxx/src/physics/mam/eamxx_mam_srf_and_online_emissions_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_srf_and_online_emissions_process_interface.cpp
@@ -42,7 +42,6 @@ void MAMSrfOnlineEmiss::create_requests() {
   using namespace ShortFieldTagsNames;
   constexpr auto m2     = pow(m, 2);
   constexpr auto s2     = pow(s, 2);
-  constexpr auto nondim = ekat::units::Units::nondimensional();
 
   const FieldLayout scalar2d   = grid_->get_2d_scalar_layout();
   const FieldLayout scalar3d_m = grid_->get_3d_scalar_layout(LEV);   // mid
@@ -81,7 +80,7 @@ void MAMSrfOnlineEmiss::create_requests() {
 
   //----------- Variables from coupler (ocean component)---------
   // Ocean fraction [unitless]
-  add_field<Required>("ocnfrac", scalar2d, nondim, grid_name);
+  add_field<Required>("ocnfrac", scalar2d, none, grid_name);
 
   // Sea surface temperature [K]
   add_field<Required>("sst", scalar2d, K, grid_name);

--- a/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.cpp
@@ -91,13 +91,10 @@ MAMWetscav::create_requests()
   // Stratiform rain production rate [kg/kg/s]
   add_field<Required>("precip_total_tend", scalar3d_mid, kg / kg / s, grid_name);
 
-  // For variables that are non dimensional (e.g., fractions etc.)
-  static constexpr auto nondim = Units::nondimensional();
-
   //----------- Variables from macrophysics scheme -------------
 
   // Total cloud fraction [fraction]
-  add_field<Required>("cldfrac_liq", scalar3d_mid, nondim, grid_name);
+  add_field<Required>("cldfrac_liq", scalar3d_mid, none, grid_name);
 
   // ---------------------------------------------------------------------
   // These variables are "updated" or inputs/outputs for the process
@@ -160,7 +157,7 @@ MAMWetscav::create_requests()
   add_field<Computed>("dgnumwet", scalar3d_mid_nmodes, m, grid_name);
 
   // Fraction of transported species that are insoluble [fraction]
-  add_field<Computed>("fracis", scalar3d_mid, nondim, grid_name);
+  add_field<Computed>("fracis", scalar3d_mid, none, grid_name);
 
   // Aerosol wet deposition (interstitial) [kg/m2/s]
   add_field<Computed>("aerdepwetis", scalar2d_pcnst, kg / m2 / s, grid_name);

--- a/components/eamxx/src/physics/mam/mam_aerosol_optics_read_tables.hpp
+++ b/components/eamxx/src/physics/mam/mam_aerosol_optics_read_tables.hpp
@@ -18,8 +18,7 @@ make_field (const std::string& name,
             const FieldLayout& layout,
             const std::shared_ptr<const AbstractGrid>& grid)
 {
-  const auto units = ekat::units::Units::nondimensional();
-  FieldIdentifier fid(name,layout,units,grid->name());
+  FieldIdentifier fid(name,layout,ekat::units::none,grid->name());
   Field f(fid);
   f.allocate_view();
   return f;

--- a/components/eamxx/src/physics/mam/readfiles/fractional_land_use_impl.hpp
+++ b/components/eamxx/src/physics/mam/readfiles/fractional_land_use_impl.hpp
@@ -55,10 +55,9 @@ fracLandUseFunctions<S, D>::create_horiz_remapper(
   const auto tgt_grid = remapper->get_tgt_grid();
 
   const auto layout_2d = tgt_grid->get_2d_vector_layout(nclass_data, "class");
-  const auto nondim    = ekat::units::Units::nondimensional();
 
   Field fractional_land_use(
-      FieldIdentifier(field_name, layout_2d, nondim, tgt_grid->name()));
+      FieldIdentifier(field_name, layout_2d, ekat::units::none, tgt_grid->name()));
   fractional_land_use.allocate_view();
 
   remapper->register_field_from_tgt(fractional_land_use);

--- a/components/eamxx/src/physics/mam/readfiles/soil_erodibility_impl.hpp
+++ b/components/eamxx/src/physics/mam/readfiles/soil_erodibility_impl.hpp
@@ -53,10 +53,9 @@ soilErodibilityFunctions<S, D>::create_horiz_remapper(
   const auto tgt_grid = remapper->get_tgt_grid();
 
   const auto layout_2d = tgt_grid->get_2d_scalar_layout();
-  const auto nondim    = ekat::units::Units::nondimensional();
 
   Field soil_erodibility(
-      FieldIdentifier(field_name, layout_2d, nondim, tgt_grid->name()));
+      FieldIdentifier(field_name, layout_2d, ekat::units::none, tgt_grid->name()));
   soil_erodibility.allocate_view();
 
   remapper->register_field_from_tgt(soil_erodibility);

--- a/components/eamxx/src/physics/mam/srf_emission_impl.hpp
+++ b/components/eamxx/src/physics/mam/srf_emission_impl.hpp
@@ -53,7 +53,6 @@ srfEmissFunctions<S, D>::create_horiz_remapper(
   const auto tgt_grid = remapper->get_tgt_grid();
 
   const auto layout_2d = tgt_grid->get_2d_scalar_layout();
-  const auto nondim    = ekat::units::Units::nondimensional();
 
   std::vector<Field> field_emiss_sectors;
 
@@ -61,7 +60,7 @@ srfEmissFunctions<S, D>::create_horiz_remapper(
   for(int icomp = 0; icomp < sector_size; ++icomp) {
     auto comp_name = sector_names[icomp];
     // set and allocate fields
-    Field f(FieldIdentifier(comp_name, layout_2d, nondim, tgt_grid->name()));
+    Field f(FieldIdentifier(comp_name, layout_2d, ekat::units::none, tgt_grid->name()));
     f.allocate_view();
     field_emiss_sectors.push_back(f);
     remapper->register_field_from_tgt(f);

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -539,10 +539,8 @@ Field Nudging::create_helper_field (const std::string& name,
                                              const std::string& grid_name,
                                              const int ps)
 {
-  using namespace ekat::units;
-
   // For helper fields we don't bother w/ units, so we set them to non-dimensional
-  FieldIdentifier id(name,layout,Units::nondimensional(),grid_name);
+  FieldIdentifier id(name,layout,ekat::units::none,grid_name);
 
   // Create the field. Init with NaN's, so we spot instances of uninited memory usage
   Field f(id);

--- a/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
+++ b/components/eamxx/src/physics/p3/eamxx_p3_process_interface.cpp
@@ -26,7 +26,6 @@ void P3Microphysics::create_requests()
 
   // The units of mixing ratio Q are technically non-dimensional.
   // Nevertheless, for output reasons, we like to see 'kg/kg'.
-  auto nondim = Units::nondimensional();
   auto micron = micro*m;
   auto m2 = pow(m,2);
 
@@ -64,10 +63,10 @@ void P3Microphysics::create_requests()
   constexpr int ps = Pack::n;
 
   // These variables are needed by the interface, but not actually passed to p3_main.
-  add_field<Required>("cldfrac_tot", scalar3d_layout_mid, nondim, grid_name, ps);
+  add_field<Required>("cldfrac_tot", scalar3d_layout_mid, none, grid_name, ps);
   if (runtime_options.use_separate_ice_liq_frac) {
-    add_field<Required>("cldfrac_liq", scalar3d_layout_mid, nondim, grid_name, ps);
-    add_field<Required>("cldfrac_ice", scalar3d_layout_mid, nondim, grid_name, ps);
+    add_field<Required>("cldfrac_liq", scalar3d_layout_mid, none, grid_name, ps);
+    add_field<Required>("cldfrac_ice", scalar3d_layout_mid, none, grid_name, ps);
   }
 
   // should we use one pressure only, wet/full?
@@ -125,23 +124,23 @@ void P3Microphysics::create_requests()
   add_field<Computed>("eff_radius_qr",           scalar3d_layout_mid, micron,    grid_name, ps);
   add_field<Computed>("precip_total_tend",       scalar3d_layout_mid, kg/(kg*s), grid_name, ps);
   add_field<Computed>("nevapr",                  scalar3d_layout_mid, kg/(kg*s), grid_name, ps);
-  add_field<Computed>("diag_equiv_reflectivity", scalar3d_layout_mid, nondim,    grid_name, ps);
+  add_field<Computed>("diag_equiv_reflectivity", scalar3d_layout_mid, none,      grid_name, ps);
   if (runtime_options.extra_p3_diags) {
-    add_field<Computed>("qr2qv_evap", scalar3d_layout_mid, kg/kg/s,  grid_name, ps);
-    add_field<Computed>("qi2qv_sublim", scalar3d_layout_mid, kg/kg/s,  grid_name, ps);
-    add_field<Computed>("qc2qr_accret", scalar3d_layout_mid, kg/kg/s,  grid_name, ps);
-    add_field<Computed>("qc2qr_autoconv", scalar3d_layout_mid, kg/kg/s,  grid_name, ps);
-    add_field<Computed>("qv2qi_vapdep", scalar3d_layout_mid, kg/kg/s,  grid_name, ps);
-    add_field<Computed>("qc2qi_berg", scalar3d_layout_mid, kg/kg/s,  grid_name, ps);
-    add_field<Computed>("qc2qr_ice_shed", scalar3d_layout_mid, kg/kg/s,  grid_name, ps);
-    add_field<Computed>("qc2qi_collect", scalar3d_layout_mid, kg/kg/s,  grid_name, ps);
-    add_field<Computed>("qr2qi_collect", scalar3d_layout_mid, kg/kg/s,  grid_name, ps);
+    add_field<Computed>("qr2qv_evap",          scalar3d_layout_mid, kg/kg/s,  grid_name, ps);
+    add_field<Computed>("qi2qv_sublim",        scalar3d_layout_mid, kg/kg/s,  grid_name, ps);
+    add_field<Computed>("qc2qr_accret",        scalar3d_layout_mid, kg/kg/s,  grid_name, ps);
+    add_field<Computed>("qc2qr_autoconv",      scalar3d_layout_mid, kg/kg/s,  grid_name, ps);
+    add_field<Computed>("qv2qi_vapdep",        scalar3d_layout_mid, kg/kg/s,  grid_name, ps);
+    add_field<Computed>("qc2qi_berg",          scalar3d_layout_mid, kg/kg/s,  grid_name, ps);
+    add_field<Computed>("qc2qr_ice_shed",      scalar3d_layout_mid, kg/kg/s,  grid_name, ps);
+    add_field<Computed>("qc2qi_collect",       scalar3d_layout_mid, kg/kg/s,  grid_name, ps);
+    add_field<Computed>("qr2qi_collect",       scalar3d_layout_mid, kg/kg/s,  grid_name, ps);
     add_field<Computed>("qc2qi_hetero_freeze", scalar3d_layout_mid, kg/kg/s,  grid_name, ps);
     add_field<Computed>("qr2qi_immers_freeze", scalar3d_layout_mid, kg/kg/s,  grid_name, ps);
-    add_field<Computed>("qi2qr_melt", scalar3d_layout_mid, kg/kg/s,  grid_name, ps);
-    add_field<Computed>("qr_sed", scalar3d_layout_mid, kg/kg/s,  grid_name, ps);
-    add_field<Computed>("qc_sed", scalar3d_layout_mid, kg/kg/s,  grid_name, ps);
-    add_field<Computed>("qi_sed", scalar3d_layout_mid, kg/kg/s,  grid_name, ps);
+    add_field<Computed>("qi2qr_melt",          scalar3d_layout_mid, kg/kg/s,  grid_name, ps);
+    add_field<Computed>("qr_sed",              scalar3d_layout_mid, kg/kg/s,  grid_name, ps);
+    add_field<Computed>("qc_sed",              scalar3d_layout_mid, kg/kg/s,  grid_name, ps);
+    add_field<Computed>("qi_sed",              scalar3d_layout_mid, kg/kg/s,  grid_name, ps);
   }
 
   // History Only: (all fields are just outputs and are really only meant for I/O purposes)
@@ -151,7 +150,7 @@ void P3Microphysics::create_requests()
   add_field<Computed>("micro_liq_ice_exchange", scalar3d_layout_mid, kg/kg,  grid_name, ps);
   add_field<Computed>("micro_vap_liq_exchange", scalar3d_layout_mid, kg/kg,  grid_name, ps);
   add_field<Computed>("micro_vap_ice_exchange", scalar3d_layout_mid, kg/kg,  grid_name, ps);
-  add_field<Computed>("rainfrac",               scalar3d_layout_mid, nondim, grid_name, ps);
+  add_field<Computed>("rainfrac",               scalar3d_layout_mid, none,   grid_name, ps);
 
   // Boundary flux fields for energy and mass conservation checks
   if (has_column_conservation_check()) {

--- a/components/eamxx/src/physics/rrtmgp/eamxx_rrtmgp_process_interface.cpp
+++ b/components/eamxx/src/physics/rrtmgp/eamxx_rrtmgp_process_interface.cpp
@@ -90,8 +90,7 @@ void RRTMGPRadiation::create_requests() {
   using namespace ShortFieldTagsNames;
 
   // Declare the set of fields used by rrtmgp
-  Units m2(m*m,"m2");
-  auto nondim = Units::nondimensional();
+  auto m2 = (m*m).rename("m2");
   auto micron = micro*m;
 
   m_grid = m_grids_manager->get_grid("physics");
@@ -142,14 +141,14 @@ void RRTMGPRadiation::create_requests() {
   add_field<Required>("p_mid" , scalar3d_mid, Pa, grid_name);
   add_field<Required>("p_int", scalar3d_int, Pa, grid_name);
   add_field<Required>("pseudo_density", scalar3d_mid, Pa, grid_name);
-  add_field<Required>("sfc_alb_dir_vis", scalar2d, nondim, grid_name);
-  add_field<Required>("sfc_alb_dir_nir", scalar2d, nondim, grid_name);
-  add_field<Required>("sfc_alb_dif_vis", scalar2d, nondim, grid_name);
-  add_field<Required>("sfc_alb_dif_nir", scalar2d, nondim, grid_name);
+  add_field<Required>("sfc_alb_dir_vis", scalar2d, none, grid_name);
+  add_field<Required>("sfc_alb_dir_nir", scalar2d, none, grid_name);
+  add_field<Required>("sfc_alb_dif_vis", scalar2d, none, grid_name);
+  add_field<Required>("sfc_alb_dif_nir", scalar2d, none, grid_name);
   add_field<Required>("qc", scalar3d_mid, kg/kg, grid_name);
   add_field<Required>("nc", scalar3d_mid, 1/kg, grid_name);
   add_field<Required>("qi", scalar3d_mid, kg/kg, grid_name);
-  add_field<Required>("cldfrac_tot", scalar3d_mid, nondim, grid_name);
+  add_field<Required>("cldfrac_tot", scalar3d_mid, none, grid_name);
   add_field<Required>("eff_radius_qc", scalar3d_mid, micron, grid_name);
   add_field<Required>("eff_radius_qi", scalar3d_mid, micron, grid_name);
   add_field<Required>("qv",scalar3d_mid,kg/kg,grid_name);
@@ -169,10 +168,10 @@ void RRTMGPRadiation::create_requests() {
   // Required aerosol optical properties from SPA
   m_do_aerosol_rad = m_params.get<bool>("do_aerosol_rad",true);
   if (m_do_aerosol_rad) {
-    add_field<Required>("aero_tau_sw", scalar3d_swband, nondim, grid_name);
-    add_field<Required>("aero_ssa_sw", scalar3d_swband, nondim, grid_name);
-    add_field<Required>("aero_g_sw"  , scalar3d_swband, nondim, grid_name);
-    add_field<Required>("aero_tau_lw", scalar3d_lwband, nondim, grid_name);
+    add_field<Required>("aero_tau_sw", scalar3d_swband, none, grid_name);
+    add_field<Required>("aero_ssa_sw", scalar3d_swband, none, grid_name);
+    add_field<Required>("aero_g_sw"  , scalar3d_swband, none, grid_name);
+    add_field<Required>("aero_tau_lw", scalar3d_lwband, none, grid_name);
   }
 
   // Whether we do extra clean/clear sky calculations
@@ -203,21 +202,21 @@ void RRTMGPRadiation::create_requests() {
   add_field<Computed>("LW_clnsky_flux_dn", scalar3d_int, W/m2, grid_name);
   add_field<Computed>("rad_heating_pdel", scalar3d_mid, Pa*K/s, grid_name);
   // Cloud properties added as computed fields for diagnostic purposes
-  add_field<Computed>("cldlow"        , scalar2d, nondim, grid_name);
-  add_field<Computed>("cldmed"        , scalar2d, nondim, grid_name);
-  add_field<Computed>("cldhgh"        , scalar2d, nondim, grid_name);
-  add_field<Computed>("cldtot"        , scalar2d, nondim, grid_name);
+  add_field<Computed>("cldlow"        , scalar2d, none, grid_name);
+  add_field<Computed>("cldmed"        , scalar2d, none, grid_name);
+  add_field<Computed>("cldhgh"        , scalar2d, none, grid_name);
+  add_field<Computed>("cldtot"        , scalar2d, none, grid_name);
   // 0.67 micron and 10.5 micron optical depth (needed for COSP)
-  add_field<Computed>("dtau067"       , scalar3d_mid, nondim, grid_name);
-  add_field<Computed>("dtau105"       , scalar3d_mid, nondim, grid_name);
-  add_field<Computed>(FieldIdentifier("sunlit_mask", scalar2d, nondim, grid_name, DataType::IntType));
-  add_field<Computed>("cldfrac_rad"   , scalar3d_mid, nondim, grid_name);
+  add_field<Computed>("dtau067"       , scalar3d_mid, none, grid_name);
+  add_field<Computed>("dtau105"       , scalar3d_mid, none, grid_name);
+  add_field<Computed>(FieldIdentifier("sunlit_mask", scalar2d, none, grid_name, DataType::IntType));
+  add_field<Computed>("cldfrac_rad"   , scalar3d_mid, none, grid_name);
   // Cloud-top diagnostics following AeroCom recommendation
   add_field<Computed>("T_mid_at_cldtop", scalar2d, K, grid_name);
   add_field<Computed>("p_mid_at_cldtop", scalar2d, Pa, grid_name);
-  add_field<Computed>("cldfrac_ice_at_cldtop", scalar2d, nondim, grid_name);
-  add_field<Computed>("cldfrac_liq_at_cldtop", scalar2d, nondim, grid_name);
-  add_field<Computed>("cldfrac_tot_at_cldtop", scalar2d, nondim, grid_name);
+  add_field<Computed>("cldfrac_ice_at_cldtop", scalar2d, none, grid_name);
+  add_field<Computed>("cldfrac_liq_at_cldtop", scalar2d, none, grid_name);
+  add_field<Computed>("cldfrac_tot_at_cldtop", scalar2d, none, grid_name);
   add_field<Computed>("cdnc_at_cldtop", scalar2d, 1 / (m * m * m), grid_name);
   add_field<Computed>("eff_radius_qc_at_cldtop", scalar2d, micron, grid_name);
   add_field<Computed>("eff_radius_qi_at_cldtop", scalar2d, micron, grid_name);
@@ -249,7 +248,7 @@ void RRTMGPRadiation::create_requests() {
   }
 
   // Working fields that we also want for diagnostic output
-  add_field<Computed>("cosine_solar_zenith_angle", scalar2d, nondim, grid_name);
+  add_field<Computed>("cosine_solar_zenith_angle", scalar2d, none, grid_name);
 
   // Load bands bounds from coefficients files and compute the band centerpoint.
   // Store both in the grid (if not already present)

--- a/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
+++ b/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
@@ -52,7 +52,6 @@ void SHOCMacrophysics::create_requests()
 
   constexpr int ps = Pack::n;
 
-  const auto nondim = Units::nondimensional();
   const auto m2 = pow(m,2);
   const auto s2 = pow(s,2);
 
@@ -77,21 +76,21 @@ void SHOCMacrophysics::create_requests()
   add_field<Required>("phis",           scalar2d    , m2/s2, grid_name);
 
   // Input/Output variables
-  add_field<Updated>("horiz_winds",   vector3d_mid,   m/s,     grid_name, ps);
+  add_field<Updated>("horiz_winds",   vector3d_mid,   m/s,   grid_name, ps);
   add_field<Updated>("sgs_buoy_flux", scalar3d_mid, K*(m/s), grid_name, ps);
   add_field<Updated>("eddy_diff_mom", scalar3d_mid, m2/s,    grid_name, ps);
-  add_field<Updated>("cldfrac_liq",   scalar3d_mid, nondim,  grid_name, ps);
+  add_field<Updated>("cldfrac_liq",   scalar3d_mid, none,    grid_name, ps);
   add_tracer<Updated>("tke", m_grid, m2/s2, ps);
   add_tracer<Updated>("qc",  m_grid, kg/kg, ps);
 
   // Output variables
-  add_field<Computed>("pbl_height",    scalar2d    , m,            grid_name);
-  add_field<Computed>("inv_qc_relvar", scalar3d_mid, pow(kg/kg,2), grid_name, ps);
-  add_field<Computed>("eddy_diff_heat",   scalar3d_mid, m2/s,        grid_name, ps);
-  add_field<Computed>("w_variance",       scalar3d_mid, m2/s2,       grid_name, ps);
-  add_field<Computed>("cldfrac_liq_prev", scalar3d_mid, nondim,      grid_name, ps);
-  add_field<Computed>("ustar",            scalar2d,     m/s,         grid_name, ps);
-  add_field<Computed>("obklen",           scalar2d,     m,           grid_name, ps);
+  add_field<Computed>("pbl_height",       scalar2d    , m,            grid_name);
+  add_field<Computed>("inv_qc_relvar",    scalar3d_mid, pow(kg/kg,2), grid_name, ps);
+  add_field<Computed>("eddy_diff_heat",   scalar3d_mid, m2/s,         grid_name, ps);
+  add_field<Computed>("w_variance",       scalar3d_mid, m2/s2,        grid_name, ps);
+  add_field<Computed>("cldfrac_liq_prev", scalar3d_mid, none,         grid_name, ps);
+  add_field<Computed>("ustar",            scalar2d,     m/s,          grid_name, ps);
+  add_field<Computed>("obklen",           scalar2d,     m,            grid_name, ps);
 
   // thl_sec is needed for ZM deep convection
   add_field<Computed>("thl_sec", scalar3d_int, pow(K,2), grid_name, ps);

--- a/components/eamxx/src/physics/spa/eamxx_spa_process_interface.cpp
+++ b/components/eamxx/src/physics/spa/eamxx_spa_process_interface.cpp
@@ -23,7 +23,6 @@ void SPA::create_requests()
   using namespace ekat::units;
   using namespace ShortFieldTagsNames;
 
-  constexpr auto nondim = Units::nondimensional();
   constexpr int ps = SCREAM_PACK_SIZE;
 
   m_model_grid = m_grids_manager->get_grid("physics");
@@ -49,11 +48,11 @@ void SPA::create_requests()
   add_field<Required>("p_mid"      , scalar3d_mid, Pa,     grid_name, ps);
 
   // Set of fields used strictly as output
-  add_field<Computed>("nccn",        scalar3d_mid,    1/kg,   grid_name, ps);
-  add_field<Computed>("aero_g_sw",   scalar3d_swband, nondim, grid_name, ps);
-  add_field<Computed>("aero_ssa_sw", scalar3d_swband, nondim, grid_name, ps);
-  add_field<Computed>("aero_tau_sw", scalar3d_swband, nondim, grid_name, ps);
-  add_field<Computed>("aero_tau_lw", scalar3d_lwband, nondim, grid_name, ps);
+  add_field<Computed>("nccn",        scalar3d_mid,    1/kg, grid_name, ps);
+  add_field<Computed>("aero_g_sw",   scalar3d_swband, none, grid_name, ps);
+  add_field<Computed>("aero_ssa_sw", scalar3d_swband, none, grid_name, ps);
+  add_field<Computed>("aero_tau_sw", scalar3d_swband, none, grid_name, ps);
+  add_field<Computed>("aero_tau_lw", scalar3d_lwband, none, grid_name, ps);
 }
 
 // =========================================================================================

--- a/components/eamxx/src/physics/spc/eamxx_spc_process_interface.cpp
+++ b/components/eamxx/src/physics/spc/eamxx_spc_process_interface.cpp
@@ -23,7 +23,6 @@ void SPC::create_requests()
   using namespace ekat::units;
   using namespace ShortFieldTagsNames;
 
-  constexpr auto nondim = Units::nondimensional();
   constexpr int ps = SCREAM_PACK_SIZE;
 
   m_model_grid = m_grids_manager->get_grid("physics");
@@ -55,7 +54,7 @@ void SPC::initialize_impl (const RunType /* run_type */)
 
   auto pmid = get_field_in("p_mid");
   
-  util::TimeLine timeline;
+  auto timeline = util::TimeLine::Linear;
   util::TimeStamp ref_ts;
   if (time_interpolation_method=="yearly_periodic") {
     timeline = util::TimeLine::YearlyPeriodic;

--- a/components/eamxx/src/physics/tms/eamxx_tms_process_interface.cpp
+++ b/components/eamxx/src/physics/tms/eamxx_tms_process_interface.cpp
@@ -28,7 +28,6 @@ void TurbulentMountainStress::create_requests()
   // Define some useful units. The units of mixing ratio
   // Q are technically non-dimensional. Nevertheless,
   // for output reasons, we like to see 'kg/kg'.
-  const auto nondim = Units::nondimensional();
   const auto m2 = pow(m,2);
 
   // Initialize grid from grids manager
@@ -48,12 +47,12 @@ void TurbulentMountainStress::create_requests()
   auto vector3d_mid = m_grid->get_3d_vector_layout(LEV,2);
 
   constexpr int ps = Pack::n;
-  add_field<Required>("horiz_winds",    vector3d_mid, m/s,    grid_name,            ps);
-  add_field<Required>("T_mid",          scalar3d_mid, K,      grid_name,            ps);
-  add_field<Required>("p_mid",          scalar3d_mid, Pa,     grid_name,            ps);
-  add_field<Required>("pseudo_density", scalar3d_mid, Pa,     grid_name,            ps);
-  add_field<Required>("sgh30",          scalar2d    , m,      grid_name);
-  add_field<Required>("landfrac",       scalar2d    , nondim, grid_name);
+  add_field<Required>("horiz_winds",    vector3d_mid, m/s,  grid_name,            ps);
+  add_field<Required>("T_mid",          scalar3d_mid, K,    grid_name,            ps);
+  add_field<Required>("p_mid",          scalar3d_mid, Pa,   grid_name,            ps);
+  add_field<Required>("pseudo_density", scalar3d_mid, Pa,   grid_name,            ps);
+  add_field<Required>("sgh30",          scalar2d    , m,    grid_name);
+  add_field<Required>("landfrac",       scalar2d    , none, grid_name);
   add_tracer<Required>("qv", m_grid, kg/kg, ps);
 
   add_field<Computed>("surf_drag_coeff_tms", scalar2d, kg/(m2*s), grid_name);

--- a/components/eamxx/src/physics/zm/eamxx_zm_process_interface.cpp
+++ b/components/eamxx/src/physics/zm/eamxx_zm_process_interface.cpp
@@ -44,10 +44,9 @@ void ZMDeepConvection::create_requests ()
   m_ncol = m_grid->get_num_local_dofs();
   m_nlev = m_grid->get_num_vertical_levels();
 
-  const auto nondim = Units::nondimensional();
-  const auto m2     = pow(m,2);
-  const auto s2     = pow(s,2);
-  const auto K2     = pow(K,2);
+  const auto m2 = pow(m,2);
+  const auto s2 = pow(s,2);
+  const auto K2 = pow(K,2);
 
   FieldLayout scalar2d     = m_grid->get_2d_scalar_layout();        // 2D variables
   FieldLayout scalar3d_mid = m_grid->get_3d_scalar_layout(LEV);    // 3D variables at mid-levels
@@ -55,16 +54,16 @@ void ZMDeepConvection::create_requests ()
   FieldLayout vector3d_mid = m_grid->get_3d_vector_layout(LEV,2);  // horiz_wind field
 
   // Input variables
-  add_field<Required>("p_mid",                scalar3d_mid, Pa,     grid_name, pack_size);
-  add_field<Required>("p_int",                scalar3d_int, Pa,     grid_name, pack_size);
-  add_field<Required>("pseudo_density",       scalar3d_mid, Pa,     grid_name, pack_size);
-  add_field<Required>("phis",                 scalar2d    , m2/s2,  grid_name);
-  add_field<Required>("omega",                scalar3d_mid, Pa/s,   grid_name, pack_size);
-  add_field<Required>("cldfrac_tot",          scalar3d_mid, nondim, grid_name, pack_size);
-  add_field<Required>("pbl_height",           scalar2d    , m,      grid_name);
-  add_field<Required>("landfrac",             scalar2d    , nondim, grid_name);
-  add_field<Required>("thl_sec",              scalar3d_int, K2,     grid_name, pack_size); // thetal variance for PBL temperature perturbation
-  add_tracer<Required>("qc",                  m_grid,       kg/kg,             pack_size);
+  add_field<Required>("p_mid",                scalar3d_mid, Pa,    grid_name, pack_size);
+  add_field<Required>("p_int",                scalar3d_int, Pa,    grid_name, pack_size);
+  add_field<Required>("pseudo_density",       scalar3d_mid, Pa,    grid_name, pack_size);
+  add_field<Required>("phis",                 scalar2d    , m2/s2, grid_name);
+  add_field<Required>("omega",                scalar3d_mid, Pa/s,  grid_name, pack_size);
+  add_field<Required>("cldfrac_tot",          scalar3d_mid, none,  grid_name, pack_size);
+  add_field<Required>("pbl_height",           scalar2d    , m,     grid_name);
+  add_field<Required>("landfrac",             scalar2d    , none,  grid_name);
+  add_field<Required>("thl_sec",              scalar3d_int, K2,    grid_name, pack_size); // thetal variance for PBL temperature perturbation
+  add_tracer<Required>("qc",                  m_grid,       kg/kg,            pack_size);
 
   // Input/Output variables
   add_field <Updated>("T_mid",                scalar3d_mid, K,      grid_name, pack_size);
@@ -76,10 +75,10 @@ void ZMDeepConvection::create_requests ()
   add_field <Updated>("precip_ice_surf_mass", scalar2d,     kg/m2,  grid_name, "ACCUMULATED");
 
   // Diagnostic Outputs
-  add_field<Computed>("zm_prec",              scalar2d,     m/s,    grid_name);
-  add_field<Computed>("zm_snow",              scalar2d,     m/s,    grid_name);
-  add_field<Computed>("zm_cape",              scalar2d,     J/kg,   grid_name);
-  add_field<Computed>("zm_activity",          scalar2d,     nondim, grid_name);
+  add_field<Computed>("zm_prec",              scalar2d,     m/s,  grid_name);
+  add_field<Computed>("zm_snow",              scalar2d,     m/s,  grid_name);
+  add_field<Computed>("zm_cape",              scalar2d,     J/kg, grid_name);
+  add_field<Computed>("zm_activity",          scalar2d,     none, grid_name);
 
   add_field<Computed>("zm_T_mid_tend",        scalar3d_mid, K/s,    grid_name, pack_size);
   add_field<Computed>("zm_qv_tend",           scalar3d_mid, kg/kg/s,grid_name, pack_size);

--- a/components/eamxx/src/share/algorithm/eamxx_data_interpolation.cpp
+++ b/components/eamxx/src/share/algorithm/eamxx_data_interpolation.cpp
@@ -626,11 +626,10 @@ create_vert_remapper (const VertRemapData& data)
       // We need to reconstruct the 3d pressure from ps, hybm, and hyam.
       // We read and store hyam/hybm in the vremap src grid
       auto layout = m_grid_after_hremap->get_vertical_layout(LEVP);
-      auto nondim = ekat::units::Units::nondimensional();
       DataType real_t = DataType::RealType;
       std::vector<Field> fields = {
-        m_grid_after_hremap->create_geometry_data("hyam",layout,nondim,real_t,SCREAM_PACK_SIZE),
-        m_grid_after_hremap->create_geometry_data("hybm",layout,nondim,real_t,SCREAM_PACK_SIZE)
+        m_grid_after_hremap->create_geometry_data("hyam",layout,ekat::units::none,real_t,SCREAM_PACK_SIZE),
+        m_grid_after_hremap->create_geometry_data("hybm",layout,ekat::units::none,real_t,SCREAM_PACK_SIZE)
       };
       AtmosphereInput hvcoord_reader (m_time_database.files.front(),m_grid_after_hremap,fields,true);
       hvcoord_reader.read_variables();

--- a/components/eamxx/src/share/algorithm/tests/time_interpolation_tests.cpp
+++ b/components/eamxx/src/share/algorithm/tests/time_interpolation_tests.cpp
@@ -333,14 +333,13 @@ get_fm (const std::shared_ptr<const AbstractGrid>& grid, const util::TimeStamp& 
 
   auto fm = std::make_shared<FieldManager>(grid,RepoState::Closed);
 
-  const auto units = ekat::units::Units::nondimensional();
   std::vector<Real> values;
   for (int i=1; i<=100; ++i)
     values.push_back(static_cast<Real>(i));
   for (const auto& fl : layouts) {
     int gl_size = fl.size();
     grid->get_comm().all_reduce(&gl_size,1,MPI_SUM);
-    FID fid("f_"+std::to_string(gl_size),fl,units,grid->name());
+    FID fid("f_"+std::to_string(gl_size),fl,ekat::units::none,grid->name());
     Field f(fid);
     f.allocate_view();
     randomize_discrete (f,seed++,values);

--- a/components/eamxx/src/share/data_managers/IOPDataManager.cpp
+++ b/components/eamxx/src/share/data_managers/IOPDataManager.cpp
@@ -170,7 +170,7 @@ initialize_iop_file(const util::TimeStamp& run_t0,
       m_iop_field_type.insert({iop_varname, IOPFieldType::FromFile});
 
       // Allocate field for variable
-      FieldIdentifier fid(iop_varname, fl, ekat::units::Units::nondimensional(), "");
+      FieldIdentifier fid(iop_varname, fl, ekat::units::none, "");
       const auto field_rank = fl.rank();
       EKAT_REQUIRE_MSG(field_rank <= 1,
                        "Error! Unexpected field rank "+std::to_string(field_rank)+" for iop file fields.\n");
@@ -245,7 +245,7 @@ initialize_iop_file(const util::TimeStamp& run_t0,
 
   // If we have the vertical component of T/Q forcing, define 3d forcing as a computed field.
   if (has_iop_field("vertdivT")) {
-    FieldIdentifier fid("divT3d", fl_vector, ekat::units::Units::nondimensional(), "");
+    FieldIdentifier fid("divT3d", fl_vector, ekat::units::none, "");
     Field field(fid);
     field.get_header().get_alloc_properties().request_allocation(Pack::n);
     field.allocate_view();
@@ -253,7 +253,7 @@ initialize_iop_file(const util::TimeStamp& run_t0,
     m_iop_field_type.insert({"divT3d", IOPFieldType::Computed});
   }
   if (has_iop_field("vertdivq")) {
-    FieldIdentifier fid("divq3d", fl_vector, ekat::units::Units::nondimensional(), "");
+    FieldIdentifier fid("divq3d", fl_vector, ekat::units::none, "");
     Field field(fid);
     field.get_header().get_alloc_properties().request_allocation(Pack::n);
     field.allocate_view();
@@ -328,7 +328,7 @@ initialize_iop_file(const util::TimeStamp& run_t0,
   const auto file_levs = scorpio::get_dimlen(iop_file, "lev");
   FieldIdentifier fid("iop_file_pressure",
                       FieldLayout({FieldTag::LevelMidPoint}, {file_levs+1}),
-                      ekat::units::Units::nondimensional(),
+                      ekat::units::none,
                       "");
   Field iop_file_pressure(fid);
   iop_file_pressure.get_header().get_alloc_properties().request_allocation(Pack::n);
@@ -345,7 +345,7 @@ initialize_iop_file(const util::TimeStamp& run_t0,
   // in read_iop_file_data())
   FieldIdentifier model_pres_fid("model_pressure",
                                   fl_vector,
-                                  ekat::units::Units::nondimensional(), "");
+                                  ekat::units::none, "");
   Field model_pressure(model_pres_fid);
   model_pressure.get_header().get_alloc_properties().request_allocation(Pack::n);
   model_pressure.allocate_view();
@@ -564,7 +564,7 @@ read_iop_file_data (const util::TimeStamp& current_ts)
       FieldIdentifier fid(file_varname+"_iop_file",
                           FieldLayout({FieldTag::LevelMidPoint},
                           {adjusted_file_levs}),
-                          ekat::units::Units::nondimensional(),
+                          ekat::units::none,
                           "");
       Field iop_file_field(fid);
       iop_file_field.get_header().get_alloc_properties().request_allocation(Pack::n);

--- a/components/eamxx/src/share/data_managers/field_manager.cpp
+++ b/components/eamxx/src/share/data_managers/field_manager.cpp
@@ -626,10 +626,7 @@ void FieldManager::registration_ends ()
 
         // The units for the monolithic field are nondimensional, cause checking whether
         // all fields in the group have the same units so we can use those is too long and pointless.
-        auto nondim = ekat::units::Units::nondimensional();
-
-        // Allocate cluster field
-        FieldIdentifier c_fid(cluster_name,c_layout,nondim,cluster_grid->name());
+        FieldIdentifier c_fid(cluster_name,c_layout,ekat::units::none,cluster_grid->name());
         register_field(c_fid);
         const auto& C = m_fields.at(cluster_grid_name).at(c_fid.name());
 

--- a/components/eamxx/src/share/data_managers/mesh_free_grids_manager.cpp
+++ b/components/eamxx/src/share/data_managers/mesh_free_grids_manager.cpp
@@ -150,9 +150,11 @@ add_geo_data (const nonconstgrid_ptr_type& grid) const
     auto layout_int = grid->get_vertical_layout(ILEV);
 
     auto mbar = (100*Pa).rename("mb");
+    auto degN = none.rename("degrees_north");
+    auto degE = none.rename("degrees_east");
 
-    auto lat  = grid->create_geometry_data("lat" ,  grid->get_2d_scalar_layout(), rad);
-    auto lon  = grid->create_geometry_data("lon" ,  grid->get_2d_scalar_layout(), rad);
+    auto lat  = grid->create_geometry_data("lat" ,  grid->get_2d_scalar_layout(), degN);
+    auto lon  = grid->create_geometry_data("lon" ,  grid->get_2d_scalar_layout(), degE);
     auto hyam = grid->create_geometry_data("hyam" , layout_mid, none);
     auto hybm = grid->create_geometry_data("hybm" , layout_mid, none);
     auto hyai = grid->create_geometry_data("hyai" , layout_int, none);
@@ -193,10 +195,12 @@ void MeshFreeGridsManager::
 load_lat_lon (const nonconstgrid_ptr_type& grid, const std::string& filename) const
 {
   using gid_type = AbstractGrid::gid_type;
-  const auto units = ekat::units::none;
 
-  auto lat = grid->create_geometry_data("lat" , grid->get_2d_scalar_layout(), units);
-  auto lon = grid->create_geometry_data("lon" , grid->get_2d_scalar_layout(), units);
+  auto degN = ekat::units::none.rename("degrees_north");
+  auto degE = ekat::units::none.rename("degrees_east");
+
+  auto lat = grid->create_geometry_data("lat" , grid->get_2d_scalar_layout(), degN);
+  auto lon = grid->create_geometry_data("lon" , grid->get_2d_scalar_layout(), degE);
 
   auto lat_v = lat.get_view<Real*,Host>();
   auto lon_v = lon.get_view<Real*,Host>();

--- a/components/eamxx/src/share/data_managers/mesh_free_grids_manager.cpp
+++ b/components/eamxx/src/share/data_managers/mesh_free_grids_manager.cpp
@@ -116,13 +116,11 @@ build_point_grid (const std::string& name, ekat::ParameterList& params)
   const int gid_base = params.get<int>("gid_base",0);
   auto pt_grid = create_point_grid(name,num_global_cols,num_vertical_levels,m_comm,gid_base);
 
-  const auto units = ekat::units::Units::nondimensional();
-
-  auto area = pt_grid->create_geometry_data("area", pt_grid->get_2d_scalar_layout(), units);
+  auto area = pt_grid->create_geometry_data("area", pt_grid->get_2d_scalar_layout(), ekat::units::sr);
 
   // Estimate cell area for a uniform grid by taking the surface area
   // of the earth divided by the number of columns.  Note we do this in
-  // units of radians-squared.
+  // units of steradians
   using PC             = scream::physics::Constants<Real>;
   const Real pi        = PC::Pi;
   const Real cell_area = 4.0*pi/num_global_cols;
@@ -146,18 +144,21 @@ add_geo_data (const nonconstgrid_ptr_type& grid) const
   const auto& geo_data_source = m_params.get<std::string>("geo_data_source");
   if (geo_data_source=="CREATE_EMPTY_DATA") {
     using namespace ShortFieldTagsNames;
-    FieldLayout layout_mid ({LEV},{grid->get_num_vertical_levels()});
-    FieldLayout layout_int ({ILEV},{grid->get_num_vertical_levels()+1});
-    const auto units = ekat::units::Units::nondimensional();
+    using namespace ekat::units;
 
-    auto lat  = grid->create_geometry_data("lat" ,  grid->get_2d_scalar_layout(), units);
-    auto lon  = grid->create_geometry_data("lon" ,  grid->get_2d_scalar_layout(), units);
-    auto hyam = grid->create_geometry_data("hyam" , layout_mid, units);
-    auto hybm = grid->create_geometry_data("hybm" , layout_mid, units);
-    auto hyai = grid->create_geometry_data("hyai" , layout_int, units);
-    auto hybi = grid->create_geometry_data("hybi" , layout_int, units);
-    auto lev  = grid->create_geometry_data("lev" ,  layout_mid, units);
-    auto ilev = grid->create_geometry_data("ilev" , layout_int, units);
+    auto layout_mid = grid->get_vertical_layout(LEV);
+    auto layout_int = grid->get_vertical_layout(ILEV);
+
+    auto mbar = (100*Pa).rename("mb");
+
+    auto lat  = grid->create_geometry_data("lat" ,  grid->get_2d_scalar_layout(), rad);
+    auto lon  = grid->create_geometry_data("lon" ,  grid->get_2d_scalar_layout(), rad);
+    auto hyam = grid->create_geometry_data("hyam" , layout_mid, none);
+    auto hybm = grid->create_geometry_data("hybm" , layout_mid, none);
+    auto hyai = grid->create_geometry_data("hyai" , layout_int, none);
+    auto hybi = grid->create_geometry_data("hybi" , layout_int, none);
+    auto lev  = grid->create_geometry_data("lev" ,  layout_mid, mbar);
+    auto ilev = grid->create_geometry_data("ilev" , layout_int, mbar);
 
     const auto invalid = ekat::invalid<Real>();
     lat.deep_copy(invalid);;
@@ -192,7 +193,7 @@ void MeshFreeGridsManager::
 load_lat_lon (const nonconstgrid_ptr_type& grid, const std::string& filename) const
 {
   using gid_type = AbstractGrid::gid_type;
-  const auto units = ekat::units::Units::nondimensional();
+  const auto units = ekat::units::none;
 
   auto lat = grid->create_geometry_data("lat" , grid->get_2d_scalar_layout(), units);
   auto lon = grid->create_geometry_data("lon" , grid->get_2d_scalar_layout(), units);
@@ -236,15 +237,14 @@ load_vertical_coordinates (const nonconstgrid_ptr_type& grid, const std::string&
   using namespace ShortFieldTagsNames;
   using namespace ekat::units;
 
-  FieldLayout layout_mid ({LEV},{grid->get_num_vertical_levels()});
-  FieldLayout layout_int ({ILEV},{grid->get_num_vertical_levels()+1});
-  Units nondim = Units::nondimensional();
-  Units mbar (100*Pa,"mb");
+  auto layout_mid = grid->get_vertical_layout(LEV);
+  auto layout_int = grid->get_vertical_layout(ILEV);
+  auto mbar = (100*Pa).rename("mb");
 
-  auto hyam = grid->create_geometry_data("hyam", layout_mid, nondim);
-  auto hybm = grid->create_geometry_data("hybm", layout_mid, nondim);
-  auto hyai = grid->create_geometry_data("hyai", layout_int, nondim);
-  auto hybi = grid->create_geometry_data("hybi", layout_int, nondim);
+  auto hyam = grid->create_geometry_data("hyam", layout_mid, none);
+  auto hybm = grid->create_geometry_data("hybm", layout_mid, none);
+  auto hyai = grid->create_geometry_data("hyai", layout_int, none);
+  auto hybi = grid->create_geometry_data("hybi", layout_int, none);
   auto lev  = grid->create_geometry_data("lev",  layout_mid, mbar);
   auto ilev = grid->create_geometry_data("ilev", layout_int, mbar);
 

--- a/components/eamxx/src/share/data_managers/tests/field_mgr_tests.cpp
+++ b/components/eamxx/src/share/data_managers/tests/field_mgr_tests.cpp
@@ -147,15 +147,13 @@ TEST_CASE("tracers_group", "") {
   std::vector<int> dims1 = {ncols1,nlevs};
   std::vector<int> dims2 = {ncols2,nlevs};
 
-  const auto nondim = Units::nondimensional();
-
   const std::string gn1 = "grid1";
   const std::string gn2 = "grid2";
 
-  FieldIdentifier qv_id("qv", {tags, dims1}, nondim, gn1);
-  FieldIdentifier a_id("a", {tags, dims1}, nondim, gn1);
-  FieldIdentifier b_id("b", {tags, dims2}, nondim, gn2);
-  FieldIdentifier c_id("c", {tags, dims1}, nondim, gn1);
+  FieldIdentifier qv_id("qv", {tags, dims1}, none, gn1);
+  FieldIdentifier a_id ("a",  {tags, dims1}, none, gn1);
+  FieldIdentifier b_id ("b",  {tags, dims2}, none, gn2);
+  FieldIdentifier c_id ("c",  {tags, dims1}, none, gn1);
 
   ekat::Comm comm(MPI_COMM_WORLD);
   auto g1 = create_point_grid(gn1,ncols1*comm.size(),nlevs,comm);

--- a/components/eamxx/src/share/diagnostics/aerocom_cld.cpp
+++ b/components/eamxx/src/share/diagnostics/aerocom_cld.cpp
@@ -30,7 +30,6 @@ create_requests() {
   auto grid             = m_grids_manager->get_grid("physics");
   const auto &grid_name = grid->name();
 
-  const auto nondim = Units::nondimensional();
   const auto micron = m / 1000000;
 
   // Set the index map and units map
@@ -64,7 +63,7 @@ create_requests() {
   add_field<Required>("qi",             scalar3d, kg / kg, grid_name);
   add_field<Required>("eff_radius_qc",  scalar3d, micron,  grid_name);
   add_field<Required>("eff_radius_qi",  scalar3d, micron,  grid_name);
-  add_field<Required>("cldfrac_tot",    scalar3d, nondim,  grid_name);
+  add_field<Required>("cldfrac_tot",    scalar3d, none,    grid_name);
   add_field<Required>("nc",             scalar3d, 1 / kg,  grid_name);
   add_field<Required>("ni",             scalar3d, 1 / kg,  grid_name);
 
@@ -74,7 +73,7 @@ create_requests() {
   m_dz.allocate_view();
 
   // Construct and allocate the output field
-  FieldIdentifier fid(name() + m_topbot, vector2d, nondim, grid_name);
+  FieldIdentifier fid(name() + m_topbot, vector2d, none, grid_name);
   m_diagnostic_output = Field(fid);
   m_diagnostic_output.allocate_view();
 

--- a/components/eamxx/src/share/diagnostics/aodvis.cpp
+++ b/components/eamxx/src/share/diagnostics/aodvis.cpp
@@ -21,8 +21,6 @@ create_requests()
   auto grid             = m_grids_manager->get_grid("physics");
   const auto &grid_name = grid->name();
 
-  const auto nondim = Units::nondimensional();
-
   m_ncols = grid->get_num_local_dofs();
   m_nlevs = grid->get_num_vertical_levels();
 
@@ -31,11 +29,11 @@ create_requests()
   auto scalar2d = grid->get_2d_scalar_layout();
 
   // The fields required for this diagnostic to be computed
-  add_field<Required>("aero_tau_sw", vector3d, nondim, grid_name);
-  add_field<Required>(FieldIdentifier("sunlit_mask", scalar2d, nondim, grid_name, DataType::IntType));
+  add_field<Required>("aero_tau_sw", vector3d, none, grid_name);
+  add_field<Required>(FieldIdentifier("sunlit_mask", scalar2d, none, grid_name, DataType::IntType));
 
   // Construct and allocate the aodvis field
-  FieldIdentifier fid(name(), scalar2d, nondim, grid_name);
+  FieldIdentifier fid(name(), scalar2d, none, grid_name);
   m_diagnostic_output = Field(fid);
   m_diagnostic_output.allocate_view();
 

--- a/components/eamxx/src/share/diagnostics/conditional_sampling.cpp
+++ b/components/eamxx/src/share/diagnostics/conditional_sampling.cpp
@@ -129,7 +129,7 @@ void ConditionalSampling::create_requests()
   // Special case: if lhs field is "lev", we don't need a lhs field.
   // We can actually precompute the output mask for a 1d col
   if (m_lhs_is_lev) {
-    FieldIdentifier lev_fid("lev_mask",g->get_vertical_layout(LEV),ekat::units::Units::nondimensional(),g->name(),DataType::IntType);
+    FieldIdentifier lev_fid("lev_mask",g->get_vertical_layout(LEV),ekat::units::none,g->name(),DataType::IntType);
     m_lev_mask = Field(lev_fid,true);
     auto lev_idx = m_lev_mask.clone("lev_idx");
     auto lev_idx_h = lev_idx.get_view<int*,Host>();
@@ -153,7 +153,7 @@ void ConditionalSampling::initialize_impl(const RunType /*run_type*/)
       m_diagnostic_output = m_lev_mask.clone(m_diag_name);
     } else {
       auto dfid = get_field_in(m_condition_lhs).get_header().get_identifier().clone(m_diag_name);
-      dfid.reset_dtype(DataType::IntType).reset_units(ekat::units::Units::nondimensional());
+      dfid.reset_dtype(DataType::IntType).reset_units(ekat::units::none);
       m_diagnostic_output = Field(dfid,true);
     }
   } else {

--- a/components/eamxx/src/share/diagnostics/exner.cpp
+++ b/components/eamxx/src/share/diagnostics/exner.cpp
@@ -18,8 +18,6 @@ void ExnerDiagnostic::create_requests()
   using namespace ekat::units;
   using namespace ShortFieldTagsNames;
 
-  auto nondim = Units::nondimensional();
-
   auto grid  = m_grids_manager->get_grid("physics");
   const auto& grid_name = grid->name();
   m_num_cols = grid->get_num_local_dofs(); // Number of columns on this rank
@@ -31,7 +29,7 @@ void ExnerDiagnostic::create_requests()
   add_field<Required>("p_mid", scalar3d, Pa, grid_name);
 
   // Construct and allocate the diagnostic field
-  FieldIdentifier fid (name(), scalar3d, nondim, grid_name);
+  FieldIdentifier fid (name(), scalar3d, none, grid_name);
   m_diagnostic_output = Field(fid);
   m_diagnostic_output.allocate_view();
 }

--- a/components/eamxx/src/share/diagnostics/histogram.cpp
+++ b/components/eamxx/src/share/diagnostics/histogram.cpp
@@ -52,8 +52,7 @@ void HistogramDiag::initialize_impl(const RunType /*run_type*/) {
   const int num_bins = m_bin_reals.size()-1;
   FieldLayout diagnostic_layout({CMP}, {num_bins}, {"bin"});
   FieldIdentifier diagnostic_id(m_diag_name, diagnostic_layout,
-                                FieldIdentifier::Units::nondimensional(),
-                                field_id.get_grid_name());
+                                ekat::units::none, field_id.get_grid_name());
   m_diagnostic_output = Field(diagnostic_id);
   m_diagnostic_output.allocate_view();
 

--- a/components/eamxx/src/share/diagnostics/relative_humidity.cpp
+++ b/components/eamxx/src/share/diagnostics/relative_humidity.cpp
@@ -19,8 +19,6 @@ void RelativeHumidityDiagnostic::create_requests()
   using namespace ekat::units;
   using namespace ShortFieldTagsNames;
 
-  auto nondim = Units::nondimensional();
-
   auto grid  = m_grids_manager->get_grid("physics");
   const auto& grid_name = grid->name();
   m_num_cols = grid->get_num_local_dofs(); // Number of columns on this rank
@@ -36,7 +34,7 @@ void RelativeHumidityDiagnostic::create_requests()
   add_field<Required>("pseudo_density_dry", scalar3d, Pa,    grid_name, SCREAM_PACK_SIZE);
 
   // Construct and allocate the diagnostic field
-  FieldIdentifier fid (name(), scalar3d, nondim, grid_name);
+  FieldIdentifier fid (name(), scalar3d, none, grid_name);
   m_diagnostic_output = Field(fid);
   auto& C_ap = m_diagnostic_output.get_header().get_alloc_properties();
   C_ap.request_allocation(SCREAM_PACK_SIZE);

--- a/components/eamxx/src/share/diagnostics/tests/aerocom_cld_test.cpp
+++ b/components/eamxx/src/share/diagnostics/tests/aerocom_cld_test.cpp
@@ -37,7 +37,6 @@ TEST_CASE("aerocom_cld") {
   // A time stamp
   util::TimeStamp t0({2024, 1, 1}, {0, 0, 0});
 
-  const auto nondim = Units::nondimensional();
   const auto micron = m / 1000000;
 
   // Create a grids manager - single column for these tests
@@ -65,7 +64,7 @@ TEST_CASE("aerocom_cld") {
                          grid->name());
   FieldIdentifier ei_fid("eff_radius_qi", scalar2d_layout, micron,
                          grid->name());
-  FieldIdentifier cd_fid("cldfrac_tot", scalar2d_layout, nondim, grid->name());
+  FieldIdentifier cd_fid("cldfrac_tot", scalar2d_layout, none, grid->name());
   FieldIdentifier nc_fid("nc", scalar2d_layout, 1 / kg, grid->name());
   FieldIdentifier ni_fid("ni", scalar2d_layout, 1 / kg, grid->name());
 

--- a/components/eamxx/src/share/diagnostics/tests/aodvis_test.cpp
+++ b/components/eamxx/src/share/diagnostics/tests/aodvis_test.cpp
@@ -37,8 +37,6 @@ TEST_CASE("aodvis") {
   // A time stamp
   util::TimeStamp t0({2022, 1, 1}, {0, 0, 0});
 
-  const auto nondim = Units::nondimensional();
-
   // Create a grids manager - single column for these tests
   constexpr int nlevs = 33;
   const int ngcols    = 10 * comm.size();
@@ -52,14 +50,13 @@ TEST_CASE("aodvis") {
   // Input (randomized) tau
   FieldLayout scalar3d_swband_layout =
       grid->get_3d_vector_layout(LEV, nbnds, "swband");
-  FieldIdentifier tau_fid("aero_tau_sw", scalar3d_swband_layout, nondim,
-                          grid->name());
+  FieldIdentifier tau_fid("aero_tau_sw", scalar3d_swband_layout, none, grid->name());
   Field tau(tau_fid);
   tau.allocate_view();
   tau.get_header().get_tracking().update_time_stamp(t0);
   // Input (randomized) sunlit
   FieldLayout scalar2d_layout = grid->get_2d_scalar_layout();
-  FieldIdentifier sunlit_fid("sunlit_mask", scalar2d_layout, nondim, grid->name(), DataType::IntType);
+  FieldIdentifier sunlit_fid("sunlit_mask", scalar2d_layout, none, grid->name(), DataType::IntType);
   Field sunlit(sunlit_fid);
   sunlit.allocate_view();
   sunlit.get_header().get_tracking().update_time_stamp(t0);

--- a/components/eamxx/src/share/diagnostics/tests/histogram_test.cpp
+++ b/components/eamxx/src/share/diagnostics/tests/histogram_test.cpp
@@ -121,8 +121,7 @@ TEST_CASE("histogram") {
   const int num_bins = bin_values.size()-1;
   const std::string bin_dim_name = diag1_field.get_header().get_identifier().get_layout().name(0);
   FieldLayout diag0_layout({CMP}, {num_bins}, {bin_dim_name});
-  FieldIdentifier diag0_id("qc_histogram_manual", diag0_layout,
-    FieldIdentifier::Units::nondimensional(), grid->name());
+  FieldIdentifier diag0_id("qc_histogram_manual", diag0_layout, ekat::units::none, grid->name());
   Field diag0_field(diag0_id);
   diag0_field.allocate_view();
 
@@ -172,8 +171,7 @@ TEST_CASE("histogram") {
 
   // Try a random case with qc3
   FieldLayout diag3m_layout({CMP}, {num_bins}, {bin_dim_name});
-  FieldIdentifier diag3m_id("qc_zonal_avg_manual", diag3m_layout,
-    FieldIdentifier::Units::nondimensional(), grid->name());
+  FieldIdentifier diag3m_id("qc_zonal_avg_manual", diag3m_layout, ekat::units::none, grid->name());
   Field diag3m_field(diag3m_id);
   diag3m_field.allocate_view();
   auto qc3_view_h    = qc3.get_view<const Real ***, Host>();

--- a/components/eamxx/src/share/diagnostics/tests/horiz_avg_test.cpp
+++ b/components/eamxx/src/share/diagnostics/tests/horiz_avg_test.cpp
@@ -29,8 +29,6 @@ std::shared_ptr<GridsManager> create_gm(const ekat::Comm &comm, const int ncols,
 TEST_CASE("horiz_avg") {
   using namespace ShortFieldTagsNames;
 
-  constexpr auto nondim = ekat::units::Units::nondimensional();
-
   // A numerical tolerance
   auto tol = std::numeric_limits<Real>::epsilon() * 100;
 
@@ -66,7 +64,7 @@ TEST_CASE("horiz_avg") {
     params.set<std::string>("field_name", "s_x");
 
     FieldLayout layout{{COL}, {ncols}};
-    FieldIdentifier scl_x_fid ("s_x" , layout, nondim, grid->name());
+    FieldIdentifier scl_x_fid ("s_x" , layout, ekat::units::none, grid->name());
     Field scl_x (scl_x_fid , true);
     scl_x.get_header().get_tracking().update_time_stamp(t0);
     randomize_uniform(scl_x,seed++);
@@ -97,7 +95,7 @@ TEST_CASE("horiz_avg") {
     params.set<std::string>("field_name", "vec_xz");
 
     FieldLayout layout{{COL,CMP,LEV}, {ncols,2,nlevs}};
-    FieldIdentifier vec_xz_fid ("vec_xz" , layout, nondim, grid->name());
+    FieldIdentifier vec_xz_fid ("vec_xz" , layout, ekat::units::none, grid->name());
     Field vec_xz (vec_xz_fid , true);
     randomize_uniform(vec_xz,seed++);
     vec_xz.get_header().get_tracking().update_time_stamp(t0);
@@ -146,7 +144,7 @@ TEST_CASE("horiz_avg") {
     params.set<std::string>("field_name", "vec_xz");
 
     FieldLayout layout{{COL,CMP,LEV}, {ncols,2,nlevs}};
-    FieldIdentifier vec_xz_fid ("vec_xz" , layout, nondim, grid->name());
+    FieldIdentifier vec_xz_fid ("vec_xz" , layout, ekat::units::none, grid->name());
     Field vec_xz (vec_xz_fid , true);
     randomize_uniform(vec_xz,seed++);
     vec_xz.get_header().get_tracking().update_time_stamp(t0);
@@ -176,7 +174,7 @@ TEST_CASE("horiz_avg") {
     params.set<std::string>("field_name", "s_xz");
 
     FieldLayout layout{{COL,LEV}, {ncols,nlevs}};
-    FieldIdentifier scl_xz_fid ("s_xz" , layout, nondim, grid->name());
+    FieldIdentifier scl_xz_fid ("s_xz" , layout, ekat::units::none, grid->name());
     Field scl_xz (scl_xz_fid , true);
     scl_xz.get_header().get_tracking().update_time_stamp(t0);
 

--- a/components/eamxx/src/share/diagnostics/tests/vert_contract_test.cpp
+++ b/components/eamxx/src/share/diagnostics/tests/vert_contract_test.cpp
@@ -170,8 +170,7 @@ TEST_CASE("vert_contract") {
     // Manual reference: ref(col) = sum_lev( f(col,lev) )
     // Use a 1D all-ones weight (same as the diagnostic)
     FieldLayout ones_lev_layout{{LEV}, {nlevs}};
-    Field ones_lev(FieldIdentifier("ones_lev", ones_lev_layout,
-                                   Units::nondimensional(), grid->name()), true);
+    Field ones_lev(FieldIdentifier("ones_lev", ones_lev_layout, none, grid->name()), true);
     ones_lev.deep_copy(1);
     auto ref = diag_f.clone("ref");
     vert_contraction(ref, fin, ones_lev);
@@ -206,7 +205,7 @@ TEST_CASE("vert_contract") {
     // Use a 1D all-ones weight (same as the diagnostic)
     FieldLayout ones_lev_layout{{LEV}, {nlevs}};
     Field ones_lev(FieldIdentifier("ones_lev", ones_lev_layout,
-                                   Units::nondimensional(), grid->name()), true);
+                                   none, grid->name()), true);
     ones_lev.deep_copy(1);
     auto fin_ones = fin.clone("fin_ones");
     fin_ones.deep_copy(1);

--- a/components/eamxx/src/share/diagnostics/tests/zonal_avg_test.cpp
+++ b/components/eamxx/src/share/diagnostics/tests/zonal_avg_test.cpp
@@ -50,9 +50,9 @@ TEST_CASE("zonal_avg") {
   Field area       = grid->get_geometry_data("area");
   auto area_view_h = area.get_view<const Real *, Host>();
 
+
   // Set latitude values
-  Field lat = gm->get_grid_nonconst("Physics")->create_geometry_data(
-      "lat", grid->get_2d_scalar_layout(), Units::nondimensional());
+  Field lat = grid->create_geometry_data("lat", grid->get_2d_scalar_layout(), none);
   auto lat_view_h      = lat.get_view<Real *, Host>();
   const Real lat_delta = sp(180.0) / nlats;
   std::vector<Real> zonal_areas(nlats, 0.0);
@@ -66,15 +66,15 @@ TEST_CASE("zonal_avg") {
   lat.sync_to_dev();
 
   // Input (randomized) qc
-  FieldLayout scalar1d_layout{{COL}, {ncols}};
-  FieldLayout scalar2d_layout{{COL, LEV}, {ncols, nlevs}};
-  FieldLayout scalar3d_layout{{COL, CMP, LEV}, {ncols, dim3, nlevs}};
+  auto scalar1d_layout = grid->get_2d_scalar_layout();
+  auto scalar2d_layout = grid->get_3d_scalar_layout(LEV);
+  auto scalar3d_layout = grid->get_3d_vector_layout(LEV,dim3);
 
-  FieldIdentifier qc1_id("qc", scalar1d_layout, kg / kg, grid->name());
+  FieldIdentifier qc1_fid("qc", scalar1d_layout, kg / kg, grid->name());
   FieldIdentifier qc2_fid("qc", scalar2d_layout, kg / kg, grid->name());
   FieldIdentifier qc3_fid("qc", scalar3d_layout, kg / kg, grid->name());
 
-  Field qc1(qc1_id);
+  Field qc1(qc1_fid);
   Field qc2(qc2_fid);
   Field qc3(qc3_fid);
 

--- a/components/eamxx/src/share/diagnostics/vert_contract.cpp
+++ b/components/eamxx/src/share/diagnostics/vert_contract.cpp
@@ -81,7 +81,7 @@ void VertContractDiag::initialize_impl(const RunType /*run_type*/)
 
   auto diag_units = fid.get_units();
 
-  auto w_units = Units::nondimensional();
+  auto w_units = none;
   // set up the weighting field
   if (m_weighting_method == "dp") {
     m_weight = get_field_in("pseudo_density").clone("vert_contract_wts");

--- a/components/eamxx/src/share/diagnostics/vertical_layer.cpp
+++ b/components/eamxx/src/share/diagnostics/vertical_layer.cpp
@@ -128,9 +128,8 @@ initialize_impl (const RunType /*run_type*/)
 
   // Initialize temporary views based on need. Can alias the diag if a temp is not needed
   auto create_temp = [&](const std::string& name, int levs) {
-    auto u = Units::nondimensional();
     FieldLayout fl({COL,LEV},{m_num_cols,levs});
-    FieldIdentifier fid (name,fl,u,grid_name);
+    FieldIdentifier fid (name,fl,none,grid_name);
     Field f = Field(fid);
     f.get_header().get_alloc_properties().request_allocation(ps);
     f.allocate_view();

--- a/components/eamxx/src/share/diagnostics/zonal_avg.cpp
+++ b/components/eamxx/src/share/diagnostics/zonal_avg.cpp
@@ -153,7 +153,7 @@ void ZonalAvgDiag::initialize_impl(const RunType /*run_type*/) {
   // allocate column counter
   FieldLayout ncols_per_bin_layout({CMP}, {m_num_zonal_bins}, {"bin"});
   FieldIdentifier ncols_per_bin_id("number of columns per bin",
-    ncols_per_bin_layout, FieldIdentifier::Units::nondimensional(),
+    ncols_per_bin_layout, ekat::units::none,
     field_id.get_grid_name(), DataType::IntType);
   Field ncols_per_bin(ncols_per_bin_id);
   ncols_per_bin.allocate_view();
@@ -194,7 +194,7 @@ void ZonalAvgDiag::initialize_impl(const RunType /*run_type*/) {
       Kokkos::Max<Int>(max_ncols_per_bin));
   FieldLayout bin_to_cols_layout = ncols_per_bin_layout.append_dim(COL, 1+max_ncols_per_bin);
   FieldIdentifier bin_to_cols_id("columns in each zonal bin",
-    bin_to_cols_layout, FieldIdentifier::Units::nondimensional(),
+    bin_to_cols_layout, ekat::units::none,
     field_id.get_grid_name(), DataType::IntType);
   m_bin_to_cols = Field(bin_to_cols_id);
   m_bin_to_cols.allocate_view();

--- a/components/eamxx/src/share/field/field.cpp
+++ b/components/eamxx/src/share/field/field.cpp
@@ -411,9 +411,8 @@ Field& Field::create_valid_mask (const std::string& mask_name, const MaskInit in
 
   const auto& fid = m_header->get_identifier();
   const auto& props = m_header->get_alloc_properties();
-  const auto nondim = ekat::units::Units::nondimensional();
 
-  auto mfid = fid.clone(mask_name).reset_units(nondim).reset_dtype(DataType::IntType);
+  auto mfid = fid.clone(mask_name).reset_units(ekat::units::none).reset_dtype(DataType::IntType);
   Field mask(mfid);
   mask.get_header().get_alloc_properties().request_allocation(props.get_largest_pack_size());
   mask.allocate_view();

--- a/components/eamxx/src/share/field/tests/compute_mask.cpp
+++ b/components/eamxx/src/share/field/tests/compute_mask.cpp
@@ -7,10 +7,10 @@ namespace scream {
 
 TEST_CASE ("compute_mask") {
   using namespace ShortFieldTagsNames;
+  using namespace ekat::units;
 
   const int ncols = 10;
   const int nlevs = 128;
-  const auto units = ekat::units::Units::nondimensional();
 
   // Create fields
   std::vector<FieldTag> tags3d = {COL, CMP, LEV};
@@ -18,11 +18,11 @@ TEST_CASE ("compute_mask") {
   std::vector<int>      dims3d = {ncols,2,nlevs};
   std::vector<int>      dims2d = {ncols,nlevs};
 
-  FieldIdentifier fid0d ("foo", {}, units, "some_grid");
-  FieldIdentifier fid0di ("foo", {}, units, "some_grid",DataType::IntType);
-  FieldIdentifier fid3d ("foo", {tags3d,dims3d}, units, "some_grid");
-  FieldIdentifier fid3di ("foo", {tags3d,dims3d}, units, "some_grid", DataType::IntType);
-  FieldIdentifier fid2d ("foo", {tags2d,dims2d}, units, "some_grid");
+  FieldIdentifier fid0d ("foo", {}, none, "some_grid");
+  FieldIdentifier fid0di ("foo", {}, none, "some_grid",DataType::IntType);
+  FieldIdentifier fid3d ("foo", {tags3d,dims3d}, none, "some_grid");
+  FieldIdentifier fid3di ("foo", {tags3d,dims3d}, none, "some_grid", DataType::IntType);
+  FieldIdentifier fid2d ("foo", {tags2d,dims2d}, none, "some_grid");
 
   SECTION ("exceptions") {
     // Test compute_mask exception handling

--- a/components/eamxx/src/share/field/tests/contractions.cpp
+++ b/components/eamxx/src/share/field/tests/contractions.cpp
@@ -12,8 +12,7 @@ namespace scream {
 
 TEST_CASE("field_contractions") {
   using namespace ShortFieldTagsNames;
-
-  constexpr auto nondim = ekat::units::Units::nondimensional();
+  using namespace ekat::units;
 
   // Accumulations in the Kokkos threaded reductions may be done in a
   // different order than the manual ones below, so we can only test
@@ -29,16 +28,16 @@ TEST_CASE("field_contractions") {
     int nlev = 17;
 
     // Set a weight field with values [1,2,...,ncols]
-    FieldIdentifier wfid("f", {{COL}, {ncol}}, nondim, "g");
+    FieldIdentifier wfid("f", {{COL}, {ncol}}, none, "g");
     Field w(wfid,true);
     randomize_uniform(w,seed++);
 
     // Create (random) sample fields
     // NOTE: suffix _x stands for "horizontal", _z for "vertical", _xz for "horiz-and-vert"
-    FieldIdentifier scl_fid("s", {{}, {}}, nondim, "g");  // scalar
-    FieldIdentifier vec_x_fid("v_x", {{COL, CMP}, {ncol, ncmp}}, nondim, "g");
-    FieldIdentifier scl_xz_fid("s_xz", {{COL, LEV}, {ncol, nlev}}, nondim, "g");
-    FieldIdentifier vec_xz_fid("v_xz", {{COL, CMP, LEV}, {ncol, ncmp, nlev}}, nondim, "g");
+    FieldIdentifier scl_fid("s", {{}, {}}, none, "g");  // scalar
+    FieldIdentifier vec_x_fid("v_x", {{COL, CMP}, {ncol, ncmp}}, none, "g");
+    FieldIdentifier scl_xz_fid("s_xz", {{COL, LEV}, {ncol, nlev}}, none, "g");
+    FieldIdentifier vec_xz_fid("v_xz", {{COL, CMP, LEV}, {ncol, ncmp, nlev}}, none, "g");
     Field scl(scl_fid,true);
     Field vec_x(vec_x_fid,true);
     Field vec_xz(vec_xz_fid,true);
@@ -46,10 +45,10 @@ TEST_CASE("field_contractions") {
     randomize_uniform(vec_x, seed++);
     randomize_uniform(vec_xz, seed++);
 
-    FieldIdentifier scl_x_fid("s_x", {{COL}, {ncol}}, nondim, "g");
-    FieldIdentifier scl_z_fid("s_z", {{LEV}, {nlev}}, nondim, "g");
-    FieldIdentifier vec_fid  ("v", {{CMP}, {ncmp}}, nondim, "g");
-    FieldIdentifier vec_z_fid("v_z", {{CMP, LEV}, {ncmp, nlev}}, nondim, "g");
+    FieldIdentifier scl_x_fid("s_x", {{COL}, {ncol}}, none, "g");
+    FieldIdentifier scl_z_fid("s_z", {{LEV}, {nlev}}, none, "g");
+    FieldIdentifier vec_fid  ("v", {{CMP}, {ncmp}}, none, "g");
+    FieldIdentifier vec_z_fid("v_z", {{CMP, LEV}, {ncmp, nlev}}, none, "g");
 
     Field scl_x(scl_x_fid);
     Field vec  (vec_fid);
@@ -148,10 +147,10 @@ TEST_CASE("field_contractions") {
     for(FieldTag lev_tag : {LEV,ILEV}) {
       // Create (random) sample fields
       // NOTE: suffix _x stands for "horizontal", _z for "vertical", _xz for "horiz-and-vert"
-      FieldIdentifier scl_fid   ("s",    {{}, {}}, nondim, "g");  // scalar
-      FieldIdentifier scl_xz_fid("s_xz", {{COL, lev_tag}, {ncol, nlev}}, nondim, "g");
-      FieldIdentifier vec_z_fid ("v_z",  {{CMP, lev_tag}, {ncmp, nlev}}, nondim, "g");
-      FieldIdentifier vec_xz_fid("v_xz", {{COL, CMP, lev_tag}, {ncol, ncmp, nlev}}, nondim, "g");
+      FieldIdentifier scl_fid   ("s",    {{}, {}}, ekat::units::none, "g");  // scalar
+      FieldIdentifier scl_xz_fid("s_xz", {{COL, lev_tag}, {ncol, nlev}}, ekat::units::none, "g");
+      FieldIdentifier vec_z_fid ("v_z",  {{CMP, lev_tag}, {ncmp, nlev}}, ekat::units::none, "g");
+      FieldIdentifier vec_xz_fid("v_xz", {{COL, CMP, lev_tag}, {ncol, ncmp, nlev}}, ekat::units::none, "g");
 
       Field scl(scl_fid,true);
       Field scl_xz(scl_xz_fid,true);
@@ -163,10 +162,10 @@ TEST_CASE("field_contractions") {
       randomize_uniform(vec_xz, seed++);
 
       // Output/utility fields
-      FieldIdentifier scl_x_fid("s_x", {{COL}, {ncol}}, nondim, "g");
-      FieldIdentifier vec_x_fid("v_x", {{COL,CMP}, {ncol,ncmp}}, nondim, "g");
-      FieldIdentifier vec_fid  ("v", {{CMP}, {ncmp}}, nondim, "g");
-      FieldIdentifier scl_z_fid ("s_z",  {{lev_tag}, {nlev}}, nondim, "g");
+      FieldIdentifier scl_x_fid("s_x", {{COL}, {ncol}}, ekat::units::none, "g");
+      FieldIdentifier vec_x_fid("v_x", {{COL,CMP}, {ncol,ncmp}}, ekat::units::none, "g");
+      FieldIdentifier vec_fid  ("v", {{CMP}, {ncmp}}, ekat::units::none, "g");
+      FieldIdentifier scl_z_fid ("s_z",  {{lev_tag}, {nlev}}, ekat::units::none, "g");
 
       Field scl_x(scl_x_fid,true);
       Field vec_x(vec_x_fid,true);

--- a/components/eamxx/src/share/field/tests/field_group_tests.cpp
+++ b/components/eamxx/src/share/field/tests/field_group_tests.cpp
@@ -18,7 +18,7 @@ TEST_CASE("field_group") {
   constexpr int ndims = 4;
   constexpr int nlevs = 8;
 
-  FID fid ("V",FL({COL,CMP,LEV},{ncols,ndims,nlevs}),Units::nondimensional(),"the_grid");
+  FID fid ("V",FL({COL,CMP,LEV},{ncols,ndims,nlevs}),none,"the_grid");
   Field f (fid);
   f.allocate_view();
 

--- a/components/eamxx/src/share/field/tests/field_tests.cpp
+++ b/components/eamxx/src/share/field/tests/field_tests.cpp
@@ -228,12 +228,12 @@ TEST_CASE("field", "") {
 
   SECTION ("rank0_field") {
     // Create 0d field
-    FieldIdentifier fid0("f_0d", FieldLayout({},{}), Units::nondimensional(), "dummy_grid");
+    FieldIdentifier fid0("f_0d", FieldLayout({},{}), none, "dummy_grid");
     Field f0(fid0);
     f0.allocate_view();
 
     // Create 1d field
-    FieldIdentifier fid1("f_1d", FieldLayout({COL}, {5}), Units::nondimensional(), "dummy_grid");
+    FieldIdentifier fid1("f_1d", FieldLayout({COL}, {5}), none, "dummy_grid");
     Field f1(fid1);
     f1.allocate_view();
 

--- a/components/eamxx/src/share/field/tests/field_utils.cpp
+++ b/components/eamxx/src/share/field/tests/field_utils.cpp
@@ -103,7 +103,6 @@ TEST_CASE("field_utils") {
     using namespace ShortFieldTagsNames;
     using IPDF = std::uniform_int_distribution<int>;
 
-    auto nondim = Units::nondimensional();
     int seed = get_random_test_seed();
     std::mt19937_64 engine(seed);
 
@@ -112,17 +111,17 @@ TEST_CASE("field_utils") {
     const int nlevs = IPDF(3,9)(engine); // between 3-9 levels
 
     // Create 1d, 2d, 3d fields with a level dimension, and set all to 1
-    FieldIdentifier fid1 ("f_1d",   FieldLayout({LEV},           {nlevs}),               nondim, "");
-    FieldIdentifier fid2a("f_2d_a", FieldLayout({CMP, LEV},      {ncmps, nlevs}),        nondim, "");
-    FieldIdentifier fid2b("f_2d_b", FieldLayout({COL, LEV},      {ncols, nlevs}),        nondim, "");
-    FieldIdentifier fid3 ("f_3d",   FieldLayout({COL, CMP, LEV}, {ncols, ncmps, nlevs}), nondim, "");
+    FieldIdentifier fid1 ("f_1d",   FieldLayout({LEV},           {nlevs}),               none, "");
+    FieldIdentifier fid2a("f_2d_a", FieldLayout({CMP, LEV},      {ncmps, nlevs}),        none, "");
+    FieldIdentifier fid2b("f_2d_b", FieldLayout({COL, LEV},      {ncols, nlevs}),        none, "");
+    FieldIdentifier fid3 ("f_3d",   FieldLayout({COL, CMP, LEV}, {ncols, ncmps, nlevs}), none, "");
     Field f1(fid1), f2a(fid2a), f2b(fid2b), f3(fid3);
     f1.allocate_view(), f2a.allocate_view(), f2b.allocate_view(), f3.allocate_view();
     f1.deep_copy(1), f2a.deep_copy(1), f2b.deep_copy(1), f3.deep_copy(1);
 
     // We need GIDs for fields with COL component. This test is not over
     // multiple ranks, so just set as [0, ncols-1].
-    Field gids(FieldIdentifier("gids", FieldLayout({COL}, {ncols}), Units::nondimensional(), "", DataType::IntType));
+    Field gids(FieldIdentifier("gids", FieldLayout({COL}, {ncols}), none, "", DataType::IntType));
     gids.allocate_view();
     auto gids_data = gids.get_internal_view_data<int,Host>();
     std::iota(gids_data, gids_data+ncols, 0);
@@ -130,7 +129,7 @@ TEST_CASE("field_utils") {
 
     // Create masks s.t. only last 3 levels are perturbed. For variety,
     // 1d and 2d fields will use lambda mask and 3 field will use a view.
-    FieldIdentifier pmask_fid("pmask",fid1.get_layout(),nondim,"",DataType::IntType);
+    FieldIdentifier pmask_fid("pmask",fid1.get_layout(),none,"",DataType::IntType);
     Field pmask(pmask_fid,true);
     auto pmask_h = pmask.get_view<int*,Host>();
     for (int i=0; i<nlevs; ++i) {

--- a/components/eamxx/src/share/field/tests/subfield_tests.cpp
+++ b/components/eamxx/src/share/field/tests/subfield_tests.cpp
@@ -445,7 +445,7 @@ TEST_CASE ("sync_subfields") {
   constexpr int nlevs = 8;
 
   // Create field with (col, cmp, lev)
-  FID fid ("V",FL({COL,CMP,LEV},{ncols,ndims,nlevs}),Units::nondimensional(),"the_grid",DataType::IntType);
+  FID fid ("V",FL({COL,CMP,LEV},{ncols,ndims,nlevs}),none,"the_grid",DataType::IntType);
   Field f (fid);
   f.allocate_view();
 

--- a/components/eamxx/src/share/field/utils/compute_mask.cpp
+++ b/components/eamxx/src/share/field/utils/compute_mask.cpp
@@ -434,7 +434,7 @@ void compute_mask (const Field& lhs, const Field& rhs, Comparison CMP, Field& ma
 Field compute_mask (const Field& x, const ScalarWrapper value, Comparison CMP) {
   const auto& fid_x = x.get_header().get_identifier();
   auto fid = fid_x.clone(x.name()+"_mask")
-                  .reset_units(ekat::units::Units::nondimensional())
+                  .reset_units(ekat::units::none)
                   .reset_dtype(DataType::IntType);
   Field mask(fid,true);
 

--- a/components/eamxx/src/share/field/utils/perturb.cpp
+++ b/components/eamxx/src/share/field/utils/perturb.cpp
@@ -66,7 +66,7 @@ void perturb (Field& f, const ST perturb_level,
     // Create a field to store perturbation values with layout
     // the same as f, but stripped of column and level dimension.
     auto perturb_fl = fl.clone().strip_dims({COL,LEV});
-    FieldIdentifier perturb_fid("perturb_field", perturb_fl, ekat::units::Units::nondimensional(), "");
+    FieldIdentifier perturb_fid("perturb_field", perturb_fl, ekat::units::none, "");
     Field perturb_f(perturb_fid);
     perturb_f.allocate_view();
 
@@ -94,7 +94,7 @@ void perturb (Field& f, const ST perturb_level,
     // Create a field to store perturbation values with layout
     // the same as f, but stripped of level dimension.
     auto perturb_fl = fl.clone().strip_dim(LEV);
-    FieldIdentifier perturb_fid("perturb_field", perturb_fl, ekat::units::Units::nondimensional(), "");
+    FieldIdentifier perturb_fid("perturb_field", perturb_fl, ekat::units::none, "");
     Field perturb_f(perturb_fid);
     perturb_f.allocate_view();
 

--- a/components/eamxx/src/share/grid/abstract_grid.cpp
+++ b/components/eamxx/src/share/grid/abstract_grid.cpp
@@ -729,15 +729,14 @@ get_remote_pids_and_lids (const gid_view_h& gids,
 void AbstractGrid::create_dof_fields (const int scalar2d_layout_rank)
 {
   using namespace ShortFieldTagsNames;
-  const auto units = ekat::units::Units::nondimensional();
 
   // The dof gids field is a 1d field, while lid2idx has rank 2.
   // For both, the 1st dim is the num of local dofs. The 2nd dime of
   // lid2idx is the rank of a 2d scalar layout.
   FieldLayout dof_layout({COL},{get_num_local_dofs()});
   FieldLayout lid2idx_layout({COL,CMP},{get_num_local_dofs(),scalar2d_layout_rank});
-  m_dofs_gids = Field(FieldIdentifier("gids",dof_layout,units,m_name,DataType::IntType));
-  m_lid_to_idx = Field(FieldIdentifier("lid2idx",lid2idx_layout,units,m_name,DataType::IntType));
+  m_dofs_gids = Field(FieldIdentifier("gids",dof_layout,ekat::units::none,m_name,DataType::IntType));
+  m_lid_to_idx = Field(FieldIdentifier("lid2idx",lid2idx_layout,ekat::units::none,m_name,DataType::IntType));
 
   m_dofs_gids.allocate_view();
   m_lid_to_idx.allocate_view();

--- a/components/eamxx/src/share/grid/se_grid.cpp
+++ b/components/eamxx/src/share/grid/se_grid.cpp
@@ -27,11 +27,10 @@ SEGrid (const std::string& grid_name,
 
   // Create the cg dofs field
   using namespace ShortFieldTagsNames;
-  const auto units = ekat::units::Units::nondimensional();
-  m_cg_dofs_gids = Field(FieldIdentifier("cg_gids",FieldLayout({CMP},{get_num_local_dofs()}),units,this->name(),DataType::IntType));
+  m_cg_dofs_gids = Field(FieldIdentifier("cg_gids",FieldLayout({CMP},{get_num_local_dofs()}),ekat::units::none,this->name(),DataType::IntType));
   m_cg_dofs_gids.allocate_view();
 
-  m_partitioned_dim_gids = Field(FieldIdentifier("el_gids",FieldLayout({EL},{m_num_local_elem}),units,this->name(),DataType::IntType));
+  m_partitioned_dim_gids = Field(FieldIdentifier("el_gids",FieldLayout({EL},{m_num_local_elem}),ekat::units::none,this->name(),DataType::IntType));
   m_partitioned_dim_gids.allocate_view();
 }
 

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -734,8 +734,7 @@ void AtmosphereOutput::set_avg_cnt_tracking(const FieldIdentifier& fid)
   // We have not created this avg count field yet.
   m_vars_dims[avg_cnt_name] = get_var_dimnames(m_transpose ? layout.transpose() : layout);
 
-  auto nondim = ekat::units::Units::nondimensional();
-  auto count_id = fid.clone(avg_cnt_name).reset_units(nondim).reset_dtype(DataType::IntType);
+  auto count_id = fid.clone(avg_cnt_name).reset_units(ekat::units::none).reset_dtype(DataType::IntType);
   Field count(count_id);
   count.allocate_view();
 

--- a/components/eamxx/src/share/io/scorpio_scm_input.cpp
+++ b/components/eamxx/src/share/io/scorpio_scm_input.cpp
@@ -104,9 +104,8 @@ void SCMInput::create_closest_col_info (double target_lat, double target_lon)
   // Read lat/lon fields
   const auto ncols = m_io_grid->get_num_local_dofs();
 
-  auto nondim = ekat::units::Units::nondimensional();
-  auto lat = m_io_grid->create_geometry_data("lat",m_io_grid->get_2d_scalar_layout(),nondim);
-  auto lon = m_io_grid->create_geometry_data("lon",m_io_grid->get_2d_scalar_layout(),nondim);
+  auto lat = m_io_grid->create_geometry_data("lat",m_io_grid->get_2d_scalar_layout(),ekat::units::none);
+  auto lon = m_io_grid->create_geometry_data("lon",m_io_grid->get_2d_scalar_layout(),ekat::units::none);
 
   std::vector<Field> latlon = {lat,lon};
 

--- a/components/eamxx/src/share/io/tests/io_alias.cpp
+++ b/components/eamxx/src/share/io/tests/io_alias.cpp
@@ -28,12 +28,11 @@ namespace scream {
 Field col_iota (const std::shared_ptr<const AbstractGrid> &grid)
 {
   using namespace ShortFieldTagsNames;
-  const auto nondim = ekat::units::Units::nondimensional();
   const auto layout = grid->get_vertical_layout(LEV);
   const int nlevs = grid->get_num_vertical_levels();
 
   // A helper field to set values depending on lev
-  FieldIdentifier fid1("col", layout, nondim, grid->name());
+  FieldIdentifier fid1("col", layout, ekat::units::none, grid->name());
   Field col(fid1);
   col.allocate_view();
   auto col_h = col.get_view<Real*,Host>();

--- a/components/eamxx/src/share/io/tests/io_basic.cpp
+++ b/components/eamxx/src/share/io/tests/io_basic.cpp
@@ -98,11 +98,10 @@ get_fm (const std::shared_ptr<const AbstractGrid>& grid,
 
   auto fm = std::make_shared<FieldManager>(grid);
 
-  const auto units = ekat::units::Units::nondimensional();
   int count=0;
   using stratts_t = std::map<std::string,std::string>;
   for (const auto& fl : layouts) {
-    FID fid("f_"+std::to_string(count),fl,units,grid->name());
+    FID fid("f_"+std::to_string(count),fl,ekat::units::none,grid->name());
     Field f(fid);
     f.allocate_view();
     auto& str_atts = f.get_header().get_extra_data<stratts_t>("io: string attributes");

--- a/components/eamxx/src/share/io/tests/io_diags.cpp
+++ b/components/eamxx/src/share/io/tests/io_diags.cpp
@@ -52,12 +52,11 @@ public:
     using namespace ShortFieldTagsNames;
     const auto grid = m_grids_manager->get_grid("point_grid");
     const auto& grid_name = grid->name();
-    auto units = ekat::units::Units::nondimensional();
     auto layout = grid->get_3d_scalar_layout(LEV);
-    add_field<Required>("my_f",layout,units,grid_name);
+    add_field<Required>("my_f",layout,ekat::units::none,grid_name);
 
     // We have to initialize the m_diagnostic_output:
-    FieldIdentifier fid ("MyDiag", layout, units, grid_name);
+    FieldIdentifier fid ("MyDiag", layout, ekat::units::none, grid_name);
     m_diagnostic_output = Field(fid);
     m_diagnostic_output.allocate_view();
     m_one = m_diagnostic_output.clone("one");
@@ -135,7 +134,7 @@ get_fm (const std::shared_ptr<const AbstractGrid>& grid,
 
   auto fm = std::make_shared<FieldManager>(grid);
 
-  const auto units = ekat::units::Units::nondimensional();
+  const auto units = ekat::units::none;
   FL fl ({COL,LEV}, {nlcols,nlevs});
 
   FID fid("my_f",fl,units,grid->name());

--- a/components/eamxx/src/share/io/tests/io_filled.cpp
+++ b/components/eamxx/src/share/io/tests/io_filled.cpp
@@ -93,9 +93,8 @@ get_fm (const std::shared_ptr<const AbstractGrid>& grid,
 
   auto fm = std::make_shared<FieldManager>(grid);
 
-  const auto units = ekat::units::Units::nondimensional();
   for (const auto& fl : layouts) {
-    FID fid("f_"+std::to_string(fl.size()),fl,units,grid->name());
+    FID fid("f_"+std::to_string(fl.size()),fl,ekat::units::none,grid->name());
     Field f(fid);
     f.allocate_view();
     f.deep_copy(0.0); // For the "filled" field we start with a filled value.

--- a/components/eamxx/src/share/io/tests/io_horiz_sampling.cpp
+++ b/components/eamxx/src/share/io/tests/io_horiz_sampling.cpp
@@ -17,8 +17,7 @@ Field create_f (const std::string& name,
                 const FieldLayout layout,
                 const std::string& grid_name)
 {
-  const auto nondim = ekat::units::Units::nondimensional();
-  FieldIdentifier fid(name,layout,nondim,grid_name);
+  FieldIdentifier fid(name,layout,ekat::units::none,grid_name);
   Field f(fid);
   f.allocate_view();
   return f;

--- a/components/eamxx/src/share/io/tests/io_latlon.cpp
+++ b/components/eamxx/src/share/io/tests/io_latlon.cpp
@@ -15,8 +15,7 @@ inline std::shared_ptr<AbstractGrid>
 create_grid(const ekat::Comm& comm, const std::string& map_file, const std::string& name, bool src)
 {
   // Note: map files are 1-based, so create pt grid with 1-based gids
-  auto nondim = ekat::units::Units::nondimensional();
-  ekat::units::Units deg(nondim,"degrees");
+  auto deg = ekat::units::none.rename("degrees");
   std::string suffix = src ? "_a" : "_b";
   int ncols = scorpio::get_dimlen(map_file,"n"+suffix);
   auto grid = create_point_grid(name,ncols,1,comm,1);

--- a/components/eamxx/src/share/io/tests/io_monthly.cpp
+++ b/components/eamxx/src/share/io/tests/io_monthly.cpp
@@ -75,10 +75,9 @@ get_fm (const std::shared_ptr<const AbstractGrid>& grid,
 
   auto fm = std::make_shared<FieldManager>(grid);
 
-  const auto units = ekat::units::Units::nondimensional();
   int count=0;
   for (const auto& fl : layouts) {
-    FID fid("f_"+std::to_string(count),fl,units,grid->name());
+    FID fid("f_"+std::to_string(count),fl,ekat::units::none,grid->name());
     Field f(fid);
     f.allocate_view();
     randomize_discrete (f,seed++,values);

--- a/components/eamxx/src/share/io/tests/io_packed.cpp
+++ b/components/eamxx/src/share/io/tests/io_packed.cpp
@@ -71,9 +71,8 @@ get_fm (const std::shared_ptr<const AbstractGrid>& grid,
 
   auto fm = std::make_shared<FieldManager>(grid);
 
-  const auto units = ekat::units::Units::nondimensional();
   for (const auto& fl : layouts) {
-    FID fid("f_"+std::to_string(fl.size()),fl,units,grid->name());
+    FID fid("f_"+std::to_string(fl.size()),fl,ekat::units::none,grid->name());
     Field f(fid);
     f.get_header().get_alloc_properties().request_allocation(ps);
     f.allocate_view();

--- a/components/eamxx/src/share/io/tests/io_scm_reader.cpp
+++ b/components/eamxx/src/share/io/tests/io_scm_reader.cpp
@@ -14,7 +14,6 @@ namespace scream {
 // Returns fields after initialization
 void write (int seed, const ekat::Comm& comm)
 {
-  using ekat::units::Units;
   using namespace ShortFieldTagsNames;
   using IPDF = std::uniform_int_distribution<int>;
 
@@ -30,14 +29,14 @@ void write (int seed, const ekat::Comm& comm)
   auto grid = create_point_grid("test",ncols,nlevs,comm);
 
   // Create lat/lon grid
-  Units deg (Units::nondimensional(),"deg");
+  auto deg = ekat::units::none.rename("deg");
   auto lat = grid->create_geometry_data("lat",grid->get_2d_scalar_layout(),deg);
   auto lon = grid->create_geometry_data("lon",grid->get_2d_scalar_layout(),deg);
   randomize_uniform(lat,seed++,-90,90);
   randomize_uniform(lon,seed++,-180,180);
 
   // Create variable data
-  FieldIdentifier fid("var",grid->get_3d_scalar_layout(LEV),Units::nondimensional(),"");
+  FieldIdentifier fid("var",grid->get_3d_scalar_layout(LEV),ekat::units::none,"");
   Field var(fid);
   var.allocate_view();
   randomize_uniform(var,seed++,-1,1);
@@ -72,7 +71,6 @@ void write (int seed, const ekat::Comm& comm)
 
 void read (const int seed, const ekat::Comm& comm)
 {
-  using ekat::units::Units;
   using namespace ShortFieldTagsNames;
   using IPDF = std::uniform_int_distribution<int>;
   using Engine = std::mt19937_64;
@@ -104,7 +102,7 @@ void read (const int seed, const ekat::Comm& comm)
   dofs_gids.deep_copy(0);
 
   // Create field to read
-  FieldIdentifier fid("var",grid->get_3d_scalar_layout(LEV),Units::nondimensional(),"");
+  FieldIdentifier fid("var",grid->get_3d_scalar_layout(LEV),ekat::units::none,"");
   Field var_f(fid);
   var_f.allocate_view();
 

--- a/components/eamxx/src/share/io/tests/io_transpose.cpp
+++ b/components/eamxx/src/share/io/tests/io_transpose.cpp
@@ -95,11 +95,10 @@ get_fm (const std::shared_ptr<const AbstractGrid>& grid,
 
   auto fm = std::make_shared<FieldManager>(grid);
 
-  const auto units = ekat::units::Units::nondimensional();
   int count=0;
   using stratts_t = std::map<std::string,std::string>;
   for (const auto& fl : layouts) {
-    FID fid("f_"+std::to_string(count),fl,units,grid->name());
+    FID fid("f_"+std::to_string(count),fl,ekat::units::none,grid->name());
     Field f(fid);
     f.allocate_view();
     auto& str_atts = f.get_header().get_extra_data<stratts_t>("io: string attributes");

--- a/components/eamxx/src/share/physics/physics_constants.hpp
+++ b/components/eamxx/src/share/physics/physics_constants.hpp
@@ -37,11 +37,9 @@ struct Constants
   static constexpr auto W   = ekat::units::W;
 
   // Some shorthand units
-  static constexpr auto m2     = Units(m*m,"m2");
-  static constexpr auto m3     = Units(m*m*m,"m3");
-  static constexpr auto s2     = Units(s*s,"s2");
-  static constexpr auto nondim = Units::nondimensional();
-  static constexpr auto rad    = Units(nondim,"rad");
+  static constexpr auto m2     = (m*m).rename("m2");
+  static constexpr auto m3     = (m*m*m).rename("m3");
+  static constexpr auto s2     = (s*s).rename("s2");
 
   // Commonly used numeric constants
   static constexpr Scalar ZERO    = 0.0;
@@ -72,7 +70,7 @@ struct Constants
   static constexpr auto MWWV            = MWH2O;
   static constexpr auto MWdry           = quantity_t(28.966, g/mol);   // dry air molar mass
   static constexpr auto ep_2            = MWH2O / MWdry;               // dimensionless (MWH2O/MWdry)
-  static constexpr auto o2mmr           = quantity_t(0.23143,nondim);  // o2 mass mixing ratio (dimensionless)
+  static constexpr auto o2mmr           = quantity_t(0.23143,ekat::units::none);  // o2 mass mixing ratio (dimensionless)
 
   static constexpr auto gravit          = quantity_t(9.80616, m/s2);
 
@@ -123,7 +121,7 @@ struct Constants
   static constexpr Scalar basetemp      = 300.0;
   static constexpr auto r_earth         = quantity_t(6.376e6,m); // Radius of the earth in m
   static constexpr auto stebol          = quantity_t(5.670374419e-8,W/m2/pow(K,4)); // Stefan-Boltzmann's constant (W/m^2/K^4)
-  static constexpr auto omega           = quantity_t(7.292e-5,rad/s); // Earth's rotation (rad/sec)
+  static constexpr auto omega           = quantity_t(7.292e-5,ekat::units::rad/s); // Earth's rotation (rad/sec)
 
   // Table dimension constants
   static constexpr int VTABLE_DIM0    = 300;

--- a/components/eamxx/src/share/property_checks/property_checks.cpp
+++ b/components/eamxx/src/share/property_checks/property_checks.cpp
@@ -64,9 +64,8 @@ TEST_CASE("property_checks", "") {
   // Create a point grid
   const auto grid = create_point_grid("some_grid",num_lcols*comm.size(),nlevs,comm);
   const auto layout = grid->get_2d_scalar_layout();
-  const auto units = ekat::units::Units::nondimensional();
-  const auto& lat = grid->create_geometry_data("lat",layout,units);
-  const auto& lon = grid->create_geometry_data("lon",layout,units);
+  const auto& lat = grid->create_geometry_data("lat",layout,rad);
+  const auto& lon = grid->create_geometry_data("lon",layout,rad);
   auto lat_h = lat.get_strided_view<Real*,Host>();
   auto lon_h = lon.get_strided_view<Real*,Host>();
   auto dofs = grid->get_dofs_gids();

--- a/components/eamxx/src/share/property_checks/tests/pc_tests_helpers.hpp
+++ b/components/eamxx/src/share/property_checks/tests/pc_tests_helpers.hpp
@@ -13,9 +13,8 @@ create_test_grid (const ekat::Comm& comm, int num_lcols, int nlevs)
   // Create a point grid
   const auto grid = create_point_grid("some_grid",num_lcols*comm.size(),nlevs,comm);
   const auto layout = grid->get_2d_scalar_layout();
-  const auto units = ekat::units::Units::nondimensional();
-  const auto& lat = grid->create_geometry_data("lat",layout,units);
-  const auto& lon = grid->create_geometry_data("lon",layout,units);
+  const auto& lat = grid->create_geometry_data("lat",layout,rad);
+  const auto& lon = grid->create_geometry_data("lon",layout,rad);
   auto lat_h = lat.get_strided_view<Real*,Host>();
   auto lon_h = lon.get_strided_view<Real*,Host>();
   auto dofs = grid->get_dofs_gids();

--- a/components/eamxx/src/share/remap/horiz_interp_remapper_data.cpp
+++ b/components/eamxx/src/share/remap/horiz_interp_remapper_data.cpp
@@ -185,12 +185,11 @@ build (const std::shared_ptr<const AbstractGrid>& grid,
 
   // Only read the lat/lon/area vars if they are present. If one is present, we assume they all are
   if (scorpio::has_var(map_file,"yc"+suffix)) {
-    const auto nondim = ekat::units::Units::nondimensional();
-    ekat::units::Units deg(nondim,"deg");
+    auto deg = ekat::units::none.rename("deg");
 
     gen_grid->create_geometry_data("lat", gen_grid->get_2d_scalar_layout(),deg);
     gen_grid->create_geometry_data("lon", gen_grid->get_2d_scalar_layout(),deg);
-    gen_grid->create_geometry_data("area",gen_grid->get_2d_scalar_layout(),nondim);
+    gen_grid->create_geometry_data("area",gen_grid->get_2d_scalar_layout(),ekat::units::sr);
     gen_grid->read_geometry_data(map_file,
                                  {"lat","lon","area"},
                                  {"yc"+suffix,"xc"+suffix,"area"+suffix},
@@ -386,7 +385,7 @@ setup_latlon_data(const std::shared_ptr<AbstractGrid>& grid,
   using namespace ShortFieldTagsNames;
 
   // Add lat/lon to the temp grid, and read from map file
-  auto nondim = ekat::units::Units::nondimensional();
+  auto nondim = ekat::units::none;
   ekat::units::Units deg(nondim,"degrees");
 
   // Declare lat/lon and read them from the map file.

--- a/components/eamxx/src/share/remap/tests/coarsening_remapper_tests.cpp
+++ b/components/eamxx/src/share/remap/tests/coarsening_remapper_tests.cpp
@@ -52,28 +52,27 @@ constexpr int tens_dim2 = 4;
 Field create_field (const std::string& name, const LayoutType lt, const AbstractGrid& grid, const FieldTag vtag)
 {
   using namespace ShortFieldTagsNames;
-  const auto u = ekat::units::Units::nondimensional();
   const auto& gn = grid.name();
   Field f;
   switch (lt) {
     case LayoutType::Scalar1D:
-      f = Field(FieldIdentifier(name,grid.get_vertical_layout(vtag),u,gn)); break;
+      f = Field(FieldIdentifier(name,grid.get_vertical_layout(vtag),ekat::units::none,gn)); break;
     case LayoutType::Scalar2D:
-      f = Field(FieldIdentifier(name,grid.get_2d_scalar_layout(),u,gn));  break;
+      f = Field(FieldIdentifier(name,grid.get_2d_scalar_layout(),ekat::units::none,gn));  break;
     case LayoutType::Vector2D:
-      f = Field(FieldIdentifier(name,grid.get_2d_vector_layout(vec_dim),u,gn));  break;
+      f = Field(FieldIdentifier(name,grid.get_2d_vector_layout(vec_dim),ekat::units::none,gn));  break;
     case LayoutType::Tensor2D:
-      f = Field(FieldIdentifier(name,grid.get_2d_tensor_layout({tens_dim1,tens_dim2}),u,gn));  break;
+      f = Field(FieldIdentifier(name,grid.get_2d_tensor_layout({tens_dim1,tens_dim2}),ekat::units::none,gn));  break;
     case LayoutType::Scalar3D:
-      f = Field(FieldIdentifier(name,grid.get_3d_scalar_layout(vtag),u,gn));
+      f = Field(FieldIdentifier(name,grid.get_3d_scalar_layout(vtag),ekat::units::none,gn));
       f.get_header().get_alloc_properties().request_allocation(SCREAM_PACK_SIZE);
       break;
     case LayoutType::Vector3D:
-      f = Field(FieldIdentifier(name,grid.get_3d_vector_layout(vtag,vec_dim),u,gn));
+      f = Field(FieldIdentifier(name,grid.get_3d_vector_layout(vtag,vec_dim),ekat::units::none,gn));
       f.get_header().get_alloc_properties().request_allocation(SCREAM_PACK_SIZE);
       break;
     case LayoutType::Tensor3D:
-      f = Field(FieldIdentifier(name,grid.get_3d_tensor_layout(vtag,{tens_dim1,tens_dim2}),u,gn));
+      f = Field(FieldIdentifier(name,grid.get_3d_tensor_layout(vtag,{tens_dim1,tens_dim2}),ekat::units::none,gn));
       f.get_header().get_alloc_properties().request_allocation(SCREAM_PACK_SIZE);
       break;
     default:

--- a/components/eamxx/src/share/remap/tests/iop_remapper_tests.cpp
+++ b/components/eamxx/src/share/remap/tests/iop_remapper_tests.cpp
@@ -25,26 +25,25 @@ Field create_field (const std::string& name,
                     const int seed)
 {
   using namespace ShortFieldTagsNames;
-  const auto u = ekat::units::Units::nondimensional();
   const auto& gn = grid.name();
   Field f;
   switch (lt) {
     case LayoutType::Scalar2D:
-      f = Field(FieldIdentifier(name,grid.get_2d_scalar_layout(),u,gn));  break;
+      f = Field(FieldIdentifier(name,grid.get_2d_scalar_layout(),ekat::units::none,gn));  break;
     case LayoutType::Vector2D:
-      f = Field(FieldIdentifier(name,grid.get_2d_vector_layout(vec_dim),u,gn));  break;
+      f = Field(FieldIdentifier(name,grid.get_2d_vector_layout(vec_dim),ekat::units::none,gn));  break;
     case LayoutType::Tensor2D:
-      f = Field(FieldIdentifier(name,grid.get_2d_tensor_layout({tens_dim1,tens_dim2}),u,gn));  break;
+      f = Field(FieldIdentifier(name,grid.get_2d_tensor_layout({tens_dim1,tens_dim2}),ekat::units::none,gn));  break;
     case LayoutType::Scalar3D:
-      f = Field(FieldIdentifier(name,grid.get_3d_scalar_layout(vtag),u,gn));
+      f = Field(FieldIdentifier(name,grid.get_3d_scalar_layout(vtag),ekat::units::none,gn));
       f.get_header().get_alloc_properties().request_allocation(SCREAM_PACK_SIZE);
       break;
     case LayoutType::Vector3D:
-      f = Field(FieldIdentifier(name,grid.get_3d_vector_layout(vtag,vec_dim),u,gn));
+      f = Field(FieldIdentifier(name,grid.get_3d_vector_layout(vtag,vec_dim),ekat::units::none,gn));
       f.get_header().get_alloc_properties().request_allocation(SCREAM_PACK_SIZE);
       break;
     case LayoutType::Tensor3D:
-      f = Field(FieldIdentifier(name,grid.get_3d_tensor_layout(vtag,{tens_dim1,tens_dim2}),u,gn));
+      f = Field(FieldIdentifier(name,grid.get_3d_tensor_layout(vtag,{tens_dim1,tens_dim2}),ekat::units::none,gn));
       f.get_header().get_alloc_properties().request_allocation(SCREAM_PACK_SIZE);
       break;
     default:

--- a/components/eamxx/src/share/remap/tests/refining_remapper_tests.cpp
+++ b/components/eamxx/src/share/remap/tests/refining_remapper_tests.cpp
@@ -12,22 +12,21 @@ namespace scream {
 Field create_field (const std::string& name, const LayoutType lt, const AbstractGrid& grid)
 {
   using namespace ShortFieldTagsNames;
-  const auto u = ekat::units::Units::nondimensional();
   const auto& gn = grid.name();
   const auto  ndims = 2;
   Field f;
   switch (lt) {
     case LayoutType::Scalar1D:
-      f = Field(FieldIdentifier(name,grid.get_vertical_layout(LEV),u,gn));  break;
+      f = Field(FieldIdentifier(name,grid.get_vertical_layout(LEV),ekat::units::none,gn));  break;
     case LayoutType::Scalar2D:
-      f = Field(FieldIdentifier(name,grid.get_2d_scalar_layout(),u,gn));  break;
+      f = Field(FieldIdentifier(name,grid.get_2d_scalar_layout(),ekat::units::none,gn));  break;
     case LayoutType::Vector2D:
-      f = Field(FieldIdentifier(name,grid.get_2d_vector_layout(ndims),u,gn));  break;
+      f = Field(FieldIdentifier(name,grid.get_2d_vector_layout(ndims),ekat::units::none,gn));  break;
     case LayoutType::Scalar3D:
-      f = Field(FieldIdentifier(name,grid.get_3d_scalar_layout(LEV),u,gn));
+      f = Field(FieldIdentifier(name,grid.get_3d_scalar_layout(LEV),ekat::units::none,gn));
       f.get_header().get_alloc_properties().request_allocation(SCREAM_PACK_SIZE);  break;
     case LayoutType::Vector3D:
-      f = Field(FieldIdentifier(name,grid.get_3d_vector_layout(ILEV,ndims),u,gn));
+      f = Field(FieldIdentifier(name,grid.get_3d_vector_layout(ILEV,ndims),ekat::units::none,gn));
       f.get_header().get_alloc_properties().request_allocation(SCREAM_PACK_SIZE);  break;
     default:
       EKAT_ERROR_MSG ("Invalid layout type for this unit test.\n");

--- a/components/eamxx/src/share/remap/tests/vertical_remapper_tests.cpp
+++ b/components/eamxx/src/share/remap/tests/vertical_remapper_tests.cpp
@@ -53,13 +53,12 @@ create_field(const std::string& name,
 {
   using namespace ShortFieldTagsNames;
   constexpr int vec_dim = 3;
-  constexpr auto units = ekat::units::Units::nondimensional();
   auto fl = twod
           ? (vec ? grid->get_2d_vector_layout (vec_dim)
                  : grid->get_2d_scalar_layout ())
           : (vec ? grid->get_3d_vector_layout (vtag,vec_dim)
                  : grid->get_3d_scalar_layout (vtag));
-  FieldIdentifier fid(name,fl,units,grid->name());
+  FieldIdentifier fid(name,fl,ekat::units::none,grid->name());
   Field f(fid);
   f.get_header().get_alloc_properties().request_allocation(ps);
   f.allocate_view();

--- a/components/eamxx/src/share/remap/vertical_remapper.cpp
+++ b/components/eamxx/src/share/remap/vertical_remapper.cpp
@@ -203,10 +203,9 @@ registration_ends_impl ()
         const auto mask_name = m_tgt_grid->name() + "_" + ekat::join(tagdim_names,"_") + "_mask";
         auto& mask = m_masks[mask_name];
         if (not mask.is_allocated()) {
-          auto nondim = ekat::units::Units::nondimensional();
           // Create this src/tgt mask fields, and assign them to these src/tgt fields extra data
 
-          FieldIdentifier mask_fid (mask_name, tgt_layout, nondim, m_tgt_grid->name(), DataType::IntType );
+          FieldIdentifier mask_fid (mask_name, tgt_layout, ekat::units::none, m_tgt_grid->name(), DataType::IntType );
           mask  = Field (mask_fid);
           if (ft.packed)
             mask.get_header().get_alloc_properties().request_allocation(SCREAM_PACK_SIZE);


### PR DESCRIPTION
Clean up usage of units, following the latest ekat update.

[BFB]

---

Quick summary:

- use `ekat::units::none` instead of `ekat::units::Units::nondimensional()`
- clean up a few places to use the self-explanatory rename method to rename derived units (e.g., `auto m2 = (m*m).rename("m2");` rather than `Units m2(m*m,"m2");`
- no need to define `rad`, as ekat now has it
- use `sr` for area in a couple of places (we were using rad*rad, which is conceptually wrong).
- in a couple of places, use `grid->get_xyz_layout` instead of manually building the layout.