### PR TITLE
Make default that nlmaps are applied to all fields

### DIFF
--- a/driver-mct/cime_config/namelist_definition_drv.xml
+++ b/driver-mct/cime_config/namelist_definition_drv.xml
@@ -1859,10 +1859,11 @@
       mapped. For these excluded fields, the low-order linear map is used,
       instead. Modify user_nl_cpl to edit this. This option is ignored if
       nlmaps_atm2srf_conserve is .true.
-      default: 'Faxa_rainc', 'Faxa_rainl', 'Faxa_snowc', 'Faxa_snowl'
+      old default: 'Faxa_rainc', 'Faxa_rainl', 'Faxa_snowc', 'Faxa_snowl'
+      default: '','','',''
     </desc>
     <values>
-      <value>'Faxa_rainc', 'Faxa_rainl', 'Faxa_snowc', 'Faxa_snowl'</value>
+      <value>'', '', '', ''</value>
     </values>
   </entry>
 

--- a/driver-mct/cime_config/namelist_definition_drv.xml
+++ b/driver-mct/cime_config/namelist_definition_drv.xml
@@ -1859,7 +1859,7 @@
       mapped. For these excluded fields, the low-order linear map is used,
       instead. Modify user_nl_cpl to edit this. This option is ignored if
       nlmaps_atm2srf_conserve is .true.
-      old default: 'Faxa_rainc', 'Faxa_rainl', 'Faxa_snowc', 'Faxa_snowl'
+      v3.0-3.1 default: 'Faxa_rainc', 'Faxa_rainl', 'Faxa_snowc', 'Faxa_snowl'
       default: '','','',''
     </desc>
     <values>

--- a/driver-moab/cime_config/namelist_definition_drv.xml
+++ b/driver-moab/cime_config/namelist_definition_drv.xml
@@ -1867,10 +1867,11 @@
       mapped. For these excluded fields, the low-order linear map is used,
       instead. Modify user_nl_cpl to edit this. This option is ignored if
       nlmaps_atm2srf_conserve is .true.
-      default: 'Faxa_rainc', 'Faxa_rainl', 'Faxa_snowc', 'Faxa_snowl'
+      old default: 'Faxa_rainc', 'Faxa_rainl', 'Faxa_snowc', 'Faxa_snowl'
+      default: '', '', '', ''
     </desc>
     <values>
-      <value>'Faxa_rainc', 'Faxa_rainl', 'Faxa_snowc', 'Faxa_snowl'</value>
+      <value>'', '', '', ''</value>
     </values>
   </entry>
 

--- a/driver-moab/cime_config/namelist_definition_drv.xml
+++ b/driver-moab/cime_config/namelist_definition_drv.xml
@@ -1867,7 +1867,7 @@
       mapped. For these excluded fields, the low-order linear map is used,
       instead. Modify user_nl_cpl to edit this. This option is ignored if
       nlmaps_atm2srf_conserve is .true.
-      old default: 'Faxa_rainc', 'Faxa_rainl', 'Faxa_snowc', 'Faxa_snowl'
+      v3.0-3.1 default: 'Faxa_rainc', 'Faxa_rainl', 'Faxa_snowc', 'Faxa_snowl'
       default: '', '', '', ''
     </desc>
     <values>


### PR DESCRIPTION
The current default excludes precipitation fields 'Faxa_rainc', 'Faxa_rainl', 'Faxa_snowc', 'Faxa_snowl' from having the nlmaps applied to them. This removes them from the nlmaps_exclude_fields list for both the mct and moab drivers.

[NML]
[non-BFB] for configurations with nonlinear mapping files