### PR TITLE
For pm-cpu and nvidia compiler, skip loading a module to ensure OpenACC not built

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -240,8 +240,11 @@
         <command name="load">cray-libsci/25.09.0</command>
       </modules>
 
-      <modules>
+      <modules compiler="!nvidia">
         <command name="load">craype-accel-host</command>
+      </modules>
+
+      <modules>
         <command name="load">craype/2.7.35</command>
         <command name="load">cray-mpich/9.0.1</command>
         <command name="load">cmake/3.30.2</command>
@@ -619,8 +622,11 @@
         <command name="load">cray-libsci/25.09.0</command>
       </modules>
 
-      <modules>
+      <modules compiler="!nvidia">
         <command name="load">craype-accel-host</command>
+      </modules>
+
+      <modules>
         <command name="load">craype/2.7.35</command>
         <command name="load">cray-mpich/9.0.1</command>
         <command name="load">cmake/3.30.2</command>
@@ -995,8 +1001,11 @@
         <command name="load">cray-libsci/25.09.0</command>
       </modules>
 
-      <modules>
+      <modules compiler="!nvidia">
         <command name="load">craype-accel-host</command>
+      </modules>
+
+      <modules>
         <command name="load">craype/2.7.35</command>
         <command name="load">cray-mpich/9.0.1</command>
         <command name="load">cmake/3.30.2</command>


### PR DESCRIPTION
The PrgEnv-nvidia module environment on pm-cpu is such that `ftn` will enable OpenACC by default.
Simple avoiding a module load of `craype-accel-host` changes that.
This fix now allows several failing tests with nvidia on pm-cpu to pass.

Fixes #7909 
Fixes https://github.com/E3SM-Project/E3SM/issues/7911
[bfb]
