### PR TITLE
For pm-cpu, add flag for Intel for one fortran source file

### DIFF
--- a/cime_config/machines/Depends.alvarez-cpu.intel.cmake
+++ b/cime_config/machines/Depends.alvarez-cpu.intel.cmake
@@ -1,4 +1,4 @@
-# https://github.com/E3SM-Project/E3SM/issues/8036
+# https://github.com/E3SM-Project/E3SM/issues/8140
 if (DEBUG)
   if (CMAKE_Fortran_COMPILER_ID STREQUAL "IntelLLVM" AND
       CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL "2025.0")
@@ -6,6 +6,11 @@ if (DEBUG)
   endif()
 endif()
 
-
-
-
+# https://github.com/E3SM-Project/E3SM/issues/8036
+# Turn off vectorization in one source file to avoid issue with Intel compiler
+if (NOT DEBUG)
+  if (CMAKE_Fortran_COMPILER_ID STREQUAL "IntelLLVM" AND
+      CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL "2025.0")
+    e3sm_add_flags("eam/src/physics/cosp2/optics/quickbeam_optics.F90" "-no-vec")
+  endif()
+endif()

--- a/cime_config/machines/Depends.muller-cpu.intel.cmake
+++ b/cime_config/machines/Depends.muller-cpu.intel.cmake
@@ -1,4 +1,4 @@
-# https://github.com/E3SM-Project/E3SM/issues/8036
+# https://github.com/E3SM-Project/E3SM/issues/8140
 if (DEBUG)
   if (CMAKE_Fortran_COMPILER_ID STREQUAL "IntelLLVM" AND
       CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL "2025.0")
@@ -6,6 +6,11 @@ if (DEBUG)
   endif()
 endif()
 
-
-
-
+# https://github.com/E3SM-Project/E3SM/issues/8036
+# Turn off vectorization in one source file to avoid issue with Intel compiler
+if (NOT DEBUG)
+  if (CMAKE_Fortran_COMPILER_ID STREQUAL "IntelLLVM" AND
+      CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL "2025.0")
+    e3sm_add_flags("eam/src/physics/cosp2/optics/quickbeam_optics.F90" "-no-vec")
+  endif()
+endif()

--- a/cime_config/machines/Depends.pm-cpu.intel.cmake
+++ b/cime_config/machines/Depends.pm-cpu.intel.cmake
@@ -1,4 +1,4 @@
-# https://github.com/E3SM-Project/E3SM/issues/8036
+# https://github.com/E3SM-Project/E3SM/issues/8140
 if (DEBUG)
   if (CMAKE_Fortran_COMPILER_ID STREQUAL "IntelLLVM" AND
       CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL "2025.0")
@@ -6,6 +6,11 @@ if (DEBUG)
   endif()
 endif()
 
-
-
-
+# https://github.com/E3SM-Project/E3SM/issues/8036
+# Turn off vectorization in one source file to avoid issue with Intel compiler
+if (NOT DEBUG)
+  if (CMAKE_Fortran_COMPILER_ID STREQUAL "IntelLLVM" AND
+      CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL "2025.0")
+    e3sm_add_flags("eam/src/physics/cosp2/optics/quickbeam_optics.F90" "-no-vec")
+  endif()
+endif()


### PR DESCRIPTION
Add a flag to turn off vectorization to `eam/src/physics/cosp2/optics/quickbeam_optics.F90` to avoid what
looks like a compiler optimization issue with intel fortran 2025.
This may not be BFB for jobs using COSP output.
Corrected comment in same file pointing to GH issue.
Made same change to muller/alvarez files (hence 3 files changed).

Fixes https://github.com/E3SM-Project/E3SM/issues/8036

[nbfb]
