### PR TITLE
EAMxx: add property tests and docs for p3 liquid relaxation timescale. 

### DIFF
--- a/components/eamxx/docs/technical/physics/p3/liq_relaxation_timescale.md
+++ b/components/eamxx/docs/technical/physics/p3/liq_relaxation_timescale.md
@@ -1,0 +1,251 @@
+# P3 Liquid Relaxation Timescale
+
+This document describes the P3 routine
+`calc_liq_relaxation_timescale`. Despite the routine name, the outputs `epsr`
+and `epsc` are relaxation-rate coefficients used in the liquid adjustment
+calculation. This document also describes the physical-property tests that
+verify the implementation.
+
+## Purpose
+
+The routine computes two liquid-phase relaxation-rate coefficients used by P3:
+
+- `epsr`, the rain relaxation-rate coefficient
+- `epsc`, the cloud-liquid relaxation-rate coefficient
+
+The rain expression combines an analytic gamma-distribution term with a
+ventilation-enhanced lookup-table term. The cloud-liquid expression is a direct
+closed-form product.
+
+## Physical Formulation
+
+For active rain lanes, defined by
+
+$$
+q_{r,\mathrm{incld}} \ge Q_{\mathrm{small}}
+\quad\text{and}\quad
+\mathrm{context}=\mathrm{true},
+$$
+
+define
+
+$$
+T(\mu_r,\lambda_r)
+=
+\mathrm{apply\_table}(\mathrm{revap\_table\_vals},
+\mathrm{lookup}(\mu_r,\lambda_r)),
+$$
+
+$$
+A = \frac{\Gamma(\mu_r+2)}{\lambda_r},
+\qquad
+B = \left(\frac{\rho}{\mu}\right)^{1/2} Sc^{1/3} T(\mu_r,\lambda_r).
+$$
+
+Then the rain relaxation-rate coefficient is
+
+$$
+\epsilon_r =
+2\pi C_r \rho D_v
+\left[
+f_{1r} A + f_{2r} B
+\right].
+$$
+
+For active cloud-liquid lanes, defined by
+
+$$
+q_{c,\mathrm{incld}} \ge Q_{\mathrm{small}}
+\quad\text{and}\quad
+\mathrm{context}=\mathrm{true},
+$$
+
+the cloud-liquid relaxation-rate coefficient is
+
+$$
+\epsilon_c = 2\pi \rho D_v C_c.
+$$
+
+For cloud-small lanes inside context,
+
+$$
+q_{c,\mathrm{incld}} < Q_{\mathrm{small}},
+$$
+
+the implementation sets
+
+$$
+\epsilon_c = 0.
+$$
+
+For rain-small lanes, and for lanes outside context, the implementation returns
+`epsr = 0` because it initializes the entire `epsr` pack to zero before
+overwriting active rain lanes.
+
+## Variable Definitions
+
+- $\rho$: air density
+- $D_v$: vapor diffusivity, `dv`
+- $\mu$: dynamic viscosity used in the ventilation term
+- $Sc$: Schmidt number, `sc`
+- $\mu_r$: rain size-distribution shape parameter
+- $\lambda_r$: rain size-distribution slope parameter, `lamr`
+- $C_r$: rain prefactor, `cdistr`
+- $C_c$: cloud-liquid prefactor, `cdist`
+- $f_{1r}$: analytic rain coefficient
+- $f_{2r}$: ventilation rain coefficient
+- $Q_{\mathrm{small}}$: hydrometeor activity threshold used separately for
+  `qr_incld` and `qc_incld`
+- $T(\mu_r,\lambda_r)$: rain evaporation lookup-table value
+
+## Implementation Details
+
+- Source:
+  `components/eamxx/src/physics/p3/impl/p3_calc_liq_relaxation_timescale_impl.hpp`
+- The threshold comparison is inclusive:
+  - `qr_incld >= QSMALL`
+  - `qc_incld >= QSMALL`
+- `epsr` is initialized globally before the context-filtered rain overwrite:
+
+  ```cpp
+  epsr = 0;
+  ```
+
+  This means out-of-context lanes are guaranteed to return `epsr = 0`.
+
+- `epsc` is only modified through `.set(... && context, ...)` operations.
+  Therefore, when `context == false`, the routine does not guarantee that
+  `epsc` is overwritten.
+
+## Lookup-Table Role
+
+The lookup-table contribution enters only the rain expression through
+$T(\mu_r,\lambda_r)$. This term depends on both `mu_r` and `lamr`, so tests
+that vary those inputs in the full rain expression can mix algebraic scaling
+with interpolation effects.
+
+To avoid false positives, the property tests isolate exact algebraic identities
+by holding `mu_r` and `lamr` fixed whenever the lookup-table value must remain
+unchanged.
+
+## Mathematical Properties
+
+For active rain lanes, the implementation can be decomposed into an analytic
+gamma-distribution term and a ventilation-enhanced table term:
+
+$$
+\epsilon_r =
+2\pi C_r \rho D_v
+\left[
+f_{1r}\frac{\Gamma(\mu_r+2)}{\lambda_r}
++
+f_{2r}\left(\frac{\rho}{\mu}\right)^{1/2}
+Sc^{1/3} T(\mu_r,\lambda_r)
+\right].
+$$
+
+This decomposition implies exact additivity between the analytic and
+ventilation terms. It also implies exact linear scaling with $D_v$ and $C_r$.
+When the ventilation term is disabled, the expression is linear in $\rho$,
+$f_{1r}$, and $\lambda_r^{-1}$. When the analytic term is disabled and the
+lookup-table term is held fixed, the expression scales as $\rho^{3/2}$,
+$\mu^{-1/2}$, and $Sc^{1/3}$.
+
+For active cloud-liquid lanes,
+
+$$
+\epsilon_c = 2\pi \rho D_v C_c,
+$$
+
+so the cloud-liquid coefficient is exactly linear in $\rho$, $D_v$, and
+$C_c$.
+
+The mixed rain expression also yields a robust density bound when both terms
+are active and non-negative:
+
+$$
+2\epsilon_r(\rho)
+\le
+\epsilon_r(2\rho)
+\le
+2\sqrt{2}\,\epsilon_r(\rho).
+$$
+
+### Connection to Bulk Microphysics
+
+The cloud-liquid expression has the form of a diffusion-limited vapor exchange
+coefficient. It is linear in vapor diffusivity, air density, and the cloud
+geometric distribution factor. The rain expression adds a ventilation-enhanced
+term. The factor $(\rho/\mu)^{1/2}Sc^{1/3}$ represents the expected
+Reynolds/Schmidt-number dependence of ventilation corrections in bulk
+microphysics.
+
+This structure implies that increasing diffusivity, air density, or the
+distribution prefactors increases the relaxation-rate coefficients. Increasing
+viscosity damps the ventilation contribution, while increasing Schmidt number
+enhances it. The tests encode these expectations as exact scaling identities
+when the lookup-table term is held fixed.
+
+## Property Tests
+
+The unit tests live in
+`components/eamxx/src/physics/p3/tests/p3_calc_liq_relaxation_timescale_unit_tests.cpp`.
+
+### Test Organization
+
+The Catch2 test case `p3_calc_liq_relaxation_timescale` has two top-level
+sections:
+
+- `properties`
+- `bfb`
+
+Inside `properties`, the nested sections cover:
+
+- context and threshold masking
+- cloud-liquid identity and exact scaling
+- rain additivity between the analytic and ventilation terms
+- full rain prefactor scaling with `dv` and `cdistr`
+- analytic-only rain identities
+- ventilation-only rain power-law identities
+- mixed microphysical scaling with `rho`, `mu`, and `sc`
+- mixed-term density bound
+- separation of cloud-liquid and rain-only factors
+- zero-coefficient and coefficient-locality behavior
+- non-negativity and finite-output checks
+
+### Tolerance Philosophy
+
+| Test Category | Tolerance Type | Value | Rationale |
+| --- | --- | --- | --- |
+| Exact identities and scaling | Identity | `100 * epsilon` | Tight algebraic checks with floating-point slack |
+| Bounds and non-negativity | Inequality | `100 * epsilon`-scaled | Stable comparisons for one-sided checks |
+| Expected-zero branches | Absolute | `1e-30` | Numerical zero floor for thresholded and zero-coefficient cases |
+
+Here, `epsilon` is machine epsilon for EAMxx `Real`
+(`std::numeric_limits<Real>::epsilon()`).
+
+### Context-Mask Coverage
+
+The suite explicitly documents the asymmetric output behavior:
+
+- `epsr` is zero for out-of-context lanes because the routine zeroes the full
+  pack before applying the rain mask.
+- `epsc` is not guaranteed to be written outside context, so the tests
+  initialize it with a sentinel value and verify that the sentinel is
+  preserved.
+
+### Table-Sensitive Identities
+
+The suite avoids asserting lookup-sensitive identities that would vary with the
+interpolated table value. In particular:
+
+- all non-coefficient inputs are held fixed for the rain-additivity check
+- `mu_r` and `lamr` are held fixed for ventilation-only scaling checks
+- the exact `lamr^{-1}` scaling is tested only in the analytic-only regime
+
+### BFB Coverage
+
+The BFB regression path is preserved to ensure the property tests do not change
+production behavior. It uses representative randomized inputs spanning active
+and inactive threshold states and compares the serialized outputs against the
+established baseline format.

--- a/components/eamxx/mkdocs.yml
+++ b/components/eamxx/mkdocs.yml
@@ -58,6 +58,7 @@ nav:
       - 'P3':
         - 'Autoconversion': 'technical/physics/p3/autoconversion.md'
         - 'Back to Cell Average': 'technical/physics/p3/back_to_cell_average.md'
+        - 'Liquid Relaxation Timescale': 'technical/physics/p3/liq_relaxation_timescale.md'
     - 'AeroCom cloud top': 'technical/aerocom_cldtop.md'
 
 edit_uri: ""

--- a/components/eamxx/src/physics/p3/tests/infra/p3_unit_tests_common.hpp
+++ b/components/eamxx/src/physics/p3/tests/infra/p3_unit_tests_common.hpp
@@ -64,10 +64,12 @@ struct UnitWrap {
 
     struct Base : public UnitBase {
 
+      const typename Functions::P3LookupTables lookup_tables;
+
       Base() :
-        UnitBase()
+        UnitBase(),
+        lookup_tables(Functions::p3_init())
       {
-        Functions::p3_init(); // many tests will need table data
       }
 
       ~Base() = default;

--- a/components/eamxx/src/physics/p3/tests/p3_calc_liq_relaxation_timescale_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_calc_liq_relaxation_timescale_unit_tests.cpp
@@ -6,30 +6,608 @@
 
 #include "share/core/eamxx_types.hpp"
 
-#include <thread>
+#include <cmath>
+#include <limits>
 #include <array>
 #include <algorithm>
-#include <random>
-#include <iomanip>      // std::setprecision
+
+/*
+ * Property tests for calc_liq_relaxation_timescale.
+ *
+ * For active rain lanes,
+ *
+ *   epsr = 2*pi*cdistr*rho*dv *
+ *          ( f1r * Gamma(mu_r + 2)/lamr
+ *          + f2r * sqrt(rho/mu) * cbrt(sc) * T(mu_r, lamr) )
+ *
+ * where T(mu_r, lamr) is the rain evaporation lookup-table value.
+ *
+ * For active cloud-liquid lanes,
+ *
+ *   epsc = 2*pi*rho*dv*cdist.
+ *
+ * These tests check algebraic identities and physical bounds implied by
+ * those formulas. They intentionally keep the production kernel as the
+ * source of truth and compare against independent identities, scalings,
+ * and threshold behavior.
+ */
 
 namespace scream {
 namespace p3 {
 namespace unit_test {
 
+namespace {
+
+constexpr Real kAbsoluteTol = 1e-30;
+
+template <typename T>
+KOKKOS_INLINE_FUNCTION T max3(const T& a, const T& b, const T& c) {
+  return a > b ? (a > c ? a : c) : (b > c ? b : c);
+}
+
+} // anonymous namespace
+
 template <typename D>
 struct UnitWrap::UnitTest<D>::TestCalcLiqRelaxationTimescale : public UnitWrap::UnitTest<D>::Base {
 
+  struct RelaxationLane {
+    Real rho, dv, mu, sc, mu_r, lamr, cdistr, cdist, qr_incld, qc_incld;
+    bool context;
+    Real epsr_in, epsc_in;
+    Real epsr_out, epsc_out;
+  };
+
+  // Build one deterministic pack of physically valid active lanes.
+  //
+  // Each lane uses slightly different positive values. This avoids a test
+  // suite that only validates one scalar point, while still keeping the
+  // expected algebra simple. qr_incld and qc_incld start above QSMALL, and
+  // context starts true, so each lane is active unless a SECTION modifies it.
+  std::array<RelaxationLane, Pack::n> make_active_lanes() const
+  {
+    std::array<RelaxationLane, Pack::n> lanes;
+    for (Int s = 0; s < Pack::n; ++s) {
+      lanes[s].rho      = Real(0.95) + Real(0.07) * s;
+      lanes[s].dv       = Real(1.2e-5) * (Real(1.0) + Real(0.1) * s);
+      lanes[s].mu       = Real(1.6e-5) * (Real(1.0) + Real(0.08) * s);
+      lanes[s].sc       = Real(0.75) + Real(0.05) * s;
+      lanes[s].mu_r     = Real(1.4) + Real(0.1) * s;
+      lanes[s].lamr     = Real(800.0) + Real(25.0) * s;
+      lanes[s].cdistr   = Real(0.85) + Real(0.04) * s;
+      lanes[s].cdist    = Real(0.65) + Real(0.03) * s;
+      lanes[s].qr_incld = Real(5.0) * C::QSMALL;
+      lanes[s].qc_incld = Real(4.0) * C::QSMALL;
+      lanes[s].context  = true;
+      lanes[s].epsr_in  = Real(-999.0);
+      lanes[s].epsc_in  = Real(-12345.0);
+      lanes[s].epsr_out = Real(0.0);
+      lanes[s].epsc_out = Real(0.0);
+    }
+    return lanes;
+  }
+
+  void run_kernel(const view_2d_table revap_table_vals, Scalar f1r,
+                  Scalar f2r, std::array<RelaxationLane, Pack::n>& lanes) const
+  {
+    // Run the production kernel on one pack and copy epsr/epsc back into lanes.
+    //
+    // The property tests modify lane inputs on the host, call this helper, and
+    // then check the outputs. Running through Kokkos keeps the test close to the
+    // real packed implementation instead of reimplementing the routine on host.
+    using KTH = KokkosTypes<HostDevice>;
+
+    KTH::view_1d<RelaxationLane> lanes_host("lanes_host", Pack::n);
+    view_1d<RelaxationLane> lanes_device("lanes_device", Pack::n);
+    std::copy(lanes.begin(), lanes.end(), lanes_host.data());
+    Kokkos::deep_copy(lanes_device, lanes_host);
+
+    Kokkos::parallel_for(1, KOKKOS_LAMBDA(const Int&) {
+      Pack rho, dv, mu, sc, mu_r, lamr, cdistr, cdist, qr_incld, qc_incld;
+      Pack epsr, epsc;
+      Mask context;
+
+      for (Int s = 0; s < Pack::n; ++s) {
+        rho[s]      = lanes_device(s).rho;
+        dv[s]       = lanes_device(s).dv;
+        mu[s]       = lanes_device(s).mu;
+        sc[s]       = lanes_device(s).sc;
+        mu_r[s]     = lanes_device(s).mu_r;
+        lamr[s]     = lanes_device(s).lamr;
+        cdistr[s]   = lanes_device(s).cdistr;
+        cdist[s]    = lanes_device(s).cdist;
+        qr_incld[s] = lanes_device(s).qr_incld;
+        qc_incld[s] = lanes_device(s).qc_incld;
+        epsr[s]     = lanes_device(s).epsr_in;
+        epsc[s]     = lanes_device(s).epsc_in;
+        context.set(s, lanes_device(s).context);
+      }
+
+      Functions::calc_liq_relaxation_timescale(revap_table_vals, rho, f1r, f2r, dv,
+                                               mu, sc, mu_r, lamr, cdistr, cdist,
+                                               qr_incld, qc_incld, epsr, epsc,
+                                               context);
+
+      for (Int s = 0; s < Pack::n; ++s) {
+        lanes_device(s).epsr_out = epsr[s];
+        lanes_device(s).epsc_out = epsc[s];
+      }
+    });
+    Kokkos::deep_copy(lanes_host, lanes_device);
+    std::copy(lanes_host.data(), lanes_host.data() + Pack::n, lanes.begin());
+  }
+
   void run_phys()
   {
-    // TODO
+    const auto revap_table_vals = this->lookup_tables.revap_table_vals;
+
+    // Algebraic identities should hold to roundoff. kAbsoluteTol protects
+    // exact-zero checks in near-zero regimes, while identity_tol scales with
+    // the magnitude of the compared values.
+    const Real identity_tol = 100 * std::numeric_limits<Real>::epsilon();
+
+    // Inequality checks need a small tolerance so that roundoff does not
+    // turn an exact bound into a false failure.
+    const Real inequality_tol = 100 * std::numeric_limits<Real>::epsilon();
+
+    const auto near_tol = [&](const Real actual, const Real expected) {
+      return kAbsoluteTol + identity_tol * max3<Real>(Real(1.0), std::abs(actual), std::abs(expected));
+    };
+
+    const auto require_near = [&](const Real actual, const Real expected) {
+      INFO("actual=" << actual << " expected=" << expected
+           << " tol=" << near_tol(actual, expected));
+      REQUIRE(std::abs(actual - expected) <= near_tol(actual, expected));
+    };
+
+    const auto require_zero = [&](const Real actual) {
+      INFO("actual=" << actual << " abs_tol=" << kAbsoluteTol);
+      REQUIRE(std::abs(actual) <= kAbsoluteTol);
+    };
+
+    const auto require_nonnegative = [&](const Real actual) {
+      INFO("actual=" << actual << " tol=" << inequality_tol);
+      REQUIRE(actual >= -inequality_tol);
+    };
+
+    const auto require_finite = [&](const Real actual) {
+      INFO("actual=" << actual);
+      REQUIRE(std::isfinite(actual));
+    };
+
+    const auto require_le = [&](const Real lhs, const Real rhs) {
+      const Real tol = kAbsoluteTol + inequality_tol * max3<Real>(Real(1.0), std::abs(lhs), std::abs(rhs));
+      INFO("lhs=" << lhs << " rhs=" << rhs << " tol=" << tol);
+      REQUIRE(lhs <= rhs + tol);
+    };
+
+    const auto require_ge = [&](const Real lhs, const Real rhs) {
+      const Real tol = kAbsoluteTol + inequality_tol * max3<Real>(Real(1.0), std::abs(lhs), std::abs(rhs));
+      INFO("lhs=" << lhs << " rhs=" << rhs << " tol=" << tol);
+      REQUIRE(lhs + tol >= rhs);
+    };
+
+    // Direct cloud formula for active cloud-liquid lanes:
+    //   epsc = 2*pi*rho*dv*cdist.
+    const auto cloud_expected = [](const RelaxationLane& lane) {
+      return Real(2.0) * C::Pi * lane.rho * lane.dv * lane.cdist;
+    };
+
+    // Analytic rain term with the ventilation term disabled:
+    //   epsr = 2*pi*cdistr*rho*dv*f1r*Gamma(mu_r + 2)/lamr.
+    const auto analytic_expected = [](const RelaxationLane& lane, const Scalar& f1r) {
+          return Real(2.0) * C::Pi * lane.cdistr * lane.rho * lane.dv * f1r
+            * std::tgamma(lane.mu_r + Real(2.0)) / lane.lamr;
+    };
+
+    // Same analytic rain term, but using the gamma recurrence
+    //   Gamma(mu_r + 2) = (mu_r + 1)*Gamma(mu_r + 1).
+    //
+    // This gives a partly independent check of the implementation formula.
+    const auto analytic_recurrence_expected = [](const RelaxationLane& lane, const Scalar& f1r) {
+          return Real(2.0) * C::Pi * lane.cdistr * lane.rho * lane.dv * f1r
+            * (lane.mu_r + Real(1.0)) * std::tgamma(lane.mu_r + Real(1.0)) / lane.lamr;
+    };
+
+    SECTION("masking_and_thresholds") {
+      // Verify activation logic for rain and cloud relaxation.
+      //
+      // Rain is active only where:
+      //   context && qr_incld >= QSMALL.
+      //
+      // Cloud liquid is active only where:
+      //   context && qc_incld >= QSMALL.
+      //
+      // Important implementation detail:
+      // epsr is reset to zero for all lanes, even outside context. epsc is
+      // only written inside context, so outside-context epsc should retain
+      // its input value.
+      const auto run_mask_case = [&](const auto& customize_lane) {
+        auto lanes = make_active_lanes();
+        for (Int s = 1; s < Pack::n; ++s) {
+          lanes[s].context = false;
+          lanes[s].qr_incld = 0;
+          lanes[s].qc_incld = 0;
+          lanes[s].epsr_in = 0;
+          lanes[s].epsc_in = 0;
+        }
+
+        customize_lane(lanes[0]);
+        run_kernel(revap_table_vals, C::f1r, C::f2r, lanes);
+        return lanes[0];
+      };
+
+      const auto outside_context = run_mask_case([](RelaxationLane& lane) {
+        lane.context = false;
+        lane.qr_incld = 10 * C::QSMALL;
+        lane.qc_incld = 10 * C::QSMALL;
+        lane.epsr_in = 777.0;
+        lane.epsc_in = -12345.0;
+      });
+      require_zero(outside_context.epsr_out);
+      require_near(outside_context.epsc_out, outside_context.epsc_in);
+
+      const auto below_threshold = run_mask_case([](RelaxationLane& lane) {
+        lane.context = true;
+        lane.qr_incld = 0.999 * C::QSMALL;
+        lane.qc_incld = 0.999 * C::QSMALL;
+      });
+      require_zero(below_threshold.epsr_out);
+      require_zero(below_threshold.epsc_out);
+
+      const auto at_threshold = run_mask_case([](RelaxationLane& lane) {
+        lane.context = true;
+        lane.qr_incld = C::QSMALL;
+        lane.qc_incld = C::QSMALL;
+      });
+      require_nonnegative(at_threshold.epsr_out);
+      require_finite(at_threshold.epsr_out);
+      require_near(at_threshold.epsc_out, cloud_expected(at_threshold));
+
+      const auto cloud_below_threshold = run_mask_case([](RelaxationLane& lane) {
+        lane.context = true;
+        lane.qr_incld = 10 * C::QSMALL;
+        lane.qc_incld = 0.1 * C::QSMALL;
+      });
+      require_nonnegative(cloud_below_threshold.epsr_out);
+      require_finite(cloud_below_threshold.epsr_out);
+      require_zero(cloud_below_threshold.epsc_out);
+    }
+
+    SECTION("cloud_identity_and_scaling") {
+      // With cloud active and rain disabled, epsc should exactly satisfy:
+      //
+      //   epsc = 2*pi*rho*dv*cdist.
+      //
+      // Therefore doubling rho, dv, or cdist should double epsc. The ratio
+      // epsc/(rho*dv*cdist) should equal 2*pi.
+      auto base = make_active_lanes();
+      for (auto& lane : base) {
+        lane.qr_incld = 0;
+        lane.qc_incld = 5 * C::QSMALL;
+      }
+      run_kernel(revap_table_vals, C::f1r, C::f2r, base);
+
+      auto rho_scaled = base;
+      auto dv_scaled = base;
+      auto cdist_scaled = base;
+      for (auto& lane : rho_scaled) lane.rho *= 2;
+      for (auto& lane : dv_scaled) lane.dv *= 2;
+      for (auto& lane : cdist_scaled) lane.cdist *= 2;
+
+      run_kernel(revap_table_vals, C::f1r, C::f2r, rho_scaled);
+      run_kernel(revap_table_vals, C::f1r, C::f2r, dv_scaled);
+      run_kernel(revap_table_vals, C::f1r, C::f2r, cdist_scaled);
+
+      for (Int s = 0; s < Pack::n; ++s) {
+        require_near(base[s].epsc_out, cloud_expected(base[s]));
+        require_near(rho_scaled[s].epsc_out, 2 * base[s].epsc_out);
+        require_near(dv_scaled[s].epsc_out, 2 * base[s].epsc_out);
+        require_near(cdist_scaled[s].epsc_out, 2 * base[s].epsc_out);
+        require_near(base[s].epsc_out / (base[s].rho * base[s].dv * base[s].cdist),
+                     2 * C::Pi);
+      }
+    }
+
+    SECTION("cloud_independence_from_rain_parameters") {
+      // The cloud-liquid formula depends only on rho, dv, and cdist when the
+      // cloud mask is active. Rain-shape and rain-prefactor changes should not
+      // affect epsc.
+      auto base = make_active_lanes();
+      auto rain_params_changed = base;
+
+      for (auto& lane : base) {
+        lane.qc_incld = 5 * C::QSMALL;
+      }
+
+      for (auto& lane : rain_params_changed) {
+        lane.qc_incld = 5 * C::QSMALL;
+        lane.mu_r *= 1.2;
+        lane.lamr *= 1.3;
+        lane.cdistr *= 1.4;
+        lane.qr_incld = 20 * C::QSMALL;
+      }
+
+      run_kernel(revap_table_vals, C::f1r, C::f2r, base);
+      run_kernel(revap_table_vals, 2 * C::f1r, 3 * C::f2r, rain_params_changed);
+
+      for (Int s = 0; s < Pack::n; ++s) {
+        require_near(rain_params_changed[s].epsc_out, base[s].epsc_out);
+      }
+    }
+
+    SECTION("rain_additivity") {
+      // The rain formula is a sum of two independent terms:
+      //
+      //   analytic term    proportional to f1r
+      //   ventilation term proportional to f2r
+      //
+      // Therefore:
+      //
+      //   epsr(f1r, f2r) = epsr(f1r, 0) + epsr(0, f2r).
+      //
+      // epsc does not depend on f1r or f2r, so it should be unchanged across
+      // the three calls.
+      auto full = make_active_lanes();
+      auto analytic_only = full;
+      auto vent_only = full;
+
+      run_kernel(revap_table_vals, C::f1r, C::f2r, full);
+      run_kernel(revap_table_vals, C::f1r, 0, analytic_only);
+      run_kernel(revap_table_vals, 0, C::f2r, vent_only);
+
+      for (Int s = 0; s < Pack::n; ++s) {
+        require_near(full[s].epsr_out,
+                     analytic_only[s].epsr_out + vent_only[s].epsr_out);
+        require_ge(full[s].epsr_out, analytic_only[s].epsr_out);
+        require_ge(full[s].epsr_out, vent_only[s].epsr_out);
+        require_near(full[s].epsc_out, analytic_only[s].epsc_out);
+        require_near(full[s].epsc_out, vent_only[s].epsc_out);
+      }
+    }
+
+    SECTION("rain_prefactor_scaling") {
+      // In the full mixed rain formula, dv and cdistr multiply both the
+      // analytic and ventilation terms as shared prefactors.
+      //
+      // Therefore:
+      //
+      //   epsr(2*dv)     = 2*epsr(dv)
+      //   epsr(2*cdistr) = 2*epsr(cdistr).
+      auto base = make_active_lanes();
+      auto dv_scaled = base;
+      auto cdistr_scaled = base;
+
+      for (auto& lane : dv_scaled) lane.dv *= 2;
+      for (auto& lane : cdistr_scaled) lane.cdistr *= 2;
+
+      run_kernel(revap_table_vals, C::f1r, C::f2r, base);
+      run_kernel(revap_table_vals, C::f1r, C::f2r, dv_scaled);
+      run_kernel(revap_table_vals, C::f1r, C::f2r, cdistr_scaled);
+
+      for (Int s = 0; s < Pack::n; ++s) {
+        require_near(dv_scaled[s].epsr_out, 2 * base[s].epsr_out);
+        require_near(cdistr_scaled[s].epsr_out, 2 * base[s].epsr_out);
+      }
+    }
+
+    SECTION("analytic_only") {
+      // Disable the ventilation term by setting f2r = 0.
+      //
+      // The remaining formula is:
+      //
+      //   epsr = 2*pi*cdistr*rho*dv*f1r*Gamma(mu_r + 2)/lamr.
+      //
+      // This implies exact scaling with rho and f1r, and inverse scaling
+      // with lamr. The test also checks the equivalent gamma-recurrence form.
+      auto base = make_active_lanes();
+      auto rho_scaled = base;
+      auto f1_scaled = base;
+      auto lamr_scaled = base;
+
+      for (auto& lane : rho_scaled) lane.rho *= 2;
+      for (auto& lane : lamr_scaled) lane.lamr *= 2;
+
+      run_kernel(revap_table_vals, C::f1r, 0, base);
+      run_kernel(revap_table_vals, C::f1r, 0, rho_scaled);
+      run_kernel(revap_table_vals, 2 * C::f1r, 0, f1_scaled);
+      run_kernel(revap_table_vals, C::f1r, 0, lamr_scaled);
+
+      for (Int s = 0; s < Pack::n; ++s) {
+        require_near(base[s].epsr_out, analytic_expected(base[s], C::f1r));
+        require_near(base[s].epsr_out, analytic_recurrence_expected(base[s], C::f1r));
+        require_near(rho_scaled[s].epsr_out, 2 * base[s].epsr_out);
+        require_near(f1_scaled[s].epsr_out, 2 * base[s].epsr_out);
+        require_near(lamr_scaled[s].epsr_out, 0.5 * base[s].epsr_out);
+      }
+    }
+
+    SECTION("ventilation_only") {
+      // Disable the analytic term by setting f1r = 0.
+      //
+      // With mu_r and lamr held fixed, the lookup-table value is unchanged.
+      // The remaining ventilation term scales as:
+      //
+      //   epsr proportional to rho^(3/2) * mu^(-1/2) * sc^(1/3) * f2r.
+      //
+      // Therefore:
+      //
+      //   rho -> 4*rho gives epsr -> 8*epsr
+      //   mu  -> 4*mu  gives epsr -> 0.5*epsr
+      //   sc  -> 8*sc  gives epsr -> 2*epsr
+      //   f2r -> 2*f2r gives epsr -> 2*epsr.
+      auto base = make_active_lanes();
+      auto rho_scaled = base;
+      auto mu_scaled = base;
+      auto sc_scaled = base;
+      auto f2_scaled = base;
+
+      for (auto& lane : rho_scaled) lane.rho *= 4;
+      for (auto& lane : mu_scaled) lane.mu *= 4;
+      for (auto& lane : sc_scaled) lane.sc *= 8;
+
+      run_kernel(revap_table_vals, 0, C::f2r, base);
+      run_kernel(revap_table_vals, 0, C::f2r, rho_scaled);
+      run_kernel(revap_table_vals, 0, C::f2r, mu_scaled);
+      run_kernel(revap_table_vals, 0, C::f2r, sc_scaled);
+      run_kernel(revap_table_vals, 0, 2 * C::f2r, f2_scaled);
+
+      for (Int s = 0; s < Pack::n; ++s) {
+        require_near(rho_scaled[s].epsr_out, 8 * base[s].epsr_out);
+        require_near(mu_scaled[s].epsr_out, 0.5 * base[s].epsr_out);
+        require_near(sc_scaled[s].epsr_out, 2 * base[s].epsr_out);
+        require_near(f2_scaled[s].epsr_out, 2 * base[s].epsr_out);
+      }
+    }
+
+    SECTION("mixed_microphysical_scaling") {
+      // With both rain terms active, changing mu, sc, or rho affects only the
+      // ventilation piece or changes the analytic and ventilation pieces with
+      // their respective bulk-microphysics scalings.
+      auto full = make_active_lanes();
+      auto analytic_only = full;
+      auto vent_only = full;
+      auto mu_scaled = full;
+      auto sc_scaled = full;
+      auto rho2_scaled = full;
+      auto rho4_scaled = full;
+
+      for (auto& lane : mu_scaled) lane.mu *= 4;
+      for (auto& lane : sc_scaled) lane.sc *= 8;
+      for (auto& lane : rho2_scaled) lane.rho *= 2;
+      for (auto& lane : rho4_scaled) lane.rho *= 4;
+
+      run_kernel(revap_table_vals, C::f1r, C::f2r, full);
+      run_kernel(revap_table_vals, C::f1r, 0, analytic_only);
+      run_kernel(revap_table_vals, 0, C::f2r, vent_only);
+      run_kernel(revap_table_vals, C::f1r, C::f2r, mu_scaled);
+      run_kernel(revap_table_vals, C::f1r, C::f2r, sc_scaled);
+      run_kernel(revap_table_vals, C::f1r, C::f2r, rho2_scaled);
+      run_kernel(revap_table_vals, C::f1r, C::f2r, rho4_scaled);
+
+      for (Int s = 0; s < Pack::n; ++s) {
+        require_near(full[s].epsr_out,
+                     analytic_only[s].epsr_out + vent_only[s].epsr_out);
+        require_near(mu_scaled[s].epsr_out,
+                     analytic_only[s].epsr_out + 0.5 * vent_only[s].epsr_out);
+        require_near(sc_scaled[s].epsr_out,
+                     analytic_only[s].epsr_out + 2.0 * vent_only[s].epsr_out);
+        require_near(rho2_scaled[s].epsr_out,
+                     2.0 * analytic_only[s].epsr_out
+                     + 2.0 * std::sqrt(2.0) * vent_only[s].epsr_out);
+        require_near(rho4_scaled[s].epsr_out,
+                     4.0 * analytic_only[s].epsr_out
+                     + 8.0 * vent_only[s].epsr_out);
+      }
+    }
+
+    SECTION("mixed_rho_bound") {
+      // With both rain terms active, rho appears in two ways:
+      //
+      //   analytic term    scales as rho
+      //   ventilation term scales as rho^(3/2)
+      //
+      // Therefore doubling rho must increase epsr by at least 2 and by at
+      // most 2*sqrt(2), assuming non-negative table values:
+      //
+      //   2*epsr(rho) <= epsr(2*rho) <= 2*sqrt(2)*epsr(rho).
+      auto base = make_active_lanes();
+      auto rho_scaled = base;
+      for (auto& lane : rho_scaled) lane.rho *= 2;
+
+      run_kernel(revap_table_vals, C::f1r, C::f2r, base);
+      run_kernel(revap_table_vals, C::f1r, C::f2r, rho_scaled);
+
+      for (Int s = 0; s < Pack::n; ++s) {
+        require_ge(rho_scaled[s].epsr_out, 2 * base[s].epsr_out);
+        require_le(rho_scaled[s].epsr_out, 2 * std::sqrt(2.0) * base[s].epsr_out);
+      }
+    }
+
+    SECTION("zero_coefficients") {
+      // Check coefficient locality and shared factors.
+      //
+      // f1r and f2r only affect rain, so setting both to zero should zero
+      // epsr but leave epsc unchanged.
+      //
+      // cdistr only appears in epsr, so setting cdistr to zero should zero
+      // epsr but leave epsc unchanged.
+      //
+      // cdist only appears in epsc, so setting cdist to zero should zero
+      // epsc but leave epsr unchanged.
+      //
+      // dv appears in both formulas, so setting dv to zero should zero both
+      // epsr and epsc.
+      auto base = make_active_lanes();
+      auto zero_f = make_active_lanes();
+      auto zero_cdistr = zero_f;
+      auto zero_dv = zero_f;
+      auto zero_cdist = zero_f;
+
+      for (auto& lane : zero_cdistr) lane.cdistr = 0;
+      for (auto& lane : zero_dv) lane.dv = 0;
+      for (auto& lane : zero_cdist) lane.cdist = 0;
+
+      run_kernel(revap_table_vals, C::f1r, C::f2r, base);
+      run_kernel(revap_table_vals, 0, 0, zero_f);
+      run_kernel(revap_table_vals, C::f1r, C::f2r, zero_cdistr);
+      run_kernel(revap_table_vals, C::f1r, C::f2r, zero_dv);
+      run_kernel(revap_table_vals, C::f1r, C::f2r, zero_cdist);
+
+      for (Int s = 0; s < Pack::n; ++s) {
+        require_zero(zero_f[s].epsr_out);
+        require_near(zero_f[s].epsc_out, base[s].epsc_out);
+
+        require_zero(zero_cdistr[s].epsr_out);
+        require_near(zero_cdistr[s].epsc_out, base[s].epsc_out);
+
+        require_zero(zero_dv[s].epsr_out);
+        require_zero(zero_dv[s].epsc_out);
+
+        require_near(zero_cdist[s].epsr_out, base[s].epsr_out);
+        require_zero(zero_cdist[s].epsc_out);
+      }
+    }
+
+    SECTION("nonnegativity_and_finite") {
+      // For physically valid positive inputs and active thresholds, both
+      // relaxation timescales should be finite and non-negative. This section
+      // samples qr_incld and qc_incld at and above QSMALL to exercise the
+      // active threshold boundary without assuming a particular Pack::n.
+      auto lanes = make_active_lanes();
+      constexpr std::array<Real, 3> qr_vals = {
+        C::QSMALL,
+        1.001 * C::QSMALL,
+        10 * C::QSMALL
+      };
+      constexpr std::array<Real, 3> qc_vals = {
+        C::QSMALL,
+        1.001 * C::QSMALL,
+        10 * C::QSMALL
+      };
+      for (Int s = 0; s < Pack::n; ++s) {
+        lanes[s].qr_incld = qr_vals[s % qr_vals.size()];
+        lanes[s].qc_incld = qc_vals[s % qc_vals.size()];
+      }
+
+      run_kernel(revap_table_vals, C::f1r, C::f2r, lanes);
+
+      for (Int s = 0; s < Pack::n; ++s) {
+        require_nonnegative(lanes[s].epsr_out);
+        require_nonnegative(lanes[s].epsc_out);
+        require_finite(lanes[s].epsr_out);
+        require_finite(lanes[s].epsc_out);
+      }
+    }
   }
 
   void run_bfb()
   {
+    // Preserve the original bit-for-bit regression test. The property tests
+    // above check mathematical behavior, while this section ensures the
+    // production outputs remain identical to the stored baseline.
     auto engine = Base::get_engine();
 
-    // Read in tables
-    auto revap_table_vals = Functions::p3_init().revap_table_vals;
+    const auto revap_table_vals = this->lookup_tables.revap_table_vals;
 
     using KTH = KokkosTypes<HostDevice>;
 
@@ -40,6 +618,9 @@ struct UnitWrap::UnitTest<D>::TestCalcLiqRelaxationTimescale : public UnitWrap::
     constexpr Scalar qc_small = 0.9 * qsmall;
     constexpr Scalar qc_not_small = 2.0 * qsmall;
     CalcLiqRelaxationData self[max_pack_size];
+
+    // Alternate rain and cloud thresholds across lanes so the BFB case covers
+    // both active and inactive branches for epsr and epsc.
     for (Int i = 0; i < max_pack_size; ++i) {
       self[i].randomize(engine);
       self[i].qr_incld = (i % 2) ? qr_small : qr_not_small;
@@ -48,7 +629,7 @@ struct UnitWrap::UnitTest<D>::TestCalcLiqRelaxationTimescale : public UnitWrap::
       self[i].f2r = C::f2r;
     }
 
-  // Read baseline data
+    // Read baseline data
     if (this->m_baseline_action == COMPARE) {
       for (Int i = 0; i < max_pack_size; ++i) {
         self[i].read(Base::m_ifile);
@@ -57,7 +638,7 @@ struct UnitWrap::UnitTest<D>::TestCalcLiqRelaxationTimescale : public UnitWrap::
 
     // Sync to device
     KTH::view_1d<CalcLiqRelaxationData> self_host("self_host", max_pack_size);
-    view_1d<CalcLiqRelaxationData> self_device("self_host", max_pack_size);
+    view_1d<CalcLiqRelaxationData> self_device("self_device", max_pack_size);
     std::copy(&self[0], &self[0] + max_pack_size, self_host.data());
     Kokkos::deep_copy(self_device, self_host);
 
@@ -119,8 +700,13 @@ TEST_CASE("p3_calc_liq_relaxation_timescale", "[p3_functions]")
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestCalcLiqRelaxationTimescale;
 
   T t;
-  t.run_phys();
-  t.run_bfb();
+  SECTION("properties") {
+    t.run_phys();
+  }
+
+  SECTION("bfb") {
+    t.run_bfb();
+  }
 }
 
 }


### PR DESCRIPTION
Add property tests and documentation for the P3 liquid relaxation timescale routine.

## Summary

Add physical-property tests and technical documentation for
`calc_liq_relaxation_timescale`.

The new test coverage checks the main behaviors of the rain and
cloud-liquid relaxation-rate coefficients. In particular, the tests verify:

- context and threshold masking behavior
- exact cloud-liquid scaling with `rho`, `dv`, and `cdist`
- rain-term additivity between the analytic and ventilation contributions
- exact rain prefactor scaling with `dv` and `cdistr`
- analytic-only rain identities
- ventilation-only rain scaling relations
- mixed-term density bounds
- zero-coefficient and coefficient-locality behavior
- finite and non-negative outputs

This change also adds a technical note describing the formulation and test
strategy for `calc_liq_relaxation_timescale`, and updates the EAMxx docs
navigation to include that page.