### PR TITLE
EAMxx: m_nu_scale_top.

### DIFF
--- a/components/eamxx/src/dynamics/homme/interface/homme_driver_mod.F90
+++ b/components/eamxx/src/dynamics/homme/interface/homme_driver_mod.F90
@@ -213,14 +213,17 @@ contains
     ! Print advective and viscious CFL estimates
     call print_cfl(elem,hybrid,1,nelemd)
 
+    ! Initialize reference states before functors so that setup() can read
+    ! nu_scale_top from ref_states (needed by HyperviscosityFunctorImpl).
+    call prim_init_ref_states_views (elem)
+
     ! Initialize the C++ functors in the C++ context
     ! Here we set allocate_buffer=false since the AD
     ! allocates local memory for each process from a
     ! single buffer.
     call prim_init_kokkos_functors (allocate_buffer)
 
-    ! Init ref_states views, and diags views
-    call prim_init_ref_states_views (elem)
+    ! Init diags views
     call prim_init_diags_views (elem)
 
     ! In order to print up to date stuff in F90

--- a/components/homme/src/share/cxx/SimulationParams.hpp
+++ b/components/homme/src/share/cxx/SimulationParams.hpp
@@ -45,6 +45,7 @@ struct SimulationParams
   bool      theta_hydrostatic_mode;   // Only for theta model
   bool      do_3d_turbulence;
 
+  double    tom_sponge_start = 0.0;   // start of TOM sponge layer, in hPa (0 = use ptop)
   double    dcmip16_mu;               // Only for theta model
   double    nu;
   double    nu_p;
@@ -108,6 +109,7 @@ inline void SimulationParams::print (std::ostream& out) {
   out << "   disable_diagnostics: " << (disable_diagnostics ? "yes" : "no") << "\n";
   out << "   theta_hydrostatic_mode: " << (theta_hydrostatic_mode ? "yes" : "no") << "\n";
   out << "   do_3d_turbulence: " << (do_3d_turbulence ? "yes" : "no") << "\n";
+  out << "   tom_sponge_start: " << tom_sponge_start << "\n";
   out << "   prescribed_wind: " << (prescribed_wind ? "yes" : "no") << "\n";
   out << "   nsplit: " << nsplit << "\n";
   out << "   scale_factor: " << scale_factor << "\n";

--- a/components/homme/src/theta-l_kokkos/cxx/ElementsState.cpp
+++ b/components/homme/src/theta-l_kokkos/cxx/ElementsState.cpp
@@ -23,9 +23,11 @@
 namespace Homme {
 
 void RefStates::init(const int num_elems) {
-  dp_ref = decltype(dp_ref)("dp_ref",num_elems);
-  phi_i_ref = decltype(phi_i_ref)("phi_i_ref",num_elems);
-  theta_ref = decltype(theta_ref)("theta_ref",num_elems);
+  dp_ref       = decltype(dp_ref)      ("dp_ref",      num_elems);
+  phi_i_ref    = decltype(phi_i_ref)   ("phi_i_ref",   num_elems);
+  theta_ref    = decltype(theta_ref)   ("theta_ref",   num_elems);
+  nu_scale_top = decltype(nu_scale_top)("nu_scale_top");
+  nu_scale_top_ilev_pack_lim = 0;
 
   m_num_elems = num_elems;
 

--- a/components/homme/src/theta-l_kokkos/cxx/ElementsState.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/ElementsState.hpp
@@ -20,6 +20,8 @@ struct RefStates {
   ExecViewManaged<Scalar * [NP][NP][NUM_LEV_P]> phi_i_ref;
   ExecViewManaged<Scalar * [NP][NP][NUM_LEV  ]> theta_ref;
   ExecViewManaged<Scalar * [NP][NP][NUM_LEV  ]> dp_ref;
+  ExecViewManaged<Scalar     [NUM_LEV         ]> nu_scale_top;
+  int                                            nu_scale_top_ilev_pack_lim;
 
   RefStates () :
     m_num_elems(0)

--- a/components/homme/src/theta-l_kokkos/cxx/HyperviscosityFunctorImpl.cpp
+++ b/components/homme/src/theta-l_kokkos/cxx/HyperviscosityFunctorImpl.cpp
@@ -72,52 +72,7 @@ void HyperviscosityFunctorImpl::init_params(const SimulationParams& params)
 {
   // Sanity check
   assert(params.params_set);
-
-  if (m_data.nu_top>0) {
-
-    m_nu_scale_top = ExecViewManaged<Scalar[NUM_LEV]>("nu_scale_top");
-    ExecViewManaged<Scalar[NUM_LEV]>::HostMirror h_nu_scale_top;
-    h_nu_scale_top = Kokkos::create_mirror_view(m_nu_scale_top);
-
-    const auto etai_h = Kokkos::create_mirror_view(m_hvcoord.etai);
-    const auto etam_h = Kokkos::create_mirror_view(m_hvcoord.etam);
-    Kokkos::deep_copy(etai_h, m_hvcoord.etai);
-    Kokkos::deep_copy(etam_h, m_hvcoord.etam);
-
-    for (int phys_lev=0; phys_lev < NUM_LEV*VECTOR_SIZE; ++phys_lev) {
-      const int ilev = phys_lev / VECTOR_SIZE;
-      const int ivec = phys_lev % VECTOR_SIZE;
-
-      Real ptop_over_press;
-
-      //prevent padding of nu_scale to get nans to avoid last interface levels
-      //of w, phi to be nans, too
-      if( phys_lev < NUM_PHYSICAL_LEV ){
-        //etai is num_interface_lev, that is, 129 or 73
-        //etam is num_lev, so packs
-        if ( etai_h(0) == 0.0) {
-          ptop_over_press = etam_h(0)[0] / etam_h(ilev)[ivec];
-        }else{
-          ptop_over_press = etai_h(0) / etam_h(ilev)[ivec];
-        }
-      }else{
-          ptop_over_press = 0.0;
-      }
-
-      auto val = 16.0*ptop_over_press*ptop_over_press / (ptop_over_press*ptop_over_press + 1);
-      if ( val < 0.15 ) val = 0.0;
-      h_nu_scale_top(ilev)[ivec] = val;
-
-      // This is the equivalent of nlev_tom in the F90 code.
-      if (val != 0) m_nu_scale_top_ilev_pack_lim = phys_lev + 1;
-    }
-    Kokkos::deep_copy(m_nu_scale_top, h_nu_scale_top);
-
-    // Convert to pack index.
-    m_nu_scale_top_ilev_pack_lim = ((m_nu_scale_top_ilev_pack_lim + VECTOR_SIZE - 1) /
-                                    VECTOR_SIZE);
-  }
-
+  
   // Init ElementOps
   m_elem_ops.init(m_hvcoord);
 
@@ -140,6 +95,15 @@ void HyperviscosityFunctorImpl::setup(const ElementsGeometry&     geometry,
   m_derived = derived;
   m_geometry = geometry;
   m_sphere_ops = Context::singleton().get<SphereOperators>();
+
+  // Update nu_scale_top from Fortran-initialized ref states if available.
+  // This handles the case where the functor was created via the (num_elems, params)
+  // constructor (before init_reference_states_c ran) and is later setup() with
+  // the fully-initialized state.
+  if (m_data.nu_top > 0 && m_state.m_ref_states.nu_scale_top.data() != nullptr) {
+    m_nu_scale_top = m_state.m_ref_states.nu_scale_top;
+    m_nu_scale_top_ilev_pack_lim = m_state.m_ref_states.nu_scale_top_ilev_pack_lim;
+  }
 
   // Make sure the sphere operators have buffers large enough to accommodate this functor's needs
   m_sphere_ops.allocate_buffers(m_tu);
@@ -378,6 +342,7 @@ void HyperviscosityFunctorImpl::run (const int np1, const Real dt, const Real et
       assert (m_be->is_registration_completed());
       GPTLstart("hvf-bexch");
       m_be_tom->exchange();
+
       GPTLstop("hvf-bexch");
 
       Kokkos::parallel_for(m_policy_nutop_update_states, *this);
@@ -471,7 +436,6 @@ void HyperviscosityFunctorImpl::operator() (const TagNutopLaplace&, const TeamMe
       Kokkos::parallel_for(
         Kokkos::ThreadVectorRange(kv.team, m_nu_scale_top_ilev_pack_lim),
         [&] (const int ilev) {
-          
           const auto xf = m_data.dt_hvs_tom  * m_nu_scale_top(ilev) * m_data.nu_top;
           utens(ilev)  *= xf;
           vtens(ilev)  *= xf;

--- a/components/homme/src/theta-l_kokkos/cxx/HyperviscosityFunctorImpl.cpp
+++ b/components/homme/src/theta-l_kokkos/cxx/HyperviscosityFunctorImpl.cpp
@@ -25,9 +25,9 @@ HyperviscosityFunctorImpl (const SimulationParams&     params,
                            const ElementsDerivedState& derived)
  : m_num_elems(state.num_elems())
  , m_data (params.hypervis_subcycle,params.hypervis_subcycle_tom,
-		       params.nu_ratio1,params.nu_ratio2,params.nu_top,params.nu,
-		       params.nu_p,params.nu_s,params.hypervis_scaling,
-                       params.do_3d_turbulence)
+           params.nu_ratio1,params.nu_ratio2,params.nu_top,params.nu,
+           params.nu_p,params.nu_s,params.hypervis_scaling,
+           params.do_3d_turbulence, params.tom_sponge_start)
  , m_state   (state)
  , m_derived (derived)
  , m_geometry (geometry)
@@ -52,9 +52,9 @@ HyperviscosityFunctorImpl::
 HyperviscosityFunctorImpl (const int num_elems, const SimulationParams &params)
   : m_num_elems(num_elems)
   , m_data (params.hypervis_subcycle,params.hypervis_subcycle_tom,
-		        params.nu_ratio1,params.nu_ratio2,params.nu_top,params.nu,
-		        params.nu_p,params.nu_s,params.hypervis_scaling,
-                        params.do_3d_turbulence)
+            params.nu_ratio1,params.nu_ratio2,params.nu_top,params.nu,
+            params.nu_p,params.nu_s,params.hypervis_scaling,
+            params.do_3d_turbulence, params.tom_sponge_start)
   , m_hvcoord (Context::singleton().get<HybridVCoord>())
   , m_policy_update_states (Homme::get_default_team_policy<ExecSpace,TagUpdateStates>(m_num_elems))
   , m_policy_first_laplace (Homme::get_default_team_policy<ExecSpace,TagFirstLaplaceHV>(m_num_elems))
@@ -72,6 +72,62 @@ void HyperviscosityFunctorImpl::init_params(const SimulationParams& params)
 {
   // Sanity check
   assert(params.params_set);
+  // tom_sponge_start is now stored in m_data
+  //NOTE: we are missing the part of the block that computes m_nu_scale_top using tom_sponge_start.
+  // As of 04/29/2026 we decided not to move this missing computation from
+  // components/homme/src/theta-l/share/model_init_mod.F90
+  // instead we will get m_nu_scale_top and m_nu_scale_top_ilev_pack_lim from the
+  //  Fortran-initialized ref states, which will have the correct values if tom_sponge_start > 0.0.
+  //  If tom_sponge_start = 0.0, then we will compute m_nu_scale_top using the existing logic in HyperviscosityFunctorImpl::init_params, 
+  // which is equivalent to the old logic when tom_sponge_start was not a parameter.
+  // In addition, we will not delete the following block of code because using the 
+  // Fortran-initialization produces non-BFB results for case when tom_sponge_start == 0.0.
+  const bool compute_nu_scale_top = m_data.tom_sponge_start > 0.0; 
+  if (m_data.nu_top>0 && !compute_nu_scale_top ) {
+    m_nu_scale_top = ExecViewManaged<Scalar[NUM_LEV]>("nu_scale_top");
+    ExecViewManaged<Scalar[NUM_LEV]>::HostMirror h_nu_scale_top;
+    h_nu_scale_top = Kokkos::create_mirror_view(m_nu_scale_top);
+
+    const auto etai_h = Kokkos::create_mirror_view(m_hvcoord.etai);
+    const auto etam_h = Kokkos::create_mirror_view(m_hvcoord.etam);
+    Kokkos::deep_copy(etai_h, m_hvcoord.etai);
+    Kokkos::deep_copy(etam_h, m_hvcoord.etam);
+
+    for (int phys_lev=0; phys_lev < NUM_LEV*VECTOR_SIZE; ++phys_lev) {
+      const int ilev = phys_lev / VECTOR_SIZE;
+      const int ivec = phys_lev % VECTOR_SIZE;
+
+      Real ptop_over_press;
+
+      //prevent padding of nu_scale to get nans to avoid last interface levels
+      //of w, phi to be nans, too
+      if( phys_lev < NUM_PHYSICAL_LEV ){
+        //etai is num_interface_lev, that is, 129 or 73
+        //etam is num_lev, so packs
+        if ( etai_h(0) == 0.0) {
+          ptop_over_press = etam_h(0)[0] / etam_h(ilev)[ivec];
+        }else{
+          ptop_over_press = etai_h(0) / etam_h(ilev)[ivec];
+        }
+      }else{
+          ptop_over_press = 0.0;
+      }
+
+      auto val = 16.0*ptop_over_press*ptop_over_press / (ptop_over_press*ptop_over_press + 1);
+      if ( val < 0.15 ) val = 0.0;
+      h_nu_scale_top(ilev)[ivec] = val;
+
+      // This is the equivalent of nlev_tom in the F90 code.
+      if (val != 0) m_nu_scale_top_ilev_pack_lim = phys_lev + 1;
+    }
+    Kokkos::deep_copy(m_nu_scale_top, h_nu_scale_top);
+
+    // Convert to pack index.
+    m_nu_scale_top_ilev_pack_lim = ((m_nu_scale_top_ilev_pack_lim + VECTOR_SIZE - 1) /
+                                    VECTOR_SIZE);
+  }
+
+
   
   // Init ElementOps
   m_elem_ops.init(m_hvcoord);
@@ -100,7 +156,7 @@ void HyperviscosityFunctorImpl::setup(const ElementsGeometry&     geometry,
   // This handles the case where the functor was created via the (num_elems, params)
   // constructor (before init_reference_states_c ran) and is later setup() with
   // the fully-initialized state.
-  if (m_data.nu_top > 0 && m_state.m_ref_states.nu_scale_top.data() != nullptr) {
+  if (m_data.nu_top > 0 && m_state.m_ref_states.nu_scale_top.data() != nullptr && m_data.tom_sponge_start > 0.0) {
     m_nu_scale_top = m_state.m_ref_states.nu_scale_top;
     m_nu_scale_top_ilev_pack_lim = m_state.m_ref_states.nu_scale_top_ilev_pack_lim;
   }

--- a/components/homme/src/theta-l_kokkos/cxx/HyperviscosityFunctorImpl.cpp
+++ b/components/homme/src/theta-l_kokkos/cxx/HyperviscosityFunctorImpl.cpp
@@ -153,12 +153,14 @@ void HyperviscosityFunctorImpl::setup(const ElementsGeometry&     geometry,
   m_sphere_ops = Context::singleton().get<SphereOperators>();
 
   // Update nu_scale_top from Fortran-initialized ref states if available.
-  // This handles the case where the functor was created via the (num_elems, params)
-  // constructor (before init_reference_states_c ran) and is later setup() with
-  // the fully-initialized state.
   if (m_data.nu_top > 0 && m_state.m_ref_states.nu_scale_top.data() != nullptr && m_data.tom_sponge_start > 0.0) {
     m_nu_scale_top = m_state.m_ref_states.nu_scale_top;
     m_nu_scale_top_ilev_pack_lim = m_state.m_ref_states.nu_scale_top_ilev_pack_lim;
+    if (m_nu_scale_top_ilev_pack_lim == 0) {
+      std::string msg = "[HyperviscosityFunctorImpl::setup] Error! m_nu_scale_top_ilev_pack_lim is zero. \n \
+                         Try increasing tom_sponge_start, or set tom_sponge_start to zero. \n";
+      Errors::runtime_abort(msg);
+    }
   }
 
   // Make sure the sphere operators have buffers large enough to accommodate this functor's needs

--- a/components/homme/src/theta-l_kokkos/cxx/HyperviscosityFunctorImpl.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/HyperviscosityFunctorImpl.hpp
@@ -40,13 +40,15 @@ public:
                        const int hypervis_subcycle_tom_in, 
                        const Real nu_ratio1_in, const Real nu_ratio2_in, const Real nu_top_in,
                        const Real nu_in, const Real nu_p_in, const Real nu_s_in,
-                       const Real hypervis_scaling_in, bool do_3d_turbulence_in)
+                       const Real hypervis_scaling_in, bool do_3d_turbulence_in,
+                       const double tom_sponge_start_in)
                       : hypervis_subcycle(hypervis_subcycle_in) 
                       , hypervis_subcycle_tom(hypervis_subcycle_tom_in)
                       , nu_ratio1(nu_ratio1_in), nu_ratio2(nu_ratio2_in)
                       , nu_top(nu_top_in), nu(nu_in), nu_p(nu_p_in), nu_s(nu_s_in)
                       , consthv(hypervis_scaling_in == 0)
-                      , do_3d_turbulence(do_3d_turbulence_in){}
+                      , do_3d_turbulence(do_3d_turbulence_in)
+                      , tom_sponge_start(tom_sponge_start_in) {}
 
     const int   hypervis_subcycle;
     const int   hypervis_subcycle_tom;
@@ -69,7 +71,10 @@ public:
     Real        eta_ave_w;
 
     bool consthv;
+    double tom_sponge_start;
   };//hyperviscosityData
+
+  // tom_sponge_start is now in HyperviscosityData
 
   struct Buffers {
     ExecViewManaged<Scalar * [NP][NP][NUM_LEV]>    dptens;

--- a/components/homme/src/theta-l_kokkos/cxx/cxx_f90_interface_theta.cpp
+++ b/components/homme/src/theta-l_kokkos/cxx/cxx_f90_interface_theta.cpp
@@ -48,7 +48,7 @@ void init_simulation_params_c (const int& remap_alg, const int& limiter_option, 
                                const int& dt_remap_factor, const int& dt_tracer_factor,
                                const double& scale_factor, const double& laplacian_rigid_factor, const int& nsplit, const int& pgrad_correction,
                                const double& dp3d_thresh, const double& vtheta_thresh, const int& internal_diagnostics_level,
-                               const int& do_3d_turbulence)
+                               const int& do_3d_turbulence, const Real& tom_sponge_start)
 {
 
   // Check that the simulation options are supported. This helps us in the future, since we
@@ -127,6 +127,7 @@ void init_simulation_params_c (const int& remap_alg, const int& limiter_option, 
   params.vtheta_thresh                 = vtheta_thresh;
   params.internal_diagnostics_level    = internal_diagnostics_level;
   params.do_3d_turbulence              = (bool)do_3d_turbulence;
+  params.tom_sponge_start              = tom_sponge_start;
 
   if (time_step_type==5) {
     //5 stage, 3rd order, explicit

--- a/components/homme/src/theta-l_kokkos/cxx/cxx_f90_interface_theta.cpp
+++ b/components/homme/src/theta-l_kokkos/cxx/cxx_f90_interface_theta.cpp
@@ -534,7 +534,8 @@ void init_elements_states_c (CF90Ptr& elem_state_v_ptr,       CF90Ptr& elem_stat
 
 void init_reference_states_c (CF90Ptr& elem_theta_ref_ptr,
                               CF90Ptr& elem_dp_ref_ptr,
-                              CF90Ptr& elem_phi_ref_ptr)
+                              CF90Ptr& elem_phi_ref_ptr,
+                              CF90Ptr& nu_scale_top_ptr)
 {
   auto& state = Context::singleton().get<ElementsState> ();
   auto& ref_states = state.m_ref_states;
@@ -549,6 +550,22 @@ void init_reference_states_c (CF90Ptr& elem_theta_ref_ptr,
   sync_to_device(theta_ref, ref_states.theta_ref);
   sync_to_device(dp_ref,    ref_states.dp_ref);
   sync_to_device(phi_ref,   ref_states.phi_i_ref);
+
+  // Unpack nu_scale_top from Fortran 1D array (nlev reals) into packed Scalar[NUM_LEV] view
+  const Real* nu_scale_top_f = static_cast<const Real*>(nu_scale_top_ptr);
+  auto h_nu_scale_top = Kokkos::create_mirror_view(ref_states.nu_scale_top);
+  ref_states.nu_scale_top_ilev_pack_lim = 0;
+  for (int phys_lev = 0; phys_lev < NUM_LEV * VECTOR_SIZE; ++phys_lev) {
+    const int ilev = phys_lev / VECTOR_SIZE;
+    const int ivec = phys_lev % VECTOR_SIZE;
+    const Real val = (phys_lev < NUM_PHYSICAL_LEV) ? nu_scale_top_f[phys_lev] : 0.0;
+    h_nu_scale_top(ilev)[ivec] = val;
+    if (val != 0.0) ref_states.nu_scale_top_ilev_pack_lim = phys_lev + 1;
+  }
+  // Convert last nonzero physical level index to pack index
+  ref_states.nu_scale_top_ilev_pack_lim =
+      (ref_states.nu_scale_top_ilev_pack_lim + VECTOR_SIZE - 1) / VECTOR_SIZE;
+  Kokkos::deep_copy(ref_states.nu_scale_top, h_nu_scale_top);
 }
 
 void init_diagnostics_c (F90Ptr& elem_state_q_ptr, F90Ptr& elem_accum_qvar_ptr,  F90Ptr& elem_accum_qmass_ptr,

--- a/components/homme/src/theta-l_kokkos/element_state.F90
+++ b/components/homme/src/theta-l_kokkos/element_state.F90
@@ -27,8 +27,8 @@ module element_state
   real (kind=real_kind), public :: max_reserr=0
 
   ! pressure based TOM sponge layer
-  real (kind=real_kind),public :: nu_scale_top(nlev)
-  integer, public              :: nlev_tom
+  real (kind=real_kind), target, public :: nu_scale_top(nlev)
+  integer, public                       :: nlev_tom
 
   ! flattened arrays for all state, derived, and accum quantities that need to be passed back and forth to CXX
 

--- a/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
+++ b/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
@@ -91,7 +91,8 @@ contains
                               dcmip16_mu, theta_advect_form, test_case,                &
                               MAX_STRING_LEN, dt_remap_factor, dt_tracer_factor,       &
                               pgrad_correction, dp3d_thresh, vtheta_thresh,            &
-                              internal_diagnostics_level, do_3d_turbulence
+                              internal_diagnostics_level, do_3d_turbulence,            &
+                              tom_sponge_start
     !
     ! Input(s)
     !
@@ -141,7 +142,8 @@ contains
                                    nsplit,                                                        &
                                    pgrad_correction,                                              &
                                    dp3d_thresh, vtheta_thresh, internal_diagnostics_level,        &
-                                   do_3d_turbulence_int)
+                                   do_3d_turbulence_int,                                          &
+                                   tom_sponge_start)
 
     ! Initialize time level structure in C++
     call init_time_level_c(tl%nm1, tl%n0, tl%np1, tl%nstep, tl%nstep0)

--- a/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
+++ b/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
@@ -296,7 +296,7 @@ contains
   subroutine prim_init_ref_states_views (elem)
     use iso_c_binding, only : c_ptr, c_loc
     use element_mod,   only : element_t
-    use element_state, onlY : elem_theta_ref, elem_dp_ref, elem_phi_ref
+    use element_state, onlY : elem_theta_ref, elem_dp_ref, elem_phi_ref, nu_scale_top
     use theta_f2c_mod, only : init_reference_states_c
     !
     ! Input(s)
@@ -306,11 +306,14 @@ contains
     ! Local(s)
     !
     type (c_ptr) :: elem_theta_ref_ptr, elem_dp_ref_ptr, elem_phi_ref_ptr
+    type (c_ptr) :: nu_scale_top_ptr
 
     elem_theta_ref_ptr = c_loc(elem_theta_ref)
     elem_dp_ref_ptr    = c_loc(elem_dp_ref)
     elem_phi_ref_ptr   = c_loc(elem_phi_ref)
-    call init_reference_states_c (elem_theta_ref_ptr, elem_dp_ref_ptr, elem_phi_ref_ptr)
+    nu_scale_top_ptr   = c_loc(nu_scale_top)
+    call init_reference_states_c (elem_theta_ref_ptr, elem_dp_ref_ptr, &
+                                  elem_phi_ref_ptr, nu_scale_top_ptr)
   end subroutine prim_init_ref_states_views
 
   subroutine prim_init_diags_views (elem)
@@ -359,7 +362,7 @@ contains
 
     ! Initialize the 3d states views in C++
     call prim_init_state_views (elem)
-
+    
     ! Initialize the reference states in C++
     call prim_init_ref_states_views (elem)
 

--- a/components/homme/src/theta-l_kokkos/theta_f2c_mod.F90
+++ b/components/homme/src/theta-l_kokkos/theta_f2c_mod.F90
@@ -16,7 +16,7 @@ interface
                                        theta_hydrostatic_mode, test_case_name, dt_remap_factor,      &
                                        dt_tracer_factor, scale_factor, laplacian_rigid_factor,       &
                                        nsplit, pgrad_correction, dp3d_thresh, vtheta_thresh,         &
-                                       internal_diagnostics_level, do_3d_turbulence) bind(c)
+                                       internal_diagnostics_level, do_3d_turbulence, tom_sponge_start) bind(c)
 
     use iso_c_binding, only: c_int, c_double, c_ptr
     !
@@ -26,12 +26,13 @@ interface
     integer(kind=c_int),  intent(in) :: dt_remap_factor, dt_tracer_factor, transport_alg
     integer(kind=c_int),  intent(in) :: state_frequency, qsize, internal_diagnostics_level
     real(kind=c_double),  intent(in) :: nu, nu_p, nu_q, nu_s, nu_div, nu_top, hypervis_scaling, dcmip16_mu, &
-                                        scale_factor, laplacian_rigid_factor, dp3d_thresh, vtheta_thresh
+                      scale_factor, laplacian_rigid_factor, dp3d_thresh, vtheta_thresh
     integer(kind=c_int),  intent(in) :: hypervis_order, hypervis_subcycle, hypervis_subcycle_tom
     integer(kind=c_int),  intent(in) :: ftype, theta_adv_form
     integer(kind=c_int),  intent(in) :: prescribed_wind, use_moisture, disable_diagnostics, use_cpstar
     integer(kind=c_int),  intent(in) :: theta_hydrostatic_mode, pgrad_correction, do_3d_turbulence
     type(c_ptr), intent(in) :: test_case_name
+    real(kind=c_double), intent(in) :: tom_sponge_start
   end subroutine init_simulation_params_c
 
   ! Creates element structures in C++

--- a/components/homme/src/theta-l_kokkos/theta_f2c_mod.F90
+++ b/components/homme/src/theta-l_kokkos/theta_f2c_mod.F90
@@ -119,12 +119,14 @@ interface
   end subroutine init_elements_states_c
 
   ! Copies reference states from f90 arrays into C++ views
-  subroutine init_reference_states_c (elem_theta_ref_ptr, elem_dp_ref_ptr, elem_phi_ref_ptr) bind(c)
+  subroutine init_reference_states_c (elem_theta_ref_ptr, elem_dp_ref_ptr, &
+                                      elem_phi_ref_ptr, nu_scale_top_ptr) bind(c)
     use iso_c_binding, only: c_ptr
     !
     ! Inputs
     !
     type (c_ptr) :: elem_theta_ref_ptr, elem_dp_ref_ptr, elem_phi_ref_ptr
+    type (c_ptr) :: nu_scale_top_ptr
   end subroutine init_reference_states_c
 
   ! Initialize SEM reference element structures (mass and pseudo-spectral deriv matrices)

--- a/components/homme/test_execs/thetal_kokkos_ut/thetal_test_interface.F90
+++ b/components/homme/test_execs/thetal_kokkos_ut/thetal_test_interface.F90
@@ -256,6 +256,7 @@ contains
   subroutine initialize_reference_states_f90(phis_ptr, dp_ref_ptr, theta_ref_ptr, phi_ref_ptr) bind(c)
     use element_ops,    only: initialize_reference_states
     use dimensions_mod, only: nelemd, nlev, nlevp, np
+    use element_state,  only: nu_scale_top
     use theta_f2c_mod,  only : init_reference_states_c
     !
     ! Inputs
@@ -266,6 +267,7 @@ contains
     !
     real (kind=real_kind), dimension(:,:,:),  pointer :: phis
     real (kind=real_kind), dimension(:,:,:,:),  pointer :: dp_ref, theta_ref, phi_ref
+    type (c_ptr) :: nu_scale_top_ptr
     integer :: ie
 
     call c_f_pointer(phis_ptr,      phis,      [np,np,      nelemd])
@@ -283,7 +285,8 @@ contains
     end do
 
     ! Initialize reference states in C++
-    call init_reference_states_c(dp_ref_ptr,theta_ref_ptr,phi_ref_ptr)
+    nu_scale_top_ptr = c_loc(nu_scale_top)
+    call init_reference_states_c(theta_ref_ptr,dp_ref_ptr,phi_ref_ptr,nu_scale_top_ptr)
 
   end subroutine initialize_reference_states_f90
 

--- a/components/homme/test_execs/thetal_kokkos_ut/thetal_test_interface.F90
+++ b/components/homme/test_execs/thetal_kokkos_ut/thetal_test_interface.F90
@@ -1,6 +1,6 @@
 module thetal_test_interface
 
-  use iso_c_binding,  only: c_int, c_bool, c_double, c_ptr, c_f_pointer
+  use iso_c_binding,  only: c_int, c_bool, c_double, c_ptr, c_f_pointer, c_loc
   use derivative_mod, only: derivative_t
   use element_mod,    only: element_t
   use kinds,          only: real_kind


### PR DESCRIPTION
PR #8224 added the namelist parameter `tom_sponge_start`. However, tom_sponge_start was not used in the computation of nu_scale_top, so it did not have any effect on the simulation. This PR uses `nu_scale_top` computed by [`model_init_mod`](https://github.com/E3SM-Project/E3SM/blob/857ef0f1d779eec6d41f6aaa65d51720fdf22824/components/homme/src/theta-l/share/model_init_mod.F90#L122) when `tom_sponge_start` is different from zero, based on PR #4723.

While running the `SMS.ne30pg2_ne30pg2.F2010-SCREAMv1.pm-cpu_gnug.eamxx-L72` case with L72, we observed that the simulation crashed with an error indicating velocities greater than 400 at the top of the model. Removing the velocity interval check allowed the simulation to run longer; however, it eventually crashed with the error:

```
label: CaarFunctorImpl::run TagPreExchange
time-level 0
lat 1.054217737593061e+00 lon 1.861061130185492e-01
ie 10 igll 1 jgll 3 lev 0: bad dphi
level          dphi          dp3d       vtheta_dp
```
As recommended by @mt5555, using `tom_sponge_start=2.0` makes the simulation stable and resolves this issue.


Notes: If the `tom_sponge_start` value is too small, the number of layers in the sponge layer can be zero (`nlev_tom`), which produces the following runtime error: `Optional nlev must be > 0`

I encountered this error with `tom_sponge_start = 2.0 `for L128.

I added a more descriptive error message to inform the user that this error could be related to tom_sponge_start:

```
[HyperviscosityFunctorImpl::setup] Error! m_nu_scale_top_ilev_pack_lim is zero.
Try increasing tom_sponge_start, or set tom_sponge_start to zero.
```



<details>
<summary>Details on BFB (click the arrow to expand)</summary>

We could remove the C++ code block that computes `m_nu_scale_top` when `tom_sponge_start = 0` and rely solely on the Fortran initialization. However, I observed that the Fortran version produces non-BFB values for a few entries of `m_nu_scale_top`, with differences only in the last digits. While I would consider these differences to be numerical noise, they still lead to non-BFB results. For this reason, I kept the C++ implementation for the `tom_sponge_start = 0` case.

In the following table, I ran the test `ERS.ne30pg2_ne30pg2.F2010-SCREAMv1.pm-gpu_gnugpu.eamxx-prod`, which uses `tom_sponge_start = 0`. In this test, I printed both the C++ version and the Fortran version of `nu_scale_top`.

| ilev | v | C++ version | Fortran | diff |
|---|---:|---:|---:|---:|
| 0  | 0 | 6.92938665202227799e+00 | 6.92938665202227888e+00 | -8.88178419700125232e-16 |
| 1  | 0 | 5.24308179845192690e+00 | 5.24308179845192690e+00 | 0.00000000000000000e+00 |
| 2  | 0 | 4.03996081024440734e+00 | 4.03996081024440734e+00 | 0.00000000000000000e+00 |
| 3  | 0 | 3.10359169059753803e+00 | 3.10359169059753892e+00 | -8.88178419700125232e-16 |
| 4  | 0 | 2.32272228570899264e+00 | 2.32272228570899264e+00 | 0.00000000000000000e+00 |
| 5  | 0 | 1.70442520504891393e+00 | 1.70442520504891393e+00 | 0.00000000000000000e+00 |
| 6  | 0 | 1.26207319730247081e+00 | 1.26207319730247081e+00 | 0.00000000000000000e+00 |
| 7  | 0 | 9.52199042385667660e-01 | 9.52199042385667660e-01 | 0.00000000000000000e+00 |
| 8  | 0 | 7.17276924434578134e-01 | 7.17276924434578134e-01 | 0.00000000000000000e+00 |
| 9  | 0 | 5.36309905915623442e-01 | 5.36309905915623442e-01 | 0.00000000000000000e+00 |
| 10 | 0 | 4.04311076629688904e-01 | 4.04311076629688904e-01 | 0.00000000000000000e+00 |
| 11 | 0 | 3.11695543485727311e-01 | 3.11695543485727311e-01 | 0.00000000000000000e+00 |
| 12 | 0 | 2.42880418339044363e-01 | 2.42880418339044363e-01 | 0.00000000000000000e+00 |
| 13 | 0 | 1.89128525227521993e-01 | 1.89128525227521993e-01 | 0.00000000000000000e+00 |

</details>




