### PR TITLE
EAMxx: preserve alloc props when creating tend field in atm proc

### DIFF
--- a/components/eamxx/src/share/atm_process/atmosphere_process.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process.cpp
@@ -266,17 +266,21 @@ void AtmosphereProcess::setup_step_tendencies (const std::string& default_grid) 
     auto gn = tokens.second;
 
     const auto& f = get_field_out(fn,gn);
-    const auto& fid = f.get_header().get_identifier();
+    const auto& fap = f.get_header().get_alloc_properties();
 
     const auto& tname = this->name() + "_" + fn + "_tend";
+    const auto& fid = f.get_header().get_identifier();
     auto tfid = fid.clone(tname).reset_units (fid.get_units() / ekat::units::s);
 
     const auto fn_gn = fn + "@" + f.get_header().get_identifier().get_grid_name();
 
     // Create tend and start-of-step fields
+    auto& tend = m_proc_tendencies[fn_gn] = Field(tfid);
+    auto& tfap = tend.get_header().get_alloc_properties();
+    tfap.request_allocation(fap);
+    tend.allocate_view();
+    add_internal_field(tend,{"ACCUMULATED","DIVIDE_BY_DT"});
     m_start_of_step_fields[fn_gn] = f.clone();
-    auto it_bool = m_proc_tendencies.try_emplace(fn_gn,tfid,true); // returns a pair <iter,bool>
-    add_internal_field(it_bool.first->second,{"ACCUMULATED","DIVIDE_BY_DT"});
   }
 }
 

--- a/components/eamxx/src/share/field/field_alloc_prop.cpp
+++ b/components/eamxx/src/share/field/field_alloc_prop.cpp
@@ -78,9 +78,10 @@ subview (const int idim, const int k, const bool dynamic) const {
     props.m_last_extent = m_layout.dim(idim);
     props.m_pack_size_max = 1;
   } else {
-    // We are keeping the last dim, so same last extent and max pack size
+    // We are keeping the last dim, so same value sizes, last extent, and max pack size
     props.m_last_extent = m_last_extent;
     props.m_pack_size_max = m_pack_size_max;
+    props.m_value_type_sizes = m_value_type_sizes;
   }
   // give it an invalid value because subviews don't get allocated
   props.m_alloc_size = -1;


### PR DESCRIPTION
Transfer alloc properties from the field to the tend field, to allow downstream code to exploit vectorization.

[BFB]

---

I'm marking this bfb, even though it's fixing a DIFF we're seeing on pm-cpu. The point is that the DIFF was introduced by #8364 by accident, so since that one was marked bfb, in order to keep the "parity", I'm keeping this bfb as well.