### PR TITLE
Revert indexing change for wave frequency arrays

### DIFF
--- a/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
+++ b/components/mpas-seaice/src/shared/mpas_seaice_icepack.F
@@ -593,8 +593,8 @@ subroutine init_column_waves(domain)
                               waveFreqBinWidth_TEMP)
 
       ! remove frequency 'tails' (which are only needed in WW3, not MPAS-SI)
-      waveFrequency(1:nFrequencies-2) = waveFrequency_TEMP(2:nFrequencies-1) 
-      waveFreqBinWidth(1:nFrequencies-2) = waveFreqBinWidth_TEMP(2:nFrequencies-1) 
+      waveFrequency = waveFrequency_TEMP(2:nFrequencies-1) 
+      waveFreqBinWidth = waveFreqBinWidth_TEMP(2:nFrequencies-1) 
 
       ! initialize HS and Spectra
       if (.not. config_do_restart) then


### PR DESCRIPTION
This PR reverts a change to the indexing for frequency arrays from [d7607ce](https://github.com/E3SM-Project/E3SM/commit/d7607ce4641f4f8082c863c251bbde3a8c35ef92)

This change was meant to fix out of bounds errors for debug gnu errors, 
but resulted in divide by zero issues.

[BFB] for cases without waves