### PR TITLE
Update default MALI calving parameter defaults for Greenland meshes used in E3SM simulations

### DIFF
--- a/components/mpas-albany-landice/bld/build-namelist
+++ b/components/mpas-albany-landice/bld/build-namelist
@@ -447,16 +447,11 @@ if ($MALI_USE_ALBANY eq 'TRUE') {
 
 if ($MALI_PROGNOSTIC_MODE eq 'PROGNOSTIC') {
     add_default($nl, 'config_velocity_solver', 'mali_use_albany'=>"$MALI_USE_ALBANY");
-    if ($GLC_GRID eq 'mpas.gis4to40km' || $GLC_GRID eq 'mpas.gis1to10kmR2') {
-         add_default($nl, 'config_flowparama_calculation', 'val'=>"PB1982");
-    } else {
-         add_default($nl, 'config_flowParamA_calculation');
-    }
 } else {
     add_default($nl, 'config_velocity_solver', 'val'=>"none");
-    add_default($nl, 'config_flowParamA_calculation');
 }
 add_default($nl, 'config_sia_tangent_slope_calculation');
+add_default($nl, 'config_flowParamA_calculation');
 add_default($nl, 'config_do_velocity_reconstruction_for_external_dycore');
 add_default($nl, 'config_simple_velocity_type');
 add_default($nl, 'config_use_glp');
@@ -502,8 +497,6 @@ add_default($nl, 'config_SLM_to_MALI_weights_file');
 if ($MALI_PROGNOSTIC_MODE eq 'PROGNOSTIC') {
     if ($GLC_GRID eq 'mpas.gis4to40km' || $GLC_GRID eq 'mpas.gis1to10kmR2') {
          add_default($nl, 'config_calving', 'val'=>"crevasse_depth");
-         add_default($nl, 'config_calving_strainrate_scaling', 'val'=>"5.0");
-         add_default($nl, 'config_crevasse_water_depth', 'val'=>"25.0");
     } else {
          add_default($nl, 'config_calving');
     }

--- a/components/mpas-albany-landice/bld/build-namelist
+++ b/components/mpas-albany-landice/bld/build-namelist
@@ -447,11 +447,16 @@ if ($MALI_USE_ALBANY eq 'TRUE') {
 
 if ($MALI_PROGNOSTIC_MODE eq 'PROGNOSTIC') {
     add_default($nl, 'config_velocity_solver', 'mali_use_albany'=>"$MALI_USE_ALBANY");
+    if ($GLC_GRID eq 'mpas.gis4to40km' || $GLC_GRID eq 'mpas.gis1to10kmR2') {
+         add_default($nl, 'config_flowparama_calculation', 'val'=>"PB1982");
+    } else {
+         add_default($nl, 'config_flowParamA_calculation');
+    }
 } else {
     add_default($nl, 'config_velocity_solver', 'val'=>"none");
+    add_default($nl, 'config_flowParamA_calculation');
 }
 add_default($nl, 'config_sia_tangent_slope_calculation');
-add_default($nl, 'config_flowParamA_calculation');
 add_default($nl, 'config_do_velocity_reconstruction_for_external_dycore');
 add_default($nl, 'config_simple_velocity_type');
 add_default($nl, 'config_use_glp');
@@ -495,7 +500,13 @@ add_default($nl, 'config_SLM_to_MALI_weights_file');
 ###########################
 
 if ($MALI_PROGNOSTIC_MODE eq 'PROGNOSTIC') {
-    add_default($nl, 'config_calving');
+    if ($GLC_GRID eq 'mpas.gis4to40km' || $GLC_GRID eq 'mpas.gis1to10kmR2') {
+         add_default($nl, 'config_calving', 'val'=>"crevasse_depth");
+         add_default($nl, 'config_calving_strainrate_scaling', 'val'=>"5.0");
+         add_default($nl, 'config_crevasse_water_depth', 'val'=>"25.0");
+    } else {
+         add_default($nl, 'config_calving');
+    }
 } else {
     add_default($nl, 'config_calving', 'val'=>"none");
 }

--- a/components/mpas-albany-landice/bld/namelist_files/namelist_defaults_mali.xml
+++ b/components/mpas-albany-landice/bld/namelist_files/namelist_defaults_mali.xml
@@ -7,7 +7,7 @@
 <config_velocity_solver mali_use_albany="FALSE">'sia'</config_velocity_solver>
 <config_velocity_solver mali_use_albany="TRUE">'FO'</config_velocity_solver>
 <config_sia_tangent_slope_calculation>'from_vertex_barycentric'</config_sia_tangent_slope_calculation>
-<config_flowParamA_calculation>'constant'</config_flowParamA_calculation>
+<config_flowParamA_calculation>'PB1982'</config_flowParamA_calculation>
 <config_do_velocity_reconstruction_for_external_dycore>.false.</config_do_velocity_reconstruction_for_external_dycore>
 <config_simple_velocity_type>'uniform'</config_simple_velocity_type>
 <config_use_glp>.false.</config_use_glp>
@@ -65,7 +65,7 @@
 <config_damage_calving_method>'none'</config_damage_calving_method>
 <config_damagecalvingParameter>1.0e-4</config_damagecalvingParameter>
 <config_crevasse_water_depth_source>'scalar'</config_crevasse_water_depth_source>
-<config_crevasse_water_depth>0.0</config_crevasse_water_depth>
+<config_crevasse_water_depth>25.0</config_crevasse_water_depth>
 <config_ismip6_retreat_k>-170.0</config_ismip6_retreat_k>
 <config_calving_error_threshold>1.0e36</config_calving_error_threshold>
 <config_distribute_unablatedVolumeDynCell>.true.</config_distribute_unablatedVolumeDynCell>


### PR DESCRIPTION
For MALI meshes that are used in prognostic, E3SM simulations with an active Greenland ice sheet, set the default calving parameters to be different than the standard default values used. This was tested via builds with the following three meshes and confirmed working: `mpas.gis4to40km`, `mpas.gis1to10kmR2`, and `mpas.gis1to10km`. For the first two, the desired default values show up in the `mali_in` file after a build. For the last one, the desired _default_ values show up in the `mali_in` file after a build.  

[non-BFB] for some configs with MALI