### PR TITLE
EAMxx: remove Diagnostic atm process type enum value

### DIFF
--- a/components/eamxx/src/share/atm_process/atmosphere_process.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process.cpp
@@ -122,23 +122,15 @@ void AtmosphereProcess::initialize (const TimeStamp& t0, const RunType run_type)
     start_timer (m_timer_prefix + this->name() + "::init");
   }
 
-  // Avoid logging and flushing if ap type is diag ...
-  // ... because we could have 100+ of those in production runs
-  if (this->type()!=AtmosphereProcessType::Diagnostic) {
-    log (LogLevel::info,"  Initializing " + name() + "...");
-    m_atm_logger->flush(); // During init, flush often (to help debug crashes)
-  }
+  log (LogLevel::info,"  Initializing " + name() + "...");
+  m_atm_logger->flush(); // During init, flush often (to help debug crashes)
 
   set_fields_and_groups_pointers();
   m_start_of_step_ts = m_end_of_step_ts = t0;
   initialize_impl(run_type);
 
-  // Avoid logging and flushing if ap type is diag ...
-  // ... because we could have 100+ of those in production runs
-  if (this->type()!=AtmosphereProcessType::Diagnostic) {
-    log (LogLevel::info,"  Initializing " + name() + "... done!");
-    m_atm_logger->flush(); // During init, flush often (to help debug crashes)
-  }
+  log (LogLevel::info,"  Initializing " + name() + "... done!");
+  m_atm_logger->flush(); // During init, flush often (to help debug crashes)
 
   m_is_initialized = true;
 

--- a/components/eamxx/src/share/atm_process/atmosphere_process_utils.hpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_utils.hpp
@@ -18,7 +18,6 @@ enum class AtmosphereProcessType {
   SurfaceCouplingImporter, // Process handling the transfers from surface models to atm
   SurfaceCouplingExporter, // Process handling the transfers from atm to surface models
   Group,                   // Process that groups a bunch of processes (so they look as a single process)
-  Diagnostic               // Process that handles a diagnostic output
 };
 
 inline std::string e2str (const AtmosphereProcessType ap_type) {
@@ -28,7 +27,6 @@ inline std::string e2str (const AtmosphereProcessType ap_type) {
     case AtmosphereProcessType::SurfaceCouplingImporter: return "Surface Coupling Importer";
     case AtmosphereProcessType::SurfaceCouplingExporter: return "Surface Coupling Exporter";
     case AtmosphereProcessType::Group:                   return "Atmosphere Process Group";
-    case AtmosphereProcessType::Diagnostic:              return "Atmosphere Diagnostic";
     default:
       EKAT_ERROR_MSG("Error! Unrecognized atmosphere process type.\n");
   }


### PR DESCRIPTION
The diagnostics classes are no longer inheriting from AtmosphereProcess.

[BFB]

---

Small PR, but I thought I cleaned up this bit of code since I stumbled on it.