### PR TITLE
EAMxx: add field utility to read values from file

### DIFF
--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -966,7 +966,8 @@ void AtmosphereDriver::restart_model ()
       }
       fields.push_back(m_field_mgr->get_field(fn,gn));
     }
-    read_fields_from_file (fields,m_grids_manager->get_grid(gn),filename);
+    auto grid = m_grids_manager->get_grid(gn);
+    read_fields(filename,fields,grid->get_partitioned_dim_gids(),m_atm_comm);
     for (auto& f : fields) {
       f.get_header().get_tracking().update_time_stamp(m_current_ts);
     }
@@ -1257,7 +1258,7 @@ void AtmosphereDriver::set_initial_conditions ()
         ic_fields.push_back(m_field_mgr->get_field(fn,grid_name));
       }
       if (not m_iop_data_manager) {
-        read_fields_from_file (ic_fields,grid,file_name);
+        read_fields(file_name,ic_fields,grid->get_partitioned_dim_gids(),m_atm_comm);
       } else {
         // For IOP enabled, we load from file and copy data from the closest
         // lat/lon column to every other column
@@ -1352,8 +1353,11 @@ void AtmosphereDriver::set_initial_conditions ()
           auto tmp_grid = io_grid->clone(io_grid->name(),true);
           tmp_grid->reset_field_tag_name(COL,"ncol_d");
           io_grid = tmp_grid;
+
+          for (auto& f : topo_fields)
+            f = f.alias(f.name(),{{COL,"ncol_d"}});
         }
-        read_fields_from_file (topo_fields,io_grid,file_name);
+        read_fields(file_name,topo_fields,io_grid->get_partitioned_dim_gids(),m_atm_comm);
       } else {
         // For IOP enabled, we load from file and copy data from the closest
         // lat/lon column to every other column
@@ -1467,20 +1471,6 @@ void AtmosphereDriver::set_initial_conditions ()
 
   m_atm_logger->info("  [EAMxx] set_initial_conditions ... done!");
   m_atm_logger->flush(); // During init, flush often (to help debug crashes)
-}
-
-void AtmosphereDriver::
-read_fields_from_file (const std::vector<Field>& fields,
-                       const std::shared_ptr<const AbstractGrid>& grid,
-                       const std::string& file_name)
-{
-  if (fields.size()==0) {
-    return;
-  }
-
-  AtmosphereInput ic_reader(file_name,grid,fields);
-  ic_reader.set_logger(m_atm_logger);
-  ic_reader.read_variables();
 }
 
 void AtmosphereDriver::

--- a/components/eamxx/src/control/atmosphere_driver.hpp
+++ b/components/eamxx/src/control/atmosphere_driver.hpp
@@ -182,10 +182,6 @@ protected:
   void set_initial_conditions ();
   void restart_model ();
 
-  // Read fields from a file
-  void read_fields_from_file (const std::vector<Field>& fields,
-                              const std::shared_ptr<const AbstractGrid>& grid,
-                              const std::string& file_name);
   void register_groups ();
 
   template<typename T>

--- a/components/eamxx/src/physics/mam/readfiles/vertical_remapper_mam4.cpp
+++ b/components/eamxx/src/physics/mam/readfiles/vertical_remapper_mam4.cpp
@@ -1,5 +1,6 @@
 #include "vertical_remapper_mam4.hpp"
-#include "share/scorpio_interface/eamxx_scorpio_interface.hpp"
+#include "share/field/field_utils.hpp"
+
 #include <mam4xx/mam4.hpp>
 
 namespace scream
@@ -40,13 +41,10 @@ set_source_pressure (const std::string& file_name )
     using namespace ShortFieldTagsNames;
     auto layout = m_src_grid->get_vertical_layout(ILEV);
     auto mbar = ekat::units::Units(100*ekat::units::Pa,"mbar");
-    Field altitude_int_src(FieldIdentifier("altitude_int_field",layout,mbar,m_src_grid->name()));
+    Field altitude_int_src(FieldIdentifier("altitude_int",layout,mbar,m_src_grid->name()));
     altitude_int_src.allocate_view();
-    scorpio::register_file(file_name,scorpio::FileMode::Read);
-    scorpio::read_var(file_name,"altitude_int",altitude_int_src.get_view<Real*,Host>().data());
-    altitude_int_src.sync_to_dev();
-    scorpio::release_file(file_name);
-    m_src_pmid=altitude_int_src;
+    read_fields(file_name,{altitude_int_src});
+    m_src_pmid = altitude_int_src;
   }
 }
 /* Invokes MAM4XX routines for vertical interpolation.*/

--- a/components/eamxx/src/physics/rrtmgp/eamxx_rrtmgp_process_interface.cpp
+++ b/components/eamxx/src/physics/rrtmgp/eamxx_rrtmgp_process_interface.cpp
@@ -8,6 +8,7 @@
 #include "share/algorithm/eamxx_fv_phys_rrtmgp_active_gases_workaround.hpp"
 #include "share/property_checks/field_within_interval_check.hpp"
 #include "share/physics/eamxx_common_physics_functions.hpp"
+#include "share/field/field_utils.hpp"
 #include "share/util/eamxx_column_ops.hpp"
 
 #include <ekat_team_policy_utils.hpp>
@@ -262,16 +263,9 @@ void RRTMGPRadiation::create_requests() {
       // NOTE: use append, so we get builtin name for (CMP,2) dim, without hard-coding it here
       FieldLayout layout({CMP},{nbands},{prefix+"band"});
       layout.append_dim(CMP,2);
-      Field bounds (FieldIdentifier(prefix + "band_bounds", layout, 1/cm, grid_name));
-      bounds.allocate_view();
-
+      auto bounds = m_grid->create_geometry_data(prefix + "band_bounds", layout, 1/cm);
       std::string fname = m_params.get<std::string>("rrtmgp_coefficients_file_" + prefix);
-      scorpio::register_file(fname,scorpio::FileMode::Read);
-      scorpio::read_var(fname,"bnd_limits_wavenumber",bounds.get_view<Real**,Host>().data());
-      scorpio::release_file(fname);
-
-      bounds.sync_to_dev();
-      m_grid->set_geometry_data(bounds);
+      read_fields(fname,{bounds.alias("bnd_limits_wavenumber")});
     }
 
     // If no bounds were in the grid, the bands centerpoint likely wouldn't either. Still, let's check...

--- a/components/eamxx/src/share/data_managers/IOPDataManager.cpp
+++ b/components/eamxx/src/share/data_managers/IOPDataManager.cpp
@@ -2,6 +2,7 @@
 #include "share/remap/iop_remapper.hpp"
 #include "share/scorpio_interface/eamxx_scorpio_interface.hpp"
 #include "share/data_managers/IOPDataManager.hpp"
+#include "share/field/field_utils.hpp"
 
 #include <ekat_assert.hpp>
 #include <ekat_pack.hpp>
@@ -11,59 +12,6 @@
 #include <numeric>
 
 namespace scream {
-
-namespace {
-
-void read_fields (const std::string& filename,
-                  const std::shared_ptr<const AbstractGrid>& grid,
-                  std::vector<Field>& fields)
-{
-  using gid_type = AbstractGrid::gid_type;
-
-  scorpio::register_file(filename,scorpio::Read);
-
-  // Some input files have the "time" dimension as non-unlimited. This messes up our
-  // scorpio interface, which stores a pointer to a "time" dim to be used to read/write
-  // slices. This ptr is automatically inited to the unlimited dim in the file. If there is
-  // no unlim dim, this ptr remains uninited.
-  if (not scorpio::has_time_dim(filename) and scorpio::has_dim(filename,"time")) {
-    scorpio::mark_dim_as_time(filename,"time");
-  }
-
-  auto min_gid = grid->get_global_min_partitioned_dim_gid();
-  auto gids_h = grid->get_dofs_gids().get_view<const gid_type*,Host>();
-  std::vector<scorpio::offset_t> offsets(gids_h.size());
-  for (size_t i=0; i<gids_h.size(); ++i) {
-    offsets[i] = gids_h[i]-min_gid;
-  }
-  const auto decomp_tag  = grid->get_partitioned_dim_tag();
-  std::string decomp_dim = grid->has_special_tag_name(decomp_tag)
-                         ? grid->get_special_tag_name(decomp_tag)
-                         : e2str(decomp_tag);
-
-  scorpio::set_dim_decomp(filename,decomp_dim,offsets);
-  for (auto& f : fields) {
-    EKAT_REQUIRE_MSG (f.get_header().get_parent()==nullptr,
-        "Error! Fields to be read from file in IOPDataManager should not be subfields.\n"
-        " - field name: " + f.name() + "\n"
-        " - parent field name: " + f.get_header().get_parent()->get_identifier().name() + "\n");
-
-    if (f.get_header().get_alloc_properties().get_padding()==0) {
-      scorpio::read_var(filename,f.name(),f.get_internal_view_data<Real,Host>());
-      f.sync_to_dev();
-    } else {
-      // Create non-padded clone
-      Field f_no_padding(f.get_header().get_identifier());
-      f_no_padding.allocate_view();
-      scorpio::read_var(filename,f.name(),f_no_padding.get_internal_view_data<Real,Host>());
-      f_no_padding.sync_to_dev();
-      f.deep_copy(f_no_padding);
-    }
-  }
-  scorpio::release_file(filename);
-}
-
-} // anonymous namespace
 
 IOPDataManager::
 IOPDataManager(const ekat::Comm& comm,
@@ -370,7 +318,7 @@ setup_io_info(const std::string& file_name,
       grid->create_geometry_data("lat",grid->get_2d_scalar_layout()),
       grid->create_geometry_data("lon",grid->get_2d_scalar_layout())
     };
-    read_fields(file_name,grid,latlon);
+    read_fields(file_name,latlon,grid->get_partitioned_dim_gids(),grid->get_comm());
 
     m_io_grids[grid_name] = grid;
   }
@@ -411,7 +359,7 @@ read_fields_from_file_for_iop (const std::string& file_name,
   for (int i=0; i<remapper->get_num_fields(); ++i) {
     io_fields.push_back(remapper->get_src_field(i));
   }
-  read_fields(file_name,io_grid,io_fields);
+  read_fields(file_name,io_fields,io_grid->get_partitioned_dim_gids(),grid->get_comm());
 
   // Remap
   remapper->remap_fwd();

--- a/components/eamxx/src/share/data_managers/mesh_free_grids_manager.cpp
+++ b/components/eamxx/src/share/data_managers/mesh_free_grids_manager.cpp
@@ -1,8 +1,10 @@
 #include "share/data_managers/mesh_free_grids_manager.hpp"
+
 #include "share/grid/point_grid.hpp"
 #include "share/grid/se_grid.hpp"
 #include "share/property_checks/field_nan_check.hpp"
 #include "share/property_checks/field_within_interval_check.hpp"
+#include "share/field/field_utils.hpp"
 #include "share/scorpio_interface/eamxx_scorpio_interface.hpp"
 
 #include "share/physics/physics_constants.hpp"
@@ -59,6 +61,8 @@ build_grids ()
 void MeshFreeGridsManager::
 build_se_grid (const std::string& name, ekat::ParameterList& params)
 {
+  using gid_type = AbstractGrid::gid_type;
+
   // Build a set of completely disconnected spectral elements.
   const int num_local_elems  = params.get<int>("number_of_local_elements");
   const int num_gp           = params.get<int>("number_of_gauss_points");
@@ -74,8 +78,8 @@ build_se_grid (const std::string& name, ekat::ParameterList& params)
   auto elem_gids = se_grid->get_partitioned_dim_gids();
   auto lid2idx   = se_grid->get_lid_to_idx_map();
 
-  auto host_dofs    = dof_gids.template get_view<AbstractGrid::gid_type*,Host>();
-  auto host_elems   = elem_gids.template get_view<AbstractGrid::gid_type*,Host>();
+  auto host_dofs    = dof_gids.template get_view<gid_type*,Host>();
+  auto host_elems   = elem_gids.template get_view<gid_type*,Host>();
   auto host_lid2idx = lid2idx.template get_view<int**,Host>();
 
   // Count unique local dofs. On all elems except the very last one (on rank N),
@@ -194,36 +198,13 @@ add_geo_data (const nonconstgrid_ptr_type& grid) const
 void MeshFreeGridsManager::
 load_lat_lon (const nonconstgrid_ptr_type& grid, const std::string& filename) const
 {
-  using gid_type = AbstractGrid::gid_type;
-
   auto degN = ekat::units::none.rename("degrees_north");
   auto degE = ekat::units::none.rename("degrees_east");
 
   auto lat = grid->create_geometry_data("lat" , grid->get_2d_scalar_layout(), degN);
   auto lon = grid->create_geometry_data("lon" , grid->get_2d_scalar_layout(), degE);
 
-  auto lat_v = lat.get_view<Real*,Host>();
-  auto lon_v = lon.get_view<Real*,Host>();
-
-  auto min_gid = grid->get_global_min_partitioned_dim_gid();
-  auto gids_h = grid->get_dofs_gids().get_view<const gid_type*,Host>();
-  std::vector<scorpio::offset_t> offsets(gids_h.size());
-  for (size_t i=0; i<gids_h.size(); ++i) {
-    offsets[i] = gids_h[i]-min_gid;
-  }
-  const auto decomp_tag  = grid->get_partitioned_dim_tag();
-  std::string decomp_dim = grid->has_special_tag_name(decomp_tag)
-                         ? grid->get_special_tag_name(decomp_tag)
-                         : e2str(decomp_tag);
-
-  scorpio::register_file(filename,scorpio::Read);
-  scorpio::set_dim_decomp(filename,decomp_dim,offsets);
-  scorpio::read_var(filename,"lat",lat_v.data());
-  scorpio::read_var(filename,"lon",lon_v.data());
-  scorpio::release_file(filename);
-
-  lat.sync_to_dev();
-  lon.sync_to_dev();
+  read_fields(filename,{lat,lon},grid->get_partitioned_dim_gids(),grid->get_comm());
 
 #ifndef NDEBUG
   auto lat_check = std::make_shared<FieldNaNCheck>(lat,grid)->check();
@@ -249,44 +230,21 @@ load_vertical_coordinates (const nonconstgrid_ptr_type& grid, const std::string&
   auto hybm = grid->create_geometry_data("hybm", layout_mid, none);
   auto hyai = grid->create_geometry_data("hyai", layout_int, none);
   auto hybi = grid->create_geometry_data("hybi", layout_int, none);
-  auto lev  = grid->create_geometry_data("lev",  layout_mid, mbar);
-  auto ilev = grid->create_geometry_data("ilev", layout_int, mbar);
 
-  auto hyam_v  = hyam.get_view<Real*,Host>();
-  auto hybm_v  = hybm.get_view<Real*,Host>();
-  auto hyai_v  = hyai.get_view<Real*,Host>();
-  auto hybi_v  = hybi.get_view<Real*,Host>();
-  auto lev_v   = lev.get_view<Real*,Host>();
-  auto ilev_v  = ilev.get_view<Real*,Host>();
+  read_fields(filename,{hyam,hybm,hyai,hybi});
 
-  scorpio::register_file(filename,scorpio::Read);
-  scorpio::read_var(filename,"hyam",hyam_v.data());
-  scorpio::read_var(filename,"hybm",hybm_v.data());
-  scorpio::read_var(filename,"hyai",hyai_v.data());
-  scorpio::read_var(filename,"hybi",hybi_v.data());
-  scorpio::read_var(filename,"lev", lev_v.data());
-  scorpio::read_var(filename,"ilev",ilev_v.data());
-  scorpio::release_file(filename);
-
-  // Build lev and ilev from hyam and hybm, and ilev from hyai and hybi
+  // Build lev=0.01*ps0*(hyam+hybm) and ilev=0.01*ps0*(hyai+hybi)
   using PC       = scream::physics::Constants<Real>;
   const Real ps0 = PC::P0.value;
 
-  auto num_lev = grid->get_num_vertical_levels();
-  for (int ii=0;ii<num_lev;ii++) {
-    lev_v(ii)  = 0.01*ps0*(hyam_v(ii)+hybm_v(ii));
-    ilev_v(ii) = 0.01*ps0*(hyai_v(ii)+hybi_v(ii));
-  }
-  // Note, ilev is just 1 more level than the number of midpoint levs
-  ilev_v(num_lev) = 0.01*ps0*(hyai_v(num_lev)+hybi_v(num_lev));
-
-  // Sync to dev
-  hyam.sync_to_dev();
-  hybm.sync_to_dev();
-  hyai.sync_to_dev();
-  hybi.sync_to_dev();
-  lev.sync_to_dev();
-  ilev.sync_to_dev();
+  auto lev  = grid->create_geometry_data("lev",  layout_mid, mbar);
+  auto ilev = grid->create_geometry_data("ilev", layout_int, mbar);
+  ilev.deep_copy(hyai);
+  ilev.update(hybi,1,1);
+  ilev.scale(0.01*ps0);
+  lev.deep_copy(hyam);
+  lev.update(hybm,1,1);
+  lev.scale(0.01*ps0);
 
 #ifndef NDEBUG
   for (auto f : {hyam, hybm, hyai, hybi}) {

--- a/components/eamxx/src/share/field/CMakeLists.txt
+++ b/components/eamxx/src/share/field/CMakeLists.txt
@@ -46,6 +46,7 @@ add_library(eamxx_field
   utils/transpose.cpp
   utils/vert_contraction.cpp
   utils/views_are_equal.cpp
+  utils/read_fields.cpp
 )
 
 if (EAMXX_ENABLE_GPU)
@@ -66,7 +67,8 @@ endif()
 
 target_link_libraries (eamxx_field PUBLIC
   eamxx_core
-  eamxx_utils)
+  eamxx_utils
+  eamxx_scorpio_interface)
 
 if (NOT SCREAM_LIB_ONLY)
   add_subdirectory(tests)

--- a/components/eamxx/src/share/field/field.hpp
+++ b/components/eamxx/src/share/field/field.hpp
@@ -161,13 +161,14 @@ public:
   template<typename ST, HostOrDevice HD = Device>
   ST* get_internal_view_data () const {
     // Check that the scalar type is correct
-    using nonconst_ST = typename std::remove_const<ST>::type;
-    EKAT_REQUIRE_MSG ((field_valid_data_types().at<nonconst_ST>()==m_header->get_identifier().data_type()
-                       or std::is_same<nonconst_ST,char>::value),
-        "Error! Attempt to access raw field pointer with the wrong scalar type.\n"
-        " - field name: " + name() + "\n"
-        " - field data type: " + e2str(data_type()) + "\n"
-        " - requested type : " + e2str(field_valid_data_types().at<nonconst_ST>()) + "\n");
+    using scalar_t = typename ekat::ScalarTraits<ST>::scalar_type;
+    if constexpr (not std::is_same<scalar_t,char>::value and not std::is_same<scalar_t,void>::value)
+      EKAT_REQUIRE_MSG (field_valid_data_types().has_t<scalar_t>() and
+                        get_data_type<scalar_t>()==m_header->get_identifier().data_type(),
+          "Error! Attempt to access raw field pointer with the wrong scalar type.\n"
+          " - field name: " + name() + "\n"
+          " - field data type: " + e2str(data_type()) + "\n"
+          " - requested type : " + e2str(field_valid_data_types().at<scalar_t>()) + "\n");
     EKAT_REQUIRE_MSG (not m_is_read_only || std::is_const<ST>::value,
         "Error! Cannot get a non-const raw pointer to the field data if the field is read-only.\n"
         " - field name: " + name() + "\n");
@@ -185,14 +186,14 @@ public:
   template<typename ST, HostOrDevice HD = Device>
   ST* get_internal_view_data_unsafe () const {
     // Check that the scalar type is correct
-    using nonconst_ST = typename std::remove_const<ST>::type;
-    EKAT_REQUIRE_MSG ((std::is_same<nonconst_ST,char>::value or std::is_same<nonconst_ST,void>::value or
-                       (field_valid_data_types().has_t<nonconst_ST>() and
-                        get_data_type<nonconst_ST>()==m_header->get_identifier().data_type())),
+    using scalar_t = typename ekat::ScalarTraits<ST>::scalar_type;
+    if constexpr (not std::is_same<scalar_t,char>::value and not std::is_same<scalar_t,void>::value)
+      EKAT_REQUIRE_MSG (field_valid_data_types().has_t<scalar_t>() and
+                        get_data_type<scalar_t>()==m_header->get_identifier().data_type(),
         "Error! Attempt to access raw field pointer with the wrong scalar type.\n"
         " - field name: " + name() + "\n"
         " - field data type: " + e2str(data_type()) + "\n"
-        " - requested type : " + e2str(field_valid_data_types().at<nonconst_ST>()) + "\n");
+        " - requested type : " + e2str(field_valid_data_types().at<scalar_t>()) + "\n");
 
     return reinterpret_cast<ST*>(get_view_impl<HD>().data());
   }

--- a/components/eamxx/src/share/field/field_alloc_prop.hpp
+++ b/components/eamxx/src/share/field/field_alloc_prop.hpp
@@ -148,6 +148,8 @@ public:
   // Get the largest pack size that this allocation was requested to accommodate
   int get_largest_pack_size () const;
 
+  int get_scalar_size () const { return m_scalar_type_size; }
+
   // Wether this allocation is contiguous
   bool contiguous () const { return m_contiguous; }
 

--- a/components/eamxx/src/share/field/field_get_view_impl.hpp
+++ b/components/eamxx/src/share/field/field_get_view_impl.hpp
@@ -192,6 +192,8 @@ auto Field::get_ND_view () const
     }
   }
 
+  auto ptr = get_internal_view_data<T,HD>();
+
   // Compute extents from FieldLayout
   const auto& alloc_prop = m_header->get_alloc_properties();
   auto num_values = alloc_prop.get_alloc_size() / sizeof(T);
@@ -204,7 +206,6 @@ auto Field::get_ND_view () const
       num_values = fl.dim(i)==0 ? 0 : num_values/fl.dim(i);
     }
   }
-  auto ptr = reinterpret_cast<T*>(get_view_impl<HD>().data());
 
   using ret_type = get_view_type<data_nd_t<T,N>,HD>;
 
@@ -226,6 +227,8 @@ auto Field::get_ND_view () const
   EKAT_REQUIRE_MSG (m_header->get_parent()==nullptr,
       "Error! A view of rank " + std::to_string(MaxRank) + " should not be the subview of another field.\n");
 
+  auto ptr = get_internal_view_data<T,HD>();
+
   // Compute extents from FieldLayout
   const auto& alloc_prop = m_header->get_alloc_properties();
   auto num_values = alloc_prop.get_alloc_size() / sizeof(T);
@@ -235,7 +238,6 @@ auto Field::get_ND_view () const
     num_values /= fl.dim(i);
   }
   kl.dimension[N-1] = num_values;
-  auto ptr = reinterpret_cast<T*>(get_view_impl<HD>().data());
 
   using ret_type = get_view_type<data_nd_t<T,N>,HD>;
   return ret_type (ptr,kl);

--- a/components/eamxx/src/share/field/field_utils.hpp
+++ b/components/eamxx/src/share/field/field_utils.hpp
@@ -4,6 +4,8 @@
 #include "share/util/eamxx_scalar_wrapper.hpp"
 #include "share/field/field.hpp"
 
+#include <ekat_comm.hpp>
+
 namespace scream {
 
 // Check that two fields store the same entries.
@@ -85,6 +87,26 @@ void compute_mask (const Field& lhs, const Field& rhs, Comparison CMP, const Fie
 // Transpose a field layout
 void transpose (const Field& src, const Field& tgt);
 Field transpose (const Field& src);
+
+// Read a list of (pre-allocated) fields from a file via scorpio interfaces
+// Notes:
+//  - first overloads assumes NO data decomposition across ranks OR
+//    that the file is already open and the decompositions are already set
+//  - field layout tags names MUST match the dim names on file.
+//    The only exception is tag name "dim", for which this util
+//    will automatically append the extent (e.g., "dim" -> "dim3")
+//  - decomp_dim_gids: used to create scorpio decomposition for || reads
+//  - time_index: which time slice to read. -1 means "last available".
+// WARNING: gids are accessed from Host WITHOUT syncing. Make sure host view is valid
+void read_fields (const std::string& filename,
+                  const std::vector<Field>& fields,
+                  const int time_index = -1);
+
+void read_fields (const std::string& filename,
+                  const std::vector<Field>& fields,
+                  const Field& decomp_dim_gids,
+                  const ekat::Comm& comm,
+                  const int time_index = -1);
 
 } // namespace scream
 

--- a/components/eamxx/src/share/field/tests/CMakeLists.txt
+++ b/components/eamxx/src/share/field/tests/CMakeLists.txt
@@ -34,6 +34,10 @@ if (NOT SCREAM_ONLY_GENERATE_BASELINES)
   CreateUnitTest(field_utils "field_utils.cpp" LIBS eamxx_field
     MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS})
 
+  # Test read_fields free functions
+  CreateUnitTest(read_fields "read_fields_tests.cpp" LIBS eamxx_field
+    MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS})
+
   if (EAMXX_ENABLE_PYTHON)
     CreateUnitTest(pyfield "pyfield.cpp" LIBS eamxx_field)
   endif()

--- a/components/eamxx/src/share/field/tests/read_fields_tests.cpp
+++ b/components/eamxx/src/share/field/tests/read_fields_tests.cpp
@@ -1,0 +1,298 @@
+#include <catch2/catch.hpp>
+
+#include "share/field/field_utils.hpp"
+#include "share/field/field_identifier.hpp"
+#include "share/field/field_header.hpp"
+#include "share/field/field.hpp"
+#include "share/scorpio_interface/eamxx_scorpio_interface.hpp"
+
+#include <ekat_comm.hpp>
+
+#include <numeric>
+
+// ============================================================ //
+//  Helpers
+// ============================================================ //
+
+namespace scream {
+
+namespace {
+
+// Build and allocate a field with a given layout and data type.
+Field make_field (const std::string& name,
+                  const FieldLayout& layout,
+                  const DataType dtype = DataType::RealType)
+{
+  return Field(FieldIdentifier(name, layout, ekat::units::none, "grid", dtype),true);
+}
+
+// Fill a field with sequentially increasing values starting from `start`.
+void iota (Field& f, const ScalarWrapper& init)
+{
+  const int n = f.get_header().get_alloc_properties().get_alloc_size()
+              / f.get_header().get_alloc_properties().get_scalar_size();
+  switch (f.data_type()) {
+    case DataType::IntType:
+    {
+      auto* ptr = f.get_internal_view_data<int, Host>();
+      std::iota(ptr, ptr + n, init.as<int>());
+      break;
+    }
+    case DataType::FloatType:
+    {
+      auto* ptr = f.get_internal_view_data<float, Host>();
+      std::iota(ptr, ptr + n, init.as<float>());
+      break;
+    }
+    case DataType::DoubleType:
+    {
+      auto* ptr = f.get_internal_view_data<double, Host>();
+      std::iota(ptr, ptr + n, init.as<double>());
+      break;
+    }
+    default:
+      EKAT_ERROR_MSG ("Unrecognized/unsupported data type.\n"
+                      " - field name: " + f.name() + "\n"
+                      " - data type : " + e2str(f.data_type()) + "\n");
+  }
+  f.sync_to_dev();
+}
+
+// Write a single variable to an already-open (and enddef'd) scorpio file.
+template <typename ST>
+void write_field_to_file (const std::string& filename, const Field& f)
+{
+  f.sync_to_host();
+  scorpio::write_var(filename, f.name(),
+                     f.get_internal_view_data<const ST, Host>());
+}
+
+} // anonymous namespace
+
+// ============================================================ //
+//  Test: non-decomposed read
+// ============================================================ //
+
+TEST_CASE ("read_fields_no_decomp")
+{
+  using namespace ShortFieldTagsNames;
+
+  ekat::Comm comm(MPI_COMM_WORLD);
+  scorpio::init_subsystem(comm);
+
+  const std::string filename =
+      "field_io_test_no_decomp_np" + std::to_string(comm.size()) + ".nc";
+
+  // Layouts
+  const int ncols = 4;
+  const int nlevs = 6;
+  FieldLayout lay2d({COL, LEV}, {ncols, nlevs});
+  FieldLayout lay1d({LEV},      {nlevs});
+
+  // ---- Write phase ---- //
+  {
+    scorpio::register_file(filename, scorpio::Write);
+    scorpio::define_dim(filename, "ncol", ncols);
+    scorpio::define_dim(filename, "lev",  nlevs);
+    scorpio::define_var(filename, "f2d", {"ncol", "lev"}, "real", false);
+    scorpio::define_var(filename, "f1d", {"lev"},          "real", false);
+    scorpio::enddef(filename);
+
+    Field f2d = make_field("f2d", lay2d);
+    Field f1d = make_field("f1d", lay1d, DataType::IntType);
+    iota(f2d,0);
+    iota(f1d,100);
+
+    write_field_to_file<Real>(filename, f2d);
+    write_field_to_file<int>(filename, f1d);
+
+    scorpio::release_file(filename);
+  }
+
+  // ---- Read phase ---- //
+  {
+    Field f2d = make_field("f2d", lay2d);
+    Field f1d = make_field("f1d", lay1d, DataType::IntType);
+    f2d.deep_copy(-1);
+    f1d.deep_copy(-1);
+
+    read_fields(filename, {f2d, f1d});
+
+    // Verify
+    f2d.sync_to_host();
+    f1d.sync_to_host();
+
+    auto v2d = f2d.get_view<const Real**, Host>();
+    auto v1d = f1d.get_view<const int*,  Host>();
+
+    int idx = 0;
+    for (int i = 0; i < ncols; ++i) {
+      for (int j = 0; j < nlevs; ++j, ++idx) {
+        REQUIRE (v2d(i, j) == Real(idx));
+      }
+    }
+    for (int j = 0; j < nlevs; ++j) {
+      REQUIRE (v1d(j) == Real(100 + j));
+    }
+  }
+
+  scorpio::finalize_subsystem();
+}
+
+// ============================================================ //
+//  Test: decomposed read (distributed column dimension)
+// ============================================================ //
+
+TEST_CASE ("read_fields_with_decomp", "[field_utils][io]")
+{
+  using namespace ShortFieldTagsNames;
+  using namespace ekat::units;
+
+  ekat::Comm comm(MPI_COMM_WORLD);
+  scorpio::init_subsystem(comm);
+
+  const std::string filename =
+      "field_io_test_decomp_np" + std::to_string(comm.size()) + ".nc";
+
+  // Global sizes: use a multiple of comm.size() so decomp divides evenly
+  const int lcols_per_rank = 3;
+  const int ncols_global   = lcols_per_rank * comm.size();
+  const int nlevs          = 4;
+
+  FieldLayout lay2d({COL, LEV}, {lcols_per_rank, nlevs});
+  FieldLayout lay1d({COL},      {lcols_per_rank});
+
+  // GIDs owned by this rank (1-based)
+  auto my_gids = make_field("gids",lay1d,DataType::IntType);
+  auto my_gids_beg = my_gids.get_internal_view_data<int,Host>();
+  auto my_gids_end = my_gids_beg + lcols_per_rank;
+  std::iota(my_gids_beg,my_gids_end, 1 + comm.rank() * lcols_per_rank);
+  my_gids.sync_to_dev();
+
+  // ---- Write phase (rank 0 writes full data) ---- //
+  {
+    scorpio::register_file(filename, scorpio::Write);
+    scorpio::define_dim(filename, "ncol", ncols_global);
+    scorpio::define_dim(filename, "lev",  nlevs);
+
+    // Decomposition offsets
+    std::vector<scorpio::offset_t> offsets(lcols_per_rank);
+    for (int i = 0; i < lcols_per_rank; ++i) {
+      offsets[i] = my_gids_beg[i] - 1;
+    }
+    scorpio::set_dim_decomp(filename, "ncol", offsets);
+
+    scorpio::define_var(filename, "f2d", {"ncol", "lev"}, "real", false);
+    scorpio::define_var(filename, "f1d", {"ncol"},        "real", false);
+    scorpio::enddef(filename);
+
+    // Fill: global value at (gcol, lev) = gcol*nlevs + lev
+    //       global value at (gcol)      = gcol
+    Field f2d = make_field("f2d", lay2d);
+    Field f1d = make_field("f1d", lay1d, DataType::IntType);
+    f2d.sync_to_host();
+    f1d.sync_to_host();
+
+    auto v2d = f2d.get_view<Real**, Host>();
+    auto v1d = f1d.get_view<int*,  Host>();
+    for (int li = 0; li < lcols_per_rank; ++li) {
+      const int gcol = my_gids_beg[li];
+      v1d(li) = gcol;
+      for (int j = 0; j < nlevs; ++j) {
+        v2d(li, j) = Real(gcol * nlevs + j);
+      }
+    }
+    f2d.sync_to_dev();
+    f1d.sync_to_dev();
+
+    write_field_to_file<Real>(filename, f2d);
+    write_field_to_file<int>(filename, f1d);
+
+    scorpio::release_file(filename);
+  }
+
+  // ---- Read phase ---- //
+  {
+    Field f2d = make_field("f2d", lay2d);
+    Field f1d = make_field("f1d", lay1d, DataType::IntType);
+    f2d.deep_copy(-1);
+    f1d.deep_copy(-1);
+
+    read_fields(filename, {f2d, f1d}, my_gids, comm);
+
+    // Verify local data
+    f2d.sync_to_host();
+    f1d.sync_to_host();
+
+    auto v2d = f2d.get_view<const Real**, Host>();
+    auto v1d = f1d.get_view<const int*,  Host>();
+
+    for (int li = 0; li < lcols_per_rank; ++li) {
+      const int gcol = my_gids_beg[li];
+      REQUIRE (v1d(li) == gcol);
+      for (int j = 0; j < nlevs; ++j) {
+        REQUIRE (v2d(li, j) == Real(gcol * nlevs + j));
+      }
+    }
+  }
+
+  scorpio::finalize_subsystem();
+}
+
+// ============================================================ //
+//  Test: reading a specific time slice
+// ============================================================ //
+
+TEST_CASE ("read_fields_time_slice")
+{
+  using namespace ShortFieldTagsNames;
+
+  ekat::Comm comm(MPI_COMM_WORLD);
+  scorpio::init_subsystem(comm);
+
+  const std::string filename =
+      "field_io_test_time_np" + std::to_string(comm.size()) + ".nc";
+
+  const int nlevs  = 5;
+  const int ntimes = 3;
+  FieldLayout lay1d({LEV}, {nlevs});
+
+  // ---- Write phase ---- //
+  {
+    scorpio::register_file(filename, scorpio::Write);
+    scorpio::define_time(filename, "s");
+    scorpio::define_dim(filename, "lev", nlevs);
+    scorpio::define_var(filename, "f1d", {"lev"}, "real", true);
+    scorpio::enddef(filename);
+
+    Field f1d = make_field("f1d", lay1d);
+
+    for (int t = 0; t < ntimes; ++t) {
+      scorpio::update_time(filename, double(t));
+      f1d.deep_copy(Real(t * 10));
+      write_field_to_file<Real>(filename, f1d);
+    }
+
+    scorpio::release_file(filename);
+  }
+
+  // ---- Read phase: request middle time slice ---- //
+  {
+    const int target_t = 1;
+
+    Field f1d = make_field("f1d", lay1d);
+    f1d.deep_copy(Real(-1));
+
+    read_fields(filename, {f1d}, target_t);
+
+    f1d.sync_to_host();
+    auto v = f1d.get_view<const Real*, Host>();
+    for (int j = 0; j < nlevs; ++j) {
+      REQUIRE (v(j) == Real(target_t * 10));
+    }
+  }
+
+  scorpio::finalize_subsystem();
+}
+
+} // namespace scream

--- a/components/eamxx/src/share/field/utils/read_fields.cpp
+++ b/components/eamxx/src/share/field/utils/read_fields.cpp
@@ -1,0 +1,158 @@
+#include "share/field/field_utils.hpp"
+#include "share/field/field_alloc_prop.hpp"
+#include "share/scorpio_interface/eamxx_scorpio_interface.hpp"
+
+#include <ekat_string_utils.hpp>
+#include <ekat_zip.hpp>
+
+#include <algorithm>
+#include <limits>
+
+namespace scream {
+
+namespace {
+
+// Creates an I/O-friendly copy of a field: no padding and no subfield parent.
+// If the field already satisfies these conditions it is returned as-is (alias).
+// Otherwise a freshly allocated copy with the same identifier is returned.
+std::vector<Field> make_io_fields (const std::vector<Field>& fields)
+{
+  std::vector<Field> io_fields;
+  for (const auto& f : fields) {
+    const auto& fh  = f.get_header();
+    const auto& fap = fh.get_alloc_properties();
+    const bool can_alias = fh.get_parent() == nullptr && fap.get_padding() == 0;
+    if (can_alias)
+      io_fields.emplace_back(f);
+    else
+      io_fields.emplace_back(fh.get_identifier(),true);
+  }
+  return io_fields;
+}
+
+// Handle possibly non-unlimited "time" dim, validate field extents against
+// the file metadata, and changes each var dtype to "real" so that read_var
+// can use the native precision.
+void setup_file_and_vars (const std::string& filename,
+                          const std::vector<Field>& io_fields)
+{
+  // Mark a non-unlimited "time" dimension so sliced reads work correctly.
+  if (!scorpio::has_time_dim(filename) && scorpio::has_dim(filename, "time")) {
+    scorpio::mark_dim_as_time(filename, "time");
+  }
+
+  for (const auto& f : io_fields) {
+    const auto& fdims = f.get_header().get_identifier().get_layout().dims();
+    const auto& fname = f.name();
+
+    EKAT_REQUIRE_MSG (scorpio::has_var(filename, fname),
+        "Error! Variable not found in input file.\n"
+        " - filename: " + filename + "\n"
+        " - varname : " + fname + "\n");
+
+    const auto& var = scorpio::get_var(filename, fname);
+    std::vector<int> vardims;
+    for (auto d : var.dims) {
+      vardims.push_back(d->length);
+      if (d->decomp_rank==1) {
+        vardims.back() = var.decomp->dim_decomp->dims[0]->length;
+      }
+    }
+    EKAT_REQUIRE_MSG (vardims == fdims,
+        "Error! Layout mismatch for variable in input file.\n"
+        " - filename     : " + filename + "\n"
+        " - varname      : " + fname + "\n"
+        " - expected dims: " + ekat::join(fdims, ",") + "\n"
+        " - file dims    : " + ekat::join(vardims, ",") + "\n");
+
+    // Allow scorpio to cast to the field's native type during read.
+    scorpio::change_var_dtype(filename, fname, "real");
+  }
+}
+
+// Read from file into io_fields, and copy into the fields (no-op for aliasing fields)
+void do_read_and_copy (const std::string& filename,
+                       const std::vector<Field>& fields,
+                       const std::vector<Field>& io_fields,
+                       const int time_index)
+{
+  for (auto [f, io_f] : ekat::zip(fields,io_fields)) {
+    const auto& fname = io_f.name();
+
+    switch (io_f.data_type()) {
+      case DataType::DoubleType:
+        scorpio::read_var(filename, fname, io_f.get_internal_view_data<double, Host>(), time_index);
+        break;
+      case DataType::FloatType:
+        scorpio::read_var(filename, fname, io_f.get_internal_view_data<float, Host>(), time_index);
+        break;
+      case DataType::IntType:
+        scorpio::read_var(filename, fname, io_f.get_internal_view_data<int, Host>(), time_index);
+        break;
+      default:
+        EKAT_ERROR_MSG (
+            "Error! Unsupported data type while reading field from file.\n"
+            " - filename  : " + filename + "\n"
+            " - field name: " + fname + "\n");
+    }
+
+    io_f.sync_to_dev();
+    f.deep_copy(io_f); // If io_f is aliasing f, this is a no-op
+  }
+}
+
+} // anonymous namespace
+
+void read_fields (const std::string& filename,
+                  const std::vector<Field>& fields,
+                  const int time_index)
+{
+  if (fields.size()==0)
+    return;
+
+  scorpio::register_file(filename, scorpio::Read);
+  auto io_fields = make_io_fields(fields);
+  setup_file_and_vars(filename, io_fields);
+  do_read_and_copy(filename, fields, io_fields, time_index);
+  scorpio::release_file(filename);
+}
+
+void read_fields (const std::string& filename,
+                  const std::vector<Field>& fields,
+                  const Field& decomp_dim_gids,
+                  const ekat::Comm& comm,
+                  const int time_index)
+{
+  if (fields.size()==0)
+    return;
+
+  EKAT_REQUIRE_MSG (decomp_dim_gids.rank()==1,
+      "Error! Decomposed dim gids field must have rank 1.\n"
+      " - field name: " + decomp_dim_gids.name() + "\n"
+      " - field rank: " + std::to_string(decomp_dim_gids.rank()) + "\n");
+  EKAT_REQUIRE_MSG (decomp_dim_gids.data_type()==DataType::IntType,
+      "Error! Decomposed dim gids field must have integer data type.\n"
+      " - field name : " + decomp_dim_gids.name() + "\n"
+      " - field dtype: " + e2str(decomp_dim_gids.data_type()) + "\n");
+
+  // Compute the global minimum GID so offsets can be 0-based.
+  auto global_min_gid = field_min(decomp_dim_gids,&comm).as<int>();
+  auto gids = decomp_dim_gids.get_view<const int*,Host>();
+  std::vector<scorpio::offset_t> offsets(gids.size());
+  for (std::size_t i = 0; i < gids.size(); ++i) {
+    offsets[i] = static_cast<scorpio::offset_t>(gids[i] - global_min_gid);
+  }
+
+  scorpio::register_file(filename, scorpio::Read);
+  auto io_fields = make_io_fields(fields);
+  setup_file_and_vars(filename, io_fields);
+
+  // Register the distributed decomposition along the requested dimension.
+  const auto& decomp_dim = decomp_dim_gids.get_header().get_identifier().get_layout().name(0);
+  scorpio::set_dim_decomp(filename, decomp_dim, offsets);
+
+  do_read_and_copy(filename, fields, io_fields, time_index);
+  scorpio::release_file(filename);
+}
+
+} // namespace scream

--- a/components/eamxx/src/share/field/utils/read_fields.cpp
+++ b/components/eamxx/src/share/field/utils/read_fields.cpp
@@ -53,9 +53,14 @@ void setup_file_and_vars (const std::string& filename,
     const auto& var = scorpio::get_var(filename, fname);
     std::vector<int> vardims;
     for (auto d : var.dims) {
-      vardims.push_back(d->length);
-      if (d->decomp_rank==1) {
-        vardims.back() = var.decomp->dim_decomp->dims[0]->length;
+      switch (d->decomp_rank) {
+        case 0: vardims.push_back(d->length); break;
+        case 1: vardims.push_back(var.decomp->dim_decomp->offsets.size()); break;
+        default:
+          EKAT_ERROR_MSG ("[read_fields] Error! Unsupported (and unexpected) decomposition rank\n"
+                          " - var name: " + var.name + "\n"
+                          " - decomp  : " + var.decomp->name + "\n"
+                          " - rank    : " + std::to_string(d->decomp_rank) + "\n");
       }
     }
     EKAT_REQUIRE_MSG (vardims == fdims,
@@ -144,12 +149,13 @@ void read_fields (const std::string& filename,
   }
 
   scorpio::register_file(filename, scorpio::Read);
-  auto io_fields = make_io_fields(fields);
-  setup_file_and_vars(filename, io_fields);
 
   // Register the distributed decomposition along the requested dimension.
   const auto& decomp_dim = decomp_dim_gids.get_header().get_identifier().get_layout().name(0);
   scorpio::set_dim_decomp(filename, decomp_dim, offsets);
+
+  auto io_fields = make_io_fields(fields);
+  setup_file_and_vars(filename, io_fields);
 
   do_read_and_copy(filename, fields, io_fields, time_index);
   scorpio::release_file(filename);

--- a/components/eamxx/src/share/grid/CMakeLists.txt
+++ b/components/eamxx/src/share/grid/CMakeLists.txt
@@ -9,7 +9,7 @@ target_link_libraries (eamxx_grid PUBLIC
   eamxx_core
   eamxx_utils
   eamxx_field
-  eamxx_scorpio_interface)
+)
 
 if (NOT SCREAM_LIB_ONLY)
   add_subdirectory(tests)

--- a/components/eamxx/src/share/grid/abstract_grid.cpp
+++ b/components/eamxx/src/share/grid/abstract_grid.cpp
@@ -1,7 +1,6 @@
 #include "share/grid/abstract_grid.hpp"
 
 #include "share/field/field_utils.hpp"
-#include "share/scorpio_interface/eamxx_scorpio_interface.hpp"
 
 #include <ekat_assert.hpp>
 
@@ -419,76 +418,6 @@ AbstractGrid::delete_geometry_data (const std::string& name)
       "  - geo data name: " + name + "\n");
 
   m_geo_fields.erase(name);
-}
-
-void AbstractGrid::
-read_geometry_data(const std::string& filename,
-                   const std::vector<std::string>& names,
-                   const std::map<std::string,std::string>& dim_to_ncdim)
-{
-  read_geometry_data(filename,names,names,dim_to_ncdim);
-}
-
-void AbstractGrid::
-read_geometry_data(const std::string& filename,
-                   const std::vector<std::string>& names,
-                   const std::vector<std::string>& nc_names,
-                   const std::map<std::string,std::string>& dim_to_ncdim)
-{
-  EKAT_REQUIRE_MSG (names.size()==nc_names.size(),
-      "[AbstractGrid] Error! Input names and nc_names sizes differ.\n"
-      "  - grid name: " + this->name() + "\n"
-      "  - geo data names: " + ekat::join(names,",") + "\n"
-      "  - nc vars names: " + ekat::join(nc_names,",") + "\n");
-  scorpio::register_file(filename,scorpio::Read);
-
-  for (size_t i=0; i<names.size(); ++i) {
-    EKAT_REQUIRE_MSG (has_geometry_data(names[i]),
-        "Error! Cannot read geometry data from file, since it is does not exist.\n"
-        "  - grid name: " + this->name() + "\n"
-        "  - geo data name: " + names[i] + "\n");
-
-    auto f = m_geo_fields.at(names[i]);
-    const auto& fl = f.get_header().get_identifier().get_layout();
-
-    // If one of the field tags corresponds to the partitioned dim, init the decomp
-    if (fl.has_tag(get_partitioned_dim_tag())) {
-      auto t = get_partitioned_dim_tag();
-      std::string dimname = has_special_tag_name(t)
-                          ? get_special_tag_name(t)
-                          : e2str(t);
-      auto gids_h = get_partitioned_dim_gids().get_view<const gid_type*,Host>();
-      auto min_gid = get_global_min_partitioned_dim_gid();
-      std::vector<scorpio::offset_t> offsets(m_num_local_dofs);
-      for (int idof=0; idof<m_num_local_dofs; ++idof) {
-        offsets[idof] = gids_h[idof] - min_gid;
-      }
-      std::string nc_dimname = dim_to_ncdim.count(dimname)==1 ? dim_to_ncdim.at(dimname) : dimname;
-      scorpio::set_dim_decomp(filename,nc_dimname,offsets);
-    }
-
-    switch (f.data_type()) {
-      case DataType::DoubleType:
-        scorpio::read_var(filename,nc_names[i],f.get_internal_view_data<double,Host>());
-        break;
-      case DataType::FloatType:
-        scorpio::read_var(filename,nc_names[i],f.get_internal_view_data<float,Host>());
-        break;
-      case DataType::IntType:
-        scorpio::read_var(filename,nc_names[i],f.get_internal_view_data<int,Host>());
-        break;
-      default:
-        EKAT_ERROR_MSG (
-            "Error! Unsupported/unrecognized data type while reading field from file.\n"
-            " - file name : " + filename + "\n"
-            " - field name: " + names[i] + "\n");
-    }
-
-    // Ensure data is up to date on device, since we read on host
-    f.sync_to_dev();
-  }
-
-  scorpio::release_file(filename);
 }
 
 void

--- a/components/eamxx/src/share/grid/abstract_grid.cpp
+++ b/components/eamxx/src/share/grid/abstract_grid.cpp
@@ -726,6 +726,24 @@ get_remote_pids_and_lids (const gid_view_h& gids,
       "  - num unique gids in: " + std::to_string(num_unique_gids) + "\n");
 }
 
+void AbstractGrid::reset_field_tag_name(const FieldTag t, const std::string &s)
+{
+  m_special_tag_names[t] = s;
+
+  // Rename the tag also in any field stored by the class
+  std::vector<Field*> fields = {
+    &m_dofs_gids,
+    &m_partitioned_dim_gids,
+    &m_lid_to_idx
+  };
+  for (auto& it : m_geo_fields) {
+    fields.push_back(&it.second);
+  }
+  for (auto f : fields) {
+    *f = f->alias(f->name(),m_special_tag_names);
+  }
+}
+
 void AbstractGrid::create_dof_fields (const int scalar2d_layout_rank)
 {
   using namespace ShortFieldTagsNames;

--- a/components/eamxx/src/share/grid/abstract_grid.hpp
+++ b/components/eamxx/src/share/grid/abstract_grid.hpp
@@ -186,17 +186,7 @@ public:
   void set_geometry_data(const Field &f) const;
   void delete_geometry_data(const std::string &name);
 
-  // Reads some geometry data from file
-  void read_geometry_data(const std::string& filename,
-                          const std::vector<std::string>& names,
-                          const std::map<std::string,std::string>& dim_to_ncdim = {});
-  void read_geometry_data(const std::string& filename,
-                          const std::vector<std::string>& names,
-                          const std::vector<std::string>& nc_names,
-                          const std::map<std::string,std::string>& dim_to_ncdim = {});
-
-  bool
-  has_geometry_data(const std::string &name) const
+  bool has_geometry_data(const std::string &name) const
   {
     return m_geo_fields.find(name) != m_geo_fields.end();
   }

--- a/components/eamxx/src/share/grid/abstract_grid.hpp
+++ b/components/eamxx/src/share/grid/abstract_grid.hpp
@@ -254,13 +254,9 @@ public:
     return true;
   }
 
-  void
-  reset_field_tag_name(const FieldTag t, const std::string &s)
-  {
-    m_special_tag_names[t] = s;
-  }
-  bool
-  has_special_tag_name(const FieldTag t) const
+  void reset_field_tag_name(const FieldTag t, const std::string &s);
+
+  bool has_special_tag_name(const FieldTag t) const
   {
     return m_special_tag_names.count(t) == 1;
   }

--- a/components/eamxx/src/share/remap/horiz_interp_remapper_data.cpp
+++ b/components/eamxx/src/share/remap/horiz_interp_remapper_data.cpp
@@ -1,5 +1,6 @@
 #include "horiz_interp_remapper_data.hpp"
 
+#include "share/field/field_utils.hpp"
 #include "share/grid/point_grid.hpp"
 #include "share/grid/grid_import_export.hpp"
 #include "share/scorpio_interface/eamxx_scorpio_interface.hpp"
@@ -154,8 +155,12 @@ build (const std::shared_ptr<const AbstractGrid>& grid,
        const std::string& map_file)
 {
   std::filesystem::path p(map_file);
+
   // The "1" stands for "build from 1 grid"
   start_timer ("HRemap1 " + p.filename().string() + " bld");
+
+  using namespace ShortFieldTagsNames;
+  using namespace ekat::units;
 
   EKAT_REQUIRE_MSG (grid,
       "[HorizRemapperDataRepo::build_data_from_src] Error! Invalid src grid pointer.\n");
@@ -187,18 +192,17 @@ build (const std::shared_ptr<const AbstractGrid>& grid,
   std::string suffix = built_from_src ? "_b" : "_a";
 
   auto gen_grid = create_point_grid(built_from_src ? "tgt_grid" : "src_grid",built_from_src ? ncol_b : ncol_a,nlev,comm,1);
+  gen_grid->reset_field_tag_name(COL,"n"+suffix);
 
   // Only read the lat/lon/area vars if they are present. If one is present, we assume they all are
   if (scorpio::has_var(map_file,"yc"+suffix)) {
-    auto deg = ekat::units::none.rename("deg");
+    auto deg = none.rename("deg");
 
-    gen_grid->create_geometry_data("lat", gen_grid->get_2d_scalar_layout(),deg);
-    gen_grid->create_geometry_data("lon", gen_grid->get_2d_scalar_layout(),deg);
-    gen_grid->create_geometry_data("area",gen_grid->get_2d_scalar_layout(),ekat::units::sr);
-    gen_grid->read_geometry_data(map_file,
-                                 {"lat","lon","area"},
-                                 {"yc"+suffix,"xc"+suffix,"area"+suffix},
-                                 {{"ncol","n"+suffix}});
+    const auto& layout2d = gen_grid->get_2d_scalar_layout();
+    auto lat  = gen_grid->create_geometry_data("lat", layout2d,deg).alias("yc"+suffix);
+    auto lon  = gen_grid->create_geometry_data("lon", layout2d,deg).alias("xc"+suffix);
+    auto area = gen_grid->create_geometry_data("area",layout2d,sr ).alias("area"+suffix);
+    read_fields(map_file,{lat,lon,area},gen_grid->get_partitioned_dim_gids(),comm);
 
     // If this is a remap TO a lat-lon grid, setup some geo data that our output classes
     // will use to write to file using (lat,lon) layout rather than (ncol)
@@ -224,21 +228,27 @@ read_mat_triplets (const std::string& map_file)
 {
   using gid_type = AbstractGrid::gid_type;
   using namespace ShortFieldTagsNames;
+  using namespace ekat::units;
 
   const auto& comm = m_src_grid->get_comm();
 
   // Split the triplets evenly across ranks, and read them
   int n_s = scorpio::get_dimlen(map_file,"n_s");
   auto io_grid = create_point_grid("remap_data_io_grid",n_s,0,comm);
-  io_grid->reset_field_tag_name(COL,"n_s");
 
-  auto row_h = io_grid->create_geometry_data<gid_type>("row",io_grid->get_2d_scalar_layout()).get_view<const gid_type*,Host>();
-  auto col_h = io_grid->create_geometry_data<gid_type>("col",io_grid->get_2d_scalar_layout()).get_view<const gid_type*,Host>();
-  auto S_h   = io_grid->create_geometry_data<Real>("S",  io_grid->get_2d_scalar_layout()).get_view<const Real*,Host>();
-  io_grid->read_geometry_data(map_file,{"row","col","S"});
+  auto fl = io_grid->get_2d_scalar_layout().rename_dim(0,"n_s");
+  auto gids = io_grid->get_partitioned_dim_gids().alias("gids",{{COL,"n_s"}});
+
+  Field row(FieldIdentifier("row",fl,none,"",DataType::IntType),true);
+  Field col(FieldIdentifier("col",fl,none,"",DataType::IntType),true);
+  Field S  (FieldIdentifier("S",fl,none,""),true);
+  read_fields(map_file,{row,col,S},gids,comm);
 
   int nlweights = io_grid->get_num_local_dofs();
 
+  auto row_h = row.get_view<const gid_type*,Host>();
+  auto col_h = col.get_view<const gid_type*,Host>();
+  auto S_h   = S.get_view<const Real*,Host>();
   std::vector<Triplet> triplets;
   for (int i=0; i<nlweights; ++i) {
     triplets.emplace_back(row_h[i],col_h[i],S_h[i]);
@@ -388,10 +398,11 @@ setup_latlon_data(const std::shared_ptr<AbstractGrid>& grid,
                   const std::string& map_file)
 {
   using namespace ShortFieldTagsNames;
+  using namespace ekat::units;
 
   // Add lat/lon to the temp grid, and read from map file
-  auto nondim = ekat::units::none;
-  ekat::units::Units deg(nondim,"degrees");
+  auto degN = none.rename("degrees_north");
+  auto degE = none.rename("degrees_east");
 
   // Declare lat/lon and read them from the map file.
   // WARNING: the vars/dims names are different from what eamxx uses
@@ -417,8 +428,8 @@ setup_latlon_data(const std::shared_ptr<AbstractGrid>& grid,
   // Re-create lat/lon geometry data with only lat (or lon) dim
   grid->delete_geometry_data("lat");
   grid->delete_geometry_data("lon");
-  auto lat = grid->create_geometry_data("lat",FieldLayout({CMP},{nlat},{"lat"}),deg);
-  auto lon = grid->create_geometry_data("lon",FieldLayout({CMP},{nlon},{"lon"}),deg);
+  auto lat = grid->create_geometry_data("lat",FieldLayout({CMP},{nlat},{"lat"}),degN);
+  auto lon = grid->create_geometry_data("lon",FieldLayout({CMP},{nlon},{"lon"}),degE);
   
   auto lat_h = lat.get_view<Real*,Host>();
   auto lon_h = lon.get_view<Real*,Host>();
@@ -428,8 +439,8 @@ setup_latlon_data(const std::shared_ptr<AbstractGrid>& grid,
   lon.sync_to_dev();
 
   auto scalar2d = grid->get_2d_scalar_layout();
-  auto lat_idx = grid->create_geometry_data("lat_idx",scalar2d,nondim,DataType::IntType);
-  auto lon_idx = grid->create_geometry_data("lon_idx",scalar2d,nondim,DataType::IntType);
+  auto lat_idx = grid->create_geometry_data("lat_idx",scalar2d,none,DataType::IntType);
+  auto lon_idx = grid->create_geometry_data("lon_idx",scalar2d,none,DataType::IntType);
   lat_idx.get_header().set_extra_data("save_as_geo_data",false);
   lon_idx.get_header().set_extra_data("save_as_geo_data",false);
 

--- a/components/eamxx/src/share/remap/vertical_remapper.cpp
+++ b/components/eamxx/src/share/remap/vertical_remapper.cpp
@@ -4,6 +4,7 @@
 #include "share/io/scorpio_input.hpp"
 #include "share/field/field_tag.hpp"
 #include "share/field/field_identifier.hpp"
+#include "share/field/field_utils.hpp"
 #include "share/util/eamxx_timing.hpp"
 #include "share/util/eamxx_universal_constants.hpp"
 #include "share/scorpio_interface/eamxx_scorpio_interface.hpp"
@@ -37,7 +38,7 @@ create_tgt_grid (const grid_ptr_type& src_grid,
   Field p_tgt(FieldIdentifier("p_levs",layout,ekat::units::Pa,tgt_grid->name()));
   p_tgt.get_header().get_alloc_properties().request_allocation(SCREAM_PACK_SIZE);
   p_tgt.allocate_view();
-  scorpio::read_var(map_file,"p_levs",p_tgt.get_view<Real*,Host>().data());
+  read_fields(map_file,{p_tgt});
   p_tgt.sync_to_dev();
 
   // Add tgt pressure levels to the tgt grid

--- a/components/eamxx/src/share/scorpio_interface/eamxx_scorpio_interface.cpp
+++ b/components/eamxx/src/share/scorpio_interface/eamxx_scorpio_interface.cpp
@@ -980,6 +980,7 @@ void set_dim_decomp (const std::string& filename,
 
   dim_decomp = std::make_shared<DimDecomp>();
   dim_decomp->offsets = my_offsets;
+  dim_decomp->dims = {f.dims.at(dimname)};
   dim.decomp_rank = 1;
 
   // If vars were already defined, we need to process them,


### PR DESCRIPTION
Simple wrapper around scorpio utils, but avoids having to use the eamxx_io lib.

[BFB]

---

I had a few reasons to ask Lucio to do this PR (which I later refined):
- grid and remap libs were doing similar calls to scorpio_interface fcns to read data into fields
- a few places were hand-rolling a similar utility to read fields
- AtmosphereInput is really a super lightweight wrapper around scorpio, and it stinks to have to link eamxx_io (which requires eamxx_diags, eamxx_data_managers, eamxx_remap) just to read some plain fields

I am also planning on making AtmosphereInput simply wrap this utility (but justtifying its existence since it can store permanent data, while the utility is for a one-and-done use case). It's currently overly complicated for a class whose cpp file should be ~50 lines total. While output requires a lot of work, input should be relatively trivial.

En passant, I noticed that Field::get_view was buggy, as it NEVER checked that the template data type was compatible with the field data type enum (it only checked that the allocation was compatible with it), so I was not getting errors when calling `f.get_field<double*>()` on an integer field; since there were an even number of ints (32 bits), the alloc size was compabitle with doubles (64 bits). This PR adds a better way to check for this (first commit).