### PR TITLE
Add v3.LR wcycl PEs on Crux in maint-3.0

### DIFF
--- a/cime_config/allactive/config_pesall.xml
+++ b/cime_config/allactive/config_pesall.xml
@@ -1388,6 +1388,53 @@
         </rootpe>
       </pes>
     </mach>
+    <mach name="crux">
+      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+SGLC.+SWAV.+_SESP$" pesize="PS">
+        <comment> --compset WCYCL* --res ne30pg2_r05_IcoswISC30E3r5 on 15 nodes pure-MPI, ~7 sypd </comment>
+        <ntasks>
+          <ntasks_atm>-11</ntasks_atm>
+          <ntasks_lnd>-5</ntasks_lnd>
+          <ntasks_rof>-5</ntasks_rof>
+          <ntasks_ice>-6</ntasks_ice>
+          <ntasks_ocn>-4</ntasks_ocn>
+          <ntasks_cpl>-11</ntasks_cpl>
+        </ntasks>
+        <rootpe>
+          <rootpe_ice>-5</rootpe_ice>
+          <rootpe_ocn>-11</rootpe_ocn>
+        </rootpe>
+      </pes>
+      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+SGLC.+SWAV.+_SESP$" pesize="PM">
+        <comment> --compset WCYCL* --res ne30pg2_r05_IcoswISC30E3r5 on 30 nodes pure-MPI, ~13 sypd </comment>
+        <ntasks>
+          <ntasks_atm>-22</ntasks_atm>
+          <ntasks_lnd>-8</ntasks_lnd>
+          <ntasks_rof>-8</ntasks_rof>
+          <ntasks_ice>-14</ntasks_ice>
+          <ntasks_ocn>-8</ntasks_ocn>
+          <ntasks_cpl>-22</ntasks_cpl>
+        </ntasks>
+        <rootpe>
+          <rootpe_ice>-8</rootpe_ice>
+          <rootpe_ocn>-22</rootpe_ocn>
+        </rootpe>
+      </pes>
+      <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+SGLC.+SWAV.+_SESP$" pesize="PL">
+        <comment> --compset WCYCL* --res ne30pg2_r05_IcoswISC30E3r5 on 58 nodes pure-MPI, ~20 sypd </comment>
+        <ntasks>
+          <ntasks_atm>-43</ntasks_atm>
+          <ntasks_lnd>-11</ntasks_lnd>
+          <ntasks_rof>-11</ntasks_rof>
+          <ntasks_ice>-32</ntasks_ice>
+          <ntasks_ocn>-15</ntasks_ocn>
+          <ntasks_cpl>-43</ntasks_cpl>
+        </ntasks>
+        <rootpe>
+          <rootpe_ice>-11</rootpe_ice>
+          <rootpe_ocn>-43</rootpe_ocn>
+        </rootpe>
+      </pes>
+    </mach>
     <mach name="gcp12">
       <pes compset=".*EAM.+ELM.+MPASSI.+MPASO.+MOSART.+SGLC.+SWAV.+" pesize="any">
         <comment> gcp12 --compset WCYCL* --res ne30pg2_r05_IcoswISC30E3r5 on 4 nodes </comment>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -3669,6 +3669,8 @@ commented out until "*** No rule to make target '.../libadios2pio-nm-lib.a'" iss
       <env name="PNETCDF_PATH">$ENV{CRAY_PARALLEL_NETCDF_PREFIX}</env>
       <env name="LD_LIBRARY_PATH">$ENV{CRAY_LD_LIBRARY_PATH}:$ENV{LD_LIBRARY_PATH}</env>
       <env name="FI_CXI_RX_MATCH_MODE">hybrid</env>
+      <env name="PALS_PING_PERIOD">240</env>
+      <env name="PALS_RPC_TIMEOUT">240</env>
     </environment_variables>
     <environment_variables BUILD_THREADED="TRUE">
       <env name="OMP_STACKSIZE">128M</env>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -3650,13 +3650,11 @@ commented out until "*** No rule to make target '.../libadios2pio-nm-lib.a'" iss
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
       <modules>
-        <command name="reset"></command>
         <command name="use">/grand/E3SMinput/soft/modulefiles/crux</command>
         <command name="load">cmake/3.27.9</command>
-        <command name="load">cray-python/3.11.7</command>
         <command name="load">craype-accel-host</command>
-        <command name="load">PrgEnv-gnu/8.5.0</command>
-        <command name="load">cray-libsci/24.03.0</command>
+        <command name="load">PrgEnv-gnu/8.6.0</command>
+        <command name="load">cray-libsci/25.09.0</command>
         <command name="load">cray-hdf5-parallel/1.12.2.11</command>
         <command name="load">cray-netcdf-hdf5parallel/4.9.0.11</command>
         <command name="load">cray-parallel-netcdf/1.12.3.11</command>


### PR DESCRIPTION
Add v3.LR wcycl PEs on Crux
- add PS, PM, PL pe-layouts on 15, 30, 58 nodes at 7, 13, 20 sypd
- update modules to newer defaults

[BFB]

---
This is the same as E3SM-Project/E3SM#8218, just for maint-3.0.
Testing:
- e3sm_prod: 9 of 9 pass -- https://my.cdash.org/builds/3524899/tests
- PS/PM/PL wcycl runs on 15/30/58 nodes at 7/13/20 sypd -- https://my.cdash.org/builds/3528219/tests