### PR TITLE
EAMxx: elevated emissions reader

### DIFF
--- a/components/eamxx/src/physics/mam/CMakeLists.txt
+++ b/components/eamxx/src/physics/mam/CMakeLists.txt
@@ -23,6 +23,7 @@ add_subdirectory(${EXTERNALS_SOURCE_DIR}/mam4xx ${CMAKE_BINARY_DIR}/externals/ma
 add_library(mam
   readfiles/vertical_remapper_mam4.cpp
   readfiles/vertical_remapper_exo_coldens.cpp
+  readfiles/vertical_remapper_elevated_emissions_mam4.cpp
   eamxx_mam_generic_process_interface.cpp
   eamxx_mam_microphysics_process_interface.cpp
   eamxx_mam_microphysics_process_functions.cpp

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -7,6 +7,7 @@
 #include "readfiles/photo_table_utils.cpp"
 #include "physics/mam/readfiles/vertical_remapper_mam4.hpp"
 #include "physics/mam/readfiles/vertical_remapper_exo_coldens.hpp"
+#include "physics/mam/readfiles/vertical_remapper_elevated_emissions_mam4.hpp"
 #include "share/algorithm/eamxx_data_interpolation.hpp"
 
 #include <ekat_team_policy_utils.hpp>
@@ -600,8 +601,7 @@ void MAMMicrophysics::set_elevated_emissions_reader()
     remap_data_vertical.pmid = z_iface;
     auto grid_after_hremap_vertical = di_vertical->get_grid_after_hremap();
     // we create elevated emission remapper
-    auto vertical_remapper_elevated = std::make_shared<VerticalRemapperMAM4>(grid_after_hremap_vertical, grid_,
-    VerticalRemapperMAM4::VertRemapType::MAM4_ELEVATED_EMISSIONS);
+    auto vertical_remapper_elevated = std::make_shared<VerticalRemapperElevatedEmissionsMAM4>(grid_after_hremap_vertical, grid_);
     // we set source and target variables for interpolation
     vertical_remapper_elevated->set_source_pressure(file_name);
     vertical_remapper_elevated->set_target_pressure(z_iface);

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -603,8 +603,8 @@ void MAMMicrophysics::set_elevated_emissions_reader()
     // we create elevated emission remapper
     auto vertical_remapper_elevated = std::make_shared<VerticalRemapperElevatedEmissionsMAM4>(grid_after_hremap_vertical, grid_);
     // we set source and target variables for interpolation
-    vertical_remapper_elevated->set_source_pressure(file_name);
-    vertical_remapper_elevated->set_target_pressure(z_iface);
+    vertical_remapper_elevated->set_source_interface_height(file_name);
+    vertical_remapper_elevated->set_target_interface_height(z_iface);
     remap_data_vertical.custom_remapper=vertical_remapper_elevated;
     di_vertical->create_vert_remapper (remap_data_vertical);
     di_vertical->init_data_interval (start_of_step_ts());

--- a/components/eamxx/src/physics/mam/readfiles/vertical_remapper_elevated_emissions_mam4.cpp
+++ b/components/eamxx/src/physics/mam/readfiles/vertical_remapper_elevated_emissions_mam4.cpp
@@ -33,7 +33,7 @@ void VerticalRemapperElevatedEmissionsMAM4::remap_fwd_impl ()
 /* Reads altitude_int from an NC file and stores it as m_alt_int_src.
  * altitude_int is a 1D field (same for all columns) in km. */
 void VerticalRemapperElevatedEmissionsMAM4::
-set_source_pressure (const std::string& file_name)
+set_source_interface_height (const std::string& file_name)
 {
   using namespace ShortFieldTagsNames;
   auto layout = m_src_grid->get_vertical_layout(ILEV);
@@ -49,7 +49,7 @@ set_source_pressure (const std::string& file_name)
 
 /* Stores the model interface height field (z_mam4_int) as m_z_iface_tgt. */
 void VerticalRemapperElevatedEmissionsMAM4::
-set_target_pressure (const Field& z_iface)
+set_target_interface_height (const Field& z_iface)
 {
   m_z_iface_tgt = z_iface;
 }

--- a/components/eamxx/src/physics/mam/readfiles/vertical_remapper_elevated_emissions_mam4.cpp
+++ b/components/eamxx/src/physics/mam/readfiles/vertical_remapper_elevated_emissions_mam4.cpp
@@ -1,0 +1,103 @@
+#include "vertical_remapper_elevated_emissions_mam4.hpp"
+#include "share/scorpio_interface/eamxx_scorpio_interface.hpp"
+#include <mam4xx/mam4.hpp>
+
+namespace scream
+{
+
+VerticalRemapperElevatedEmissionsMAM4::VerticalRemapperElevatedEmissionsMAM4(
+  const grid_ptr_type& src_grid,
+  const grid_ptr_type& tgt_grid)
+{
+  set_name("Vertical " + tgt_grid->name());
+
+  m_bwd_allowed = false;
+
+  EKAT_REQUIRE_MSG(
+    src_grid->get_2d_scalar_layout().congruent(tgt_grid->get_2d_scalar_layout()),
+    "Error! Source and target grid can only differ for their number of levels.\n");
+
+  set_grids(src_grid, tgt_grid);
+}
+
+void VerticalRemapperElevatedEmissionsMAM4::remap_fwd_impl ()
+{
+  for (int i=0; i<m_num_fields; ++i) {
+    const auto& f_src = m_src_fields[i];
+          auto& f_tgt = m_tgt_fields[i];
+    apply_vertical_interpolation(f_src, f_tgt);
+  }
+}
+
+/* Reads altitude_int from an NC file and stores it as m_alt_int_src.
+ * altitude_int is a 1D field (same for all columns) in km. */
+void VerticalRemapperElevatedEmissionsMAM4::
+set_source_pressure (const std::string& file_name)
+{
+  using namespace ShortFieldTagsNames;
+  auto layout = m_src_grid->get_vertical_layout(ILEV);
+  auto mbar = ekat::units::Units(100*ekat::units::Pa,"mbar");
+  Field altitude_int_src(FieldIdentifier("altitude_int_field",layout,mbar,m_src_grid->name()));
+  altitude_int_src.allocate_view();
+  scorpio::register_file(file_name,scorpio::FileMode::Read);
+  scorpio::read_var(file_name,"altitude_int",altitude_int_src.get_view<Real*,Host>().data());
+  altitude_int_src.sync_to_dev();
+  scorpio::release_file(file_name);
+  m_alt_int_src = altitude_int_src;
+}
+
+/* Stores the model interface height field (z_mam4_int) as m_z_iface_tgt. */
+void VerticalRemapperElevatedEmissionsMAM4::
+set_target_pressure (const Field& z_iface)
+{
+  m_z_iface_tgt = z_iface;
+}
+
+/* Invokes the MAM4xx rebin routine for vertical interpolation from altitude
+ * levels (km) to model interface heights. */
+void VerticalRemapperElevatedEmissionsMAM4::
+apply_vertical_interpolation(const Field& f_src, const Field& f_tgt) const
+{
+  const auto p_tgt_c = m_z_iface_tgt.get_view<const Real **>();
+  const auto src_x   = m_alt_int_src.get_view<const Real *>();
+  const auto datain  = f_src.get_view<Real **>();
+  const auto dataout = f_tgt.get_view<Real **>();
+
+  const auto& f_tgt_l = f_tgt.get_header().get_identifier().get_layout();
+  const int ncols     = m_src_grid->get_num_local_dofs();
+  const int nlevs_tgt = f_tgt_l.dims().back();
+
+  const auto& f_src_l = f_src.get_header().get_identifier().get_layout();
+  const int levsiz    = f_src_l.dims().back();
+
+  const int pverp = nlevs_tgt + 1;
+  //FIXME: get this value from grid.
+  constexpr int nlev  = mam4::nlev;
+  constexpr Real m2km = 1e-3;
+
+  using TPF  = ekat::TeamPolicyFactory<KT::ExeSpace>;
+  using Team = Kokkos::TeamPolicy<KT::ExeSpace>::member_type;
+  const auto policy = TPF::get_default_team_policy(ncols, nlevs_tgt);
+
+  Kokkos::parallel_for(
+    "vert_interpolation_elevated_emissions", policy,
+    KOKKOS_LAMBDA(const Team &team) {
+      const int icol = team.league_rank();
+      const auto datain_at_icol  = ekat::subview(datain, icol);
+      const auto dataout_at_icol = ekat::subview(dataout, icol);
+
+      // FIXME: Try to avoid copy of trg_x by modifying rebin
+      // Reverse z_mam4_int from top-to-bottom to bottom-to-top (as required
+      // by rebin) and convert from m to km.
+      // This mirrors: model_z(1:pverp) = m2km * state(c)%zi(i,pverp:1:-1)
+      Real trg_x[nlev + 1];
+      for(int i = 0; i < pverp; ++i) {
+        trg_x[pverp - i - 1] = m2km * p_tgt_c(icol, i);
+      }
+      team.team_barrier();
+      mam4::vertical_interpolation::rebin(team, levsiz, nlevs_tgt,
+                                          src_x, trg_x, datain_at_icol, dataout_at_icol);
+    });
+}
+
+} // namespace scream

--- a/components/eamxx/src/physics/mam/readfiles/vertical_remapper_elevated_emissions_mam4.cpp
+++ b/components/eamxx/src/physics/mam/readfiles/vertical_remapper_elevated_emissions_mam4.cpp
@@ -1,5 +1,6 @@
 #include "vertical_remapper_elevated_emissions_mam4.hpp"
 #include "share/scorpio_interface/eamxx_scorpio_interface.hpp"
+#include <ekat_team_policy_utils.hpp>
 #include <mam4xx/mam4.hpp>
 
 namespace scream

--- a/components/eamxx/src/physics/mam/readfiles/vertical_remapper_elevated_emissions_mam4.hpp
+++ b/components/eamxx/src/physics/mam/readfiles/vertical_remapper_elevated_emissions_mam4.hpp
@@ -1,0 +1,45 @@
+#ifndef EAMXX_VERTICAL_REMAPPER_ELEVATED_EMISSIONS_MAM4_HPP
+#define EAMXX_VERTICAL_REMAPPER_ELEVATED_EMISSIONS_MAM4_HPP
+
+#include "share/remap/abstract_remapper.hpp"
+
+namespace scream
+{
+
+/**
+ * @class VerticalRemapperElevatedEmissionsMAM4
+ * @brief Vertical remapper specialized for MAM4 elevated emissions.
+ *
+ * Remaps emission species from altitude-based source levels (km) to model
+ * interface height levels (z_mam4_int) using the MAM4xx rebin routine.
+ */
+class VerticalRemapperElevatedEmissionsMAM4 : public AbstractRemapper
+{
+public:
+
+  VerticalRemapperElevatedEmissionsMAM4 (const grid_ptr_type& src_grid,
+                                         const grid_ptr_type& tgt_grid);
+
+  ~VerticalRemapperElevatedEmissionsMAM4 () = default;
+
+  void set_source_pressure (const std::string& file_name);
+  void set_target_pressure (const Field& z_iface);
+
+protected:
+
+  Field m_alt_int_src;
+  Field m_z_iface_tgt;
+
+  using KT = KokkosTypes<DefaultDevice>;
+
+  void remap_fwd_impl () override;
+
+#ifdef KOKKOS_ENABLE_CUDA
+public:
+#endif
+  void apply_vertical_interpolation (const Field& f_src, const Field& f_tgt) const;
+};
+
+} // namespace scream
+
+#endif // EAMXX_VERTICAL_REMAPPER_ELEVATED_EMISSIONS_MAM4_HPP

--- a/components/eamxx/src/physics/mam/readfiles/vertical_remapper_elevated_emissions_mam4.hpp
+++ b/components/eamxx/src/physics/mam/readfiles/vertical_remapper_elevated_emissions_mam4.hpp
@@ -22,8 +22,8 @@ public:
 
   ~VerticalRemapperElevatedEmissionsMAM4 () = default;
 
-  void set_source_pressure (const std::string& file_name);
-  void set_target_pressure (const Field& z_iface);
+  void set_source_interface_height (const std::string& file_name);
+  void set_target_interface_height (const Field& z_iface);
 
 protected:
 

--- a/components/eamxx/src/physics/mam/readfiles/vertical_remapper_mam4.cpp
+++ b/components/eamxx/src/physics/mam/readfiles/vertical_remapper_mam4.cpp
@@ -81,6 +81,9 @@ apply_vertical_interpolation(const Field& f_src, const Field& f_tgt,
         mam4::vertical_interpolation::vert_interp(
             team, levsiz, nlevs_tgt, p_src_c, pmid_at_icol, datain_at_icol,
             dataout_at_icol, unit_factor_pin);
-          });}
+          });
+  }
+
+}
 
 } // namespace scream

--- a/components/eamxx/src/physics/mam/readfiles/vertical_remapper_mam4.cpp
+++ b/components/eamxx/src/physics/mam/readfiles/vertical_remapper_mam4.cpp
@@ -1,5 +1,4 @@
 #include "vertical_remapper_mam4.hpp"
-#include "share/scorpio_interface/eamxx_scorpio_interface.hpp"
 #include <mam4xx/mam4.hpp>
 
 namespace scream
@@ -26,34 +25,6 @@ void VerticalRemapperMAM4::remap_fwd_impl ()
           auto& f_tgt    = m_tgt_fields[i];
 
     apply_vertical_interpolation(f_src, f_tgt, src_p, tgt_p);
-  }
-}
-/* The DataInterpolation class only uses this method if the Custom type is employed.
-   We only use this function for elevated emissions. */
-void VerticalRemapperMAM4::
-set_target_pressure (const Field& p)
-{
-  using namespace ShortFieldTagsNames;
-  m_tgt_pressure[LEV] = p;
-}
-/* It reads altitude from an NC file and sets m_src_pmid as altitude_int_src.
-* DataInterpolation assumes that pressure is the variable for interpolation.
-* Here, we use m_src_pmid to pass altitude, but note that we are using
-* the MAM4XX interpolation for elevated emissions.*/
-void VerticalRemapperMAM4::
-set_source_pressure (const std::string& file_name )
-{
-  if (m_vremap_type == MAM4_ELEVATED_EMISSIONS) {
-    using namespace ShortFieldTagsNames;
-    auto layout = m_src_grid->get_vertical_layout(ILEV);
-    auto mbar = ekat::units::Units(100*ekat::units::Pa,"mbar");
-    Field altitude_src(FieldIdentifier("altitude_int",layout,mbar,m_src_grid->name()));
-    altitude_src.allocate_view();
-    scorpio::register_file(file_name,scorpio::FileMode::Read);
-    scorpio::read_var(file_name,"altitude_int",altitude_src.get_view<Real*,Host>().data());
-    altitude_src.sync_to_dev();
-    scorpio::release_file(file_name);
-    m_src_pressure[LEV] = altitude_src;
   }
 }
 /* Invokes MAM4XX routines for vertical interpolation.*/
@@ -110,35 +81,6 @@ apply_vertical_interpolation(const Field& f_src, const Field& f_tgt,
         mam4::vertical_interpolation::vert_interp(
             team, levsiz, nlevs_tgt, p_src_c, pmid_at_icol, datain_at_icol,
             dataout_at_icol, unit_factor_pin);
-          });
-  } else if (m_vremap_type == MAM4_ELEVATED_EMISSIONS)
-  {
-      const auto src_x = p_src.get_view<const Real *>();
-      const int pverp=nlevs_tgt+1;
-      //FIXME: get this values from grid.
-      constexpr int nlev = mam4::nlev;
-      constexpr Real m2km    = 1e-3;
-      Kokkos::parallel_for(
-      "vert_interpolation_elevated_emissions", policy,
-      KOKKOS_LAMBDA(const Team &team) {
-        const int icol = team.league_rank();
-        const auto datain_at_icol  = ekat::subview(datain, icol);
-        const auto dataout_at_icol = ekat::subview(dataout, icol);
-
-        // FIXME: Try to avoid copy of trg_x by modifying rebin
-        // trg_x
-        Real trg_x[nlev + 1];
-        // I am trying to do this:
-        // model_z(1:pverp) = m2km * state(c)%zi(i,pverp:1:-1)
-        for(int i = 0; i < pverp; ++i) {
-          trg_x[pverp - i - 1] = m2km * p_tgt_c(icol, i);
-        }
-        team.team_barrier();
-        mam4::vertical_interpolation::rebin(team, levsiz, nlevs_tgt,
-                                            src_x, trg_x, datain_at_icol, dataout_at_icol);
-      });
-  }
-
-}
+          });}
 
 } // namespace scream

--- a/components/eamxx/src/physics/mam/readfiles/vertical_remapper_mam4.hpp
+++ b/components/eamxx/src/physics/mam/readfiles/vertical_remapper_mam4.hpp
@@ -22,7 +22,6 @@ public:
     None,
     MAM4_PSRef, // Reconstructs a reference 3d pressure from time-dep PS in input data
     MAM4_ZONAL, // For zonal-type files that are employed in LINOZ.
-    MAM4_ELEVATED_EMISSIONS,// for vertical interpolation using altitude instead of pressure.
   };
 
   VerticalRemapperMAM4 (const grid_ptr_type& src_grid,
@@ -30,11 +29,6 @@ public:
                         const VertRemapType& vremp_type);
 
   ~VerticalRemapperMAM4 () = default;
-
-  // This remapper is a bit tricky, as it stores an ILEV field as a LEV one,
-  // since it needs to use a special type of interpolation
-  void set_target_pressure (const Field& p);
-  void set_source_pressure (const std::string& file_name);
 
 protected:
 


### PR DESCRIPTION
Creating a separate custom vertical remapper for vertical or elevated emissions: previously, we had three options in the MAM4xx remapper, VerticalRemapperMAM4, and two of them used pressure for interpolation. In the case of vertical emissions, altitude is used for interpolation. Therefore, to make the code easier to maintain, I created a new remapper.

Closes mam4xx issue 553.

[BFB]