### PR TITLE
Disables mixed layer heat budget when tracer budgets are disabled

### DIFF
--- a/components/mpas-ocean/src/analysis_members/mpas_ocn_analysis_driver.F
+++ b/components/mpas-ocean/src/analysis_members/mpas_ocn_analysis_driver.F
@@ -456,6 +456,13 @@ contains
          configName = 'config_AM_' // poolItr % memberName(1:nameLength) // '_enable'
          call mpas_pool_get_config(domain % configs, configName, config_AM_enable)
 
+         if ( poolItr % memberName(1:nameLength) == 'mixedLayerHeatBudget' .and. .not. config_compute_active_tracer_budgets) then
+            call mpas_log_write( &
+               'Cannot run mixed layer heat budget AM without config_compute_active_tracer_budget=.true., Disabling AM', &
+                MPAS_LOG_WARN)
+            config_AM_enable = .false.
+         end if
+
          if ( config_AM_enable ) then
 #ifdef MPAS_DEBUG
             call mpas_log_write( '      Initializing AM ' // poolItr % memberName(1:nameLength))


### PR DESCRIPTION
The mixed layer heat budget requires tracer budgets to be active for the analysis member to function properly.  If `config_compute_active_tracer_budgets = .false.` and `config_AM_mixedLayerHeatBudget_enable = .true.` some arrays in the analysis member are not initialized properly on some machines/compilers causing errors.  This PR issues a warning to the MPAS-ocean log when this happens and disables the heat budget analysis member.

Fixes #8328 

[BFB]