### PR TITLE
EAMxx: add log-linear interpolation option to VerticalRemapper and FieldAtPressureLevel diagnostic

### DIFF
--- a/components/eamxx/src/physics/spa/eamxx_spa_process_interface.cpp
+++ b/components/eamxx/src/physics/spa/eamxx_spa_process_interface.cpp
@@ -122,6 +122,7 @@ void SPA::initialize_impl (const RunType /* run_type */)
   vremap_data.pname = "PS";
   vremap_data.pmid = pmid;
   vremap_data.pint = pint;
+  vremap_data.interp_type = m_params.get<std::string>("vert_interpolation_type","linear");
   m_data_interpolation->create_vert_remapper (vremap_data);
   m_data_interpolation->init_data_interval (start_of_step_ts());
 

--- a/components/eamxx/src/physics/spc/eamxx_spc_process_interface.cpp
+++ b/components/eamxx/src/physics/spc/eamxx_spc_process_interface.cpp
@@ -89,6 +89,7 @@ void SPC::initialize_impl (const RunType /* run_type */)
   vremap_data.vr_type = DataInterpolation::Dynamic3DRef;
   vremap_data.pname = "PS";
   vremap_data.pmid = pmid;
+  vremap_data.interp_type = m_params.get<std::string>("vert_interpolation_type","linear");
   m_data_interpolation->create_vert_remapper (vremap_data);
   m_data_interpolation->init_data_interval (start_of_step_ts());
 

--- a/components/eamxx/src/share/algorithm/eamxx_data_interpolation.cpp
+++ b/components/eamxx/src/share/algorithm/eamxx_data_interpolation.cpp
@@ -587,7 +587,13 @@ create_vert_remapper (const VertRemapData& data)
 
     // We need to build a vert remapper based on the input data.
     // Note: on src grid, we don't distinguish midpoints from interfaces, while on tgt we do.
-    auto vremap = std::make_shared<VerticalRemapper>(m_grid_after_hremap,m_model_grid);
+    EKAT_REQUIRE_MSG (data.interp_type=="linear" or data.interp_type=="log-linear",
+        "[DataInterpolation] Error! Invalid/unsupported vertical interpolation type.\n"
+        " - input value : " + data.interp_type + "\n"
+        " - valid values: linear, log-linear\n");
+
+    auto interp_type = data.interp_type=="log-linear" ? VerticalRemapper::LogLinear : VerticalRemapper::Linear;
+    auto vremap = std::make_shared<VerticalRemapper>(m_grid_after_hremap,m_model_grid,interp_type);
 
     vremap->set_extrapolation_type(s2et(data.extrap_top),VerticalRemapper::Top);
     vremap->set_extrapolation_type(s2et(data.extrap_bot),VerticalRemapper::Bot);

--- a/components/eamxx/src/share/algorithm/eamxx_data_interpolation.hpp
+++ b/components/eamxx/src/share/algorithm/eamxx_data_interpolation.hpp
@@ -41,6 +41,7 @@ public:
     VRemapType vr_type = None;
     std::string extrap_top = "P0";
     std::string extrap_bot = "P0";
+    std::string interp_type = "linear"; // Valid values: "linear", "log-linear"
     std::string pname; // What we need to load from nc file
     Field pmid, pint;  // The model pmid/pint
     std::shared_ptr<AbstractRemapper> custom_remapper; // Use this custom remapper

--- a/components/eamxx/src/share/diagnostics/field_at_pressure_level.cpp
+++ b/components/eamxx/src/share/diagnostics/field_at_pressure_level.cpp
@@ -33,6 +33,16 @@ FieldAtPressureLevel (const ekat::Comm& comm, const ekat::ParameterList& params,
 
   m_diag_name = m_field_name + "_at_" + p_value + units;
 
+  // Determine interpolation type (default: log-linear)
+  const auto vit = m_params.get<std::string>("vert_interpolation_type","log-linear");
+  EKAT_REQUIRE_MSG (vit=="linear" or vit=="log-linear",
+      "Error! Invalid value for 'vert_interpolation_type' in FieldAtPressureLevel.\n"
+      " - input value: " + vit + "\n"
+      " - valid values: linear, log-linear\n");
+  m_log_linear = (vit=="log-linear");
+  if (m_log_linear)
+    m_log_pressure_level = std::log(m_pressure_level);
+
   m_field_in_names.push_back(m_field_name);
 
   // We don't know yet which one we need
@@ -102,6 +112,8 @@ void FieldAtPressureLevel::compute_impl()
   const int nlevs = pl.dim(1);
 
   auto p_tgt = m_pressure_level;
+  auto log_p_tgt = m_log_pressure_level;
+  auto log_linear = m_log_linear;
   constexpr auto fval = constants::fill_value<Real>;
   bool masked = f.has_valid_mask();
   if (rank==2) {
@@ -141,8 +153,14 @@ void FieldAtPressureLevel::compute_impl()
         } else {
           if (not masked or
               (fmask(icol,k1)!=0 and fmask(icol,k1-1)!=0)) {
-            // General case: interpolate between k1 and k1-1
-            diag(icol) = y1(k1-1) + (y1(k1)-y1(k1-1))/(x1(k1) - x1(k1-1)) * (p_tgt-x1(k1-1));
+            if (log_linear) {
+              auto lx0 = Kokkos::log(x1(k1-1));
+              auto lx1 = Kokkos::log(x1(k1));
+              diag(icol) = y1(k1-1) + (y1(k1)-y1(k1-1))/(lx1 - lx0) * (log_p_tgt - lx0);
+            } else {
+              // General case: interpolate between k1 and k1-1
+              diag(icol) = y1(k1-1) + (y1(k1)-y1(k1-1))/(x1(k1) - x1(k1-1)) * (p_tgt-x1(k1-1));
+            }
             dmask(icol) = 1;
           } else {
             dmask(icol) = 0;
@@ -190,8 +208,15 @@ void FieldAtPressureLevel::compute_impl()
           } else {
             if (not masked or
                 (fmask(icol,idim,k1)!=0 and fmask(icol,idim,k1-1)!=0)) {
-              // General case: interpolate between k1 and k1-1
-              diag(icol,idim) = y1(k1-1) + (y1(k1)-y1(k1-1))/(x1(k1) - x1(k1-1)) * (p_tgt-x1(k1-1));
+              // General case: interpolate between k1-1 and k1
+              if (log_linear) {
+                auto lx0 = Kokkos::log(x1(k1-1));
+                auto lx1 = Kokkos::log(x1(k1));
+                diag(icol,idim) = y1(k1-1) + (y1(k1)-y1(k1-1))/(lx1 - lx0) * (log_p_tgt - lx0);
+              } else {
+                // General case: interpolate between k1 and k1-1
+                diag(icol,idim) = y1(k1-1) + (y1(k1)-y1(k1-1))/(x1(k1) - x1(k1-1)) * (p_tgt-x1(k1-1));
+              }
               dmask(icol,idim) = 1;
             } else {
               dmask(icol,idim) = 0;

--- a/components/eamxx/src/share/diagnostics/field_at_pressure_level.hpp
+++ b/components/eamxx/src/share/diagnostics/field_at_pressure_level.hpp
@@ -13,8 +13,6 @@ namespace scream
 class FieldAtPressureLevel : public AbstractDiagnostic
 {
 public:
-
-  // Constructors
   FieldAtPressureLevel (const ekat::Comm& comm, const ekat::ParameterList& params,
                         const std::shared_ptr<const AbstractGrid>& grid);
 
@@ -34,6 +32,9 @@ protected:
   std::string         m_diag_name;
 
   Real                m_pressure_level;
+
+  Real                m_log_pressure_level = 0; // log(m_pressure_level), for log-linear interp
+  bool                m_log_linear;             // whether to use log-linear interpolation
 };
 
 } //namespace scream

--- a/components/eamxx/src/share/diagnostics/tests/field_at_pressure_level_tests.cpp
+++ b/components/eamxx/src/share/diagnostics/tests/field_at_pressure_level_tests.cpp
@@ -198,6 +198,7 @@ get_test_diag(const std::map<std::string,Field>& fields,
   params.set("field_name",fname);
   params.set("pressure_value",std::to_string(plevel));
   params.set("pressure_units",std::string("Pa"));
+  params.set("vert_interpolation_type",std::string("linear")); // use linear for this test (field is linear in p)
   const auto& comm = grid->get_comm();
   auto diag = std::make_shared<FieldAtPressureLevel>(comm,params,grid);
   for (const auto& fname : diag->get_input_fields_names()) {

--- a/components/eamxx/src/share/field/field.cpp
+++ b/components/eamxx/src/share/field/field.cpp
@@ -138,8 +138,8 @@ Field::get_const() const {
 }
 
 Field
-Field::clone() const {
-  return clone(name());
+Field::clone(const  bool copy) const {
+  return clone(name(), copy);
 }
 
 Field
@@ -171,12 +171,12 @@ Field::alias (const std::string& name, const std::string& grid_name, const std::
 }
 
 Field
-Field::clone(const std::string& name) const {
-  return clone(name, get_header().get_identifier().get_grid_name());
+Field::clone(const std::string& name, const bool copy) const {
+  return clone(name, get_header().get_identifier().get_grid_name(), copy);
 }
 
 Field
-Field::clone(const std::string& name, const std::string& grid_name) const {
+Field::clone(const std::string& name, const std::string& grid_name, const bool copy) const {
   // Create new field
   const auto& my_fid = get_header().get_identifier();
   auto fid = my_fid.clone(name).reset_grid(grid_name);
@@ -194,10 +194,11 @@ Field::clone(const std::string& name, const std::string& grid_name) const {
   const auto& ts = get_header().get_tracking().get_time_stamp();
   f.get_header().get_tracking().update_time_stamp(ts);
 
-  // Deep copy
-  f.deep_copy(*this);
-  f.sync_to_host();
-
+  if (copy) {
+    // Deep copy
+    f.deep_copy(*this);
+    f.sync_to_host();
+  }
   return f;
 }
 

--- a/components/eamxx/src/share/field/field.hpp
+++ b/components/eamxx/src/share/field/field.hpp
@@ -111,9 +111,9 @@ public:
 
   // Creates a deep copy version of this field.
   // It is created with a pristine header (no providers/customers)
-  Field clone () const;
-  Field clone (const std::string& name) const;
-  Field clone (const std::string& name, const std::string& grid_name) const;
+  Field clone (const bool copy = true) const;
+  Field clone (const std::string& name, const bool copy = true) const;
+  Field clone (const std::string& name, const std::string& grid_name, const bool copy = true) const;
 
   Field alias (const std::string& name) const;
   Field alias (const std::string& name, const std::string& grid_name) const;

--- a/components/eamxx/src/share/io/eamxx_io_utils.cpp
+++ b/components/eamxx/src/share/io/eamxx_io_utils.cpp
@@ -224,7 +224,8 @@ parse_cf_time_units (const std::string& units_str,
 
 std::shared_ptr<AbstractDiagnostic>
 create_diagnostic (const std::string& diag_field_name,
-                   const std::shared_ptr<const AbstractGrid>& grid)
+                   const std::shared_ptr<const AbstractGrid>& grid,
+                   const std::string& vert_interp_type)
 {
   // Note: use grouping (the (..) syntax), so you can later query the content
   //       of each group in the matches output var!
@@ -242,7 +243,7 @@ create_diagnostic (const std::string& diag_field_name,
     std::regex bt (generic_field + "_atm_backtend$");
     if (std::regex_search(diag_field_name, alias_matches, bt)) {
       const auto f = alias_matches[1].str();
-      return create_diagnostic(f + "_minus_" + f + "_prev_over_dt", grid);
+      return create_diagnostic(f + "_minus_" + f + "_prev_over_dt", grid,vert_interp_type);
     }
     // More built-in aliases may be added here.
   }
@@ -280,6 +281,7 @@ create_diagnostic (const std::string& diag_field_name,
     params.set("grid_name",grid->name());
     params.set("pressure_value",matches[2].str());
     params.set("pressure_units", matches[4].str());
+    params.set("vert_interpolation_type", vert_interp_type);
     diag_name = "FieldAtPressureLevel";
   } else if (std::regex_search(diag_field_name,matches,field_at_h)) {
     params.set("field_name",matches[1].str());

--- a/components/eamxx/src/share/io/eamxx_io_utils.hpp
+++ b/components/eamxx/src/share/io/eamxx_io_utils.hpp
@@ -95,9 +95,13 @@ parse_cf_time_units (const std::string& units_str,
 
 // Create a diagnostic from a string representation of it.
 // E.g., create the diag to compute fieldX_at_500hPa.
+// vert_interp_type controls vertical interpolation for diagnostics that use
+// pressure-level interpolation (e.g., FieldAtPressureLevel).
+// Valid values: "linear", "log-linear". Default is "log-linear".
 std::shared_ptr<AbstractDiagnostic>
 create_diagnostic (const std::string& diag_name,
-                   const std::shared_ptr<const AbstractGrid>& grid);
+                   const std::shared_ptr<const AbstractGrid>& grid,
+                   const std::string& vert_interp_type = "log-linear");
 
 } // namespace scream
 

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -196,6 +196,15 @@ AtmosphereOutput::AtmosphereOutput(const ekat::Comm &comm, const ekat::Parameter
     fm_model->add_field(*f_ptr);
   }
 
+  // Read the vertical interpolation type once; used for both vert remapping and diagnostics.
+  m_vert_interp_type = params.isParameter("vert_interpolation_type")
+      ? params.get<std::string>("vert_interpolation_type")
+      : std::string("log-linear");
+  EKAT_REQUIRE_MSG (m_vert_interp_type=="linear" or m_vert_interp_type=="log-linear",
+      "Error! Invalid value for 'vert_interpolation_type'.\n"
+      "  - input value: " + m_vert_interp_type + "\n"
+      "  - valid values: linear, log-linear\n");
+
   // Then we 1) create aliases, and b) create diagnostics, adding alias/diag fields to fm_model
   process_requested_fields ();
 
@@ -229,7 +238,8 @@ AtmosphereOutput::AtmosphereOutput(const ekat::Comm &comm, const ekat::Parameter
     auto vert_remap_file   = params.get<std::string>("vertical_remap_file");
     auto p_mid = fm_model->get_field("p_mid");
     auto p_int = fm_model->get_field("p_int");
-    auto vert_remapper = std::make_shared<VerticalRemapper>(fm_model->get_grid(),vert_remap_file);
+    auto interp_type = m_vert_interp_type=="linear" ? VerticalRemapper::Linear : VerticalRemapper::LogLinear;
+    auto vert_remapper = std::make_shared<VerticalRemapper>(fm_model->get_grid(),vert_remap_file,interp_type);
     vert_remapper->set_source_pressure(p_mid);
     vert_remapper->set_source_pressure(p_int);
     vert_remapper->set_extrapolation_type(VerticalRemapper::Mask); // both Top AND Bot
@@ -1231,7 +1241,7 @@ process_requested_fields()
         auto& diag = m_diag_repo[name];
         if (not diag) {
           // First time we run into this diag. Create it
-          diag = create_diagnostic(name,fm_model->get_grid());
+          diag = create_diagnostic(name,fm_model->get_grid(),m_vert_interp_type);
         }
         // Add its deps to the list of fields to process (if not already in fm_model)
         bool deps_met = true;

--- a/components/eamxx/src/share/io/scorpio_output.hpp
+++ b/components/eamxx/src/share/io/scorpio_output.hpp
@@ -254,6 +254,7 @@ protected:
       console_logger(ekat::logger::LogLevel::warn);
 
   std::string m_stream_name; // used in error msgs to help distinguish which stream this is
+  std::string m_vert_interp_type = "log-linear"; // vertical interpolation type for IO diagnostics
 };
 
 } // namespace scream

--- a/components/eamxx/src/share/io/tests/io_remap_test.cpp
+++ b/components/eamxx/src/share/io/tests/io_remap_test.cpp
@@ -33,14 +33,6 @@ Real calculate_output(const Real pressure, const int col, const int cmp);
 ekat::ParameterList set_output_params(const std::string& name, const std::string& remap_filename, const int p_ref, const bool vert_remap, const bool horiz_remap);
 ekat::ParameterList set_input_params(const std::string& name, ekat::Comm& comm, const std::string& tstamp, const int p_ref);
 
-bool approx(const Real a, const Real b) {
-  const Real tol = std::numeric_limits<Real>::epsilon()*100000;
-  if (std::abs(a-b) >= tol) {
-    printf("Error::approx - difference of |%e - %e| = %e is greater than the max tolerance of %e\n",a,b,std::abs(a-b),tol);
-  }
-  return std::abs(a-b) < tol;
-}
-
 void print (const std::string& msg, const ekat::Comm& comm) {
   if (comm.am_i_root()) {
     printf("%s",msg.c_str());
@@ -57,6 +49,7 @@ TEST_CASE("io_remap_test","io_remap_test")
 
 
   print (" -> Test Setup ...\n",io_comm);
+  const Real rel_tol = Real(1e5) * std::numeric_limits<Real>::epsilon();
   scorpio::init_subsystem(io_comm);
   const int ncols_src = 64*io_comm.size();
   const int nlevs_src = 2*packsize + 1;
@@ -95,7 +88,7 @@ TEST_CASE("io_remap_test","io_remap_test")
     col.push_back(1+src_col);
     col.push_back(1+src_col+1);
     S.push_back(wgt);
-    S.push_back(1.0-wgt);
+    S.push_back(1-wgt);
   }
   // For vertical remapping we will prokject onto a set of equally
   // spaced pressure levels from p_top to b_bot that is nearly half
@@ -237,6 +230,7 @@ TEST_CASE("io_remap_test","io_remap_test")
 
   print ("    -> source data ... \n",io_comm);
   auto source_remap_control = set_output_params("remap_source",remap_filename,p_ref,false,false);
+  source_remap_control.set<std::string>("vert_interpolation_type","linear");
   om_source.initialize(io_comm,source_remap_control,t0,false);
   om_source.setup(field_manager,gm->get_grid_names());
   io_comm.barrier();
@@ -247,6 +241,7 @@ TEST_CASE("io_remap_test","io_remap_test")
 
   print ("    -> vertical remap ... \n",io_comm);
   auto vert_remap_control = set_output_params("remap_vertical",remap_filename,p_ref,true,false);
+  vert_remap_control.set<std::string>("vert_interpolation_type","linear");
   om_vert.initialize(io_comm,vert_remap_control,t0,false);
   om_vert.setup(field_manager,gm->get_grid_names());
   io_comm.barrier();
@@ -257,6 +252,7 @@ TEST_CASE("io_remap_test","io_remap_test")
 
   print ("    -> horizontal remap ... \n",io_comm);
   auto horiz_remap_control = set_output_params("remap_horizontal",remap_filename,p_ref,false,true);
+  horiz_remap_control.set<std::string>("vert_interpolation_type","linear");
   om_horiz.initialize(io_comm,horiz_remap_control,t0,false);
   om_horiz.setup(field_manager,gm->get_grid_names());
   io_comm.barrier();
@@ -267,6 +263,7 @@ TEST_CASE("io_remap_test","io_remap_test")
 
   print ("    -> vertical-horizontal remap ... \n",io_comm);
   auto vert_horiz_remap_control = set_output_params("remap_vertical_horizontal",remap_filename,p_ref,true,true);
+  vert_horiz_remap_control.set<std::string>("vert_interpolation_type","linear");
   om_vert_horiz.initialize(io_comm,vert_horiz_remap_control,t0,false);
   om_vert_horiz.setup(field_manager,gm->get_grid_names());
   io_comm.barrier();
@@ -274,6 +271,100 @@ TEST_CASE("io_remap_test","io_remap_test")
   om_vert_horiz.run(t0+dt);
   om_vert_horiz.finalize();
   print ("    -> vertical-horizontal remap ... done\n",io_comm);
+
+  print ("    -> log-linear vertical remap ... \n",io_comm);
+  // Use q_scale = 1/p_bot to normalize q values to [0,1], so exp(q) stays in [1,e].
+  const Real q_scale = p_bot > 0 ? 1/p_bot : Real(1);
+  // Create a remap file with exp-transformed target levels to test log-linear interp.
+  // With log-linear remapping and source pressures exp(q_src), the remapper internally
+  // computes log(exp(q_src)) = q_src and interpolates linearly in q-space.
+  const std::string log_remap_filename = "log_remap_weights_np"+std::to_string(io_comm.size())+".nc";
+  std::vector<Real> p_tgt_exp;
+  for (int ii=0; ii<nlevs_tgt; ++ii) {
+    p_tgt_exp.push_back(std::exp(p_tgt[ii]*q_scale));
+  }
+  scorpio::register_file(log_remap_filename, scorpio::FileMode::Write);
+  scorpio::define_dim(log_remap_filename,"n_a",ncols_src);
+  scorpio::define_dim(log_remap_filename,"n_b",ncols_tgt);
+  scorpio::define_dim(log_remap_filename,"n_s",ncols_src);
+  scorpio::define_dim(log_remap_filename,"lev",nlevs_tgt);
+  scorpio::define_var(log_remap_filename,"col",   {"n_s"},"int");
+  scorpio::define_var(log_remap_filename,"row",   {"n_s"},"int");
+  scorpio::define_var(log_remap_filename,"S",     {"n_s"},"real");
+  scorpio::define_var(log_remap_filename,"p_levs",{"lev"},"real");
+  scorpio::set_dim_decomp(log_remap_filename,"n_s",io_comm.rank()*ncols_src_l,ncols_src_l);
+  scorpio::enddef(log_remap_filename);
+  scorpio::write_var(log_remap_filename,"row",   row.data());
+  scorpio::write_var(log_remap_filename,"col",   col.data());
+  scorpio::write_var(log_remap_filename,"S",     S.data());
+  scorpio::write_var(log_remap_filename,"p_levs",p_tgt_exp.data());
+  scorpio::release_file(log_remap_filename);
+
+  // Build a source field manager with exp-transformed pressures.
+  // Field values are set as linear in q = p*q_scale (= log of the exp-transformed pressure),
+  // so log-linear interp on exp(q) coords gives identical results to linear interp on q.
+  auto fm_log = get_test_fm(grid, false);
+  fm_log->init_fields_time_stamp(t0);
+
+  const auto& pm_log_f = fm_log->get_field("p_mid");
+  const auto& pi_log_f = fm_log->get_field("p_int");
+  const auto& ps_log_f = fm_log->get_field("p_surf");
+  const auto& pm_log_v = pm_log_f.get_view<Real**,Host>();
+  const auto& pi_log_v = pi_log_f.get_view<Real**,Host>();
+  const auto& ps_log_v = ps_log_f.get_view<Real*,Host>();
+  for (int ii=0; ii<ncols_src_l; ii++) {
+    ps_log_v(ii)   = std::exp(p_surf(ii)*q_scale);
+    pi_log_v(ii,0) = std::exp(pi_v(ii,0)*q_scale);
+    for (int jj=0; jj<nlevs_src; jj++) {
+      pi_log_v(ii,jj+1) = std::exp(pi_v(ii,jj+1)*q_scale);
+      pm_log_v(ii,jj)   = std::exp(pm_v(ii,jj)*q_scale);
+    }
+  }
+  pm_log_f.sync_to_dev();
+  pi_log_f.sync_to_dev();
+  ps_log_f.sync_to_dev();
+
+  const auto& Yf_log_f = fm_log->get_field("Y_flat");
+  const auto& Ym_log_f = fm_log->get_field("Y_mid");
+  const auto& Yi_log_f = fm_log->get_field("Y_int");
+  const auto& Vm_log_f = fm_log->get_field("V_mid");
+  const auto& Vi_log_f = fm_log->get_field("V_int");
+  const auto& Yf_log_v = Yf_log_f.get_view<Real*,Host>();
+  const auto& Ym_log_v = Ym_log_f.get_view<Real**,Host>();
+  const auto& Yi_log_v = Yi_log_f.get_view<Real**,Host>();
+  const auto& Vm_log_v = Vm_log_f.get_view<Real***,Host>();
+  const auto& Vi_log_v = Vi_log_f.get_view<Real***,Host>();
+  for (int ii=0; ii<ncols_src_l; ii++) {
+    Yf_log_v(ii)   = calculate_output(pm_v(ii,0)*q_scale,ii,0);
+    Yi_log_v(ii,0) = calculate_output(pi_v(ii,0)*q_scale,ii,0);
+    for (int cc=0; cc<2; cc++) {
+      Vi_log_v(ii,cc,0) = calculate_output(pi_v(ii,0)*q_scale,ii,cc+1);
+    }
+    for (int jj=0; jj<nlevs_src; jj++) {
+      Ym_log_v(ii,jj)   = calculate_output(pm_v(ii,jj)*q_scale,  ii,0);
+      Yi_log_v(ii,jj+1) = calculate_output(pi_v(ii,jj+1)*q_scale,ii,0);
+      for (int cc=0; cc<2; cc++) {
+        Vm_log_v(ii,cc,jj)   = calculate_output(pm_v(ii,jj)*q_scale,  ii,cc+1);
+        Vi_log_v(ii,cc,jj+1) = calculate_output(pi_v(ii,jj+1)*q_scale,ii,cc+1);
+      }
+    }
+  }
+  Yf_log_f.sync_to_dev();
+  Ym_log_f.sync_to_dev();
+  Yi_log_f.sync_to_dev();
+  Vm_log_f.sync_to_dev();
+  Vi_log_f.sync_to_dev();
+
+  OutputManager om_log_vert;
+  auto log_vert_params = set_output_params("remap_log_vertical",log_remap_filename,-1,true,false);
+  log_vert_params.set<std::string>("vert_interpolation_type","log-linear");
+  om_log_vert.initialize(io_comm,log_vert_params,t0,false);
+  om_log_vert.setup(fm_log,gm->get_grid_names());
+  io_comm.barrier();
+  om_log_vert.init_timestep(t0,dt);
+  om_log_vert.run(t0+dt);
+  om_log_vert.finalize();
+  print ("    -> log-linear vertical remap ... done\n",io_comm);
   print (" -> Create output ... done\n",io_comm);
 
 
@@ -331,19 +422,36 @@ TEST_CASE("io_remap_test","io_remap_test")
 
     for (int ii=0; ii<ncols_src_l; ii++) {
       const bool ref_masked = (p_ref>pi_v(ii,nlevs_src) || p_ref<pi_v(ii,0));
-      const Real test_val = ref_masked ? fill_val : calculate_output(p_ref,ii,0);
-      REQUIRE(approx(Ys_v_vert(ii),test_val));
+      if (ref_masked)
+        REQUIRE(Ys_v_vert(ii)==fill_val);
+      else
+        REQUIRE_THAT(Ys_v_vert(ii), Catch::Matchers::WithinRel(calculate_output(p_ref,ii,0), rel_tol));
 
-      REQUIRE(approx(Yf_v_vert(ii), Yf_v(ii)));
+      REQUIRE_THAT(Yf_v_vert(ii), Catch::Matchers::WithinRel(Yf_v(ii), rel_tol));
       for (int jj=0; jj<nlevs_tgt; jj++) {
         auto p_jj = p_tgt[jj];
         const bool mid_masked = (p_jj>pm_v(ii,nlevs_src-1) || p_jj<pm_v(ii,0));
         const bool int_masked = (p_jj>pi_v(ii,nlevs_src)   || p_jj<pi_v(ii,0));
-        REQUIRE(approx(Ym_v_vert(ii,jj),(mid_masked ? fill_val : calculate_output(p_jj,ii,0))));
-        REQUIRE(approx(Yi_v_vert(ii,jj),(int_masked ? fill_val : calculate_output(p_jj,ii,0))));
+        if (mid_masked)
+          REQUIRE(Ym_v_vert(ii,jj)==fill_val);
+        else
+          REQUIRE_THAT(Ym_v_vert(ii,jj), Catch::Matchers::WithinRel(calculate_output(p_jj,ii,0), rel_tol));
+
+        if (int_masked)
+          REQUIRE(Yi_v_vert(ii,jj)==fill_val);
+        else
+          REQUIRE_THAT(Yi_v_vert(ii,jj), Catch::Matchers::WithinRel(calculate_output(p_jj,ii,0), rel_tol));
+
         for (int cc=0; cc<2; cc++) {
-          REQUIRE(approx(Vm_v_vert(ii,cc,jj), (mid_masked ? fill_val : calculate_output(p_jj,ii,cc+1))));
-          REQUIRE(approx(Vi_v_vert(ii,cc,jj), (int_masked ? fill_val : calculate_output(p_jj,ii,cc+1))));
+          if (mid_masked)
+            REQUIRE(Vm_v_vert(ii,cc,jj)==fill_val);
+          else
+            REQUIRE_THAT(Vm_v_vert(ii,cc,jj), Catch::Matchers::WithinRel(calculate_output(p_jj,ii,cc+1), rel_tol));
+
+          if (int_masked)
+            REQUIRE(Vi_v_vert(ii,cc,jj)==fill_val);
+          else
+            REQUIRE_THAT(Vi_v_vert(ii,cc,jj), Catch::Matchers::WithinRel(calculate_output(p_jj,ii,cc+1), rel_tol));
         }
       }
     }
@@ -398,17 +506,17 @@ TEST_CASE("io_remap_test","io_remap_test")
     for (int ii=0; ii<ncols_tgt_l; ii++) {
       const int col1 = 2*ii;
       const int col2 = 2*ii+1;
-      REQUIRE(approx(Yf_v_horiz(ii),Yf_v(col1)*wgt + Yf_v(col2)*(1.0-wgt)));
-      REQUIRE(approx(Yi_v_horiz(ii,0), Yi_v(col1,0)*wgt + Yi_v(col2,0)*(1.0-wgt)));
+      REQUIRE_THAT(Yf_v_horiz(ii), Catch::Matchers::WithinRel(Yf_v(col1)*wgt + Yf_v(col2)*(1-wgt), rel_tol));
+      REQUIRE_THAT(Yi_v_horiz(ii,0), Catch::Matchers::WithinRel(Yi_v(col1,0)*wgt + Yi_v(col2,0)*(1-wgt), rel_tol));
       for (int cc=0; cc<2; cc++) {
-        REQUIRE(approx(Vi_v_horiz(ii,cc,0), Vi_v(col1,cc,0)*wgt + Vi_v(col2,cc,0)*(1.0-wgt)));
+        REQUIRE_THAT(Vi_v_horiz(ii,cc,0), Catch::Matchers::WithinRel(Vi_v(col1,cc,0)*wgt + Vi_v(col2,cc,0)*(1-wgt), rel_tol));
       }
       for (int jj=0; jj<nlevs_src; jj++) {
-        REQUIRE(approx(Ym_v_horiz(ii,jj),   Ym_v(col1,jj)*wgt   + Ym_v(col2,jj)*(1.0-wgt)));
-        REQUIRE(approx(Yi_v_horiz(ii,jj+1), Yi_v(col1,jj+1)*wgt + Yi_v(col2,jj+1)*(1.0-wgt)));
+        REQUIRE_THAT(Ym_v_horiz(ii,jj), Catch::Matchers::WithinRel(Ym_v(col1,jj)*wgt   + Ym_v(col2,jj)*(1-wgt), rel_tol));
+        REQUIRE_THAT(Yi_v_horiz(ii,jj+1), Catch::Matchers::WithinRel(Yi_v(col1,jj+1)*wgt + Yi_v(col2,jj+1)*(1-wgt), rel_tol));
         for (int cc=0; cc<2; cc++) {
-          REQUIRE(approx(Vm_v_horiz(ii,cc,jj),   Vm_v(col1,cc,jj)*wgt   + Vm_v(col2,cc,jj)*(1.0-wgt)));
-          REQUIRE(approx(Vi_v_horiz(ii,cc,jj+1), Vi_v(col1,cc,jj+1)*wgt + Vi_v(col2,cc,jj+1)*(1.0-wgt)));
+          REQUIRE_THAT(Vm_v_horiz(ii,cc,jj), Catch::Matchers::WithinRel(Vm_v(col1,cc,jj)*wgt   + Vm_v(col2,cc,jj)*(1-wgt), rel_tol));
+          REQUIRE_THAT(Vi_v_horiz(ii,cc,jj+1), Catch::Matchers::WithinRel(Vi_v(col1,cc,jj+1)*wgt + Vi_v(col2,cc,jj+1)*(1-wgt), rel_tol));
         }
       }
       // For the pressured sliced variable we expect some masking which needs to be checked.
@@ -422,15 +530,15 @@ TEST_CASE("io_remap_test","io_remap_test")
       }
       if (p_ref<=pi_v(col2,nlevs_src) && p_ref>=pi_v(col2,0)) {
         found = true;
-        Ys_exp += calculate_output(p_ref,col2,0)*(1.0-wgt);
-        Ys_wgt += (1.0 - wgt);
+        Ys_exp += calculate_output(p_ref,col2,0)*(1-wgt);
+        Ys_wgt += (1 - wgt);
       }
       if (found) {
         Ys_exp /= Ys_wgt;
       } else {
         Ys_exp = fill_val;
       }
-      REQUIRE(approx(Ys_v_horiz(ii), Ys_exp));
+      REQUIRE_THAT(Ys_v_horiz(ii), Catch::Matchers::WithinRel(Ys_exp, rel_tol));
     }
     print ("    -> horizontal remap ... done\n",io_comm);
   }
@@ -484,7 +592,7 @@ TEST_CASE("io_remap_test","io_remap_test")
     for (int ii=0; ii<ncols_tgt_l; ii++) {
       const int col1 = 2*ii;
       const int col2 = 2*ii+1;
-      REQUIRE(approx(Yf_v_vh(ii),Yf_v(col1)*wgt + Yf_v(col2)*(1.0-wgt)));
+      REQUIRE_THAT(Yf_v_vh(ii), Catch::Matchers::WithinRel(Yf_v(col1)*wgt + Yf_v(col2)*(1-wgt), rel_tol));
       for (int jj=0; jj<nlevs_tgt; jj++) {
         auto p_jj = p_tgt[jj];
         const Real mid_mask_1 = (p_jj<=pm_v(col1,nlevs_src-1) && p_jj>=pm_v(col1,0));
@@ -505,8 +613,8 @@ TEST_CASE("io_remap_test","io_remap_test")
           // This point is completely masked out, assign masked value
           test_int = fill_val;
         }
-        REQUIRE(approx(Ym_v_vh(ii,jj), test_mid));
-        REQUIRE(approx(Yi_v_vh(ii,jj), test_int));
+        REQUIRE_THAT(Ym_v_vh(ii,jj), Catch::Matchers::WithinRel(test_mid, rel_tol));
+        REQUIRE_THAT(Yi_v_vh(ii,jj), Catch::Matchers::WithinRel(test_int, rel_tol));
         for (int cc=0; cc<2; cc++) {
           if (mid_mask_1 + mid_mask_2 > 0.0) {
             test_mid = (mid_mask_1*calculate_output(p_jj,col1,cc+1)*wgt + mid_mask_2*calculate_output(p_jj,col2,cc+1)*(1-wgt))/(mid_mask_1*wgt + mid_mask_2*(1-wgt));
@@ -520,8 +628,8 @@ TEST_CASE("io_remap_test","io_remap_test")
             // This point is completely masked out, assign masked value
             test_int = fill_val;
           }
-          REQUIRE(approx(Vm_v_vh(ii,cc,jj), test_mid));
-          REQUIRE(approx(Vi_v_vh(ii,cc,jj), test_int));
+          REQUIRE_THAT(Vm_v_vh(ii,cc,jj), Catch::Matchers::WithinRel(test_mid, rel_tol));
+          REQUIRE_THAT(Vi_v_vh(ii,cc,jj), Catch::Matchers::WithinRel(test_int, rel_tol));
         }
       }
       // For the pressured sliced variable we expect it to match the solution from horizontal mapping only so we use the same syntax.
@@ -535,17 +643,59 @@ TEST_CASE("io_remap_test","io_remap_test")
       }
       if (p_ref<=pi_v(col2,nlevs_src) && p_ref>=pi_v(col2,0)) {
         found = true;
-        Ys_exp += calculate_output(p_ref,col2,0)*(1.0-wgt);
-        Ys_wgt += (1.0 - wgt);
+        Ys_exp += calculate_output(p_ref,col2,0)*(1-wgt);
+        Ys_wgt += (1 - wgt);
       }
       if (found) {
         Ys_exp /= Ys_wgt;
       } else {
         Ys_exp = fill_val;
       }
-      REQUIRE(approx(Ys_v_vh(ii), Ys_exp));
+      REQUIRE_THAT(Ys_v_vh(ii), Catch::Matchers::WithinRel(Ys_exp, rel_tol));
     }
     print ("    -> vertical + horizontal remap ... done\n",io_comm);
+  }
+  // ------------------------------------------------------------------------------------------------------
+  //                           ---  Log-linear Vertical Remapping ---
+  {
+    // The log-linear remap with exp-transformed coordinates (exp(p*q_scale)) should yield
+    // the same result as linear remap on the q = p*q_scale coordinates directly, since
+    // the remapper internally computes log(exp(q)) = q before interpolating.
+    print ("    -> log-linear vertical remap ... \n",io_comm);
+    auto gm_log_vert   = get_test_gm(io_comm,ncols_src,nlevs_tgt);
+    auto grid_log_vert = gm_log_vert->get_grid("point_grid");
+    auto fm_log_vert   = get_test_fm(grid_log_vert,true,-1);
+    auto log_vert_in   = set_input_params("remap_log_vertical",io_comm,t0.to_string(),-1);
+    AtmosphereInput test_input(log_vert_in,fm_log_vert);
+    test_input.read_variables();
+    test_input.finalize();
+
+    const auto& Yf_f_lv = fm_log_vert->get_field("Y_flat");
+    const auto& Ym_f_lv = fm_log_vert->get_field("Y_mid");
+    const auto& Yi_f_lv = fm_log_vert->get_field("Y_int");
+    const auto& Vm_f_lv = fm_log_vert->get_field("V_mid");
+    const auto& Vi_f_lv = fm_log_vert->get_field("V_int");
+    const auto& Yf_v_lv = Yf_f_lv.get_view<Real*,Host>();
+    const auto& Ym_v_lv = Ym_f_lv.get_view<Real**,Host>();
+    const auto& Yi_v_lv = Yi_f_lv.get_view<Real**,Host>();
+    const auto& Vm_v_lv = Vm_f_lv.get_view<Real***,Host>();
+    const auto& Vi_v_lv = Vi_f_lv.get_view<Real***,Host>();
+
+    for (int ii=0; ii<ncols_src_l; ii++) {
+      REQUIRE_THAT(Yf_v_lv(ii), Catch::Matchers::WithinRel(Yf_log_v(ii), rel_tol));
+      for (int jj=0; jj<nlevs_tgt; jj++) {
+        const Real q_jj = p_tgt[jj]*q_scale;
+        const bool mid_masked = (p_tgt[jj]>pm_v(ii,nlevs_src-1) || p_tgt[jj]<pm_v(ii,0));
+        const bool int_masked = (p_tgt[jj]>pi_v(ii,nlevs_src)   || p_tgt[jj]<pi_v(ii,0));
+        REQUIRE_THAT(Ym_v_lv(ii,jj), Catch::Matchers::WithinRel((mid_masked ? fill_val : calculate_output(q_jj,ii,0)), rel_tol));
+        REQUIRE_THAT(Yi_v_lv(ii,jj), Catch::Matchers::WithinRel((int_masked ? fill_val : calculate_output(q_jj,ii,0)), rel_tol));
+        for (int cc=0; cc<2; cc++) {
+          REQUIRE_THAT(Vm_v_lv(ii,cc,jj), Catch::Matchers::WithinRel((mid_masked ? fill_val : calculate_output(q_jj,ii,cc+1)), rel_tol));
+          REQUIRE_THAT(Vi_v_lv(ii,cc,jj), Catch::Matchers::WithinRel((int_masked ? fill_val : calculate_output(q_jj,ii,cc+1)), rel_tol));
+        }
+      }
+    }
+    print ("    -> log-linear vertical remap ... done\n",io_comm);
   }
   // ------------------------------------------------------------------------------------------------------
   // All Done

--- a/components/eamxx/src/share/remap/tests/vertical_remapper_tests.cpp
+++ b/components/eamxx/src/share/remap/tests/vertical_remapper_tests.cpp
@@ -6,6 +6,8 @@
 #include "share/util/eamxx_timing.hpp"
 #include "share/field/field_utils.hpp"
 
+#include <cmath>
+
 namespace scream {
 
 constexpr int vec_dim = 3;
@@ -584,6 +586,171 @@ TEST_CASE ("vertical_remapper") {
   scorpio::finalize_subsystem();
 
   print ("Testing vertical remapper ... done!\n",comm);
+}
+
+TEST_CASE ("log_linear_vertical_remapper") {
+  using namespace ShortFieldTagsNames;
+
+  // -------------------------------------- //
+  //           Init MPI and PIO             //
+  // -------------------------------------- //
+
+  ekat::Comm comm(MPI_COMM_WORLD);
+
+  print ("Testing log-linear vertical remapper ...\n",comm);
+
+  scorpio::init_subsystem(comm);
+
+  // -------------------------------------- //
+  //           Set grid/map sizes           //
+  // -------------------------------------- //
+
+  // Idea: if src/tgt midpoint pressure coords are p_k = exp(q_k) for linearly
+  // spaced q_k, then log-linear interp with p_k coords gives the same result
+  // as linear interp directly using q_k coords, provided the data function
+  // is linear in q (= log(p)).
+
+  const int nlevs_src = 2*SCREAM_PACK_SIZE + 2;
+  const int nlevs_tgt = nlevs_src/2;
+  const int nldofs = 2;
+
+  // -------------------------------------- //
+  //             Build src/tgt grids        //
+  // -------------------------------------- //
+
+  auto src_grid = build_grid(comm, nldofs, nlevs_src);
+  auto tgt_grid = src_grid->clone("tgt",true);
+  tgt_grid->reset_vertical_configuration(nlevs_tgt, AbstractGrid::VKind::Pressure);
+
+  // -------------------------------------- //
+  //       Create pressure coordinates      //
+  // -------------------------------------- //
+
+  // q: uniformly spaced in [qtop, qbot] (log-space coordinates)
+  // tgt range is strictly inside src range, so no extrapolation is needed
+  const Real qtop_src = 2.0;
+  const Real qbot_src = 7.0;
+  const Real qtop_tgt = 3.0;
+  const Real qbot_tgt = 6.0;
+
+  // Helper to create a 1d midpoint pressure field
+  auto create_pmid = [](const auto& grid, const Real qtop, const Real qbot, const FieldTag vtag, bool use_exp) {
+    auto layout = grid->get_vertical_layout(vtag);  // midpoints (LEV tag)
+    FieldIdentifier fid("p_mid",layout,ekat::units::Pa,grid->name());
+    Field pmid(fid);
+    pmid.get_header().get_alloc_properties().request_allocation(SCREAM_PACK_SIZE);
+    pmid.allocate_view();
+
+    const int nlevs = grid->get_num_vertical_levels();
+    const Real dq = (qbot-qtop)/(nlevs-1);
+    auto v = pmid.get_view<Real*,Host>();
+    for (int k=0; k<nlevs; ++k) {
+      Real q = qtop + k*dq;
+      v(k) = use_exp ? std::exp(q) : q;
+    }
+    pmid.sync_to_dev();
+    return pmid;
+  };
+
+  // Pressure coords for log-linear remapper: p_k = exp(q_k)
+  // After internal log transformation: log(p_k) = q_k (same as linear coords)
+  auto pmid_exp_src = create_pmid(src_grid, qtop_src, qbot_src, LEV,  true);
+  auto pmid_exp_tgt = create_pmid(tgt_grid, qtop_tgt, qbot_tgt, LEVP, true);
+
+  // Pressure coords for linear remapper: p_k = q_k (uniform spacing in q)
+  auto pmid_lin_src = create_pmid(src_grid, qtop_src, qbot_src, LEV,  false);
+  auto pmid_lin_tgt = create_pmid(tgt_grid, qtop_tgt, qbot_tgt, LEVP, false);
+
+  // -------------------------------------- //
+  //           Create src/tgt fields        //
+  // -------------------------------------- //
+
+  // Data function linear in q_k. Since both interps operate in q-space
+  // (log-linear via log(exp(q_k))=q_k, linear directly via q_k), both produce
+  // exact results for a linear function of q.
+  // The source field values are the same in both cases.
+  auto fill_field = [&](Field& f, const Field& pmid, bool use_log) {
+    const auto& l = f.get_header().get_identifier().get_layout();
+    const int ncols = l.dims().front();
+    const int nlevs = l.dims().back();
+    auto fv = f.get_view<Real**,Host>();
+    auto pv = pmid.get_view<const Real*,Host>();
+    for (int i=0; i<ncols; ++i) {
+      for (int k=0; k<nlevs; ++k) {
+        Real q = use_log ? std::log(pv(k)) : pv(k);
+        fv(i,k) = (i+1)*q;
+      }
+    }
+    f.sync_to_dev();
+  };
+
+  // Create fields (scalar 3d midpoint)
+  auto src_loglin = create_field("s3d_m", src_grid, false, false, false, LEV,  1);
+  auto tgt_loglin = create_field("s3d_m", tgt_grid, false, false, false, LEVP, 1);
+  auto src_lin    = create_field("s3d_m", src_grid, false, false, false, LEV,  1);
+  auto tgt_lin    = create_field("s3d_m", tgt_grid, false, false, false, LEVP, 1);
+
+  // f(i,k) = (i+1) * q_k  (same values in both cases since log(exp(q_k)) = q_k)
+  fill_field(src_loglin, pmid_exp_src, true);   // use log(exp(q_k)) = q_k
+  fill_field(src_lin,    pmid_lin_src, false);  // use q_k directly
+
+  // -------------------------------------- //
+  //        Build and run log-linear remap  //
+  // -------------------------------------- //
+
+  tgt_loglin.deep_copy(0.0);
+  for (auto fixed_src : {true,false}) {
+    for (auto fixed_tgt : {true,false}) {
+      print (" -> Check LogLinear interpolation matches Linear with q coords (src/tgt fixed= %s,%s) ...",
+             comm, (fixed_src ? "true" : "false"), (fixed_tgt ? "true" : "false") );
+      auto remap_loglin = std::make_shared<VerticalRemapper>(src_grid, tgt_grid, VerticalRemapper::LogLinear);
+      remap_loglin->set_source_pressure(pmid_exp_src, fixed_src);
+      remap_loglin->set_target_pressure(pmid_exp_tgt, fixed_tgt);
+
+      remap_loglin->register_field(src_loglin, tgt_loglin);
+      remap_loglin->registration_ends();
+      remap_loglin->remap_fwd();
+
+      // -------------------------------------- //
+      //         Build and run linear remap     //
+      // -------------------------------------- //
+
+      auto remap_lin = std::make_shared<VerticalRemapper>(src_grid, tgt_grid);
+      remap_lin->set_source_pressure(pmid_lin_src);
+      remap_lin->set_target_pressure(pmid_lin_tgt);
+      remap_lin->register_field(src_lin, tgt_lin);
+      remap_lin->registration_ends();
+      remap_lin->remap_fwd();
+
+      // -------------------------------------- //
+      //         Compare results                //
+      // -------------------------------------- //
+
+      using namespace Catch::Matchers;
+      const Real tol = 100*std::numeric_limits<Real>::epsilon();
+
+      tgt_loglin.sync_to_host();
+      tgt_lin.sync_to_host();
+      const auto& l = tgt_loglin.get_header().get_identifier().get_layout();
+      const int ncols_out = l.dims().front();
+      const int nlevs_out = l.dims().back();
+      auto vloglin = tgt_loglin.get_view<const Real**,Host>();
+      auto vlin    = tgt_lin.get_view<const Real**,Host>();
+
+      for (int i=0; i<ncols_out; ++i) {
+        for (int k=0; k<nlevs_out; ++k) {
+          REQUIRE (std::abs(vloglin(i,k)-vlin(i,k)) <= tol*std::abs(vlin(i,k)) + tol);
+        }
+      }
+      print (" -> Check LogLinear interpolation matches Linear with q coords (src/tgt fixed= %s,%s) ... done!\n",
+             comm, (fixed_src ? "true" : "false"), (fixed_tgt ? "true" : "false") );
+    }
+  }
+
+  // Clean up scorpio stuff
+  scorpio::finalize_subsystem();
+
+  print ("Testing log-linear vertical remapper ... done!\n",comm);
 }
 
 } // namespace scream

--- a/components/eamxx/src/share/remap/vertical_remapper.cpp
+++ b/components/eamxx/src/share/remap/vertical_remapper.cpp
@@ -46,10 +46,11 @@ create_tgt_grid (const grid_ptr_type& src_grid,
 
 VerticalRemapper::
 VerticalRemapper (const grid_ptr_type& src_grid,
-                  const std::string& map_file)
- : VerticalRemapper(src_grid,create_tgt_grid(src_grid,map_file))
+                  const std::string& map_file,
+                  const InterpType itype)
+ : VerticalRemapper(src_grid,create_tgt_grid(src_grid,map_file),itype)
 {
-  set_target_pressure (m_tgt_grid->get_geometry_data("p_levs"));
+  set_target_pressure (m_tgt_grid->get_geometry_data("p_levs"),true);
   std::filesystem::path p(map_file);
 
   set_name("VRemap " + p.filename().string());
@@ -57,7 +58,8 @@ VerticalRemapper (const grid_ptr_type& src_grid,
 
 VerticalRemapper::
 VerticalRemapper (const grid_ptr_type& src_grid,
-                  const grid_ptr_type& tgt_grid)
+                  const grid_ptr_type& tgt_grid,
+                  const InterpType itype)
 {
   set_name("VRemap " + tgt_grid->name());
 
@@ -70,6 +72,10 @@ VerticalRemapper (const grid_ptr_type& src_grid,
       "Error! Source and target grid can only differ for their number of level.\n");
 
   this->set_grids (src_grid,tgt_grid);
+
+  EKAT_REQUIRE_MSG (itype==Linear or itype==LogLinear,
+      "[VerticalRemapper] Unrecognized interpolation type.\n");
+  m_interp_type = itype;
 }
 
 void VerticalRemapper::
@@ -84,19 +90,19 @@ set_extrapolation_type (const ExtrapType etype, const TopBot where)
 }
 
 void VerticalRemapper::
-set_source_pressure (const Field& p)
+set_source_pressure (const Field& p, const bool fixed)
 {
-  set_pressure (p, "source");
+  set_pressure (p, "source", fixed);
 }
 
 void VerticalRemapper::
-set_target_pressure (const Field& p)
+set_target_pressure (const Field& p, const bool fixed)
 {
-  set_pressure (p, "target");
+  set_pressure (p, "target", fixed);
 }
 
 void VerticalRemapper::
-set_pressure (const Field& p, const std::string& src_or_tgt)
+set_pressure (const Field& p, const std::string& src_or_tgt, const bool fixed)
 {
   using namespace ShortFieldTagsNames;
   using PackT = ekat::Pack<Real,SCREAM_PACK_SIZE>;
@@ -121,16 +127,58 @@ set_pressure (const Field& p, const std::string& src_or_tgt)
       " - pressure layout: " + p_layout.to_string() + "\n");
 
   const auto vtag = p_layout.tags().back();
-  if (src)
+
+  if (src) {
     m_src_pressure[vtag] = p;
-  else
+  } else {
     m_tgt_pressure[vtag] = p;
+  }
+
+  // Decide if the coord field is going to alias p or be a clone (to store log(p))
+  auto& coord = src ? m_src_coord[vtag] : m_tgt_coord[vtag];
+  if (m_interp_type==LogLinear) {
+    coord = p.clone(p.name()+"_log", false);
+    if (fixed) {
+      coord.deep_copy(p);
+      log_pressure(coord);
+    }
+    coord.get_header().set_extra_data("fixed",fixed);
+  } else {
+    coord = p;
+  }
 
   // If already in the map, do &=, otherwise set.
   // Equivalent to inserting 'true' (if missing) and doing &= after
   bool pack_compatible = p.get_header().get_alloc_properties().is_compatible<PackT>();
   auto res = m_packs_supported.emplace(vtag,true);
   res.first->second &= pack_compatible;
+}
+
+void VerticalRemapper::
+log_pressure (Field& f) const
+{
+  const auto& layout = f.get_header().get_identifier().get_layout();
+  const int nlevs = layout.dims().back();
+
+  if (f.rank()==1) {
+    auto v = f.get_view<Real*>();
+    Kokkos::parallel_for("VerticalRemapper::log_pressure",
+                         Kokkos::RangePolicy<>(0,nlevs),
+                         KOKKOS_LAMBDA(int k) {
+      v(k) = Kokkos::log(v(k));
+    });
+  } else {
+    const int ncols = layout.dims().front();
+    auto v = f.get_view<Real**>();
+    Kokkos::parallel_for("VerticalRemapper::log_pressure",
+                         Kokkos::RangePolicy<>(0,ncols*nlevs),
+                         KOKKOS_LAMBDA(int idx) {
+      const int i = idx / nlevs;
+      const int k = idx % nlevs;
+      v(i,k) = Kokkos::log(v(i,k));
+    });
+  }
+  Kokkos::fence();
 }
 
 void VerticalRemapper::
@@ -373,6 +421,27 @@ void VerticalRemapper::remap_fwd_impl ()
 {
   using namespace ShortFieldTagsNames;
 
+  // 0. For log-linear interpolation when the src/tgt pressures is NOT constant,
+  //    recompute the log. We must deep_copy from the stored pressure first so that
+  //    repeated calls to remap_fwd_impl don't accumulate log applications (log(log(p))).
+  //    We stored a bool flag (under key "fixed") in the coord header extra data.
+  if (m_interp_type == LogLinear) {
+    for (auto& [vtag, coord] : m_src_coord) {
+      const auto& p = m_src_pressure.at(vtag);
+      if (not coord.get_header().get_extra_data<bool>("fixed")) {
+        coord.deep_copy(p);
+        log_pressure(coord);
+      }
+    }
+    for (auto& [vtag, coord] : m_tgt_coord) {
+      const auto& p = m_tgt_pressure.at(vtag);
+      if (not coord.get_header().get_extra_data<bool>("fixed")) {
+        coord.deep_copy(p);
+        log_pressure(coord);
+      }
+    }
+  }
+
   // 1. Setup any interp object that was created (if nullptr, no fields need it)
   if (m_timers_enabled)
     start_timer(name() + " setup LI");
@@ -380,20 +449,20 @@ void VerticalRemapper::remap_fwd_impl ()
   bool src_grid_levp = m_src_grid->get_vkind()==AbstractGrid::VKind::Pressure;
   bool tgt_grid_levp = m_tgt_grid->get_vkind()==AbstractGrid::VKind::Pressure;
 
-  // For a Pressure grid, there is a single pressure (keyed LEVP) used for all fields.
-  // For a Model grid, the pressure key matches the field's vtag (LEV or ILEV).
-  auto src_pressure = [&](FieldTag vtag) -> const Field& {
-    return src_grid_levp ? m_src_pressure.at(LEVP) : m_src_pressure.at(vtag);
+  // For a Pressure grid, there is a single coord (keyed LEVP) used for all fields.
+  // For a Model grid, the coord key matches the field's vtag (LEV or ILEV).
+  auto src_coord = [&](FieldTag vtag) -> const Field& {
+    return src_grid_levp ? m_src_coord.at(LEVP) : m_src_coord.at(vtag);
   };
-  auto tgt_pressure = [&](FieldTag vtag) -> const Field& {
-    return tgt_grid_levp ? m_tgt_pressure.at(LEVP) : m_tgt_pressure.at(vtag);
+  auto tgt_coord = [&](FieldTag vtag) -> const Field& {
+    return tgt_grid_levp ? m_tgt_coord.at(LEVP) : m_tgt_coord.at(vtag);
   };
 
   for (auto& [vtag, li] : m_lin_interp_packed) {
-    setup_lin_interp(li, src_pressure(vtag), tgt_pressure(vtag));
+    setup_lin_interp(li, src_coord(vtag), tgt_coord(vtag));
   }
   for (auto& [vtag, li] : m_lin_interp_scalar) {
-    setup_lin_interp(li, src_pressure(vtag), tgt_pressure(vtag));
+    setup_lin_interp(li, src_coord(vtag), tgt_coord(vtag));
   }
   if (m_timers_enabled)
     stop_timer(name() + " setup LI");
@@ -409,8 +478,8 @@ void VerticalRemapper::remap_fwd_impl ()
           auto& f_tgt    = m_tgt_fields[i];
     const auto& type = m_field2type.at(f_src.name());
     if (type.li_vtag!=INV) {
-      const auto& x_src = src_pressure(type.src_vtag);
-      const auto& x_tgt = tgt_pressure(type.tgt_vtag);
+      const auto& x_src = src_coord(type.src_vtag);
+      const auto& x_tgt = tgt_coord(type.tgt_vtag);
       if (type.packs_supported) {
         apply_vertical_interpolation(m_lin_interp_packed.at(type.li_vtag),f_src,f_tgt,x_src,x_tgt);
       } else {

--- a/components/eamxx/src/share/remap/vertical_remapper.hpp
+++ b/components/eamxx/src/share/remap/vertical_remapper.hpp
@@ -26,18 +26,25 @@ public:
     TopAndBot = Top | Bot
   };
 
-  VerticalRemapper (const grid_ptr_type& src_grid,
-                    const std::string& map_file);
+  enum InterpType {
+    Linear,     // Standard linear interpolation
+    LogLinear   // Log-linear interpolation (pressure coordinates are log-transformed)
+  };
 
   VerticalRemapper (const grid_ptr_type& src_grid,
-                    const grid_ptr_type& tgt_grid);
+                    const std::string& map_file,
+                    const InterpType itype = Linear);
+
+  VerticalRemapper (const grid_ptr_type& src_grid,
+                    const grid_ptr_type& tgt_grid,
+                    const InterpType itype = Linear);
 
   ~VerticalRemapper () = default;
 
   void set_extrapolation_type (const ExtrapType etype, const TopBot where = TopAndBot);
 
-  void set_source_pressure (const Field& p);
-  void set_target_pressure (const Field& p);
+  void set_source_pressure (const Field& p, const bool is_fixed = false);
+  void set_target_pressure (const Field& p, const bool is_fixed = false);
 
   // This method simply creates the tgt grid from a map file
   static std::shared_ptr<AbstractGrid>
@@ -49,7 +56,7 @@ public:
   bool is_valid_src_layout (const FieldLayout& layout) const override;
 protected:
 
-  void set_pressure (const Field& p, const std::string& src_or_tgt);
+  void set_pressure (const Field& p, const std::string& src_or_tgt, const bool fixed);
 
   FieldLayout create_layout (const FieldLayout& from_layout,
                              const std::shared_ptr<const AbstractGrid>& to_grid) const override;
@@ -61,6 +68,8 @@ protected:
 #ifdef KOKKOS_ENABLE_CUDA
 public:
 #endif
+  // Apply log element-wise in-place to f (rank 1 or 2)
+  void log_pressure (Field& f) const;
 
   template<int N>
   void apply_vertical_interpolation (const ekat::LinInterp<Real,N>& lin_interp,
@@ -89,9 +98,21 @@ protected:
   // Tgt grid masks (in case extrap type at top or bot is Mask)
   std::map<std::string,Field>    m_masks;
 
-  // Vertical profile fields, both for source and target.
+  // NOTE: m_src/tgt_pressure ALWAYS hold the Fields that were passed to the remapper,
+  //       regardless of the interpolation type. Log transformation is handled
+  //       either during set_pressure or at remap time, depending on whether
+  //       the pressure field is fixed (e.g. from map file) or not (e.g., from model).
   std::map<FieldTag,Field> m_src_pressure;
   std::map<FieldTag,Field> m_tgt_pressure;
+
+  InterpType m_interp_type;
+
+  // The coordinate fields used during interpolation.
+  // If m_interp_type==Linear, these are just aliasing the corresponding pressure fields.
+  // For LogLinear interpolation these will be SEPARATE fields, storing the log of the
+  // corresponding pressure field.
+  std::map<FieldTag,Field> m_src_coord;
+  std::map<FieldTag,Field> m_tgt_coord;
 
   // If user provides pressure profiles that are NOT compatible with SCREAM_PACK_SIZE,
   // we will set these booleans to false, and use ONLY the "scalar" LinInterp structures

--- a/components/eamxx/tests/multi-process/dynamics_physics/homme_shoc_cld_p3_rrtmgp_pg2/output.yaml
+++ b/components/eamxx/tests/multi-process/dynamics_physics/homme_shoc_cld_p3_rrtmgp_pg2/output.yaml
@@ -2,6 +2,7 @@
 ---
 filename_prefix: homme_shoc_cld_p3_rrtmgp_pg2_output
 averaging_type: instant
+vert_interpolation_type: linear
 fields:
   physics_pg2:
     field_names:

--- a/components/eamxx/tests/multi-process/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/output.yaml
+++ b/components/eamxx/tests/multi-process/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/output.yaml
@@ -2,6 +2,7 @@
 ---
 filename_prefix: homme_shoc_cld_spa_p3_rrtmgp_output
 averaging_type: instant
+vert_interpolation_type: linear
 fields:
   physics_gll:
     field_names:

--- a/components/eamxx/tests/multi-process/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/output.yaml
+++ b/components/eamxx/tests/multi-process/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/output.yaml
@@ -2,6 +2,7 @@
 ---
 filename_prefix: homme_shoc_cld_spa_p3_rrtmgp_128levels_output
 averaging_type: instant
+vert_interpolation_type: linear
 fields:
   physics_gll:
     field_names:

--- a/components/eamxx/tests/multi-process/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_pg2_dp/output.yaml
+++ b/components/eamxx/tests/multi-process/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_pg2_dp/output.yaml
@@ -2,6 +2,7 @@
 ---
 filename_prefix: homme_shoc_cld_spa_p3_rrtmgp_pg2_dp_output
 averaging_type: instant
+vert_interpolation_type: linear
 fields:
   physics_pg2:
     field_names:

--- a/components/eamxx/tests/multi-process/dynamics_physics/mam/homme_shoc_cld_mam_aci_p3_mam_optics_rrtmgp_mam_drydep/output.yaml
+++ b/components/eamxx/tests/multi-process/dynamics_physics/mam/homme_shoc_cld_mam_aci_p3_mam_optics_rrtmgp_mam_drydep/output.yaml
@@ -2,6 +2,7 @@
 ---
 filename_prefix: homme_shoc_cld_mam_aci_p3_mam_optics_rrtmgp_mam_drydep
 averaging_type: instant
+vert_interpolation_type: linear
 fields:
   physics_gll:
     field_names:

--- a/components/eamxx/tests/multi-process/dynamics_physics/mam/homme_shoc_cld_p3_mam_optics_rrtmgp/output.yaml
+++ b/components/eamxx/tests/multi-process/dynamics_physics/mam/homme_shoc_cld_p3_mam_optics_rrtmgp/output.yaml
@@ -2,6 +2,7 @@
 ---
 filename_prefix: homme_shoc_cld_p3_mam_optics_rrtmgp
 averaging_type: instant
+vert_interpolation_type: linear
 fields:
   physics_gll:
     field_names:

--- a/components/eamxx/tests/multi-process/dynamics_physics/mam/homme_shoc_cld_spa_p3_rrtmgp_mam4_wetscav/output.yaml
+++ b/components/eamxx/tests/multi-process/dynamics_physics/mam/homme_shoc_cld_spa_p3_rrtmgp_mam4_wetscav/output.yaml
@@ -2,6 +2,7 @@
 ---
 filename_prefix: homme_shoc_cld_spa_p3_rrtmgp_mam4_wetscav_output
 averaging_type: instant
+vert_interpolation_type: linear
 fields:
   physics_gll:
     field_names:

--- a/components/eamxx/tests/multi-process/physics_only/shoc_p3_nudging/output_remapped.yaml
+++ b/components/eamxx/tests/multi-process/physics_only/shoc_p3_nudging/output_remapped.yaml
@@ -3,6 +3,7 @@
 filename_prefix: shoc_p3_${POSTFIX}_nudged_remapped
 averaging_type: instant
 vertical_remap_file: vertical_remap.nc
+vert_interpolation_type: linear
 field_names:
   - T_mid
   - qv


### PR DESCRIPTION
Allows to perform interpolation w.r.t. the log of the pressure coordinate.

[non-BFB] Only for streams that used vertical remapping (via remapper or pressure-level diag).

---

This PR replaces #8183 and depends on #8375, so it may get rebased while we wait for that PR to be integrated.

fixes https://github.com/E3SM-Project/E3SM/issues/8170