### PR TITLE
Add physical-property tests and documentation for P3 cloud-liquid immersion freezing

### DIFF
--- a/components/eamxx/docs/technical/physics/p3/cldliq_immersion_freezing.md
+++ b/components/eamxx/docs/technical/physics/p3/cldliq_immersion_freezing.md
@@ -1,0 +1,223 @@
+# P3 Cloud-Liquid Immersion Freezing
+
+This document describes the P3 routine `cldliq_immersion_freezing`. The
+routine computes heterogeneous immersion freezing tendencies for cloud-liquid
+mass and cloud-droplet number, and it summarizes the physical-property tests
+that verify the implementation.
+
+## Purpose
+
+The routine computes:
+
+- `qc2qi_hetero_freeze_tend`: cloud-liquid mass converted to ice by
+  heterogeneous immersion freezing
+- `nc2ni_immers_freeze_tend`: cloud-droplet number converted to ice number by
+  immersion freezing
+
+These tendencies are used when supercooled cloud droplets freeze into ice in
+the P3 microphysics scheme.
+
+## Physical Context
+
+Cloud-liquid immersion freezing represents heterogeneous freezing of
+supercooled cloud droplets. For the current positive runtime exponent, the
+rate increases with supercooling and depends on the assumed cloud-droplet size
+distribution. The mass tendency and number tendency are different moments of
+that same size distribution, so their ratio encodes the mean mass of newly
+frozen droplets.
+
+## Active Mask
+
+The routine is active when all of the following conditions hold:
+
+- `qc_incld >= QSMALL`
+- `T_atm <= T_rainfrz`
+- `context == true`
+
+Both thresholds are inclusive. If any of these conditions fail, the routine
+does not modify the output lane.
+
+## Governing Formulas
+
+For active lanes, define
+
+$$
+\theta = T_{\mathrm{zerodegc}} - T_{\mathrm{atm}},
+\qquad
+a = \texttt{runtime\_options.immersion\_freezing\_exponent},
+$$
+
+$$
+\expAimmDt = e^{a\theta},
+\qquad
+\lambda = \lambda_c,
+\qquad
+\mu = \mu_c,
+\qquad
+c = \texttt{cdist1}.
+$$
+
+The implementation computes
+
+$$
+qc2qi_{\mathrm{hetero\_freeze\_tend}} =
+CONS6 \; c \; \Gamma(\mu + 7) \; e^{a\theta} \; \lambda^{-6},
+$$
+
+$$
+nc2ni_{\mathrm{immers\_freeze\_tend}} =
+CONS5 \; c \; \Gamma(\mu + 4) \; e^{a\theta} \; \lambda^{-3}.
+$$
+
+The code forms these powers through `inv_lamc3 = (1/lamc)^3`, so the mass
+tendency uses `square(inv_lamc3)` and the number tendency uses `inv_lamc3`.
+
+## Moment Identity
+
+Let
+
+$$
+M = qc2qi_{\mathrm{hetero\_freeze\_tend}},
+\qquad
+N = nc2ni_{\mathrm{immers\_freeze\_tend}}.
+$$
+
+Then the mass-to-number ratio simplifies exactly to
+
+$$
+\frac{M}{N} =
+\frac{CONS6}{CONS5}
+\frac{(\mu_c + 4)(\mu_c + 5)(\mu_c + 6)}{\lambda_c^3}.
+$$
+
+This follows from
+
+$$
+\frac{\Gamma(\mu + 7)}{\Gamma(\mu + 4)}
+= (\mu + 4)(\mu + 5)(\mu + 6).
+$$
+
+Using
+
+$$
+CONS5 = \frac{\pi}{6} BIMM,
+\qquad
+CONS6 = \left(\frac{\pi}{6}\right)^2 \rho_w BIMM,
+$$
+
+the constant ratio is
+
+$$
+\frac{CONS6}{CONS5} = \frac{\pi \rho_w}{6}.
+$$
+
+This ratio is the mean mass per newly frozen droplet implied by the assumed
+cloud-droplet size distribution. Since $CONS6 / CONS5 = \pi \rho_w / 6$, the
+ratio has the same structure as the mass of a spherical water droplet, with
+the effective droplet-volume factor supplied by the Gamma-distribution moment
+ratio. Temperature, the runtime exponent, and the distribution prefactor
+`cdist1` cancel out because they multiply the mass and number moments
+identically.
+
+## Implementation Notes
+
+`qc_incld` is currently a gate only. Above threshold it does not enter the
+active-lane formulas directly. Cloud-water dependence enters through the
+diagnosed distribution parameters `lamc`, `mu_c`, and `cdist1`.
+This does not mean cloud water is physically irrelevant; it means this small
+kernel receives cloud-water dependence through the precomputed droplet-spectrum
+parameters.
+
+`inv_qc_relvar` is currently inactive in this routine because the code uses
+
+```cpp
+// sgs_var_coef = subgrid_variance_scaling(inv_qc_relvar, 2);
+sgs_var_coef = 1;
+```
+
+If subgrid-variance scaling is restored, the physical-property tests should be
+updated from invariance to the corresponding exact scaling law.
+
+When `context` is false, or when the lane fails the `qc_incld` or temperature
+activation gate, the routine leaves the incoming output values unchanged.
+The property tests therefore seed outputs with sentinel values when checking
+inactive lanes.
+
+## Mathematical Properties
+
+For active lanes, the separable structure implies exact logarithmic scaling
+identities:
+
+$$
+\frac{d\ln M}{d\theta} = a,
+\qquad
+\frac{d\ln N}{d\theta} = a,
+$$
+
+$$
+\frac{d\ln M}{d\ln \lambda_c} = -6,
+\qquad
+\frac{d\ln N}{d\ln \lambda_c} = -3,
+$$
+
+$$
+\frac{d\ln M}{d\ln cdist1} = 1,
+\qquad
+\frac{d\ln N}{d\ln cdist1} = 1.
+$$
+
+These identities encode the key physics:
+
+- for positive `a`, stronger supercooling increases both tendencies
+  exponentially
+- smaller `lamc` corresponds to larger characteristic droplets, with a stronger
+  effect on frozen mass than on frozen number because mass samples a higher
+  moment of the droplet distribution
+- `cdist1` scales both tendencies linearly
+
+## Physical-Property Tests
+
+The unit tests live in
+`components/eamxx/src/physics/p3/tests/p3_cldliq_imm_freezing_unit_tests.cpp`.
+
+The `run_phys()` implementation uses separate Catch2 sections for:
+
+- `activation_and_thresholds`
+- `temperature_supercooling_scaling`
+- `runtime_exponent_sensitivity`
+- `lambda_power_law_scaling`
+- `mass_number_moment_identity`
+- `distribution_prefactor_scaling`
+- `scalar_multiplier_cancellation_in_mass_number_ratio`
+- `qc_gate_only_behavior`
+- `inv_qc_relvar_currently_inactive`
+- `context_mask_preserves_inactive_lanes`
+- `finite_nonnegative_outputs`
+
+These tests use deterministic inputs, run the production
+`Functions::cldliq_immersion_freezing` kernel, and compare the outputs against
+independent identities, exact ratios, and one-sided physical inequalities.
+The BFB regression path remains separate in `run_bfb()`.
+
+## Tolerance Philosophy
+
+The tests use identity tolerances for exact algebraic relations such as the
+moment identity and the separable scaling ratios. Exact equality is used for
+inactive-lane preservation checks because the kernel should not touch those
+lanes. Near-zero floors remain separate from scaled relative checks so that
+inactive preservation and positive-tendency assertions are not conflated.
+
+## Validation
+
+Build and run the targeted test with:
+
+```bash
+cd /pscratch/sd/k/kylepres/e3sm_scratch/pm-cpu/full_debug
+module load python
+eval "$(/global/homes/k/kylepres/EAMXX/components/eamxx/scripts/eamxx-env-cmd pm-cpu)"
+module load PrgEnv-gnu cray-mpich
+export CC=mpicc CXX=mpicxx FC=mpifort
+export MPICH_GPU_SUPPORT_ENABLED=0
+make -j 8 p3_tests
+./src/physics/p3/tests/p3_tests "p3_cldliq_immersion_freezing"
+```

--- a/components/eamxx/docs/technical/physics/p3/cldliq_immersion_freezing.md
+++ b/components/eamxx/docs/technical/physics/p3/cldliq_immersion_freezing.md
@@ -257,18 +257,3 @@ inactive preservation and positive-tendency assertions are not conflated. The
 volume-weighted size-bias test also uses this identity tolerance, because the
 comparison still goes through production-kernel outputs involving `tgamma`,
 `exp`, and ratio formation.
-
-## Validation
-
-Build and run the targeted test with:
-
-```bash
-cd /pscratch/sd/k/kylepres/e3sm_scratch/pm-cpu/full_debug
-module load python
-eval "$(/global/homes/k/kylepres/EAMXX/components/eamxx/scripts/eamxx-env-cmd pm-cpu)"
-module load PrgEnv-gnu cray-mpich
-export CC=mpicc CXX=mpicxx FC=mpifort
-export MPICH_GPU_SUPPORT_ENABLED=0
-make -j 8 p3_tests
-./src/physics/p3/tests/p3_tests "p3_cldliq_immersion_freezing"
-```

--- a/components/eamxx/docs/technical/physics/p3/cldliq_immersion_freezing.md
+++ b/components/eamxx/docs/technical/physics/p3/cldliq_immersion_freezing.md
@@ -86,7 +86,7 @@ Then the mass-to-number ratio simplifies exactly to
 
 $$
 \frac{M}{N} =
-\frac{CONS6}{CONS5}
+\frac{\mathrm{CONS6}}{\mathrm{CONS5}}
 \frac{(\mu_c + 4)(\mu_c + 5)(\mu_c + 6)}{\lambda_c^3}.
 $$
 
@@ -100,24 +100,24 @@ $$
 Using
 
 $$
-CONS5 = \frac{\pi}{6} BIMM,
+\mathrm{CONS5} = \frac{\pi}{6}\mathrm{BIMM},
 \qquad
-CONS6 = \left(\frac{\pi}{6}\right)^2 \rho_w BIMM,
+\mathrm{CONS6} = \left(\frac{\pi}{6}\right)^2 \rho_w\mathrm{BIMM},
 $$
 
 the constant ratio is
 
 $$
-\frac{CONS6}{CONS5} = \frac{\pi \rho_w}{6}.
+\frac{\mathrm{CONS6}}{\mathrm{CONS5}} = \frac{\pi \rho_w}{6}.
 $$
 
 This ratio is the mean mass per newly frozen droplet implied by the assumed
-cloud-droplet size distribution. Since $CONS6 / CONS5 = \pi \rho_w / 6$, the
-ratio has the same structure as the mass of a spherical water droplet, with
-the effective droplet-volume factor supplied by the Gamma-distribution moment
-ratio. Temperature, the runtime exponent, and the distribution prefactor
-`cdist1` cancel out because they multiply the mass and number moments
-identically.
+cloud-droplet size distribution. Since
+\(\mathrm{CONS6} / \mathrm{CONS5} = \pi \rho_w / 6\), the ratio has the same
+structure as the mass of a spherical water droplet, with the effective
+droplet-volume factor supplied by the Gamma-distribution moment ratio.
+Temperature, the runtime exponent, and the distribution prefactor `cdist1`
+cancel out because they multiply the mass and number moments identically.
 
 ## Volume-Weighted Freezing Interpretation
 
@@ -129,7 +129,7 @@ $$
 $$
 
 the ratio has the structure of the mass of a spherical water droplet,
-$m = (\pi \rho_w / 6) D^3$.
+\(m = (\pi \rho_w / 6)D^3\).
 
 For an ordinary Gamma cloud droplet number distribution, the ordinary mean
 cloud droplet mass is

--- a/components/eamxx/docs/technical/physics/p3/cldliq_immersion_freezing.md
+++ b/components/eamxx/docs/technical/physics/p3/cldliq_immersion_freezing.md
@@ -48,7 +48,7 @@ a = \texttt{runtime\_options.immersion\_freezing\_exponent},
 $$
 
 $$
-\expAimmDt = e^{a\theta},
+\mathrm{expAimmDt} = e^{a\theta},
 \qquad
 \lambda = \lambda_c,
 \qquad

--- a/components/eamxx/docs/technical/physics/p3/cldliq_immersion_freezing.md
+++ b/components/eamxx/docs/technical/physics/p3/cldliq_immersion_freezing.md
@@ -119,6 +119,24 @@ ratio. Temperature, the runtime exponent, and the distribution prefactor
 `cdist1` cancel out because they multiply the mass and number moments
 identically.
 
+The same identity implies a size-bias interpretation. If
+
+$$
+D_{\mathrm{mean}} = \frac{\mu_c + 4}{\lambda_c}
+$$
+
+is the mean diameter of the freezing-weighted droplet population, then
+
+$$
+\frac{D_{\mathrm{eff}}^3}{D_{\mathrm{mean}}^3}
+= \frac{(\mu_c + 5)(\mu_c + 6)}{(\mu_c + 4)^2} > 1
+\qquad \text{for } \mu_c \ge 0.
+$$
+
+So the implied mean mass per newly frozen droplet corresponds to a
+larger-than-mean droplet, consistent with larger droplets being preferentially
+represented in the freezing-weighted moments.
+
 ## Implementation Notes
 
 `qc_incld` is currently a gate only. Above threshold it does not enter the
@@ -174,6 +192,8 @@ These identities encode the key physics:
   effect on frozen mass than on frozen number because mass samples a higher
   moment of the droplet distribution
 - `cdist1` scales both tendencies linearly
+- `cdist1 = 0` gives zero mass and number freezing tendencies for otherwise
+  active lanes
 
 ## Physical-Property Tests
 
@@ -187,7 +207,9 @@ The `run_phys()` implementation uses separate Catch2 sections for:
 - `runtime_exponent_sensitivity`
 - `lambda_power_law_scaling`
 - `mass_number_moment_identity`
+- `frozen_droplet_size_bias`
 - `distribution_prefactor_scaling`
+- `zero_distribution_prefactor_gives_zero`
 - `scalar_multiplier_cancellation_in_mass_number_ratio`
 - `qc_gate_only_behavior`
 - `inv_qc_relvar_currently_inactive`

--- a/components/eamxx/docs/technical/physics/p3/cldliq_immersion_freezing.md
+++ b/components/eamxx/docs/technical/physics/p3/cldliq_immersion_freezing.md
@@ -242,10 +242,11 @@ The `run_phys()` implementation uses separate Catch2 sections for:
 - `context_mask_preserves_inactive_lanes`
 - `finite_nonnegative_outputs`
 
-These tests use deterministic inputs, run the production
-`Functions::cldliq_immersion_freezing` kernel, and compare the outputs against
-independent identities, exact ratios, and one-sided physical inequalities.
-The BFB regression path remains separate in `run_bfb()`.
+These tests use deterministic inputs, launch the production
+`Functions::cldliq_immersion_freezing` kernel through Kokkos, copy the results
+back to host, and compare the outputs against independent identities, exact
+ratios, and one-sided physical inequalities. The BFB regression path remains
+separate in `run_bfb()`.
 
 ## Tolerance Philosophy
 

--- a/components/eamxx/docs/technical/physics/p3/cldliq_immersion_freezing.md
+++ b/components/eamxx/docs/technical/physics/p3/cldliq_immersion_freezing.md
@@ -119,23 +119,49 @@ ratio. Temperature, the runtime exponent, and the distribution prefactor
 `cdist1` cancel out because they multiply the mass and number moments
 identically.
 
-The same identity implies a size-bias interpretation. If
+## Volume-Weighted Freezing Interpretation
+
+The implemented mass-to-number tendency ratio can be interpreted as the mean
+mass per newly frozen droplet. Because
 
 $$
-D_{\mathrm{mean}} = \frac{\mu_c + 4}{\lambda_c}
+\frac{CONS6}{CONS5} = \frac{\pi \rho_w}{6},
 $$
 
-is the mean diameter of the freezing-weighted droplet population, then
+the ratio has the structure of the mass of a spherical water droplet,
+$m = (\pi \rho_w / 6) D^3$.
+
+For an ordinary Gamma cloud droplet number distribution, the ordinary mean
+cloud droplet mass is
 
 $$
-\frac{D_{\mathrm{eff}}^3}{D_{\mathrm{mean}}^3}
-= \frac{(\mu_c + 5)(\mu_c + 6)}{(\mu_c + 4)^2} > 1
+m_{\mathrm{cloud}} =
+\frac{\pi \rho_w}{6}
+\frac{(\mu_c + 1)(\mu_c + 2)(\mu_c + 3)}{\lambda_c^3}.
+$$
+
+For the newly frozen droplets implied by the P3 immersion-freezing closure,
+
+$$
+m_{\mathrm{frozen}} =
+\frac{\pi \rho_w}{6}
+\frac{(\mu_c + 4)(\mu_c + 5)(\mu_c + 6)}{\lambda_c^3}.
+$$
+
+Therefore,
+
+$$
+\frac{m_{\mathrm{frozen}}}{m_{\mathrm{cloud}}}
+= \frac{(\mu_c + 4)(\mu_c + 5)(\mu_c + 6)}
+  {(\mu_c + 1)(\mu_c + 2)(\mu_c + 3)}
+> 1
 \qquad \text{for } \mu_c \ge 0.
 $$
 
-So the implied mean mass per newly frozen droplet corresponds to a
-larger-than-mean droplet, consistent with larger droplets being preferentially
-represented in the freezing-weighted moments.
+This expresses a general microphysical property of volume-proportional
+immersion freezing: newly frozen droplets are biased toward larger droplets
+than the ordinary cloud droplet population, because larger droplets have more
+volume in which to contain an immersed ice-nucleating site.
 
 ## Implementation Notes
 
@@ -207,7 +233,7 @@ The `run_phys()` implementation uses separate Catch2 sections for:
 - `runtime_exponent_sensitivity`
 - `lambda_power_law_scaling`
 - `mass_number_moment_identity`
-- `frozen_droplet_size_bias`
+- `volume_nucleation_prefers_larger_than_mean_droplets`
 - `distribution_prefactor_scaling`
 - `zero_distribution_prefactor_gives_zero`
 - `scalar_multiplier_cancellation_in_mass_number_ratio`
@@ -227,7 +253,10 @@ The tests use identity tolerances for exact algebraic relations such as the
 moment identity and the separable scaling ratios. Exact equality is used for
 inactive-lane preservation checks because the kernel should not touch those
 lanes. Near-zero floors remain separate from scaled relative checks so that
-inactive preservation and positive-tendency assertions are not conflated.
+inactive preservation and positive-tendency assertions are not conflated. The
+volume-weighted size-bias test also uses this identity tolerance, because the
+comparison still goes through production-kernel outputs involving `tgamma`,
+`exp`, and ratio formation.
 
 ## Validation
 

--- a/components/eamxx/mkdocs.yml
+++ b/components/eamxx/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
         - 'Back to Cell Average': 'technical/physics/p3/back_to_cell_average.md'
         - 'Liquid Relaxation Timescale': 'technical/physics/p3/liq_relaxation_timescale.md'
         - 'Rime Density': 'technical/physics/p3/rime_density.md'
+        - 'Cloud-Liquid Immersion Freezing': 'technical/physics/p3/cldliq_immersion_freezing.md'
     - 'AeroCom cloud top': 'technical/aerocom_cldtop.md'
 
 edit_uri: ""

--- a/components/eamxx/src/physics/p3/tests/p3_cldliq_imm_freezing_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_cldliq_imm_freezing_unit_tests.cpp
@@ -6,10 +6,10 @@
 
 #include "share/core/eamxx_types.hpp"
 
-#include <thread>
+#include <cmath>
 #include <array>
 #include <algorithm>
-#include <random>
+#include <limits>
 
 namespace scream {
 namespace p3 {
@@ -18,15 +18,468 @@ namespace unit_test {
 template <typename D>
 struct UnitWrap::UnitTest<D>::TestCldliqImmersionFreezing : public UnitWrap::UnitTest<D>::Base {
 
-void run_phys()
-{
-  // TODO
+  static constexpr Scalar identity_tol =
+    1000 * std::numeric_limits<Scalar>::epsilon();
+  static constexpr Scalar zero_tol = 1e-30;
+
+  static_assert(max_pack_size >= 8,
+                "This test assumes at least 8 pack lanes.");
+
+  struct ImmFreezeResult {
+    Scalar mass;
+    Scalar number;
+  };
+
+  struct ImmFreezeLane {
+    Scalar T_atm, lamc, mu_c, cdist1, qc_incld, inv_qc_relvar;
+    bool context;
+    Scalar mass_in, number_in;
+    Scalar mass_out, number_out;
+  };
+
+  static bool rel_close(const Scalar got,
+                        const Scalar expected,
+                        const Scalar rtol = identity_tol,
+                        const Scalar atol = zero_tol)
+  {
+    const auto scale = std::max(std::abs(got), std::abs(expected));
+    return std::abs(got - expected) <= atol + rtol * scale;
+  }
+
+  static Scalar cube_host(const Scalar x) { return x * x * x; }
+
+  static Scalar expected_mass_number_ratio(const Scalar mu_c,
+                                           const Scalar lamc)
+  {
+    return (C::CONS6 / C::CONS5)
+         * (mu_c + 4)
+         * (mu_c + 5)
+         * (mu_c + 6)
+         / cube_host(lamc);
+  }
+
+  static Mask uniform_context(const bool value)
+  {
+    Mask context;
+    for (Int s = 0; s < Pack::n; ++s) {
+      context.set(s, value);
+    }
+    return context;
+  }
+
+  static ImmFreezeResult run_case(
+    const Scalar T_atm,
+    const Scalar lamc,
+    const Scalar mu_c,
+    const Scalar cdist1,
+    const Scalar qc_incld,
+    const Scalar inv_qc_relvar,
+    const Scalar exponent,
+    const bool context_value,
+    const Scalar mass_seed = 0,
+    const Scalar number_seed = 0)
+  {
+    typename Functions::P3Runtime runtime_options;
+    runtime_options.immersion_freezing_exponent = exponent;
+
+    Pack T_atm_p(T_atm), lamc_p(lamc), mu_c_p(mu_c), cdist1_p(cdist1);
+    Pack qc_incld_p(qc_incld), inv_qc_relvar_p(inv_qc_relvar);
+    Pack qc2qi_hetero_freeze_tend(mass_seed);
+    Pack nc2ni_immers_freeze_tend(number_seed);
+    const auto context = uniform_context(context_value);
+
+    Functions::cldliq_immersion_freezing(
+      T_atm_p, lamc_p, mu_c_p, cdist1_p, qc_incld_p, inv_qc_relvar_p,
+      qc2qi_hetero_freeze_tend, nc2ni_immers_freeze_tend,
+      runtime_options, context);
+
+    return {qc2qi_hetero_freeze_tend[0], nc2ni_immers_freeze_tend[0]};
+  }
+
+  std::array<ImmFreezeLane, max_pack_size> make_lanes() const
+  {
+    std::array<ImmFreezeLane, max_pack_size> lanes;
+    for (Int s = 0; s < max_pack_size; ++s) {
+      lanes[s].T_atm = C::T_rainfrz.value - (1.0 + 0.5 * s);
+      lanes[s].lamc = 2.5 + 0.15 * s;
+      lanes[s].mu_c = 1.0 + 0.2 * s;
+      lanes[s].cdist1 = 0.25 + 0.1 * s;
+      lanes[s].qc_incld = 5.0 * C::QSMALL;
+      lanes[s].inv_qc_relvar = 2.0 + 0.25 * s;
+      lanes[s].context = true;
+      lanes[s].mass_in = 0.0;
+      lanes[s].number_in = 0.0;
+      lanes[s].mass_out = 0.0;
+      lanes[s].number_out = 0.0;
+    }
+    return lanes;
+  }
+
+  void run_kernel(std::array<ImmFreezeLane, max_pack_size>& lanes,
+                  const Scalar exponent) const
+  {
+    typename Functions::P3Runtime runtime_options;
+    runtime_options.immersion_freezing_exponent = exponent;
+
+    for (Int i = 0; i < num_test_itrs; ++i) {
+      const Int offset = i * Pack::n;
+      Pack T_atm, lamc, mu_c, cdist1, qc_incld, inv_qc_relvar;
+      Pack qc2qi_hetero_freeze_tend, nc2ni_immers_freeze_tend;
+      Mask context;
+
+      for (Int s = 0; s < Pack::n; ++s) {
+        const Int vs = offset + s;
+        T_atm[s] = lanes[vs].T_atm;
+        lamc[s] = lanes[vs].lamc;
+        mu_c[s] = lanes[vs].mu_c;
+        cdist1[s] = lanes[vs].cdist1;
+        qc_incld[s] = lanes[vs].qc_incld;
+        inv_qc_relvar[s] = lanes[vs].inv_qc_relvar;
+        qc2qi_hetero_freeze_tend[s] = lanes[vs].mass_in;
+        nc2ni_immers_freeze_tend[s] = lanes[vs].number_in;
+        context.set(s, lanes[vs].context);
+      }
+
+      Functions::cldliq_immersion_freezing(
+        T_atm, lamc, mu_c, cdist1, qc_incld, inv_qc_relvar,
+        qc2qi_hetero_freeze_tend, nc2ni_immers_freeze_tend,
+        runtime_options, context);
+
+      for (Int s = 0; s < Pack::n; ++s) {
+        const Int vs = offset + s;
+        lanes[vs].mass_out = qc2qi_hetero_freeze_tend[s];
+        lanes[vs].number_out = nc2ni_immers_freeze_tend[s];
+      }
+    }
+  }
+
+  // For active lanes, cloud-liquid immersion freezing computes two moments of
+  // the same cloud droplet size distribution:
+  //
+  //   M = CONS6 * cdist1 * Gamma(mu_c + 7) * exp(a * (T0 - T)) * lamc^-6
+  //   N = CONS5 * cdist1 * Gamma(mu_c + 4) * exp(a * (T0 - T)) * lamc^-3
+  //
+  // The property tests below avoid duplicating the full production formula.
+  // They instead check scaling identities, activation behavior, and the
+  // moment-ratio identity:
+  //
+  //   M / N = (CONS6 / CONS5)
+  //         * (mu_c + 4)(mu_c + 5)(mu_c + 6) / lamc^3.
+  void run_phys()
+  {
+  const auto require_rel_close = [&](const Scalar got, const Scalar expected,
+                                     const Scalar rtol = identity_tol,
+                                     const Scalar atol = zero_tol) {
+    INFO("got=" << got << " expected=" << expected
+         << " rtol=" << rtol << " atol=" << atol);
+    REQUIRE(rel_close(got, expected, rtol, atol));
+  };
+
+  const auto require_preserved = [&](const Scalar got, const Scalar expected) {
+    INFO("got=" << got << " expected=" << expected);
+    REQUIRE(got == expected);
+  };
+
+  const auto require_positive_finite = [&](const ImmFreezeResult& result) {
+    INFO("mass=" << result.mass << " number=" << result.number);
+    REQUIRE(std::isfinite(result.mass));
+    REQUIRE(std::isfinite(result.number));
+    REQUIRE(result.mass > 0);
+    REQUIRE(result.number > 0);
+  };
+
+  SECTION("activation_and_thresholds") {
+    const Scalar lamc = 5.0;
+    const Scalar mu_c = 2.0;
+    const Scalar cdist1 = 0.75;
+    const Scalar inv_qc_relvar = 2.0;
+    const Scalar exponent = 0.65;
+    const Scalar seed_mass = -123.0;
+    const Scalar seed_number = -456.0;
+    const Scalar t_cold = C::T_rainfrz.value - 5.0;
+    const Scalar t_threshold = C::T_rainfrz.value;
+    const Scalar t_warm = C::T_rainfrz.value + 1.0;
+    const Scalar qc_small = 0.9 * C::QSMALL;
+    const Scalar qc_edge = C::QSMALL;
+    const Scalar qc_active = 2.0 * C::QSMALL;
+
+    const auto below_qsmall = run_case(t_cold, lamc, mu_c, cdist1, qc_small,
+                                       inv_qc_relvar, exponent, true,
+                                       seed_mass, seed_number);
+    require_preserved(below_qsmall.mass, seed_mass);
+    require_preserved(below_qsmall.number, seed_number);
+
+    const auto at_qsmall = run_case(t_cold, lamc, mu_c, cdist1, qc_edge,
+                                    inv_qc_relvar, exponent, true,
+                                    seed_mass, seed_number);
+    require_positive_finite(at_qsmall);
+
+    const auto active = run_case(t_cold, lamc, mu_c, cdist1, qc_active,
+                                 inv_qc_relvar, exponent, true,
+                                 seed_mass, seed_number);
+    require_positive_finite(active);
+
+    const auto at_freezing = run_case(t_threshold, lamc, mu_c, cdist1, qc_active,
+                                      inv_qc_relvar, exponent, true,
+                                      seed_mass, seed_number);
+    require_positive_finite(at_freezing);
+
+    const auto warm = run_case(t_warm, lamc, mu_c, cdist1, qc_active,
+                               inv_qc_relvar, exponent, true,
+                               seed_mass, seed_number);
+    require_preserved(warm.mass, seed_mass);
+    require_preserved(warm.number, seed_number);
+
+    const auto masked = run_case(t_cold, lamc, mu_c, cdist1, qc_active,
+                                 inv_qc_relvar, exponent, false,
+                                 seed_mass, seed_number);
+    require_preserved(masked.mass, seed_mass);
+    require_preserved(masked.number, seed_number);
+  }
+
+  SECTION("temperature_supercooling_scaling") {
+    const Scalar lamc = 5.0;
+    const Scalar mu_c = 2.0;
+    const Scalar cdist1 = 0.75;
+    const Scalar qc_incld = 2.0 * C::QSMALL;
+    const Scalar inv_qc_relvar = 2.0;
+    const Scalar exponent = 0.65;
+    const Scalar t_warm = C::T_rainfrz.value;
+    const Scalar t_cold = C::T_rainfrz.value - 10.0;
+
+    const auto warm = run_case(t_warm, lamc, mu_c, cdist1, qc_incld,
+                               inv_qc_relvar, exponent, true);
+    const auto cold = run_case(t_cold, lamc, mu_c, cdist1, qc_incld,
+                               inv_qc_relvar, exponent, true);
+    const auto expected_ratio = std::exp(exponent * (t_warm - t_cold));
+
+    REQUIRE(cold.mass > warm.mass);
+    REQUIRE(cold.number > warm.number);
+    require_rel_close(cold.mass / warm.mass, expected_ratio);
+    require_rel_close(cold.number / warm.number, expected_ratio);
+  }
+
+  SECTION("runtime_exponent_sensitivity") {
+    const Scalar T_atm = C::T_rainfrz.value - 5.0;
+    const Scalar lamc = 5.0;
+    const Scalar mu_c = 2.0;
+    const Scalar cdist1 = 0.75;
+    const Scalar qc_incld = 2.0 * C::QSMALL;
+    const Scalar inv_qc_relvar = 2.0;
+    const Scalar a1 = 0.2;
+    const Scalar a2 = 1.1;
+
+    const auto r1 = run_case(T_atm, lamc, mu_c, cdist1, qc_incld,
+                             inv_qc_relvar, a1, true);
+    const auto r2 = run_case(T_atm, lamc, mu_c, cdist1, qc_incld,
+                             inv_qc_relvar, a2, true);
+    const auto theta = C::T_zerodegc.value - T_atm;
+    const auto expected_ratio = std::exp((a2 - a1) * theta);
+
+    REQUIRE(r2.mass > r1.mass);
+    REQUIRE(r2.number > r1.number);
+    require_rel_close(r2.mass / r1.mass, expected_ratio);
+    require_rel_close(r2.number / r1.number, expected_ratio);
+
+    const auto z1 = run_case(C::T_rainfrz.value, lamc, mu_c, cdist1, qc_incld,
+                             inv_qc_relvar, 0.0, true);
+    const auto z2 = run_case(C::T_rainfrz.value - 10.0, lamc, mu_c, cdist1,
+                             qc_incld, inv_qc_relvar, 0.0, true);
+    REQUIRE(z1.mass == z2.mass);
+    REQUIRE(z1.number == z2.number);
+  }
+
+  SECTION("lambda_power_law_scaling") {
+    const Scalar T_atm = C::T_rainfrz.value - 5.0;
+    const Scalar mu_c = 2.0;
+    const Scalar cdist1 = 0.75;
+    const Scalar qc_incld = 2.0 * C::QSMALL;
+    const Scalar inv_qc_relvar = 2.0;
+    const Scalar exponent = 0.65;
+    const Scalar lam1 = 2.5;
+    const Scalar lam2 = 5.0;
+
+    const auto r1 = run_case(T_atm, lam1, mu_c, cdist1, qc_incld,
+                             inv_qc_relvar, exponent, true);
+    const auto r2 = run_case(T_atm, lam2, mu_c, cdist1, qc_incld,
+                             inv_qc_relvar, exponent, true);
+
+    require_rel_close(r2.mass / r1.mass, std::pow(lam1 / lam2, 6));
+    require_rel_close(r2.number / r1.number, std::pow(lam1 / lam2, 3));
+  }
+
+  SECTION("mass_number_moment_identity") {
+    constexpr std::array<Scalar, 3> mus = {0.0, 2.0, 5.0};
+    constexpr std::array<Scalar, 3> lams = {2.0, 5.0, 10.0};
+    const Scalar T_atm = C::T_rainfrz.value - 5.0;
+    const Scalar cdist1 = 0.75;
+    const Scalar qc_incld = 2.0 * C::QSMALL;
+    const Scalar inv_qc_relvar = 2.0;
+    const Scalar exponent = 0.65;
+
+    for (const auto mu : mus) {
+      for (const auto lam : lams) {
+        const auto result = run_case(T_atm, lam, mu, cdist1, qc_incld,
+                                     inv_qc_relvar, exponent, true);
+        require_positive_finite(result);
+        require_rel_close(result.mass / result.number,
+                          expected_mass_number_ratio(mu, lam));
+      }
+    }
+  }
+
+  SECTION("distribution_prefactor_scaling") {
+    const Scalar T_atm = C::T_rainfrz.value - 5.0;
+    const Scalar lamc = 5.0;
+    const Scalar mu_c = 2.0;
+    const Scalar qc_incld = 2.0 * C::QSMALL;
+    const Scalar inv_qc_relvar = 2.0;
+    const Scalar exponent = 0.65;
+    const Scalar c1 = 0.25;
+    const Scalar c2 = 1.25;
+
+    const auto r1 = run_case(T_atm, lamc, mu_c, c1, qc_incld,
+                             inv_qc_relvar, exponent, true);
+    const auto r2 = run_case(T_atm, lamc, mu_c, c2, qc_incld,
+                             inv_qc_relvar, exponent, true);
+
+    require_rel_close(r2.mass / r1.mass, c2 / c1);
+    require_rel_close(r2.number / r1.number, c2 / c1);
+  }
+
+  SECTION("scalar_multiplier_cancellation_in_mass_number_ratio") {
+    const Scalar T_base = C::T_rainfrz.value - 5.0;
+    const Scalar T_cold = C::T_rainfrz.value - 10.0;
+    const Scalar lamc = 5.0;
+    const Scalar mu_c = 2.0;
+    const Scalar qc_incld = 2.0 * C::QSMALL;
+    const Scalar inv_qc_relvar = 2.0;
+    const Scalar c_base = 0.5;
+    const Scalar c_bigger = 1.4;
+    const Scalar a_base = 0.65;
+    const Scalar a_bigger = 1.1;
+
+    const auto base = run_case(T_base, lamc, mu_c, c_base, qc_incld,
+                               inv_qc_relvar, a_base, true);
+    const auto colder = run_case(T_cold, lamc, mu_c, c_base, qc_incld,
+                                 inv_qc_relvar, a_base, true);
+    const auto bigger_a = run_case(T_base, lamc, mu_c, c_base, qc_incld,
+                                   inv_qc_relvar, a_bigger, true);
+    const auto bigger_c = run_case(T_base, lamc, mu_c, c_bigger, qc_incld,
+                                   inv_qc_relvar, a_base, true);
+    const auto base_ratio = base.mass / base.number;
+
+    require_rel_close(colder.mass / colder.number, base_ratio);
+    require_rel_close(bigger_a.mass / bigger_a.number, base_ratio);
+    require_rel_close(bigger_c.mass / bigger_c.number, base_ratio);
+  }
+
+  SECTION("qc_gate_only_behavior") {
+    const Scalar T_atm = C::T_rainfrz.value - 5.0;
+    const Scalar lamc = 5.0;
+    const Scalar mu_c = 2.0;
+    const Scalar cdist1 = 0.75;
+    const Scalar inv_qc_relvar = 2.0;
+    const Scalar exponent = 0.65;
+    const Scalar qc1 = C::QSMALL;
+    const Scalar qc2 = 10.0 * C::QSMALL;
+
+    const auto r1 = run_case(T_atm, lamc, mu_c, cdist1, qc1,
+                             inv_qc_relvar, exponent, true);
+    const auto r2 = run_case(T_atm, lamc, mu_c, cdist1, qc2,
+                             inv_qc_relvar, exponent, true);
+
+    REQUIRE(r1.mass == r2.mass);
+    REQUIRE(r1.number == r2.number);
+  }
+
+  SECTION("inv_qc_relvar_currently_inactive") {
+    const Scalar T_atm = C::T_rainfrz.value - 5.0;
+    const Scalar lamc = 5.0;
+    const Scalar mu_c = 2.0;
+    const Scalar cdist1 = 0.75;
+    const Scalar qc_incld = 2.0 * C::QSMALL;
+    const Scalar exponent = 0.65;
+
+    const auto low_r = run_case(T_atm, lamc, mu_c, cdist1, qc_incld,
+                                0.5, exponent, true);
+    const auto high_r = run_case(T_atm, lamc, mu_c, cdist1, qc_incld,
+                                 10.0, exponent, true);
+
+    REQUIRE(low_r.mass == high_r.mass);
+    REQUIRE(low_r.number == high_r.number);
+  }
+
+  SECTION("context_mask_preserves_inactive_lanes") {
+    auto lanes = make_lanes();
+    const Scalar exponent = 0.65;
+    for (Int s = 0; s < max_pack_size; ++s) {
+      lanes[s].context = false;
+      lanes[s].mass_in = -1000.0 - s;
+      lanes[s].number_in = -2000.0 - s;
+    }
+
+    lanes[0].context = true;
+    lanes[1].context = true;
+    lanes[2].context = true;
+    lanes[2].T_atm = C::T_rainfrz.value + 1.0;
+    lanes[3].context = true;
+    lanes[3].qc_incld = 0.9 * C::QSMALL;
+    lanes[4].T_atm = C::T_rainfrz.value - 5.0;
+    lanes[4].qc_incld = 5.0 * C::QSMALL;
+    lanes[5].context = true;
+    lanes[7].context = true;
+    lanes[7].T_atm = C::T_rainfrz.value;
+
+    run_kernel(lanes, exponent);
+
+    for (Int s = 0; s < max_pack_size; ++s) {
+      const bool active = lanes[s].context
+        && lanes[s].qc_incld >= C::QSMALL
+        && lanes[s].T_atm <= C::T_rainfrz.value;
+      INFO("lane=" << s << " active=" << active
+           << " mass_out=" << lanes[s].mass_out
+           << " number_out=" << lanes[s].number_out);
+      if (active) {
+        REQUIRE(std::isfinite(lanes[s].mass_out));
+        REQUIRE(std::isfinite(lanes[s].number_out));
+        REQUIRE(lanes[s].mass_out > 0);
+        REQUIRE(lanes[s].number_out > 0);
+      } else {
+        REQUIRE(lanes[s].mass_out == lanes[s].mass_in);
+        REQUIRE(lanes[s].number_out == lanes[s].number_in);
+      }
+    }
+  }
+
+  SECTION("finite_nonnegative_outputs") {
+    constexpr std::array<Scalar, 3> mus = {0.0, 2.0, 5.0};
+    constexpr std::array<Scalar, 3> lams = {2.0, 5.0, 10.0};
+    const Scalar exponent = 0.65;
+    const Scalar cdist1 = 0.75;
+    const Scalar qc_incld = 2.0 * C::QSMALL;
+    const Scalar inv_qc_relvar = 2.0;
+    const Scalar T_atm = C::T_rainfrz.value - 5.0;
+
+    for (Int i = 0; i < static_cast<Int>(mus.size()); ++i) {
+      const auto result = run_case(T_atm, lams[i], mus[i], cdist1, qc_incld,
+                                   inv_qc_relvar, exponent, true);
+      INFO("mass=" << result.mass << " number=" << result.number);
+      REQUIRE(std::isfinite(result.mass));
+      REQUIRE(std::isfinite(result.number));
+      REQUIRE(result.mass >= 0);
+      REQUIRE(result.number >= 0);
+      REQUIRE(result.mass > 0);
+      REQUIRE(result.number > 0);
+    }
+  }
 }
 
 void run_bfb()
 {
-  // This is the threshold for whether the qc and qr cloud mixing ratios are
-  // large enough to affect the warm-phase process rates qc2qr_accret_tend and nc_accret_tend.
+  // Cloud-liquid immersion freezing is active only when cloud liquid is
+  // present above QSMALL and the temperature is at or below the
+  // rain-freezing threshold.
   constexpr Scalar qsmall = C::QSMALL;
 
   constexpr Scalar t_freezing = 0.9 * C::T_rainfrz.value,
@@ -40,25 +493,25 @@ void run_bfb()
 
   CldliqImmersionFreezingData cldliq_imm_freezing_data[max_pack_size] = {
     // T_atm, lamc, mu_c, cdist1, qc_incld, inv_qc_relvar
-    {t_not_freezing, lamc1, mu_c1, cdist11, qc_incld_small,inv_qc_relvar_val},
-    {t_not_freezing, lamc2, mu_c2, cdist12, qc_incld_small,inv_qc_relvar_val},
-    {t_not_freezing, lamc3, mu_c3, cdist13, qc_incld_small,inv_qc_relvar_val},
-    {t_not_freezing, lamc4, mu_c4, cdist14, qc_incld_small,inv_qc_relvar_val},
+    {t_not_freezing, lamc1, mu_c1, cdist11, qc_incld_small, inv_qc_relvar_val},
+    {t_not_freezing, lamc2, mu_c2, cdist12, qc_incld_small, inv_qc_relvar_val},
+    {t_not_freezing, lamc3, mu_c3, cdist13, qc_incld_small, inv_qc_relvar_val},
+    {t_not_freezing, lamc4, mu_c4, cdist14, qc_incld_small, inv_qc_relvar_val},
 
-    {t_not_freezing, lamc1, mu_c1, cdist11, qc_incld_not_small,inv_qc_relvar_val},
-    {t_not_freezing, lamc2, mu_c2, cdist12, qc_incld_not_small,inv_qc_relvar_val},
-    {t_not_freezing, lamc3, mu_c3, cdist13, qc_incld_not_small,inv_qc_relvar_val},
-    {t_not_freezing, lamc4, mu_c4, cdist14, qc_incld_not_small,inv_qc_relvar_val},
+    {t_not_freezing, lamc1, mu_c1, cdist11, qc_incld_not_small, inv_qc_relvar_val},
+    {t_not_freezing, lamc2, mu_c2, cdist12, qc_incld_not_small, inv_qc_relvar_val},
+    {t_not_freezing, lamc3, mu_c3, cdist13, qc_incld_not_small, inv_qc_relvar_val},
+    {t_not_freezing, lamc4, mu_c4, cdist14, qc_incld_not_small, inv_qc_relvar_val},
 
-    {t_freezing, lamc1, mu_c1, cdist11, qc_incld_small,inv_qc_relvar_val},
-    {t_freezing, lamc2, mu_c2, cdist12, qc_incld_small,inv_qc_relvar_val},
-    {t_freezing, lamc3, mu_c3, cdist13, qc_incld_small,inv_qc_relvar_val},
-    {t_freezing, lamc4, mu_c4, cdist14, qc_incld_small,inv_qc_relvar_val},
+    {t_freezing, lamc1, mu_c1, cdist11, qc_incld_small, inv_qc_relvar_val},
+    {t_freezing, lamc2, mu_c2, cdist12, qc_incld_small, inv_qc_relvar_val},
+    {t_freezing, lamc3, mu_c3, cdist13, qc_incld_small, inv_qc_relvar_val},
+    {t_freezing, lamc4, mu_c4, cdist14, qc_incld_small, inv_qc_relvar_val},
 
-    {t_freezing, lamc1, mu_c1, cdist11, qc_incld_not_small,inv_qc_relvar_val},
-    {t_freezing, lamc2, mu_c2, cdist12, qc_incld_not_small,inv_qc_relvar_val},
-    {t_freezing, lamc3, mu_c3, cdist13, qc_incld_not_small,inv_qc_relvar_val},
-    {t_freezing, lamc4, mu_c4, cdist14, qc_incld_not_small,inv_qc_relvar_val}
+    {t_freezing, lamc1, mu_c1, cdist11, qc_incld_not_small, inv_qc_relvar_val},
+    {t_freezing, lamc2, mu_c2, cdist12, qc_incld_not_small, inv_qc_relvar_val},
+    {t_freezing, lamc3, mu_c3, cdist13, qc_incld_not_small, inv_qc_relvar_val},
+    {t_freezing, lamc4, mu_c4, cdist14, qc_incld_not_small, inv_qc_relvar_val}
   };
 
   // Sync to device
@@ -87,16 +540,17 @@ void run_bfb()
       mu_c[s]         = device_data(vs).mu_c;
       cdist1[s]       = device_data(vs).cdist1;
       qc_incld[s]     = device_data(vs).qc_incld;
-      inv_qc_relvar[s]= device_data(vs).inv_qc_relvar;
+      inv_qc_relvar[s] = device_data(vs).inv_qc_relvar;
     }
 
     Pack qc2qi_hetero_freeze_tend{0.0};
     Pack nc2ni_immers_freeze_tend{0.0};
 
+    typename Functions::P3Runtime runtime_options;
     Functions::cldliq_immersion_freezing(
-        T_atm, lamc, mu_c, cdist1, qc_incld, inv_qc_relvar,
-        qc2qi_hetero_freeze_tend, nc2ni_immers_freeze_tend,
-        p3::Functions<Real,DefaultDevice>::P3Runtime());
+      T_atm, lamc, mu_c, cdist1, qc_incld, inv_qc_relvar,
+      qc2qi_hetero_freeze_tend, nc2ni_immers_freeze_tend,
+      runtime_options);
 
     // Copy results back into views
     for (Int s = 0, vs = offset; s < Pack::n; ++s, ++vs) {
@@ -135,8 +589,13 @@ TEST_CASE("p3_cldliq_immersion_freezing", "[p3_functions]")
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestCldliqImmersionFreezing;
 
   T t;
-  t.run_phys();
-  t.run_bfb();
+  SECTION("properties") {
+    t.run_phys();
+  }
+
+  SECTION("bfb") {
+    t.run_bfb();
+  }
 }
 
 } // namespace

--- a/components/eamxx/src/physics/p3/tests/p3_cldliq_imm_freezing_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_cldliq_imm_freezing_unit_tests.cpp
@@ -62,16 +62,7 @@ struct UnitWrap::UnitTest<D>::TestCldliqImmersionFreezing : public UnitWrap::Uni
          / cube_host(lamc);
   }
 
-  static Mask uniform_context(const bool value)
-  {
-    Mask context;
-    for (Int s = 0; s < Pack::n; ++s) {
-      context.set(s, value);
-    }
-    return context;
-  }
-
-  static ImmFreezeResult run_case(
+  ImmFreezeResult run_case(
     const Scalar T_atm,
     const Scalar lamc,
     const Scalar mu_c,
@@ -81,23 +72,35 @@ struct UnitWrap::UnitTest<D>::TestCldliqImmersionFreezing : public UnitWrap::Uni
     const Scalar exponent,
     const bool context_value,
     const Scalar mass_seed = 0,
-    const Scalar number_seed = 0)
+    const Scalar number_seed = 0) const
   {
-    typename Functions::P3Runtime runtime_options;
-    runtime_options.immersion_freezing_exponent = exponent;
+    auto lanes = make_lanes();
 
-    Pack T_atm_p(T_atm), lamc_p(lamc), mu_c_p(mu_c), cdist1_p(cdist1);
-    Pack qc_incld_p(qc_incld), inv_qc_relvar_p(inv_qc_relvar);
-    Pack qc2qi_hetero_freeze_tend(mass_seed);
-    Pack nc2ni_immers_freeze_tend(number_seed);
-    const auto context = uniform_context(context_value);
+    lanes[0].T_atm = T_atm;
+    lanes[0].lamc = lamc;
+    lanes[0].mu_c = mu_c;
+    lanes[0].cdist1 = cdist1;
+    lanes[0].qc_incld = qc_incld;
+    lanes[0].inv_qc_relvar = inv_qc_relvar;
+    lanes[0].context = context_value;
+    lanes[0].mass_in = mass_seed;
+    lanes[0].number_in = number_seed;
 
-    Functions::cldliq_immersion_freezing(
-      T_atm_p, lamc_p, mu_c_p, cdist1_p, qc_incld_p, inv_qc_relvar_p,
-      qc2qi_hetero_freeze_tend, nc2ni_immers_freeze_tend,
-      runtime_options, context);
+    for (Int s = 1; s < max_pack_size; ++s) {
+      lanes[s].context = false;
+      lanes[s].mass_in = Scalar(0.0);
+      lanes[s].number_in = Scalar(0.0);
+      lanes[s].T_atm = C::T_rainfrz.value - Scalar(1.0);
+      lanes[s].lamc = Scalar(5.0);
+      lanes[s].mu_c = Scalar(2.0);
+      lanes[s].cdist1 = Scalar(1.0);
+      lanes[s].qc_incld = Scalar(2.0) * C::QSMALL;
+      lanes[s].inv_qc_relvar = Scalar(2.0);
+    }
 
-    return {qc2qi_hetero_freeze_tend[0], nc2ni_immers_freeze_tend[0]};
+    run_kernel(lanes, exponent);
+
+    return {lanes[0].mass_out, lanes[0].number_out};
   }
 
   std::array<ImmFreezeLane, max_pack_size> make_lanes() const
@@ -122,10 +125,14 @@ struct UnitWrap::UnitTest<D>::TestCldliqImmersionFreezing : public UnitWrap::Uni
   void run_kernel(std::array<ImmFreezeLane, max_pack_size>& lanes,
                   const Scalar exponent) const
   {
-    typename Functions::P3Runtime runtime_options;
-    runtime_options.immersion_freezing_exponent = exponent;
+    using KTH = KokkosTypes<HostDevice>;
 
-    for (Int i = 0; i < num_test_itrs; ++i) {
+    KTH::view_1d<ImmFreezeLane> lanes_host("lanes_host", max_pack_size);
+    view_1d<ImmFreezeLane> lanes_device("lanes_device", max_pack_size);
+    std::copy(lanes.begin(), lanes.end(), lanes_host.data());
+    Kokkos::deep_copy(lanes_device, lanes_host);
+
+    Kokkos::parallel_for(num_test_itrs, KOKKOS_LAMBDA(const Int& i) {
       const Int offset = i * Pack::n;
       Pack T_atm, lamc, mu_c, cdist1, qc_incld, inv_qc_relvar;
       Pack qc2qi_hetero_freeze_tend, nc2ni_immers_freeze_tend;
@@ -133,16 +140,19 @@ struct UnitWrap::UnitTest<D>::TestCldliqImmersionFreezing : public UnitWrap::Uni
 
       for (Int s = 0; s < Pack::n; ++s) {
         const Int vs = offset + s;
-        T_atm[s] = lanes[vs].T_atm;
-        lamc[s] = lanes[vs].lamc;
-        mu_c[s] = lanes[vs].mu_c;
-        cdist1[s] = lanes[vs].cdist1;
-        qc_incld[s] = lanes[vs].qc_incld;
-        inv_qc_relvar[s] = lanes[vs].inv_qc_relvar;
-        qc2qi_hetero_freeze_tend[s] = lanes[vs].mass_in;
-        nc2ni_immers_freeze_tend[s] = lanes[vs].number_in;
-        context.set(s, lanes[vs].context);
+        T_atm[s] = lanes_device(vs).T_atm;
+        lamc[s] = lanes_device(vs).lamc;
+        mu_c[s] = lanes_device(vs).mu_c;
+        cdist1[s] = lanes_device(vs).cdist1;
+        qc_incld[s] = lanes_device(vs).qc_incld;
+        inv_qc_relvar[s] = lanes_device(vs).inv_qc_relvar;
+        qc2qi_hetero_freeze_tend[s] = lanes_device(vs).mass_in;
+        nc2ni_immers_freeze_tend[s] = lanes_device(vs).number_in;
+        context.set(s, lanes_device(vs).context);
       }
+
+      typename Functions::P3Runtime runtime_options;
+      runtime_options.immersion_freezing_exponent = exponent;
 
       Functions::cldliq_immersion_freezing(
         T_atm, lamc, mu_c, cdist1, qc_incld, inv_qc_relvar,
@@ -151,10 +161,13 @@ struct UnitWrap::UnitTest<D>::TestCldliqImmersionFreezing : public UnitWrap::Uni
 
       for (Int s = 0; s < Pack::n; ++s) {
         const Int vs = offset + s;
-        lanes[vs].mass_out = qc2qi_hetero_freeze_tend[s];
-        lanes[vs].number_out = nc2ni_immers_freeze_tend[s];
+        lanes_device(vs).mass_out = qc2qi_hetero_freeze_tend[s];
+        lanes_device(vs).number_out = nc2ni_immers_freeze_tend[s];
       }
-    }
+    });
+
+    Kokkos::deep_copy(lanes_host, lanes_device);
+    std::copy(lanes_host.data(), lanes_host.data() + max_pack_size, lanes.begin());
   }
 
   // For active lanes, cloud-liquid immersion freezing computes two moments of

--- a/components/eamxx/src/physics/p3/tests/p3_cldliq_imm_freezing_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_cldliq_imm_freezing_unit_tests.cpp
@@ -23,7 +23,9 @@ struct UnitWrap::UnitTest<D>::TestCldliqImmersionFreezing : public UnitWrap::Uni
   static constexpr Scalar zero_tol = 1e-30;
 
   static_assert(max_pack_size >= 8,
-                "This test assumes at least 8 pack lanes.");
+                "This test assumes at least 8 scenario slots.");
+  static_assert(max_pack_size % Pack::n == 0,
+                "max_pack_size must be divisible by Pack::n.");
 
   struct ImmFreezeResult {
     Scalar mass;
@@ -167,354 +169,355 @@ struct UnitWrap::UnitTest<D>::TestCldliqImmersionFreezing : public UnitWrap::Uni
   //         * (mu_c + 4)(mu_c + 5)(mu_c + 6) / lamc^3.
   void run_phys()
   {
-  const auto require_rel_close = [&](const Scalar got, const Scalar expected,
-                                     const Scalar rtol = identity_tol,
-                                     const Scalar atol = zero_tol) {
-    INFO("got=" << got << " expected=" << expected
-         << " rtol=" << rtol << " atol=" << atol);
-    REQUIRE(rel_close(got, expected, rtol, atol));
-  };
+    const auto require_rel_close = [&](const Scalar got, const Scalar expected,
+                                       const Scalar rtol = identity_tol,
+                                       const Scalar atol = zero_tol) {
+      INFO("got=" << got << " expected=" << expected
+           << " rtol=" << rtol << " atol=" << atol);
+      REQUIRE(rel_close(got, expected, rtol, atol));
+    };
 
-  const auto require_preserved = [&](const Scalar got, const Scalar expected) {
-    INFO("got=" << got << " expected=" << expected);
-    REQUIRE(got == expected);
-  };
+    const auto require_preserved = [&](const Scalar got, const Scalar expected) {
+      INFO("got=" << got << " expected=" << expected);
+      REQUIRE(got == expected);
+    };
 
-  const auto require_positive_finite = [&](const ImmFreezeResult& result) {
-    INFO("mass=" << result.mass << " number=" << result.number);
-    REQUIRE(std::isfinite(result.mass));
-    REQUIRE(std::isfinite(result.number));
-    REQUIRE(result.mass > 0);
-    REQUIRE(result.number > 0);
-  };
-
-  SECTION("activation_and_thresholds") {
-    const Scalar lamc = 5.0;
-    const Scalar mu_c = 2.0;
-    const Scalar cdist1 = 0.75;
-    const Scalar inv_qc_relvar = 2.0;
-    const Scalar exponent = 0.65;
-    const Scalar seed_mass = -123.0;
-    const Scalar seed_number = -456.0;
-    const Scalar t_cold = C::T_rainfrz.value - 5.0;
-    const Scalar t_threshold = C::T_rainfrz.value;
-    const Scalar t_warm = C::T_rainfrz.value + 1.0;
-    const Scalar qc_small = 0.9 * C::QSMALL;
-    const Scalar qc_edge = C::QSMALL;
-    const Scalar qc_active = 2.0 * C::QSMALL;
-
-    const auto below_qsmall = run_case(t_cold, lamc, mu_c, cdist1, qc_small,
-                                       inv_qc_relvar, exponent, true,
-                                       seed_mass, seed_number);
-    require_preserved(below_qsmall.mass, seed_mass);
-    require_preserved(below_qsmall.number, seed_number);
-
-    const auto at_qsmall = run_case(t_cold, lamc, mu_c, cdist1, qc_edge,
-                                    inv_qc_relvar, exponent, true,
-                                    seed_mass, seed_number);
-    require_positive_finite(at_qsmall);
-
-    const auto active = run_case(t_cold, lamc, mu_c, cdist1, qc_active,
-                                 inv_qc_relvar, exponent, true,
-                                 seed_mass, seed_number);
-    require_positive_finite(active);
-
-    const auto at_freezing = run_case(t_threshold, lamc, mu_c, cdist1, qc_active,
-                                      inv_qc_relvar, exponent, true,
-                                      seed_mass, seed_number);
-    require_positive_finite(at_freezing);
-
-    const auto warm = run_case(t_warm, lamc, mu_c, cdist1, qc_active,
-                               inv_qc_relvar, exponent, true,
-                               seed_mass, seed_number);
-    require_preserved(warm.mass, seed_mass);
-    require_preserved(warm.number, seed_number);
-
-    const auto masked = run_case(t_cold, lamc, mu_c, cdist1, qc_active,
-                                 inv_qc_relvar, exponent, false,
-                                 seed_mass, seed_number);
-    require_preserved(masked.mass, seed_mass);
-    require_preserved(masked.number, seed_number);
-  }
-
-  SECTION("temperature_supercooling_scaling") {
-    const Scalar lamc = 5.0;
-    const Scalar mu_c = 2.0;
-    const Scalar cdist1 = 0.75;
-    const Scalar qc_incld = 2.0 * C::QSMALL;
-    const Scalar inv_qc_relvar = 2.0;
-    const Scalar exponent = 0.65;
-    const Scalar t_warm = C::T_rainfrz.value;
-    const Scalar t_cold = C::T_rainfrz.value - 10.0;
-
-    const auto warm = run_case(t_warm, lamc, mu_c, cdist1, qc_incld,
-                               inv_qc_relvar, exponent, true);
-    const auto cold = run_case(t_cold, lamc, mu_c, cdist1, qc_incld,
-                               inv_qc_relvar, exponent, true);
-    const auto expected_ratio = std::exp(exponent * (t_warm - t_cold));
-
-    REQUIRE(cold.mass > warm.mass);
-    REQUIRE(cold.number > warm.number);
-    require_rel_close(cold.mass / warm.mass, expected_ratio);
-    require_rel_close(cold.number / warm.number, expected_ratio);
-  }
-
-  SECTION("runtime_exponent_sensitivity") {
-    const Scalar T_atm = C::T_rainfrz.value - 5.0;
-    const Scalar lamc = 5.0;
-    const Scalar mu_c = 2.0;
-    const Scalar cdist1 = 0.75;
-    const Scalar qc_incld = 2.0 * C::QSMALL;
-    const Scalar inv_qc_relvar = 2.0;
-    const Scalar a1 = 0.2;
-    const Scalar a2 = 1.1;
-
-    const auto r1 = run_case(T_atm, lamc, mu_c, cdist1, qc_incld,
-                             inv_qc_relvar, a1, true);
-    const auto r2 = run_case(T_atm, lamc, mu_c, cdist1, qc_incld,
-                             inv_qc_relvar, a2, true);
-    const auto theta = C::T_zerodegc.value - T_atm;
-    const auto expected_ratio = std::exp((a2 - a1) * theta);
-
-    REQUIRE(r2.mass > r1.mass);
-    REQUIRE(r2.number > r1.number);
-    require_rel_close(r2.mass / r1.mass, expected_ratio);
-    require_rel_close(r2.number / r1.number, expected_ratio);
-
-    const auto z1 = run_case(C::T_rainfrz.value, lamc, mu_c, cdist1, qc_incld,
-                             inv_qc_relvar, 0.0, true);
-    const auto z2 = run_case(C::T_rainfrz.value - 10.0, lamc, mu_c, cdist1,
-                             qc_incld, inv_qc_relvar, 0.0, true);
-    REQUIRE(z1.mass == z2.mass);
-    REQUIRE(z1.number == z2.number);
-  }
-
-  SECTION("lambda_power_law_scaling") {
-    const Scalar T_atm = C::T_rainfrz.value - 5.0;
-    const Scalar mu_c = 2.0;
-    const Scalar cdist1 = 0.75;
-    const Scalar qc_incld = 2.0 * C::QSMALL;
-    const Scalar inv_qc_relvar = 2.0;
-    const Scalar exponent = 0.65;
-    const Scalar lam1 = 2.5;
-    const Scalar lam2 = 5.0;
-
-    const auto r1 = run_case(T_atm, lam1, mu_c, cdist1, qc_incld,
-                             inv_qc_relvar, exponent, true);
-    const auto r2 = run_case(T_atm, lam2, mu_c, cdist1, qc_incld,
-                             inv_qc_relvar, exponent, true);
-
-    require_rel_close(r2.mass / r1.mass, std::pow(lam1 / lam2, 6));
-    require_rel_close(r2.number / r1.number, std::pow(lam1 / lam2, 3));
-  }
-
-  SECTION("mass_number_moment_identity") {
-    constexpr std::array<Scalar, 3> mus = {0.0, 2.0, 5.0};
-    constexpr std::array<Scalar, 3> lams = {2.0, 5.0, 10.0};
-    const Scalar T_atm = C::T_rainfrz.value - 5.0;
-    const Scalar cdist1 = 0.75;
-    const Scalar qc_incld = 2.0 * C::QSMALL;
-    const Scalar inv_qc_relvar = 2.0;
-    const Scalar exponent = 0.65;
-
-    for (const auto mu : mus) {
-      for (const auto lam : lams) {
-        const auto result = run_case(T_atm, lam, mu, cdist1, qc_incld,
-                                     inv_qc_relvar, exponent, true);
-        require_positive_finite(result);
-        require_rel_close(result.mass / result.number,
-                          expected_mass_number_ratio(mu, lam));
-      }
-    }
-  }
-
-  SECTION("frozen_droplet_size_bias") {
-    constexpr std::array<Scalar, 3> mus = {0.0, 2.0, 5.0};
-    constexpr std::array<Scalar, 3> lams = {2.0, 5.0, 10.0};
-    const Scalar T_atm = C::T_rainfrz.value - 5.0;
-    const Scalar cdist1 = 0.75;
-    const Scalar qc_incld = 2.0 * C::QSMALL;
-    const Scalar inv_qc_relvar = 2.0;
-    const Scalar exponent = 0.65;
-
-    for (const auto mu : mus) {
-      for (const auto lam : lams) {
-        const auto result = run_case(T_atm, lam, mu, cdist1, qc_incld,
-                                     inv_qc_relvar, exponent, true);
-        const Scalar d_eff_cubed =
-          (result.mass / result.number) / (C::CONS6 / C::CONS5);
-        const Scalar d_mean = (mu + 4) / lam;
-        const Scalar expected_ratio =
-          ((mu + 5) * (mu + 6)) / ((mu + 4) * (mu + 4));
-
-        REQUIRE(d_eff_cubed > cube_host(d_mean));
-        require_rel_close(d_eff_cubed / cube_host(d_mean), expected_ratio);
-      }
-    }
-  }
-
-  SECTION("distribution_prefactor_scaling") {
-    const Scalar T_atm = C::T_rainfrz.value - 5.0;
-    const Scalar lamc = 5.0;
-    const Scalar mu_c = 2.0;
-    const Scalar qc_incld = 2.0 * C::QSMALL;
-    const Scalar inv_qc_relvar = 2.0;
-    const Scalar exponent = 0.65;
-    const Scalar c1 = 0.25;
-    const Scalar c2 = 1.25;
-
-    const auto r1 = run_case(T_atm, lamc, mu_c, c1, qc_incld,
-                             inv_qc_relvar, exponent, true);
-    const auto r2 = run_case(T_atm, lamc, mu_c, c2, qc_incld,
-                             inv_qc_relvar, exponent, true);
-
-    require_rel_close(r2.mass / r1.mass, c2 / c1);
-    require_rel_close(r2.number / r1.number, c2 / c1);
-  }
-
-  SECTION("zero_distribution_prefactor_gives_zero") {
-    const Scalar T_atm = C::T_rainfrz.value - 5.0;
-    const Scalar lamc = 5.0;
-    const Scalar mu_c = 2.0;
-    const Scalar cdist1 = 0.0;
-    const Scalar qc_incld = 2.0 * C::QSMALL;
-    const Scalar inv_qc_relvar = 2.0;
-    const Scalar exponent = 0.65;
-
-    const auto result = run_case(T_atm, lamc, mu_c, cdist1, qc_incld,
-                                 inv_qc_relvar, exponent, true,
-                                 -123.0, -456.0);
-
-    REQUIRE(result.mass == 0);
-    REQUIRE(result.number == 0);
-  }
-
-  SECTION("scalar_multiplier_cancellation_in_mass_number_ratio") {
-    const Scalar T_base = C::T_rainfrz.value - 5.0;
-    const Scalar T_cold = C::T_rainfrz.value - 10.0;
-    const Scalar lamc = 5.0;
-    const Scalar mu_c = 2.0;
-    const Scalar qc_incld = 2.0 * C::QSMALL;
-    const Scalar inv_qc_relvar = 2.0;
-    const Scalar c_base = 0.5;
-    const Scalar c_bigger = 1.4;
-    const Scalar a_base = 0.65;
-    const Scalar a_bigger = 1.1;
-
-    const auto base = run_case(T_base, lamc, mu_c, c_base, qc_incld,
-                               inv_qc_relvar, a_base, true);
-    const auto colder = run_case(T_cold, lamc, mu_c, c_base, qc_incld,
-                                 inv_qc_relvar, a_base, true);
-    const auto bigger_a = run_case(T_base, lamc, mu_c, c_base, qc_incld,
-                                   inv_qc_relvar, a_bigger, true);
-    const auto bigger_c = run_case(T_base, lamc, mu_c, c_bigger, qc_incld,
-                                   inv_qc_relvar, a_base, true);
-    const auto base_ratio = base.mass / base.number;
-
-    require_rel_close(colder.mass / colder.number, base_ratio);
-    require_rel_close(bigger_a.mass / bigger_a.number, base_ratio);
-    require_rel_close(bigger_c.mass / bigger_c.number, base_ratio);
-  }
-
-  SECTION("qc_gate_only_behavior") {
-    const Scalar T_atm = C::T_rainfrz.value - 5.0;
-    const Scalar lamc = 5.0;
-    const Scalar mu_c = 2.0;
-    const Scalar cdist1 = 0.75;
-    const Scalar inv_qc_relvar = 2.0;
-    const Scalar exponent = 0.65;
-    const Scalar qc1 = C::QSMALL;
-    const Scalar qc2 = 10.0 * C::QSMALL;
-
-    const auto r1 = run_case(T_atm, lamc, mu_c, cdist1, qc1,
-                             inv_qc_relvar, exponent, true);
-    const auto r2 = run_case(T_atm, lamc, mu_c, cdist1, qc2,
-                             inv_qc_relvar, exponent, true);
-
-    REQUIRE(r1.mass == r2.mass);
-    REQUIRE(r1.number == r2.number);
-  }
-
-  SECTION("inv_qc_relvar_currently_inactive") {
-    const Scalar T_atm = C::T_rainfrz.value - 5.0;
-    const Scalar lamc = 5.0;
-    const Scalar mu_c = 2.0;
-    const Scalar cdist1 = 0.75;
-    const Scalar qc_incld = 2.0 * C::QSMALL;
-    const Scalar exponent = 0.65;
-
-    const auto low_r = run_case(T_atm, lamc, mu_c, cdist1, qc_incld,
-                                0.5, exponent, true);
-    const auto high_r = run_case(T_atm, lamc, mu_c, cdist1, qc_incld,
-                                 10.0, exponent, true);
-
-    REQUIRE(low_r.mass == high_r.mass);
-    REQUIRE(low_r.number == high_r.number);
-  }
-
-  SECTION("context_mask_preserves_inactive_lanes") {
-    auto lanes = make_lanes();
-    const Scalar exponent = 0.65;
-    for (Int s = 0; s < max_pack_size; ++s) {
-      lanes[s].context = false;
-      lanes[s].mass_in = -1000.0 - s;
-      lanes[s].number_in = -2000.0 - s;
-    }
-
-    lanes[0].context = true;
-    lanes[1].context = true;
-    lanes[2].context = true;
-    lanes[2].T_atm = C::T_rainfrz.value + 1.0;
-    lanes[3].context = true;
-    lanes[3].qc_incld = 0.9 * C::QSMALL;
-    lanes[4].T_atm = C::T_rainfrz.value - 5.0;
-    lanes[4].qc_incld = 5.0 * C::QSMALL;
-    lanes[5].context = true;
-    lanes[7].context = true;
-    lanes[7].T_atm = C::T_rainfrz.value;
-
-    run_kernel(lanes, exponent);
-
-    for (Int s = 0; s < max_pack_size; ++s) {
-      const bool active = lanes[s].context
-        && lanes[s].qc_incld >= C::QSMALL
-        && lanes[s].T_atm <= C::T_rainfrz.value;
-      INFO("lane=" << s << " active=" << active
-           << " mass_out=" << lanes[s].mass_out
-           << " number_out=" << lanes[s].number_out);
-      if (active) {
-        REQUIRE(std::isfinite(lanes[s].mass_out));
-        REQUIRE(std::isfinite(lanes[s].number_out));
-        REQUIRE(lanes[s].mass_out > 0);
-        REQUIRE(lanes[s].number_out > 0);
-      } else {
-        REQUIRE(lanes[s].mass_out == lanes[s].mass_in);
-        REQUIRE(lanes[s].number_out == lanes[s].number_in);
-      }
-    }
-  }
-
-  SECTION("finite_nonnegative_outputs") {
-    constexpr std::array<Scalar, 3> mus = {0.0, 2.0, 5.0};
-    constexpr std::array<Scalar, 3> lams = {2.0, 5.0, 10.0};
-    const Scalar exponent = 0.65;
-    const Scalar cdist1 = 0.75;
-    const Scalar qc_incld = 2.0 * C::QSMALL;
-    const Scalar inv_qc_relvar = 2.0;
-    const Scalar T_atm = C::T_rainfrz.value - 5.0;
-
-    for (Int i = 0; i < static_cast<Int>(mus.size()); ++i) {
-      const auto result = run_case(T_atm, lams[i], mus[i], cdist1, qc_incld,
-                                   inv_qc_relvar, exponent, true);
+    const auto require_positive_finite = [&](const ImmFreezeResult& result) {
       INFO("mass=" << result.mass << " number=" << result.number);
       REQUIRE(std::isfinite(result.mass));
       REQUIRE(std::isfinite(result.number));
-      REQUIRE(result.mass >= 0);
-      REQUIRE(result.number >= 0);
       REQUIRE(result.mass > 0);
       REQUIRE(result.number > 0);
+    };
+
+    SECTION("activation_and_thresholds") {
+      const Scalar lamc = 5.0;
+      const Scalar mu_c = 2.0;
+      const Scalar cdist1 = 0.75;
+      const Scalar inv_qc_relvar = 2.0;
+      const Scalar exponent = 0.65;
+      const Scalar seed_mass = -123.0;
+      const Scalar seed_number = -456.0;
+      const Scalar t_cold = C::T_rainfrz.value - 5.0;
+      const Scalar t_threshold = C::T_rainfrz.value;
+      const Scalar t_warm = C::T_rainfrz.value + 1.0;
+      const Scalar qc_small = 0.9 * C::QSMALL;
+      const Scalar qc_edge = C::QSMALL;
+      const Scalar qc_active = 2.0 * C::QSMALL;
+
+      const auto below_qsmall = run_case(t_cold, lamc, mu_c, cdist1, qc_small,
+                                         inv_qc_relvar, exponent, true,
+                                         seed_mass, seed_number);
+      require_preserved(below_qsmall.mass, seed_mass);
+      require_preserved(below_qsmall.number, seed_number);
+
+      const auto at_qsmall = run_case(t_cold, lamc, mu_c, cdist1, qc_edge,
+                                      inv_qc_relvar, exponent, true,
+                                      seed_mass, seed_number);
+      require_positive_finite(at_qsmall);
+
+      const auto active = run_case(t_cold, lamc, mu_c, cdist1, qc_active,
+                                   inv_qc_relvar, exponent, true,
+                                   seed_mass, seed_number);
+      require_positive_finite(active);
+
+      const auto at_freezing = run_case(t_threshold, lamc, mu_c, cdist1, qc_active,
+                                        inv_qc_relvar, exponent, true,
+                                        seed_mass, seed_number);
+      require_positive_finite(at_freezing);
+
+      const auto warm = run_case(t_warm, lamc, mu_c, cdist1, qc_active,
+                                 inv_qc_relvar, exponent, true,
+                                 seed_mass, seed_number);
+      require_preserved(warm.mass, seed_mass);
+      require_preserved(warm.number, seed_number);
+
+      const auto masked = run_case(t_cold, lamc, mu_c, cdist1, qc_active,
+                                   inv_qc_relvar, exponent, false,
+                                   seed_mass, seed_number);
+      require_preserved(masked.mass, seed_mass);
+      require_preserved(masked.number, seed_number);
     }
-  }
+
+    SECTION("temperature_supercooling_scaling") {
+      const Scalar lamc = 5.0;
+      const Scalar mu_c = 2.0;
+      const Scalar cdist1 = 0.75;
+      const Scalar qc_incld = 2.0 * C::QSMALL;
+      const Scalar inv_qc_relvar = 2.0;
+      const Scalar exponent = 0.65;
+      const Scalar t_warm = C::T_rainfrz.value;
+      const Scalar t_cold = C::T_rainfrz.value - 10.0;
+
+      const auto warm = run_case(t_warm, lamc, mu_c, cdist1, qc_incld,
+                                 inv_qc_relvar, exponent, true);
+      const auto cold = run_case(t_cold, lamc, mu_c, cdist1, qc_incld,
+                                 inv_qc_relvar, exponent, true);
+      const auto expected_ratio = std::exp(exponent * (t_warm - t_cold));
+
+      REQUIRE(cold.mass > warm.mass);
+      REQUIRE(cold.number > warm.number);
+      require_rel_close(cold.mass / warm.mass, expected_ratio);
+      require_rel_close(cold.number / warm.number, expected_ratio);
+    }
+
+    SECTION("runtime_exponent_sensitivity") {
+      const Scalar T_atm = C::T_rainfrz.value - 5.0;
+      const Scalar lamc = 5.0;
+      const Scalar mu_c = 2.0;
+      const Scalar cdist1 = 0.75;
+      const Scalar qc_incld = 2.0 * C::QSMALL;
+      const Scalar inv_qc_relvar = 2.0;
+      const Scalar a1 = 0.2;
+      const Scalar a2 = 1.1;
+
+      const auto r1 = run_case(T_atm, lamc, mu_c, cdist1, qc_incld,
+                               inv_qc_relvar, a1, true);
+      const auto r2 = run_case(T_atm, lamc, mu_c, cdist1, qc_incld,
+                               inv_qc_relvar, a2, true);
+      const auto theta = C::T_zerodegc.value - T_atm;
+      const auto expected_ratio = std::exp((a2 - a1) * theta);
+
+      REQUIRE(r2.mass > r1.mass);
+      REQUIRE(r2.number > r1.number);
+      require_rel_close(r2.mass / r1.mass, expected_ratio);
+      require_rel_close(r2.number / r1.number, expected_ratio);
+
+      const auto z1 = run_case(C::T_rainfrz.value, lamc, mu_c, cdist1, qc_incld,
+                               inv_qc_relvar, 0.0, true);
+      const auto z2 = run_case(C::T_rainfrz.value - 10.0, lamc, mu_c, cdist1,
+                               qc_incld, inv_qc_relvar, 0.0, true);
+      REQUIRE(z1.mass == z2.mass);
+      REQUIRE(z1.number == z2.number);
+    }
+
+    SECTION("lambda_power_law_scaling") {
+      const Scalar T_atm = C::T_rainfrz.value - 5.0;
+      const Scalar mu_c = 2.0;
+      const Scalar cdist1 = 0.75;
+      const Scalar qc_incld = 2.0 * C::QSMALL;
+      const Scalar inv_qc_relvar = 2.0;
+      const Scalar exponent = 0.65;
+      const Scalar lam1 = 2.5;
+      const Scalar lam2 = 5.0;
+
+      const auto r1 = run_case(T_atm, lam1, mu_c, cdist1, qc_incld,
+                               inv_qc_relvar, exponent, true);
+      const auto r2 = run_case(T_atm, lam2, mu_c, cdist1, qc_incld,
+                               inv_qc_relvar, exponent, true);
+
+      require_rel_close(r2.mass / r1.mass, std::pow(lam1 / lam2, 6));
+      require_rel_close(r2.number / r1.number, std::pow(lam1 / lam2, 3));
+    }
+
+    SECTION("mass_number_moment_identity") {
+      constexpr std::array<Scalar, 3> mus = {0.0, 2.0, 5.0};
+      constexpr std::array<Scalar, 3> lams = {2.0, 5.0, 10.0};
+      const Scalar T_atm = C::T_rainfrz.value - 5.0;
+      const Scalar cdist1 = 0.75;
+      const Scalar qc_incld = 2.0 * C::QSMALL;
+      const Scalar inv_qc_relvar = 2.0;
+      const Scalar exponent = 0.65;
+
+      for (const auto mu : mus) {
+        for (const auto lam : lams) {
+          const auto result = run_case(T_atm, lam, mu, cdist1, qc_incld,
+                                       inv_qc_relvar, exponent, true);
+          require_positive_finite(result);
+          require_rel_close(result.mass / result.number,
+                            expected_mass_number_ratio(mu, lam));
+        }
+      }
+    }
+
+    SECTION("frozen_droplet_size_bias") {
+      constexpr std::array<Scalar, 3> mus = {0.0, 2.0, 5.0};
+      constexpr std::array<Scalar, 3> lams = {2.0, 5.0, 10.0};
+      const Scalar T_atm = C::T_rainfrz.value - 5.0;
+      const Scalar cdist1 = 0.75;
+      const Scalar qc_incld = 2.0 * C::QSMALL;
+      const Scalar inv_qc_relvar = 2.0;
+      const Scalar exponent = 0.65;
+
+      for (const auto mu : mus) {
+        for (const auto lam : lams) {
+          const auto result = run_case(T_atm, lam, mu, cdist1, qc_incld,
+                                       inv_qc_relvar, exponent, true);
+          require_positive_finite(result);
+          const Scalar d_eff_cubed =
+            (result.mass / result.number) / (C::CONS6 / C::CONS5);
+          const Scalar d_mean = (mu + 4) / lam;
+          const Scalar expected_ratio =
+            ((mu + 5) * (mu + 6)) / ((mu + 4) * (mu + 4));
+
+          REQUIRE(d_eff_cubed > cube_host(d_mean));
+          require_rel_close(d_eff_cubed / cube_host(d_mean), expected_ratio);
+        }
+      }
+    }
+
+    SECTION("distribution_prefactor_scaling") {
+      const Scalar T_atm = C::T_rainfrz.value - 5.0;
+      const Scalar lamc = 5.0;
+      const Scalar mu_c = 2.0;
+      const Scalar qc_incld = 2.0 * C::QSMALL;
+      const Scalar inv_qc_relvar = 2.0;
+      const Scalar exponent = 0.65;
+      const Scalar c1 = 0.25;
+      const Scalar c2 = 1.25;
+
+      const auto r1 = run_case(T_atm, lamc, mu_c, c1, qc_incld,
+                               inv_qc_relvar, exponent, true);
+      const auto r2 = run_case(T_atm, lamc, mu_c, c2, qc_incld,
+                               inv_qc_relvar, exponent, true);
+
+      require_rel_close(r2.mass / r1.mass, c2 / c1);
+      require_rel_close(r2.number / r1.number, c2 / c1);
+    }
+
+    SECTION("zero_distribution_prefactor_gives_zero") {
+      const Scalar T_atm = C::T_rainfrz.value - 5.0;
+      const Scalar lamc = 5.0;
+      const Scalar mu_c = 2.0;
+      const Scalar cdist1 = 0.0;
+      const Scalar qc_incld = 2.0 * C::QSMALL;
+      const Scalar inv_qc_relvar = 2.0;
+      const Scalar exponent = 0.65;
+
+      const auto result = run_case(T_atm, lamc, mu_c, cdist1, qc_incld,
+                                   inv_qc_relvar, exponent, true,
+                                   -123.0, -456.0);
+
+      REQUIRE(result.mass == 0);
+      REQUIRE(result.number == 0);
+    }
+
+    SECTION("scalar_multiplier_cancellation_in_mass_number_ratio") {
+      const Scalar T_base = C::T_rainfrz.value - 5.0;
+      const Scalar T_cold = C::T_rainfrz.value - 10.0;
+      const Scalar lamc = 5.0;
+      const Scalar mu_c = 2.0;
+      const Scalar qc_incld = 2.0 * C::QSMALL;
+      const Scalar inv_qc_relvar = 2.0;
+      const Scalar c_base = 0.5;
+      const Scalar c_bigger = 1.4;
+      const Scalar a_base = 0.65;
+      const Scalar a_bigger = 1.1;
+
+      const auto base = run_case(T_base, lamc, mu_c, c_base, qc_incld,
+                                 inv_qc_relvar, a_base, true);
+      const auto colder = run_case(T_cold, lamc, mu_c, c_base, qc_incld,
+                                   inv_qc_relvar, a_base, true);
+      const auto bigger_a = run_case(T_base, lamc, mu_c, c_base, qc_incld,
+                                     inv_qc_relvar, a_bigger, true);
+      const auto bigger_c = run_case(T_base, lamc, mu_c, c_bigger, qc_incld,
+                                     inv_qc_relvar, a_base, true);
+      const auto base_ratio = base.mass / base.number;
+
+      require_rel_close(colder.mass / colder.number, base_ratio);
+      require_rel_close(bigger_a.mass / bigger_a.number, base_ratio);
+      require_rel_close(bigger_c.mass / bigger_c.number, base_ratio);
+    }
+
+    SECTION("qc_gate_only_behavior") {
+      const Scalar T_atm = C::T_rainfrz.value - 5.0;
+      const Scalar lamc = 5.0;
+      const Scalar mu_c = 2.0;
+      const Scalar cdist1 = 0.75;
+      const Scalar inv_qc_relvar = 2.0;
+      const Scalar exponent = 0.65;
+      const Scalar qc1 = C::QSMALL;
+      const Scalar qc2 = 10.0 * C::QSMALL;
+
+      const auto r1 = run_case(T_atm, lamc, mu_c, cdist1, qc1,
+                               inv_qc_relvar, exponent, true);
+      const auto r2 = run_case(T_atm, lamc, mu_c, cdist1, qc2,
+                               inv_qc_relvar, exponent, true);
+
+      REQUIRE(r1.mass == r2.mass);
+      REQUIRE(r1.number == r2.number);
+    }
+
+    SECTION("inv_qc_relvar_currently_inactive") {
+      const Scalar T_atm = C::T_rainfrz.value - 5.0;
+      const Scalar lamc = 5.0;
+      const Scalar mu_c = 2.0;
+      const Scalar cdist1 = 0.75;
+      const Scalar qc_incld = 2.0 * C::QSMALL;
+      const Scalar exponent = 0.65;
+
+      const auto low_r = run_case(T_atm, lamc, mu_c, cdist1, qc_incld,
+                                  0.5, exponent, true);
+      const auto high_r = run_case(T_atm, lamc, mu_c, cdist1, qc_incld,
+                                   10.0, exponent, true);
+
+      REQUIRE(low_r.mass == high_r.mass);
+      REQUIRE(low_r.number == high_r.number);
+    }
+
+    SECTION("context_mask_preserves_inactive_lanes") {
+      auto lanes = make_lanes();
+      const Scalar exponent = 0.65;
+      for (Int s = 0; s < max_pack_size; ++s) {
+        lanes[s].context = false;
+        lanes[s].mass_in = -1000.0 - s;
+        lanes[s].number_in = -2000.0 - s;
+      }
+
+      lanes[0].context = true;
+      lanes[1].context = true;
+      lanes[2].context = true;
+      lanes[2].T_atm = C::T_rainfrz.value + 1.0;
+      lanes[3].context = true;
+      lanes[3].qc_incld = 0.9 * C::QSMALL;
+      lanes[4].T_atm = C::T_rainfrz.value - 5.0;
+      lanes[4].qc_incld = 5.0 * C::QSMALL;
+      lanes[5].context = true;
+      lanes[7].context = true;
+      lanes[7].T_atm = C::T_rainfrz.value;
+
+      run_kernel(lanes, exponent);
+
+      for (Int s = 0; s < max_pack_size; ++s) {
+        const bool active = lanes[s].context
+          && lanes[s].qc_incld >= C::QSMALL
+          && lanes[s].T_atm <= C::T_rainfrz.value;
+        INFO("lane=" << s << " active=" << active
+             << " mass_out=" << lanes[s].mass_out
+             << " number_out=" << lanes[s].number_out);
+        if (active) {
+          REQUIRE(std::isfinite(lanes[s].mass_out));
+          REQUIRE(std::isfinite(lanes[s].number_out));
+          REQUIRE(lanes[s].mass_out > 0);
+          REQUIRE(lanes[s].number_out > 0);
+        } else {
+          REQUIRE(lanes[s].mass_out == lanes[s].mass_in);
+          REQUIRE(lanes[s].number_out == lanes[s].number_in);
+        }
+      }
+    }
+
+    SECTION("finite_nonnegative_outputs") {
+      constexpr std::array<Scalar, 3> mus = {0.0, 2.0, 5.0};
+      constexpr std::array<Scalar, 3> lams = {2.0, 5.0, 10.0};
+      const Scalar exponent = 0.65;
+      const Scalar cdist1 = 0.75;
+      const Scalar qc_incld = 2.0 * C::QSMALL;
+      const Scalar inv_qc_relvar = 2.0;
+      const Scalar T_atm = C::T_rainfrz.value - 5.0;
+
+      for (Int i = 0; i < static_cast<Int>(mus.size()); ++i) {
+        const auto result = run_case(T_atm, lams[i], mus[i], cdist1, qc_incld,
+                                     inv_qc_relvar, exponent, true);
+        INFO("mass=" << result.mass << " number=" << result.number);
+        REQUIRE(std::isfinite(result.mass));
+        REQUIRE(std::isfinite(result.number));
+        REQUIRE(result.mass >= 0);
+        REQUIRE(result.number >= 0);
+        REQUIRE(result.mass > 0);
+        REQUIRE(result.number > 0);
+      }
+    }
 }
 
 void run_bfb()

--- a/components/eamxx/src/physics/p3/tests/p3_cldliq_imm_freezing_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_cldliq_imm_freezing_unit_tests.cpp
@@ -18,9 +18,11 @@ namespace unit_test {
 template <typename D>
 struct UnitWrap::UnitTest<D>::TestCldliqImmersionFreezing : public UnitWrap::UnitTest<D>::Base {
 
+  // These identities involve exp, tgamma, and ratio formation, so use a
+  // modestly loose epsilon-scaled tolerance that remains robust in SP builds.
   static constexpr Scalar identity_tol =
     1000 * std::numeric_limits<Scalar>::epsilon();
-  static constexpr Scalar zero_tol = 1e-30;
+  static constexpr Scalar zero_tol = Scalar(1e-30);
 
   static_assert(max_pack_size >= 8,
                 "This test assumes at least 8 scenario slots.");
@@ -191,19 +193,19 @@ struct UnitWrap::UnitTest<D>::TestCldliqImmersionFreezing : public UnitWrap::Uni
     };
 
     SECTION("activation_and_thresholds") {
-      const Scalar lamc = 5.0;
-      const Scalar mu_c = 2.0;
-      const Scalar cdist1 = 0.75;
-      const Scalar inv_qc_relvar = 2.0;
-      const Scalar exponent = 0.65;
-      const Scalar seed_mass = -123.0;
-      const Scalar seed_number = -456.0;
-      const Scalar t_cold = C::T_rainfrz.value - 5.0;
+      const Scalar lamc = Scalar(5.0);
+      const Scalar mu_c = Scalar(2.0);
+      const Scalar cdist1 = Scalar(0.75);
+      const Scalar inv_qc_relvar = Scalar(2.0);
+      const Scalar exponent = Scalar(0.65);
+      const Scalar seed_mass = Scalar(-123.0);
+      const Scalar seed_number = Scalar(-456.0);
+      const Scalar t_cold = C::T_rainfrz.value - Scalar(5.0);
       const Scalar t_threshold = C::T_rainfrz.value;
-      const Scalar t_warm = C::T_rainfrz.value + 1.0;
-      const Scalar qc_small = 0.9 * C::QSMALL;
+      const Scalar t_warm = C::T_rainfrz.value + Scalar(1.0);
+      const Scalar qc_small = Scalar(0.9) * C::QSMALL;
       const Scalar qc_edge = C::QSMALL;
-      const Scalar qc_active = 2.0 * C::QSMALL;
+      const Scalar qc_active = Scalar(2.0) * C::QSMALL;
 
       const auto below_qsmall = run_case(t_cold, lamc, mu_c, cdist1, qc_small,
                                          inv_qc_relvar, exponent, true,
@@ -240,14 +242,14 @@ struct UnitWrap::UnitTest<D>::TestCldliqImmersionFreezing : public UnitWrap::Uni
     }
 
     SECTION("temperature_supercooling_scaling") {
-      const Scalar lamc = 5.0;
-      const Scalar mu_c = 2.0;
-      const Scalar cdist1 = 0.75;
-      const Scalar qc_incld = 2.0 * C::QSMALL;
-      const Scalar inv_qc_relvar = 2.0;
-      const Scalar exponent = 0.65;
+      const Scalar lamc = Scalar(5.0);
+      const Scalar mu_c = Scalar(2.0);
+      const Scalar cdist1 = Scalar(0.75);
+      const Scalar qc_incld = Scalar(2.0) * C::QSMALL;
+      const Scalar inv_qc_relvar = Scalar(2.0);
+      const Scalar exponent = Scalar(0.65);
       const Scalar t_warm = C::T_rainfrz.value;
-      const Scalar t_cold = C::T_rainfrz.value - 10.0;
+      const Scalar t_cold = C::T_rainfrz.value - Scalar(10.0);
 
       const auto warm = run_case(t_warm, lamc, mu_c, cdist1, qc_incld,
                                  inv_qc_relvar, exponent, true);
@@ -262,14 +264,14 @@ struct UnitWrap::UnitTest<D>::TestCldliqImmersionFreezing : public UnitWrap::Uni
     }
 
     SECTION("runtime_exponent_sensitivity") {
-      const Scalar T_atm = C::T_rainfrz.value - 5.0;
-      const Scalar lamc = 5.0;
-      const Scalar mu_c = 2.0;
-      const Scalar cdist1 = 0.75;
-      const Scalar qc_incld = 2.0 * C::QSMALL;
-      const Scalar inv_qc_relvar = 2.0;
-      const Scalar a1 = 0.2;
-      const Scalar a2 = 1.1;
+      const Scalar T_atm = C::T_rainfrz.value - Scalar(5.0);
+      const Scalar lamc = Scalar(5.0);
+      const Scalar mu_c = Scalar(2.0);
+      const Scalar cdist1 = Scalar(0.75);
+      const Scalar qc_incld = Scalar(2.0) * C::QSMALL;
+      const Scalar inv_qc_relvar = Scalar(2.0);
+      const Scalar a1 = Scalar(0.2);
+      const Scalar a2 = Scalar(1.1);
 
       const auto r1 = run_case(T_atm, lamc, mu_c, cdist1, qc_incld,
                                inv_qc_relvar, a1, true);
@@ -284,22 +286,23 @@ struct UnitWrap::UnitTest<D>::TestCldliqImmersionFreezing : public UnitWrap::Uni
       require_rel_close(r2.number / r1.number, expected_ratio);
 
       const auto z1 = run_case(C::T_rainfrz.value, lamc, mu_c, cdist1, qc_incld,
-                               inv_qc_relvar, 0.0, true);
-      const auto z2 = run_case(C::T_rainfrz.value - 10.0, lamc, mu_c, cdist1,
-                               qc_incld, inv_qc_relvar, 0.0, true);
+               inv_qc_relvar, Scalar(0.0), true);
+      const auto z2 = run_case(C::T_rainfrz.value - Scalar(10.0), lamc, mu_c,
+               cdist1, qc_incld, inv_qc_relvar, Scalar(0.0),
+               true);
       REQUIRE(z1.mass == z2.mass);
       REQUIRE(z1.number == z2.number);
     }
 
     SECTION("lambda_power_law_scaling") {
-      const Scalar T_atm = C::T_rainfrz.value - 5.0;
-      const Scalar mu_c = 2.0;
-      const Scalar cdist1 = 0.75;
-      const Scalar qc_incld = 2.0 * C::QSMALL;
-      const Scalar inv_qc_relvar = 2.0;
-      const Scalar exponent = 0.65;
-      const Scalar lam1 = 2.5;
-      const Scalar lam2 = 5.0;
+      const Scalar T_atm = C::T_rainfrz.value - Scalar(5.0);
+      const Scalar mu_c = Scalar(2.0);
+      const Scalar cdist1 = Scalar(0.75);
+      const Scalar qc_incld = Scalar(2.0) * C::QSMALL;
+      const Scalar inv_qc_relvar = Scalar(2.0);
+      const Scalar exponent = Scalar(0.65);
+      const Scalar lam1 = Scalar(2.5);
+      const Scalar lam2 = Scalar(5.0);
 
       const auto r1 = run_case(T_atm, lam1, mu_c, cdist1, qc_incld,
                                inv_qc_relvar, exponent, true);
@@ -311,13 +314,17 @@ struct UnitWrap::UnitTest<D>::TestCldliqImmersionFreezing : public UnitWrap::Uni
     }
 
     SECTION("mass_number_moment_identity") {
-      constexpr std::array<Scalar, 3> mus = {0.0, 2.0, 5.0};
-      constexpr std::array<Scalar, 3> lams = {2.0, 5.0, 10.0};
-      const Scalar T_atm = C::T_rainfrz.value - 5.0;
-      const Scalar cdist1 = 0.75;
-      const Scalar qc_incld = 2.0 * C::QSMALL;
-      const Scalar inv_qc_relvar = 2.0;
-      const Scalar exponent = 0.65;
+      constexpr std::array<Scalar, 3> mus = {
+        Scalar(0.0), Scalar(2.0), Scalar(5.0)
+      };
+      constexpr std::array<Scalar, 3> lams = {
+        Scalar(2.0), Scalar(5.0), Scalar(10.0)
+      };
+      const Scalar T_atm = C::T_rainfrz.value - Scalar(5.0);
+      const Scalar cdist1 = Scalar(0.75);
+      const Scalar qc_incld = Scalar(2.0) * C::QSMALL;
+      const Scalar inv_qc_relvar = Scalar(2.0);
+      const Scalar exponent = Scalar(0.65);
 
       for (const auto mu : mus) {
         for (const auto lam : lams) {
@@ -331,13 +338,17 @@ struct UnitWrap::UnitTest<D>::TestCldliqImmersionFreezing : public UnitWrap::Uni
     }
 
     SECTION("frozen_droplet_size_bias") {
-      constexpr std::array<Scalar, 3> mus = {0.0, 2.0, 5.0};
-      constexpr std::array<Scalar, 3> lams = {2.0, 5.0, 10.0};
-      const Scalar T_atm = C::T_rainfrz.value - 5.0;
-      const Scalar cdist1 = 0.75;
-      const Scalar qc_incld = 2.0 * C::QSMALL;
-      const Scalar inv_qc_relvar = 2.0;
-      const Scalar exponent = 0.65;
+      constexpr std::array<Scalar, 3> mus = {
+        Scalar(0.0), Scalar(2.0), Scalar(5.0)
+      };
+      constexpr std::array<Scalar, 3> lams = {
+        Scalar(2.0), Scalar(5.0), Scalar(10.0)
+      };
+      const Scalar T_atm = C::T_rainfrz.value - Scalar(5.0);
+      const Scalar cdist1 = Scalar(0.75);
+      const Scalar qc_incld = Scalar(2.0) * C::QSMALL;
+      const Scalar inv_qc_relvar = Scalar(2.0);
+      const Scalar exponent = Scalar(0.65);
 
       for (const auto mu : mus) {
         for (const auto lam : lams) {
@@ -357,14 +368,14 @@ struct UnitWrap::UnitTest<D>::TestCldliqImmersionFreezing : public UnitWrap::Uni
     }
 
     SECTION("distribution_prefactor_scaling") {
-      const Scalar T_atm = C::T_rainfrz.value - 5.0;
-      const Scalar lamc = 5.0;
-      const Scalar mu_c = 2.0;
-      const Scalar qc_incld = 2.0 * C::QSMALL;
-      const Scalar inv_qc_relvar = 2.0;
-      const Scalar exponent = 0.65;
-      const Scalar c1 = 0.25;
-      const Scalar c2 = 1.25;
+      const Scalar T_atm = C::T_rainfrz.value - Scalar(5.0);
+      const Scalar lamc = Scalar(5.0);
+      const Scalar mu_c = Scalar(2.0);
+      const Scalar qc_incld = Scalar(2.0) * C::QSMALL;
+      const Scalar inv_qc_relvar = Scalar(2.0);
+      const Scalar exponent = Scalar(0.65);
+      const Scalar c1 = Scalar(0.25);
+      const Scalar c2 = Scalar(1.25);
 
       const auto r1 = run_case(T_atm, lamc, mu_c, c1, qc_incld,
                                inv_qc_relvar, exponent, true);
@@ -376,33 +387,33 @@ struct UnitWrap::UnitTest<D>::TestCldliqImmersionFreezing : public UnitWrap::Uni
     }
 
     SECTION("zero_distribution_prefactor_gives_zero") {
-      const Scalar T_atm = C::T_rainfrz.value - 5.0;
-      const Scalar lamc = 5.0;
-      const Scalar mu_c = 2.0;
-      const Scalar cdist1 = 0.0;
-      const Scalar qc_incld = 2.0 * C::QSMALL;
-      const Scalar inv_qc_relvar = 2.0;
-      const Scalar exponent = 0.65;
+      const Scalar T_atm = C::T_rainfrz.value - Scalar(5.0);
+      const Scalar lamc = Scalar(5.0);
+      const Scalar mu_c = Scalar(2.0);
+      const Scalar cdist1 = Scalar(0.0);
+      const Scalar qc_incld = Scalar(2.0) * C::QSMALL;
+      const Scalar inv_qc_relvar = Scalar(2.0);
+      const Scalar exponent = Scalar(0.65);
 
       const auto result = run_case(T_atm, lamc, mu_c, cdist1, qc_incld,
                                    inv_qc_relvar, exponent, true,
-                                   -123.0, -456.0);
+                                   Scalar(-123.0), Scalar(-456.0));
 
       REQUIRE(result.mass == 0);
       REQUIRE(result.number == 0);
     }
 
     SECTION("scalar_multiplier_cancellation_in_mass_number_ratio") {
-      const Scalar T_base = C::T_rainfrz.value - 5.0;
-      const Scalar T_cold = C::T_rainfrz.value - 10.0;
-      const Scalar lamc = 5.0;
-      const Scalar mu_c = 2.0;
-      const Scalar qc_incld = 2.0 * C::QSMALL;
-      const Scalar inv_qc_relvar = 2.0;
-      const Scalar c_base = 0.5;
-      const Scalar c_bigger = 1.4;
-      const Scalar a_base = 0.65;
-      const Scalar a_bigger = 1.1;
+      const Scalar T_base = C::T_rainfrz.value - Scalar(5.0);
+      const Scalar T_cold = C::T_rainfrz.value - Scalar(10.0);
+      const Scalar lamc = Scalar(5.0);
+      const Scalar mu_c = Scalar(2.0);
+      const Scalar qc_incld = Scalar(2.0) * C::QSMALL;
+      const Scalar inv_qc_relvar = Scalar(2.0);
+      const Scalar c_base = Scalar(0.5);
+      const Scalar c_bigger = Scalar(1.4);
+      const Scalar a_base = Scalar(0.65);
+      const Scalar a_bigger = Scalar(1.1);
 
       const auto base = run_case(T_base, lamc, mu_c, c_base, qc_incld,
                                  inv_qc_relvar, a_base, true);
@@ -420,14 +431,14 @@ struct UnitWrap::UnitTest<D>::TestCldliqImmersionFreezing : public UnitWrap::Uni
     }
 
     SECTION("qc_gate_only_behavior") {
-      const Scalar T_atm = C::T_rainfrz.value - 5.0;
-      const Scalar lamc = 5.0;
-      const Scalar mu_c = 2.0;
-      const Scalar cdist1 = 0.75;
-      const Scalar inv_qc_relvar = 2.0;
-      const Scalar exponent = 0.65;
+      const Scalar T_atm = C::T_rainfrz.value - Scalar(5.0);
+      const Scalar lamc = Scalar(5.0);
+      const Scalar mu_c = Scalar(2.0);
+      const Scalar cdist1 = Scalar(0.75);
+      const Scalar inv_qc_relvar = Scalar(2.0);
+      const Scalar exponent = Scalar(0.65);
       const Scalar qc1 = C::QSMALL;
-      const Scalar qc2 = 10.0 * C::QSMALL;
+      const Scalar qc2 = Scalar(10.0) * C::QSMALL;
 
       const auto r1 = run_case(T_atm, lamc, mu_c, cdist1, qc1,
                                inv_qc_relvar, exponent, true);
@@ -439,17 +450,17 @@ struct UnitWrap::UnitTest<D>::TestCldliqImmersionFreezing : public UnitWrap::Uni
     }
 
     SECTION("inv_qc_relvar_currently_inactive") {
-      const Scalar T_atm = C::T_rainfrz.value - 5.0;
-      const Scalar lamc = 5.0;
-      const Scalar mu_c = 2.0;
-      const Scalar cdist1 = 0.75;
-      const Scalar qc_incld = 2.0 * C::QSMALL;
-      const Scalar exponent = 0.65;
+      const Scalar T_atm = C::T_rainfrz.value - Scalar(5.0);
+      const Scalar lamc = Scalar(5.0);
+      const Scalar mu_c = Scalar(2.0);
+      const Scalar cdist1 = Scalar(0.75);
+      const Scalar qc_incld = Scalar(2.0) * C::QSMALL;
+      const Scalar exponent = Scalar(0.65);
 
       const auto low_r = run_case(T_atm, lamc, mu_c, cdist1, qc_incld,
-                                  0.5, exponent, true);
+                                  Scalar(0.5), exponent, true);
       const auto high_r = run_case(T_atm, lamc, mu_c, cdist1, qc_incld,
-                                   10.0, exponent, true);
+                                   Scalar(10.0), exponent, true);
 
       REQUIRE(low_r.mass == high_r.mass);
       REQUIRE(low_r.number == high_r.number);
@@ -457,23 +468,30 @@ struct UnitWrap::UnitTest<D>::TestCldliqImmersionFreezing : public UnitWrap::Uni
 
     SECTION("context_mask_preserves_inactive_lanes") {
       auto lanes = make_lanes();
-      const Scalar exponent = 0.65;
+      const Scalar exponent = Scalar(0.65);
       for (Int s = 0; s < max_pack_size; ++s) {
         lanes[s].context = false;
-        lanes[s].mass_in = -1000.0 - s;
-        lanes[s].number_in = -2000.0 - s;
+        lanes[s].mass_in = Scalar(-1000.0) - s;
+        lanes[s].number_in = Scalar(-2000.0) - s;
       }
 
-      lanes[0].context = true;
-      lanes[1].context = true;
-      lanes[2].context = true;
-      lanes[2].T_atm = C::T_rainfrz.value + 1.0;
-      lanes[3].context = true;
-      lanes[3].qc_incld = 0.9 * C::QSMALL;
-      lanes[4].T_atm = C::T_rainfrz.value - 5.0;
-      lanes[4].qc_incld = 5.0 * C::QSMALL;
-      lanes[5].context = true;
-      lanes[7].context = true;
+      // These are scenario slots in a max_pack_size host array, not assumptions
+      // about Pack::n. run_kernel processes them in chunks of Pack::n, so this
+      // remains valid when SCREAM_PACK_SIZE == 1.
+      lanes[0].context = true; // active
+      lanes[1].context = true; // active
+
+      lanes[2].context = true; // warm but context true: threshold-inactive
+      lanes[2].T_atm = C::T_rainfrz.value + Scalar(1.0);
+
+      lanes[3].context = true; // below QSMALL but context true: threshold-inactive
+      lanes[3].qc_incld = Scalar(0.9) * C::QSMALL;
+
+      lanes[4].T_atm = C::T_rainfrz.value - Scalar(5.0); // context false but otherwise active
+      lanes[4].qc_incld = Scalar(5.0) * C::QSMALL;
+
+      lanes[5].context = true; // active
+      lanes[7].context = true; // active at inclusive temperature threshold
       lanes[7].T_atm = C::T_rainfrz.value;
 
       run_kernel(lanes, exponent);
@@ -498,13 +516,17 @@ struct UnitWrap::UnitTest<D>::TestCldliqImmersionFreezing : public UnitWrap::Uni
     }
 
     SECTION("finite_nonnegative_outputs") {
-      constexpr std::array<Scalar, 3> mus = {0.0, 2.0, 5.0};
-      constexpr std::array<Scalar, 3> lams = {2.0, 5.0, 10.0};
-      const Scalar exponent = 0.65;
-      const Scalar cdist1 = 0.75;
-      const Scalar qc_incld = 2.0 * C::QSMALL;
-      const Scalar inv_qc_relvar = 2.0;
-      const Scalar T_atm = C::T_rainfrz.value - 5.0;
+      constexpr std::array<Scalar, 3> mus = {
+        Scalar(0.0), Scalar(2.0), Scalar(5.0)
+      };
+      constexpr std::array<Scalar, 3> lams = {
+        Scalar(2.0), Scalar(5.0), Scalar(10.0)
+      };
+      const Scalar exponent = Scalar(0.65);
+      const Scalar cdist1 = Scalar(0.75);
+      const Scalar qc_incld = Scalar(2.0) * C::QSMALL;
+      const Scalar inv_qc_relvar = Scalar(2.0);
+      const Scalar T_atm = C::T_rainfrz.value - Scalar(5.0);
 
       for (Int i = 0; i < static_cast<Int>(mus.size()); ++i) {
         const auto result = run_case(T_atm, lams[i], mus[i], cdist1, qc_incld,
@@ -578,7 +600,7 @@ void run_bfb()
     const Int offset = i * Pack::n;
 
     // Init pack inputs
-    Pack T_atm, lamc, mu_c, cdist1, qc_incld,inv_qc_relvar;
+    Pack T_atm, lamc, mu_c, cdist1, qc_incld, inv_qc_relvar;
     for (Int s = 0, vs = offset; s < Pack::n; ++s, ++vs) {
       T_atm[s]        = device_data(vs).T_atm;
       lamc[s]         = device_data(vs).lamc;

--- a/components/eamxx/src/physics/p3/tests/p3_cldliq_imm_freezing_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_cldliq_imm_freezing_unit_tests.cpp
@@ -337,7 +337,7 @@ struct UnitWrap::UnitTest<D>::TestCldliqImmersionFreezing : public UnitWrap::Uni
       }
     }
 
-    SECTION("frozen_droplet_size_bias") {
+    SECTION("volume_nucleation_prefers_larger_than_mean_droplets") {
       constexpr std::array<Scalar, 3> mus = {
         Scalar(0.0), Scalar(2.0), Scalar(5.0)
       };
@@ -355,14 +355,18 @@ struct UnitWrap::UnitTest<D>::TestCldliqImmersionFreezing : public UnitWrap::Uni
           const auto result = run_case(T_atm, lam, mu, cdist1, qc_incld,
                                        inv_qc_relvar, exponent, true);
           require_positive_finite(result);
-          const Scalar d_eff_cubed =
-            (result.mass / result.number) / (C::CONS6 / C::CONS5);
-          const Scalar d_mean = (mu + 4) / lam;
+          const Scalar frozen_mean_mass = result.mass / result.number;
+          const Scalar cloud_mean_mass =
+            (C::CONS6 / C::CONS5)
+            * (mu + 1) * (mu + 2) * (mu + 3)
+            / cube_host(lam);
           const Scalar expected_ratio =
-            ((mu + 5) * (mu + 6)) / ((mu + 4) * (mu + 4));
+            ((mu + 4) * (mu + 5) * (mu + 6))
+            / ((mu + 1) * (mu + 2) * (mu + 3));
 
-          REQUIRE(d_eff_cubed > cube_host(d_mean));
-          require_rel_close(d_eff_cubed / cube_host(d_mean), expected_ratio);
+          REQUIRE(frozen_mean_mass > cloud_mean_mass);
+          require_rel_close(frozen_mean_mass / cloud_mean_mass,
+                            expected_ratio);
         }
       }
     }

--- a/components/eamxx/src/physics/p3/tests/p3_cldliq_imm_freezing_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_cldliq_imm_freezing_unit_tests.cpp
@@ -328,6 +328,31 @@ struct UnitWrap::UnitTest<D>::TestCldliqImmersionFreezing : public UnitWrap::Uni
     }
   }
 
+  SECTION("frozen_droplet_size_bias") {
+    constexpr std::array<Scalar, 3> mus = {0.0, 2.0, 5.0};
+    constexpr std::array<Scalar, 3> lams = {2.0, 5.0, 10.0};
+    const Scalar T_atm = C::T_rainfrz.value - 5.0;
+    const Scalar cdist1 = 0.75;
+    const Scalar qc_incld = 2.0 * C::QSMALL;
+    const Scalar inv_qc_relvar = 2.0;
+    const Scalar exponent = 0.65;
+
+    for (const auto mu : mus) {
+      for (const auto lam : lams) {
+        const auto result = run_case(T_atm, lam, mu, cdist1, qc_incld,
+                                     inv_qc_relvar, exponent, true);
+        const Scalar d_eff_cubed =
+          (result.mass / result.number) / (C::CONS6 / C::CONS5);
+        const Scalar d_mean = (mu + 4) / lam;
+        const Scalar expected_ratio =
+          ((mu + 5) * (mu + 6)) / ((mu + 4) * (mu + 4));
+
+        REQUIRE(d_eff_cubed > cube_host(d_mean));
+        require_rel_close(d_eff_cubed / cube_host(d_mean), expected_ratio);
+      }
+    }
+  }
+
   SECTION("distribution_prefactor_scaling") {
     const Scalar T_atm = C::T_rainfrz.value - 5.0;
     const Scalar lamc = 5.0;
@@ -345,6 +370,23 @@ struct UnitWrap::UnitTest<D>::TestCldliqImmersionFreezing : public UnitWrap::Uni
 
     require_rel_close(r2.mass / r1.mass, c2 / c1);
     require_rel_close(r2.number / r1.number, c2 / c1);
+  }
+
+  SECTION("zero_distribution_prefactor_gives_zero") {
+    const Scalar T_atm = C::T_rainfrz.value - 5.0;
+    const Scalar lamc = 5.0;
+    const Scalar mu_c = 2.0;
+    const Scalar cdist1 = 0.0;
+    const Scalar qc_incld = 2.0 * C::QSMALL;
+    const Scalar inv_qc_relvar = 2.0;
+    const Scalar exponent = 0.65;
+
+    const auto result = run_case(T_atm, lamc, mu_c, cdist1, qc_incld,
+                                 inv_qc_relvar, exponent, true,
+                                 -123.0, -456.0);
+
+    REQUIRE(result.mass == 0);
+    REQUIRE(result.number == 0);
   }
 
   SECTION("scalar_multiplier_cancellation_in_mass_number_ratio") {

--- a/components/eamxx/src/physics/p3/tests/p3_cldliq_imm_freezing_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_cldliq_imm_freezing_unit_tests.cpp
@@ -548,9 +548,9 @@ struct UnitWrap::UnitTest<D>::TestCldliqImmersionFreezing : public UnitWrap::Uni
 
 void run_bfb()
 {
-  // Cloud-liquid immersion freezing is active only when cloud liquid is
-  // present above QSMALL and the temperature is at or below the
-  // rain-freezing threshold.
+  // This BFB path uses the default all-true context, so cloud-liquid
+  // immersion freezing is active only when cloud liquid is present above
+  // QSMALL and the temperature is at or below the rain-freezing threshold.
   constexpr Scalar qsmall = C::QSMALL;
 
   constexpr Scalar t_freezing = 0.9 * C::T_rainfrz.value,

--- a/components/eamxx/src/physics/p3/tests/p3_cldliq_imm_freezing_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_cldliq_imm_freezing_unit_tests.cpp
@@ -173,8 +173,10 @@ struct UnitWrap::UnitTest<D>::TestCldliqImmersionFreezing : public UnitWrap::Uni
   // For active lanes, cloud-liquid immersion freezing computes two moments of
   // the same cloud droplet size distribution:
   //
-  //   M = CONS6 * cdist1 * Gamma(mu_c + 7) * exp(a * (T0 - T)) * lamc^-6
-  //   N = CONS5 * cdist1 * Gamma(mu_c + 4) * exp(a * (T0 - T)) * lamc^-3
+  //   M = CONS6 * cdist1 * Gamma(mu_c + 7)
+  //     * exp(a * (T_zerodegc - T_atm)) * lamc^-6
+  //   N = CONS5 * cdist1 * Gamma(mu_c + 4)
+  //     * exp(a * (T_zerodegc - T_atm)) * lamc^-3
   //
   // The property tests below avoid duplicating the full production formula.
   // They instead check scaling identities, activation behavior, and the


### PR DESCRIPTION
# PR description

Add physical-property tests and documentation for P3 cloud-liquid immersion
freezing.

## Summary

This PR adds deterministic physical-property tests for
`cldliq_immersion_freezing` and documents the cloud-liquid immersion-freezing
closure used by P3. The tests verify activation behavior, supercooling
dependence, Gamma-distribution moment consistency, volume-weighted freezing
interpretation, and current interface contracts.

This is a test/doc-only PR. The production P3 implementation is not changed,
and the existing BFB path is preserved.

## Changes

- Add `run_phys()` coverage for `cldliq_immersion_freezing`
- Preserve the existing BFB path in `run_bfb()`
- Verify activation and threshold behavior, including:
  - inclusive `qc_incld >= QSMALL`
  - inclusive `T_atm <= T_rainfrz`
  - `context == false` output preservation
  - sentinel preservation for inactive lanes
- Verify supercooling dependence:
  - colder active temperatures produce larger mass and number tendencies
  - exact exponential temperature-ratio scaling
- Verify runtime exponent sensitivity:
  - larger positive exponent gives stronger freezing for fixed supercooling
  - zero exponent removes temperature dependence
  - exact exponent-ratio scaling
- Verify cloud size-distribution scaling:
  - mass tendency scales as `lamc^-6`
  - number tendency scales as `lamc^-3`
- Verify the central mass/number moment identity:

  ```text
  qc2qi_hetero_freeze_tend / nc2ni_immers_freeze_tend
  =
  (CONS6 / CONS5)
  * (mu_c + 4)(mu_c + 5)(mu_c + 6)
  / lamc^3
  ```

- Verify the volume-weighted freezing interpretation:
  - the mean mass per newly frozen droplet is larger than the ordinary
    cloud-droplet mean mass
  - this reflects volume-proportional immersion freezing, where larger droplets
    are preferentially represented because they contain more volume in which to
    host an immersed ice-nucleating site
- Verify distribution-prefactor behavior:
  - both tendencies scale linearly with `cdist1`
  - `cdist1 = 0` gives zero mass and number tendencies for otherwise active
    lanes
- Verify that scalar freezing-rate multipliers cancel from the mass/number
  ratio:
  - temperature
  - runtime exponent
  - `cdist1`
- Verify `qc_incld` gate-only behavior above threshold
- Verify current invariance to `inv_qc_relvar` while subgrid variance scaling is
  disabled
- Verify finite, non-negative, positive outputs for valid active inputs
- Add a technical documentation page for the cloud-liquid immersion-freezing
  closure, including:
  - active mask and threshold behavior
  - governing local formulas
  - mass/number moment identity
  - `CONS6 / CONS5 = pi * rho_w / 6` interpretation
  - volume-weighted freezing interpretation
  - `qc_incld` gate-only behavior
  - current inactive `inv_qc_relvar` behavior
  - physical-property test strategy
  - tolerance philosophy
- Add the new page to the EAMxx technical docs navigation

## Notes

The tests run the production `Functions::cldliq_immersion_freezing` kernel and
compare outputs against independent identities, exact ratios, and one-sided
physical inequalities rather than duplicating the full production formula on the
host.

The identity tolerance is intentionally epsilon-scaled but modestly loose
because several checks involve `exp`, `tgamma`, and ratio formation, including
single-precision builds.

The mixed-lane context test uses fixed scenario slots in a `max_pack_size` host
array, not assumptions about `Pack::n`, so it remains valid for
`SCREAM_PACK_SIZE == 1`.

The existing BFB regression path is preserved.

[BFB]
