### PR TITLE
EAMxx: shorten remap timers names

### DIFF
--- a/components/eamxx/src/share/algorithm/eamxx_data_interpolation.cpp
+++ b/components/eamxx/src/share/algorithm/eamxx_data_interpolation.cpp
@@ -442,8 +442,8 @@ create_horiz_remappers (const std::string& map_file)
     nlevs_data = get_input_files_dimlen(m_input_files_dimnames[ILEV]);
   }
 
-  m_data_grid = create_point_grid("data",ncols_data,nlevs_data,m_model_grid->get_comm(),1);
-  m_grid_after_hremap = m_model_grid->clone("after_hremap",true);
+  m_data_grid = create_point_grid(m_name+"_data",ncols_data,nlevs_data,m_model_grid->get_comm(),1);
+  m_grid_after_hremap = m_model_grid->clone(m_name+"_post_hremap",true);
   m_grid_after_hremap->reset_vertical_configuration(nlevs_data, AbstractGrid::VKind::Model);
 
   if (map_file!="") {
@@ -485,7 +485,7 @@ create_horiz_remappers (const Real iop_lat, const Real iop_lon)
   int ncols_data = m_fields_have_col_dim ? get_input_files_dimlen (m_input_files_dimnames[COL]) : ncols_model;
 
   // Create grid for IO and load lat/lon field in IO grid from any data file
-  m_data_grid = create_point_grid("data",ncols_data,nlevs_data,m_model_grid->get_comm());
+  m_data_grid = create_point_grid(m_name+"_data",ncols_data,nlevs_data,m_model_grid->get_comm());
   std::vector<Field> latlon = {
     m_data_grid->create_geometry_data("lat",m_data_grid->get_2d_scalar_layout()),
     m_data_grid->create_geometry_data("lon",m_data_grid->get_2d_scalar_layout())
@@ -494,7 +494,7 @@ create_horiz_remappers (const Real iop_lat, const Real iop_lon)
   latlon_reader.read_variables();
 
   // Create iop remap tgt grid
-  m_grid_after_hremap = m_model_grid->clone("after_hremap",true);
+  m_grid_after_hremap = m_model_grid->clone(m_name+"_post_hremap",true);
   m_grid_after_hremap->reset_vertical_configuration(nlevs_data, AbstractGrid::VKind::Model);
   m_horiz_remapper_beg = std::make_shared<IOPRemapper>(m_data_grid,m_grid_after_hremap,iop_lat,iop_lon);
   m_horiz_remapper_end = std::make_shared<IOPRemapper>(m_data_grid,m_grid_after_hremap,iop_lat,iop_lon);

--- a/components/eamxx/src/share/algorithm/eamxx_data_interpolation.hpp
+++ b/components/eamxx/src/share/algorithm/eamxx_data_interpolation.hpp
@@ -75,6 +75,8 @@ public:
 
   std::shared_ptr<AbstractGrid> get_grid_after_hremap () const { return m_grid_after_hremap; }
 
+  void set_name (const std::string& name) { m_name = name; }
+
 protected:
 
   void shift_data_interval ();
@@ -144,6 +146,8 @@ protected:
   bool                  m_fields_have_col_dim = false;
   bool                  m_fields_have_lev_dim = false;
   bool                  m_fields_have_ilev_dim = false;
+
+  std::string           m_name = "DataInterp";
 
   std::shared_ptr<ekat::logger::LoggerBase> m_logger;
 };

--- a/components/eamxx/src/share/remap/abstract_remapper.cpp
+++ b/components/eamxx/src/share/remap/abstract_remapper.cpp
@@ -119,7 +119,7 @@ void AbstractRemapper::registration_ends ()
 void AbstractRemapper::remap_fwd ()
 {
   if (m_timers_enabled)
-    start_timer(name()+" remap_fwd");
+    start_timer(name()+" fwd");
   EKAT_REQUIRE_MSG(m_state!=RepoState::Open,
       "Error! Cannot perform remapping at this time.\n"
       "       Did you forget to call 'registration_ends'?\n");
@@ -130,13 +130,13 @@ void AbstractRemapper::remap_fwd ()
       "Error! Forward remap IS allowed by this remapper, but some of the tgt fields are read-only\n");
   remap_fwd_impl ();
   if (m_timers_enabled)
-    stop_timer(name()+" remap_fwd");
+    stop_timer(name()+" fwd");
 }
 
 void AbstractRemapper::remap_bwd ()
 {
   if (m_timers_enabled)
-    start_timer(name()+" remap_bwd");
+    start_timer(name()+" bwd");
   EKAT_REQUIRE_MSG(m_state!=RepoState::Open,
       "Error! Cannot perform remapping at this time.\n"
       "       Did you forget to call 'registration_ends'?\n");
@@ -147,7 +147,7 @@ void AbstractRemapper::remap_bwd ()
       "Error! Backward remap IS allowed by this remapper, but some of the src fields are read-only\n");
   remap_bwd_impl ();
   if (m_timers_enabled)
-    stop_timer(name()+" remap_bwd");
+    stop_timer(name()+" bwd");
 }
 
 void AbstractRemapper::

--- a/components/eamxx/src/share/remap/horiz_interp_remapper_data.cpp
+++ b/components/eamxx/src/share/remap/horiz_interp_remapper_data.cpp
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <numeric>
+#include <filesystem>
 
 namespace scream {
 
@@ -85,7 +86,9 @@ build (const std::shared_ptr<const AbstractGrid>& src_grid,
        const std::shared_ptr<const AbstractGrid>& tgt_grid,
        const std::string& map_file)
 {
-  start_timer ("Build HorizRemap data (two grids)" + map_file);
+  std::filesystem::path p(map_file);
+  // The "2" stands for "2 grids bld"
+  start_timer ("HRemap2 " + p.filename().string() + " bld");
 
   EKAT_REQUIRE_MSG (src_grid->type()==GridType::Point,
       "Error! Horizontal interpolatory remap only works on PointGrid grids.\n"
@@ -144,13 +147,15 @@ build (const std::shared_ptr<const AbstractGrid>& src_grid,
   } else {
     m_imp_exp = std::make_shared<GridImportExport>(src_grid,m_overlap_grid);
   }
-  stop_timer ("Build HorizRemap data (two grids)" + map_file);
+  stop_timer ("HRemap2 " + p.filename().string() + " bld");
 }
 void HorizRemapperData::
 build (const std::shared_ptr<const AbstractGrid>& grid,
        const std::string& map_file)
 {
-  start_timer ("Build HorizRemap data (one grid)" + map_file);
+  std::filesystem::path p(map_file);
+  // The "1" stands for "build from 1 grid"
+  start_timer ("HRemap1 " + p.filename().string() + " bld");
 
   EKAT_REQUIRE_MSG (grid,
       "[HorizRemapperDataRepo::build_data_from_src] Error! Invalid src grid pointer.\n");
@@ -210,7 +215,7 @@ build (const std::shared_ptr<const AbstractGrid>& grid,
     build(gen_grid,grid,map_file);
   }
 
-  stop_timer ("Build HorizRemap data (one grid)" + map_file);
+  stop_timer ("HRemap1 " + p.filename().string() + " bld");
 }
 
 std::vector<Triplet>

--- a/components/eamxx/src/share/remap/horizontal_remapper.cpp
+++ b/components/eamxx/src/share/remap/horizontal_remapper.cpp
@@ -10,6 +10,7 @@
 #include <ekat_pack_utils.hpp>
 
 #include <numeric>
+#include <filesystem>
 
 namespace scream
 {
@@ -21,7 +22,8 @@ HorizontalRemapper (const grid_ptr_type& src_grid,
                     const bool track_mask)
  : m_track_mask (track_mask)
 {
-  set_name("HorizRemapper " + map_file);
+  std::filesystem::path p(map_file);
+  set_name("HRemap " + p.filename().string());
 
   m_remap_data = HorizRemapperDataRepo::instance().get_data(src_grid,tgt_grid,map_file);
 
@@ -45,7 +47,8 @@ HorizontalRemapper (const grid_ptr_type& grid,
                     const bool track_mask)
  : m_track_mask (track_mask)
 {
-  set_name("HorizRemapper " + map_file);
+  std::filesystem::path p(map_file);
+  set_name("HRemap " + p.filename().string());
 
   m_remap_data = HorizRemapperDataRepo::instance().get_data(grid,map_file);
 
@@ -358,7 +361,7 @@ void HorizontalRemapper::
 local_mat_vec (const Field& x, const Field& y) const
 {
   if (m_timers_enabled)
-    start_timer(name()+" mat-vec");
+    start_timer(name()+" matvec");
 
   using RangePolicy = typename KT::RangePolicy;
   using MemberType  = typename KT::MemberType;
@@ -476,7 +479,7 @@ local_mat_vec (const Field& x, const Field& y) const
       EKAT_ERROR_MSG("[HorizInterpRemapperBase::local_mat_vec] Error! Fields of rank 4 or greater are not supported.\n");
   }
   if (m_timers_enabled)
-    stop_timer(name()+" mat-vec");
+    stop_timer(name()+" matvec");
 }
 
 template<int PackSize>
@@ -615,7 +618,7 @@ void HorizontalRemapper::
 local_mat_vec_masked (const Field& x, const Field& y) const
 {
   if (m_timers_enabled)
-    start_timer(name()+" mat-vec (masked)");
+    start_timer(name()+" matvec masked");
 
   using RangePolicy = typename KT::RangePolicy;
   using MemberType  = typename KT::MemberType;
@@ -738,7 +741,7 @@ local_mat_vec_masked (const Field& x, const Field& y) const
     }
   }
   if (m_timers_enabled)
-    stop_timer(name()+" mat-vec (masked)");
+    stop_timer(name()+" matvec masked");
 }
 
 void HorizontalRemapper::pack_and_send ()

--- a/components/eamxx/src/share/remap/vertical_remapper.cpp
+++ b/components/eamxx/src/share/remap/vertical_remapper.cpp
@@ -14,6 +14,7 @@
 #include <ekat_pack_kokkos.hpp>
 
 #include <numeric>
+#include <filesystem>
 
 namespace scream
 {
@@ -27,7 +28,7 @@ create_tgt_grid (const grid_ptr_type& src_grid,
   scorpio::register_file(map_file,scorpio::FileMode::Read);
   auto nlevs_tgt = scorpio::get_dimlen(map_file,"lev");
 
-  auto tgt_grid = src_grid->clone("vertical_remap_tgt_grid",true);
+  auto tgt_grid = src_grid->clone(src_grid->name()+"_vremap_tgt",true);
   tgt_grid->reset_vertical_configuration(nlevs_tgt, AbstractGrid::VKind::Pressure);
 
   // Gather the pressure level data for vertical remapping
@@ -53,13 +54,16 @@ VerticalRemapper (const grid_ptr_type& src_grid,
  : VerticalRemapper(src_grid,create_tgt_grid(src_grid,map_file))
 {
   set_target_pressure (m_tgt_grid->get_geometry_data("p_levs"),Both);
+  std::filesystem::path p(map_file);
+
+  set_name("VRemap " + p.filename().string());
 }
 
 VerticalRemapper::
 VerticalRemapper (const grid_ptr_type& src_grid,
                   const grid_ptr_type& tgt_grid)
 {
-  set_name("Vertical " + tgt_grid->name());
+  set_name("VRemap " + tgt_grid->name());
 
   // We only go in one direction for simplicity, since we need to setup some
   // infrsatructures, and we don't want to setup 2x as many "just in case".


### PR DESCRIPTION
Make length of names of timers from eamxx remappers more reasonable.

[BFB]

---

As an example, this should change

```
                  "a_i:Build HorizRemap data (two grids)/lus/flare/projects/E3SMinput/data/atm/scream/maps/map_ne30pg2_to_ne256pg2_20231201.nc"                -       1    -       0.955694     0.955694     0.955694         0.000000 
```
to
```
                  "a_i:HRemap map_ne30pg2_to_ne256pg2_20231201.nc bld"                -       1    -       0.955694     0.955694     0.955694         0.000000 
```
Closes #8337.

Note: if we could assume that map files names are `map_SRC_to_DST_TIMESTAMP.nc`, we could shorten names even more, making them `HRemap SRC_to_DST <PHASE>` (where PHASE can be `bld`, `fwd`, `bwd`, `matvec`, etc., depending on what the remapper is and what it's doing).