### PR TITLE
Add nonlinear maps (nlmaps) support for MOAB driver

### DIFF
--- a/driver-moab/main/cime_comp_mod.F90
+++ b/driver-moab/main/cime_comp_mod.F90
@@ -171,9 +171,6 @@ module cime_comp_mod
   use seq_flds_mod, only : seq_flds_set
   use seq_flds_mod, only : seq_flds_z2x_fluxes, seq_flds_x2z_fluxes
 
-  ! nonlinear maps
-  use seq_nlmap_mod, only : seq_nlmap_setopts, seq_nlmap_init_a2oi_cons, seq_nlmap_init_a2l_cons
-
   ! component type and accessor functions
   use component_type_mod, only: component_get_iamin_compid, component_get_suffix
   use component_type_mod, only: component_get_iamroot_compid
@@ -1071,10 +1068,8 @@ contains
     integer(i8) :: beg_count          ! start time
     integer(i8) :: end_count          ! end time
     integer(i8) :: irtc_rate          ! factor to convert time to seconds
-    integer :: nlmaps_verbosity
     logical :: nlmaps_atm2srf_conserve
     character(nlmaps_exclude_nchar) :: nlmaps_exclude_fields(nlmaps_exclude_max_number)
-    type(seq_map), pointer :: mapper_lcl
 
     !----------------------------------------------------------
     !| Timer initialization (has to be after mpi init)
@@ -1228,7 +1223,6 @@ contains
          reprosum_diffmax=reprosum_diffmax         , &
          reprosum_recompute=reprosum_recompute     , &
          max_cplstep_time=max_cplstep_time         , &
-         nlmaps_verbosity=nlmaps_verbosity         , &
          nlmaps_atm2srf_conserve=nlmaps_atm2srf_conserve, &
          nlmaps_exclude_fields=nlmaps_exclude_fields)
 

--- a/driver-moab/main/cime_comp_mod.F90
+++ b/driver-moab/main/cime_comp_mod.F90
@@ -1243,8 +1243,7 @@ contains
          repro_sum_rel_diff_max_in = reprosum_diffmax, &
          repro_sum_recompute_in    = reprosum_recompute)
 
-    call seq_nlmap_setopts(nlmaps_verbosity_in = nlmaps_verbosity, &
-         nlmaps_exclude_fields_in = nlmaps_exclude_fields, &
+    call seq_nlmap_setopts(nlmaps_exclude_fields_in = nlmaps_exclude_fields, &
          nlmaps_atm2srf_conserve_in = nlmaps_atm2srf_conserve)
 
     ! Check cpl_seq_option

--- a/driver-moab/main/cime_comp_mod.F90
+++ b/driver-moab/main/cime_comp_mod.F90
@@ -118,6 +118,10 @@ module cime_comp_mod
   use seq_infodata_mod, only: seq_infodata_init, seq_infodata_exchange
   use seq_infodata_mod, only: seq_infodata_type, seq_infodata_orb_variable_year
   use seq_infodata_mod, only: seq_infodata_print, seq_infodata_init2
+  use seq_infodata_mod, only: nlmaps_exclude_max_number, nlmaps_exclude_nchar
+
+  ! nonlinear maps
+  use seq_nlmap_mod, only : seq_nlmap_setopts, seq_nlmap_init_a2oi_cons, seq_nlmap_init_a2l_cons
 
   ! domain related routines
   use seq_domain_mct, only : seq_domain_check_moab
@@ -166,6 +170,9 @@ module cime_comp_mod
   use seq_flds_mod, only : seq_flds_r2x_fluxes, seq_flds_x2r_fluxes
   use seq_flds_mod, only : seq_flds_set
   use seq_flds_mod, only : seq_flds_z2x_fluxes, seq_flds_x2z_fluxes
+
+  ! nonlinear maps
+  use seq_nlmap_mod, only : seq_nlmap_setopts, seq_nlmap_init_a2oi_cons, seq_nlmap_init_a2l_cons
 
   ! component type and accessor functions
   use component_type_mod, only: component_get_iamin_compid, component_get_suffix
@@ -1064,6 +1071,10 @@ contains
     integer(i8) :: beg_count          ! start time
     integer(i8) :: end_count          ! end time
     integer(i8) :: irtc_rate          ! factor to convert time to seconds
+    integer :: nlmaps_verbosity
+    logical :: nlmaps_atm2srf_conserve
+    character(nlmaps_exclude_nchar) :: nlmaps_exclude_fields(nlmaps_exclude_max_number)
+    type(seq_map), pointer :: mapper_lcl
 
     !----------------------------------------------------------
     !| Timer initialization (has to be after mpi init)
@@ -1216,7 +1227,10 @@ contains
          reprosum_allow_infnan=reprosum_allow_infnan, &
          reprosum_diffmax=reprosum_diffmax         , &
          reprosum_recompute=reprosum_recompute     , &
-         max_cplstep_time=max_cplstep_time)
+         max_cplstep_time=max_cplstep_time         , &
+         nlmaps_verbosity=nlmaps_verbosity         , &
+         nlmaps_atm2srf_conserve=nlmaps_atm2srf_conserve, &
+         nlmaps_exclude_fields=nlmaps_exclude_fields)
 
     ! above - cpl_decomp is set to pass the cpl_decomp value to seq_mctext_decomp
     ! (via a use statement)
@@ -1228,6 +1242,10 @@ contains
          repro_sum_allow_infnan_in = reprosum_allow_infnan, &
          repro_sum_rel_diff_max_in = reprosum_diffmax, &
          repro_sum_recompute_in    = reprosum_recompute)
+
+    call seq_nlmap_setopts(nlmaps_verbosity_in = nlmaps_verbosity, &
+         nlmaps_exclude_fields_in = nlmaps_exclude_fields, &
+         nlmaps_atm2srf_conserve_in = nlmaps_atm2srf_conserve)
 
     ! Check cpl_seq_option
 
@@ -1456,6 +1474,7 @@ contains
 
     integer :: nfields, numpts
     type(mct_list) :: temp_list
+    type(seq_map), pointer :: mapper_lcl
 
 103 format( 5A )
 104 format( A, i10.8, i8)
@@ -2398,6 +2417,20 @@ contains
           call t_stopf ('CPL:init_aoflux')
        endif
     endif
+
+    !----------------------------------------------------------
+    !| Initialize atm/srf exact mass conservation if requested
+    !----------------------------------------------------------
+
+    if (iamin_CPLID) then
+       if (atm_present .and. ocn_present .and. lnd_present .and. ice_present) then
+          ! Returns immediately if atm2srf_conserve is .false.
+          mapper_lcl => prep_lnd_get_mapper_Fa2l()
+          call seq_nlmap_init_a2l_cons(mapper_lcl, fractions_ax)
+          mapper_lcl => prep_ocn_get_mapper_Fa2o()
+          call seq_nlmap_init_a2oi_cons(mapper_lcl, fractions_ax)
+       end if
+    end if
 
     !----------------------------------------------------------
     !| ATM PREP for recalculation of initial solar

--- a/driver-moab/main/component_mod.F90
+++ b/driver-moab/main/component_mod.F90
@@ -478,7 +478,7 @@ contains
           dom_s  => component_get_dom_cx(atm(1))   !dom_ax
           dom_d  => component_get_dom_cx(ocn(1))   !dom_ox
           ! project now aream from atm to ocean.  This is a rearrange since samegrid_ao is true
-          call seq_map_map(mapper_Fa2o, av_s=dom_s%data, av_d=dom_d%data, fldlist='aream')
+          call seq_map_map(mapper_Fa2o, av_s=dom_s%data, av_d=dom_d%data, fldlist='aream', omit_nonlinear=.true.)
        endif
     endif
 
@@ -487,7 +487,7 @@ contains
        dom_d  => component_get_dom_cx(ice(1))   !dom_ix
 
        ! copy aream from ocean to ice.  This is always a copy since ice and ocean have same mesh
-       call seq_map_map(mapper_SFo2i, av_s=dom_s%data, av_d=dom_d%data, fldlist='aream')
+       call seq_map_map(mapper_SFo2i, av_s=dom_s%data, av_d=dom_d%data, fldlist='aream', omit_nonlinear=.true.)
     endif
 
     if (rof_c2_ocn) then
@@ -503,7 +503,7 @@ contains
           dom_s  => component_get_dom_cx(atm(1))   !dom_ax
           dom_d  => component_get_dom_cx(lnd(1))   !dom_lx
           ! it should work for FV and spectral too
-          call seq_map_map(mapper_Sa2l, av_s=dom_s%data, av_d=dom_d%data, fldlist='aream') 
+          call seq_map_map(mapper_Sa2l, av_s=dom_s%data, av_d=dom_d%data, fldlist='aream', omit_nonlinear=.true.) 
        endif
     end if
 
@@ -512,7 +512,7 @@ contains
           dom_s  => component_get_dom_cx(lnd(1))   !dom_lx
           dom_d  => component_get_dom_cx(glc(1))   !dom_gx
 
-          call seq_map_map(mapper_Sl2g, av_s=dom_s%data, av_d=dom_d%data, fldlist='aream')
+          call seq_map_map(mapper_Sl2g, av_s=dom_s%data, av_d=dom_d%data, fldlist='aream', omit_nonlinear=.true.)
        endif
     endif
 #ifdef MOABDEBUG

--- a/driver-moab/main/prep_atm_mod.F90
+++ b/driver-moab/main/prep_atm_mod.F90
@@ -805,12 +805,16 @@ contains
 
          if (iamroot_CPLID) then
             write(logunit,*) ' '
-            write(logunit,F00) 'Initializing mapper_Fl2a'
+            write(logunit,F00) 'Initializing l2a mappers'
          endif
          call seq_map_mapinit(mapper_Fl2a, mpicom_CPLID)
+         call seq_map_mapinit(mapper_Sl2a, mpicom_CPLID)
+
          if (samegrid_al) then
             mapper_Fl2a%rearrange_only = .true.
             mapper_Fl2a%strategy = "rearrange"
+            mapper_Sl2a%rearrange_only = .true.
+            mapper_Sl2a%strategy = "rearrange"
          endif
 
          ! important change: do not compute intx at all between atm and land when we have samegrid_al
@@ -977,7 +981,6 @@ contains
             write(logunit,*) ' '
             write(logunit,F00) 'Initializing mapper_Sl2a'
          endif
-         call seq_map_mapinit(mapper_Sl2a, mpicom_CPLID)
          if (samegrid_al) then
             mapper_Sl2a%rearrange_only = .true.
             mapper_Sl2a%strategy = "rearrange"

--- a/driver-moab/main/prep_atm_mod.F90
+++ b/driver-moab/main/prep_atm_mod.F90
@@ -376,7 +376,7 @@ contains
                   type1 = 3 ! this is type of grid, maybe should be saved on imoab app ?
                   arearead = 0 ! do not read area_a and area_b from scalar map file
                   ! set up the scalar map for OCN to ATM
-                  call moab_map_init_rcfile( mboxid, mbaxid, mbintxoa, type1, &
+                  call moab_map_init_rcfile( mapper_So2a, type1, &
                         'seq_maps.rc', 'ocn2atm_smapname:', 'ocn2atm_smaptype:',samegrid_ao, &
                         arearead, wgtIdSo2a, 'mapper_So2a MOAB init', esmf_map_flag)
 
@@ -437,12 +437,15 @@ contains
               write(logunit,*) ' '
               write(logunit,F00) 'Initializing MOAB mapper_Fo2a with copy of mapper_So2a'
             endif
+            mapper_Fo2a%src_mbid = mboxid
+            mapper_Fo2a%tgt_mbid = mbaxid
+            mapper_Fo2a%intx_mbid = mbintxoa
 
             ! If loading map from disk, then load the scalar map as well
             if (.not. compute_maps_online_o2a .and. .not. samegrid_ao) then
                type1 = 3 ! this is type of grid
                arearead = 3 ! read area_a and area_b from flux map file
-               call moab_map_init_rcfile( mboxid, mbaxid, mbintxoa, type1, &
+               call moab_map_init_rcfile( mapper_Fo2a, type1, &
                      'seq_maps.rc', 'ocn2atm_fmapname:', 'ocn2atm_fmaptype:', samegrid_ao, &
                      arearead, wgtIdFo2a, 'mapper_Fo2a MOAB init', esmf_map_flag )
 
@@ -469,9 +472,6 @@ contains
 
             end if
             ! now take care of the mapper
-            mapper_Fo2a%src_mbid = mboxid
-            mapper_Fo2a%tgt_mbid = mbaxid
-            mapper_Fo2a%intx_mbid = mbintxoa
             mapper_Fo2a%src_context = mapper_So2a%src_context ! ocn(1)%cplcompid
             mapper_Fo2a%intx_context = mapper_So2a%intx_context ! it could be different, based on samegrid_ao
             mapper_Fo2a%weight_identifier = wgtIdFo2a
@@ -693,7 +693,7 @@ contains
                if (.not. samegrid_ao) then
                   type1 = 3 ! this is type of grid, maybe should be saved on imoab app ?
                   arearead = 0 ! do not read area, we do not need it
-                  call moab_map_init_rcfile(mbixid, mbaxid, mbintxia, type1, &
+                  call moab_map_init_rcfile(mapper_Si2a, type1, &
                         'seq_maps.rc', 'ice2atm_smapname:', 'ice2atm_smaptype:', samegrid_ao, &
                         arearead, wgtIdSi2a, 'mapper_Si2a MOAB init', esmf_map_flag)
                endif
@@ -730,7 +730,10 @@ contains
          !!!!!!!!!!!!!!!!!!!!!!!
             type1 = 3 ! this is type of grid
             arearead = 0 ! no need for areas
-            call moab_map_init_rcfile( mbixid, mbaxid, mbintxia, type1, &
+            mapper_Fi2a%src_mbid = mbixid
+            mapper_Fi2a%tgt_mbid = mbaxid
+            mapper_Fi2a%intx_mbid = mbintxia
+            call moab_map_init_rcfile( mapper_Fi2a, type1, &
                   'seq_maps.rc', 'ice2atm_fmapname:', 'ice2atm_fmaptype:', samegrid_ao, &
                   arearead, wgtIdFi2a, 'mapper_Fi2a MOAB init', esmf_map_flag )
 
@@ -911,12 +914,15 @@ contains
                else
                   type1 = 3 ! this is type of grid, maybe should be saved on imoab app ?
                   arearead = 0 ! do not read areas, we do not need it
-                  call moab_map_init_rcfile( mblxid, mbaxid, mbintxla, type1, &
+                  call moab_map_init_rcfile( mapper_Fl2a, type1, &
                         'seq_maps.rc', 'lnd2atm_fmapname:', 'lnd2atm_fmaptype:', samegrid_al, &
                         arearead, wgtIdFl2a, 'mapper_Fl2a MOAB initialization', esmf_map_flag)
 
                   ! If loading map from disk, then load the scalar map as well for the tri grid case
-                  call moab_map_init_rcfile( mblxid, mbaxid, mbintxla, type1, &
+                  mapper_Sl2a%src_mbid = mblxid
+                  mapper_Sl2a%tgt_mbid = mbaxid
+                  mapper_Sl2a%intx_mbid = mbintxla
+                  call moab_map_init_rcfile( mapper_Sl2a, type1, &
                         'seq_maps.rc', 'lnd2atm_smapname:', 'lnd2atm_smaptype:', samegrid_al, &
                         arearead, wgtIdSl2a, 'mapper_Sl2a MOAB initialization', esmf_map_flag, wgtIdFl2a )
 

--- a/driver-moab/main/prep_ice_mod.F90
+++ b/driver-moab/main/prep_ice_mod.F90
@@ -317,17 +317,17 @@ contains
               call shr_sys_abort(subname//' ERROR in registering ROF-ICE intersection')
             endif
 
+            mapper_Rr2i%src_mbid = mbrxid
+            mapper_Rr2i%tgt_mbid = mbixid
+            mapper_Rr2i%intx_mbid = mbintxri
             ! If loading map from disk, then load the scalar map as well
             if (.not. compute_maps_online_r2i) then
                type1 = 3 ! this is type of grid
                arearead = 0
-               call moab_map_init_rcfile( mbrxid, mbixid, mbintxri, type1, &
+               call moab_map_init_rcfile( mapper_Rr2i, type1, &
                      'seq_maps.rc', 'rof2ice_rmapname:', 'rof2ice_rmaptype:', samegrid_ro, &
                      arearead, wgtIdSr2i, 'mapper_Rr2i MOAB initialization', esmf_map_flag )
             end if
-            mapper_Rr2i%src_mbid = mbrxid
-            mapper_Rr2i%tgt_mbid = mbixid
-            mapper_Rr2i%intx_mbid = mbintxri
             mapper_Rr2i%src_context = rof(1)%cplcompid
             mapper_Rr2i%intx_context = idintx
             mapper_Rr2i%weight_identifier = wgtIdSr2i

--- a/driver-moab/main/prep_lnd_mod.F90
+++ b/driver-moab/main/prep_lnd_mod.F90
@@ -368,7 +368,7 @@ contains
               else ! read maps
                   type1 = 3 ! this is type of grid, maybe should be saved on imoab app ?
                   arearead = 0
-                  call moab_map_init_rcfile( mbrxid, mblxid, mbintxrl, type1, &
+                  call moab_map_init_rcfile( mapper_Fr2l, type1, &
                         'seq_maps.rc', 'rof2lnd_fmapname:', 'rof2lnd_fmaptype:',samegrid_lr, &
                         arearead, wgtIdFr2l, 'mapper_Fr2l MOAB initialization', esmf_map_flag)
 
@@ -575,7 +575,7 @@ contains
               else ! offline maps for atm to lnd
                   type1 = 3 ! this is type of grid, maybe should be saved on imoab app ?
                   arearead = 0 ! no need for areas
-                  call moab_map_init_rcfile( mbaxid, mblxid, mbintxal, type1, &
+                  call moab_map_init_rcfile( mapper_Sa2l, type1, &
                         'seq_maps.rc', 'atm2lnd_smapname:', 'atm2lnd_smaptype:', samegrid_al, &
                         arearead, wgtIdSa2l, 'mapper_Sa2l MOAB initialization', esmf_map_flag)
 
@@ -584,7 +584,10 @@ contains
                   ! read as the second one the f map, this one has the aream for land correct, so it should be fine
                   ! the area_b for the bilinear map above is 0 ! which caused grief
                   arearead = 2 !  area_b for land aream
-                  call moab_map_init_rcfile( mbaxid, mblxid, mbintxal, type1, &
+                  mapper_Fa2l%src_mbid = mbaxid
+                  mapper_Fa2l%tgt_mbid = mblxid
+                  mapper_Fa2l%intx_mbid = mbintxal
+                  call moab_map_init_rcfile( mapper_Fa2l, type1, &
                         'seq_maps.rc', 'atm2lnd_fmapname:', 'atm2lnd_fmaptype:',samegrid_al, &
                         arearead, wgtIdFa2l, 'mapper_Fa2l MOAB initialization', esmf_map_flag)
 

--- a/driver-moab/main/prep_ocn_mod.F90
+++ b/driver-moab/main/prep_ocn_mod.F90
@@ -406,9 +406,10 @@ contains
 
           if (iamroot_CPLID) then
              write(logunit,*) ' '
-             write(logunit,F00) 'Initializing mapper_Fa2o'
+             write(logunit,F00) 'Initializing a2o mappers'
           end if
           call seq_map_mapinit(mapper_Fa2o, mpicom_CPLID)
+          call seq_map_mapinit(mapper_Sa2o, mpicom_CPLID)
           if (samegrid_ao) then
              mapper_Fa2o%rearrange_only = .true.
              mapper_Fa2o%strategy = "rearrange"
@@ -609,7 +610,6 @@ contains
              write(logunit,*) ' '
              write(logunit,F00) 'Initializing mapper_Sa2o'
           end if
-          call seq_map_mapinit(mapper_Sa2o, mpicom_CPLID)
           if (samegrid_ao) then
              mapper_Sa2o%rearrange_only = .true.
              mapper_Sa2o%strategy = "rearrange"

--- a/driver-moab/main/prep_ocn_mod.F90
+++ b/driver-moab/main/prep_ocn_mod.F90
@@ -560,11 +560,14 @@ contains
                else
                   type1 = 3 ! this is type of grid, maybe should be saved on imoab app ?
                   arearead = 0 ! no need to read areas
-                  call moab_map_init_rcfile(mbaxid, mboxid, mbintxao, type1, &
+                  call moab_map_init_rcfile(mapper_Fa2o, type1, &
                         'seq_maps.rc', 'atm2ocn_fmapname:', 'atm2ocn_fmaptype:',samegrid_ao, &
                         arearead, wgtIdFa2o, 'mapper_Fa2o moab initialization', esmf_map_flag)
 
-                  call moab_map_init_rcfile(mbaxid, mboxid, mbintxao, type1, &
+                  mapper_Sa2o%src_mbid = mbaxid
+                  mapper_Sa2o%tgt_mbid = mboxid
+                  mapper_Sa2o%intx_mbid = mbintxao
+                  call moab_map_init_rcfile(mapper_Sa2o, type1, &
                         'seq_maps.rc', 'atm2ocn_smapname:', 'atm2ocn_smaptype:',samegrid_ao, &
                         arearead, wgtIdSa2o, 'mapper_Sa2o moab initialization', esmf_map_flag)
                endif
@@ -648,7 +651,10 @@ contains
             if (.not. compute_maps_online_a2o .and. .not. samegrid_ao ) then
                type1 = 3 ! this is type of grid
                arearead = 0 ! no need for areas
-               call moab_map_init_rcfile( mbaxid, mboxid, mbintxao, type1, &
+               mapper_Va2o%src_mbid = mbaxid
+               mapper_Va2o%tgt_mbid = mboxid
+               mapper_Va2o%intx_mbid = mbintxao
+               call moab_map_init_rcfile( mapper_Va2o, type1, &
                      'seq_maps.rc', 'atm2ocn_vmapname:', 'atm2ocn_vmaptype:', samegrid_ao, &
                      arearead, wgtIdVa2o, 'mapper_Va2o MOAB initialization', esmf_map_flag)
 
@@ -776,7 +782,10 @@ contains
           if (.not. compute_maps_online_r2o .and. .not. samegrid_ro) then
             type_grid = 3 ! this is type of grid
             arearead = 1 ! read area_a for river model
-            call moab_map_init_rcfile( mbrxid, mboxid, mbintxro, type_grid, &
+            mapper_Rr2o_liq%src_mbid = mbrxid
+            mapper_Rr2o_liq%tgt_mbid = mboxid
+            mapper_Rr2o_liq%intx_mbid = mbintxro
+            call moab_map_init_rcfile( mapper_Rr2o_liq, type_grid, &
                   'seq_maps.rc', 'rof2ocn_liq_rmapname:', 'rof2ocn_liq_rmaptype:', samegrid_ro, &
                   arearead, wgtIdFr2ol, 'mapper_Rr2o_liq MOAB initialization', esmf_map_flag )
           end if
@@ -857,16 +866,16 @@ contains
          end if
 
          ! If loading map from disk, then load the R2O_ice map
-         if (.not. compute_maps_online_r2o  .and. .not. samegrid_ro) then
-            type_grid = 3 ! this is type of grid
-            arearead = 0 ! no need for areas
-            call moab_map_init_rcfile( mbrxid, mboxid, mbintxro, type_grid, &
-                  'seq_maps.rc', 'rof2ocn_ice_rmapname:', 'rof2ocn_ice_rmaptype:', samegrid_ro, &
-                  arearead, wgtIdFr2oi, 'mapper_Rr2o_ice moab initialization', esmf_map_flag, wgtIdFr2ol )
-         end if
          mapper_Rr2o_ice%src_mbid = mbrxid
          mapper_Rr2o_ice%tgt_mbid = mboxid
          mapper_Rr2o_ice%intx_mbid = mbintxro
+         if (.not. compute_maps_online_r2o  .and. .not. samegrid_ro) then
+            type_grid = 3 ! this is type of grid
+            arearead = 0 ! no need for areas
+            call moab_map_init_rcfile( mapper_Rr2o_ice, type_grid, &
+                  'seq_maps.rc', 'rof2ocn_ice_rmapname:', 'rof2ocn_ice_rmaptype:', samegrid_ro, &
+                  arearead, wgtIdFr2oi, 'mapper_Rr2o_ice moab initialization', esmf_map_flag, wgtIdFr2ol )
+         end if
          mapper_Rr2o_ice%src_context = rof(1)%cplcompid
          mapper_Rr2o_ice%intx_context = rmapid ! read map is the same context as intersection now
          mapper_Rr2o_ice%weight_identifier = wgtIdFr2oi
@@ -891,7 +900,10 @@ contains
             if (.not. compute_maps_online_r2o .and. .not. samegrid_ro) then
                type_grid = 3 ! this is type of grid
                arearead = 0 ! no need for areas
-               call moab_map_init_rcfile( mbrxid, mboxid, mbintxro, type_grid, &
+               mapper_Fr2o%src_mbid = mbrxid
+               mapper_Fr2o%tgt_mbid = mboxid
+               mapper_Fr2o%intx_mbid = mbintxro
+               call moab_map_init_rcfile( mapper_Fr2o, type_grid, &
                      'seq_maps.rc', 'rof2ocn_fmapname:', 'rof2ocn_fmaptype:', samegrid_ro, &
                      arearead, wgtIdFr2o, 'mapper_Fr2o MOAB initialization', esmf_map_flag, wgtIdFr2ol )
             end if

--- a/driver-moab/main/prep_rof_mod.F90
+++ b/driver-moab/main/prep_rof_mod.F90
@@ -439,7 +439,7 @@ contains
                else
                   type1 = 3 ! this is type of grid, maybe should be saved on imoab app ?
                   arearead = 0 ! no need for areas
-                  call moab_map_init_rcfile( mblxid, mbrxid, mbintxlr, type1, &
+                  call moab_map_init_rcfile( mapper_Fl2r, type1, &
                         'seq_maps.rc', 'lnd2rof_fmapname:', 'lnd2rof_fmaptype:',samegrid_lr, &
                         arearead, wgtIdl2r, 'mapper_Fl2r MOAB initialization', esmf_map_flag)
 
@@ -652,7 +652,7 @@ contains
                else
                   type1 = 3 ! this is type of grid, maybe should be saved on imoab app ?
                   arearead = 0 ! no need for areas
-                  call moab_map_init_rcfile( mbaxid, mbrxid, mbintxar, type1, &
+                  call moab_map_init_rcfile( mapper_Fa2r, type1, &
                         'seq_maps.rc', 'atm2rof_fmapname:', 'atm2rof_fmaptype:',samegrid_ar, &
                         arearead, wgtIdFa2r, 'mapper_Fa2r MOAB initialization', esmf_map_flag)
                end if
@@ -696,7 +696,7 @@ contains
                if (.not. compute_maps_online_a2r) then
                   type1 = 3 ! this is type of grid
                   arearead = 0 ! no need for areas
-                  call moab_map_init_rcfile( mbaxid, mbrxid, mbintxar, type1, &
+                  call moab_map_init_rcfile( mapper_Sa2r, type1, &
                         'seq_maps.rc', 'atm2rof_smapname:', 'atm2rof_smaptype:', samegrid_ar, &
                         arearead, wgtIdSa2r, 'mapper_Sa2r MOAB initialization', esmf_map_flag )
 
@@ -819,10 +819,13 @@ contains
             endif
 
             ! If loading map from disk, then load the scalar map as well
+            mapper_So2r%src_mbid = mboxid
+            mapper_So2r%tgt_mbid = mbrxid
+            mapper_So2r%intx_mbid = mbintxor
             if (.not. compute_maps_online_o2r) then
                type1 = 3 ! this is type of grid
                arearead = 0 ! no need for areas
-               call moab_map_init_rcfile( mboxid, mbrxid, mbintxor, type1, &
+               call moab_map_init_rcfile( mapper_So2r, type1, &
                      'seq_maps.rc','ocn2rof_smapname:','ocn2rof_smaptype:',samegrid_ro, &
                      arearead, wgtIdSo2r, 'mapper_So2r MOAB initialization', esmf_map_flag)
 
@@ -835,9 +838,6 @@ contains
                endif
             end if ! if (.not. compute_maps_online_o2r) then
 
-            mapper_So2r%src_mbid = mboxid
-            mapper_So2r%tgt_mbid = mbrxid
-            mapper_So2r%intx_mbid = mbintxor
             mapper_So2r%src_context = ocn(1)%cplcompid
             mapper_So2r%intx_context = idintx
             mapper_So2r%weight_identifier = wgtIdSo2r

--- a/driver-moab/main/seq_frac_mct.F90
+++ b/driver-moab/main/seq_frac_mct.F90
@@ -451,8 +451,8 @@ contains
        if (atm_present) then
           mapper_l2a => prep_atm_get_mapper_Fl2a()
           mapper_a2l => prep_lnd_get_mapper_Fa2l()
-          call seq_map_map(mapper_l2a, fractions_l, fractions_a, fldlist='lfrin', norm=.false.)
-          call seq_map_map(mapper_a2l, fractions_a, fractions_l, fldlist='afrac', norm=.false.)
+          call seq_map_map(mapper_l2a, fractions_l, fractions_a, fldlist='lfrin', norm=.false., omit_nonlinear=.true.)
+          call seq_map_map(mapper_a2l, fractions_a, fractions_l, fldlist='afrac', norm=.false., omit_nonlinear=.true.)
        endif
 
     end if  ! end of (if lnd_present)
@@ -554,7 +554,7 @@ contains
 
        if (atm_present) then
           mapper_i2a => prep_atm_get_mapper_Fi2a()
-          call seq_map_map(mapper_i2a,fractions_i,fractions_a,fldlist='ofrac',norm=.false.)
+          call seq_map_map(mapper_i2a,fractions_i,fractions_a,fldlist='ofrac',norm=.false., omit_nonlinear=.true.)
        endif
 #ifdef MOABDEBUG
        wopts   = ';PARALLEL=WRITE_PART'//C_NULL_CHAR
@@ -606,7 +606,8 @@ contains
        if (ice_present) then
           mapper_i2o => prep_ocn_get_mapper_SFi2o()
           ! this will be a copy
-          call seq_map_map(mapper_i2o,fractions_i,fractions_o,fldlist='ofrac',norm=.false.)
+          call seq_map_map(mapper_i2o,fractions_i,fractions_o,fldlist='ofrac',norm=.false., &
+               omit_nonlinear=.true.)
 
           ! copy the computed ofrac to mbofxid
           allocate(tagValues(arrSize) )
@@ -626,7 +627,8 @@ contains
           deallocate(tagValues)
           ! map ofrac to atm
           mapper_o2a => prep_atm_get_mapper_Fo2a()
-          call seq_map_map(mapper_o2a, fractions_o, fractions_a, fldlist='ofrac',norm=.false.)
+          call seq_map_map(mapper_o2a, fractions_o, fractions_a, fldlist='ofrac',norm=.false., &
+               omit_nonlinear=.true.)
 #ifdef MOABDEBUG
          wopts   = ';PARALLEL=WRITE_PART'//C_NULL_CHAR
          if (mbaxid .ge. 0  ) then
@@ -642,13 +644,15 @@ contains
 
        if (atm_present) then
           mapper_a2o => prep_ocn_get_mapper_Fa2o()
-          call seq_map_map(mapper_a2o, fractions_a, fractions_o, fldlist='afrac',norm=.false.)
+          call seq_map_map(mapper_a2o, fractions_a, fractions_o, fldlist='afrac',norm=.false., &
+               omit_nonlinear=.true.)
        endif
 
        if (ice_present) then
           ! --- this should be an atm2ice call above, but atm2ice doesn't work
           mapper_o2i => prep_ice_get_mapper_SFo2i()
-          call seq_map_map(mapper_o2i,fractions_o,fractions_i,fldlist='afrac',norm=.false.)
+          call seq_map_map(mapper_o2i,fractions_o,fractions_i,fldlist='afrac',norm=.false., &
+               omit_nonlinear=.true.)
        endif
     end if  ! end of if ocn present
 
@@ -735,7 +739,8 @@ contains
 
        if (atm_present) then
           mapper_a2l => prep_lnd_get_mapper_Fa2l()
-          call seq_map_map(mapper_a2l, fractions_a, fractions_l, fldlist='lfrac', norm=.false.)
+          call seq_map_map(mapper_a2l, fractions_a, fractions_l, fldlist='lfrac', norm=.false., &
+              omit_nonlinear=.true.)
        else
           ! If the atmosphere is absent, then simply set fractions_l(lfrac) = fractions_l(lfrin)
           ! MCT
@@ -749,11 +754,13 @@ contains
     end if
     if (lnd_present .and. rof_present) then
        mapper_l2r => prep_rof_get_mapper_Fl2r()
-       call seq_map_map(mapper_l2r, fractions_l, fractions_r, fldlist='lfrac:lfrin', norm=.false.)
+       call seq_map_map(mapper_l2r, fractions_l, fractions_r, fldlist='lfrac:lfrin', norm=.false., &
+            omit_nonlinear=.true.)
     endif
     if (lnd_present .and. glc_present) then
        mapper_l2g => prep_glc_get_mapper_Fl2g()
-       call seq_map_map(mapper_l2g, fractions_l, fractions_g, fldlist='lfrac', norm=.false.)
+       call seq_map_map(mapper_l2g, fractions_l, fractions_g, fldlist='lfrac', norm=.false., &
+             omit_nonlinear=.true.)
     end if
 
 
@@ -939,7 +946,7 @@ contains
           endif
           mapper_i2o => prep_ocn_get_mapper_SFi2o()
           call seq_map_map(mapper_i2o, fractions_i, fractions_o, &
-               fldlist='ofrac:ifrac',norm=.false.)
+               fldlist='ofrac:ifrac',norm=.false., omit_nonlinear=.true.)
           call seq_frac_check(fractions_o,mboxid,'ocn set')
 
           ! set the ofrac on mbofxid instance, because it is needed for prep_aoxflux
@@ -952,7 +959,7 @@ contains
        if (atm_present) then
           mapper_i2a => prep_atm_get_mapper_Fi2a()
           call seq_map_map(mapper_i2a, fractions_i, fractions_a, &
-               fldlist='ofrac:ifrac', norm=.false.)
+               fldlist='ofrac:ifrac', norm=.false., omit_nonlinear=.true.)
 #ifdef MOABDEBUG
             write(lnum,"(I0.2)")num_moab_exports
             outfile = 'atmCplFr_'//trim(lnum)//'.h5m'//C_NULL_CHAR

--- a/driver-moab/main/seq_map_mod.F90
+++ b/driver-moab/main/seq_map_mod.F90
@@ -1349,7 +1349,6 @@ contains
 
     integer :: i, n, start, ipos
     character(len=128) :: name
-    character(len=*), parameter :: subname = '(build_nlmap_sublists) '
 
     fldlist_caas    = ''
     fldlist_lo_only = ''
@@ -1370,6 +1369,21 @@ contains
           nlo = 1
        end if
        return
+    end if
+
+    ! Defense-in-depth: upper-bound buffer-size check. If every input field
+    ! landed in one output list, that list would hold the entire input string
+    ! (n chars including the colons between fields) plus the final
+    ! C_NULL_CHAR -> n+1 chars. fldlist_lo_only additionally may need
+    ! ':norm8wt' (8 chars) appended when mbnorm is true. If either output
+    ! buffer is smaller than that worst case, abort with a clear message
+    ! instead of silently truncating (which would manifest as an opaque
+    ! "tag not found" error downstream in iMOAB).
+    if (len(fldlist_caas) < n + 1) then
+       call shr_sys_abort('(build_nlmap_sublists) ERROR: fldlist_caas buffer too small for input field list')
+    end if
+    if (len(fldlist_lo_only) < n + 1 + merge(8, 0, mbnorm)) then
+       call shr_sys_abort('(build_nlmap_sublists) ERROR: fldlist_lo_only buffer too small for input field list')
     end if
 
     ! Walk the colon-separated list.

--- a/driver-moab/main/seq_map_mod.F90
+++ b/driver-moab/main/seq_map_mod.F90
@@ -357,7 +357,9 @@ contains
     integer  :: ierr, nfields, lsize_src, lsize_tgt, arrsize_tgt, j, arrsize_src
     character(len=CXX) :: fldlist_moab
     character(len=CXX) :: fldlist_data    ! data fields only (no norm8wt) for nlmap CAAS path
-    character(len=CXX) :: norm8wt_only    ! "norm8wt" alone, for separate low-order pass
+    character(len=CXX) :: fldlist_caas    ! non-excluded data fields → dual-map CAAS
+    character(len=CXX) :: fldlist_lo_only ! excluded data + norm8wt → low-order projection
+    integer            :: ncaas_fields, nlo_fields  ! field counts for the two sub-lists
     character(len=CXX) :: tagname
     character(len=CXX) :: lo_weights_identifier
     integer    :: nvert(3), nvise(3), nbl(3), nsurf(3), nvisBC(3) ! for moab info
@@ -463,7 +465,6 @@ contains
        ! row-sum-1, so the CAAS-clipped result no longer matches MCT's
        ! mct_sMat_avMult-mapped target norm8wt that the post-divide expects.
        fldlist_data = trim(fldlist_moab)//C_NULL_CHAR
-       norm8wt_only = "norm8wt"//C_NULL_CHAR
 
        if (mbnorm) then
           fldlist_moab = trim(fldlist_moab)//":norm8wt"//C_NULL_CHAR
@@ -707,40 +708,57 @@ contains
              endif
           else
              ! Dual-map nonlinear remapping path. To match MCT's
-             ! seq_nlmap_avNormArr exactly we split the work in two:
-             !   (a) DATA fields go through the dual-map CAAS so they get the
-             !       high-order interpolation with low-order CAAS bounds.
-             !       filter_type must be != CAAS_NONE for ApplyWeightsWithDualMap
-             !       to actually run (otherwise iMOAB falls through to plain
-             !       high-order without bounds — produces OOB values that
-             !       crash icepack).
-             !   (b) norm8wt goes through a SEPARATE low-order projection so
-             !       the target norm8wt = row-sum of the low-order map
-             !       (matching MCT's mct_sMat_avMult on the appended ffld
-             !       column). The post-norm divide below then divides data by
-             !       this low-order row-sum, which is what MCT does and what
-             !       restores correct normalization at partial-coverage cells.
-             filter_type = 2 ! CAAS_LOCAL
-             ierr = iMOAB_ApplyScalarProjectionWeights ( mapper%intx_mbid, filter_type, mapper%howeight_identifier, &
-               fldlist_data, fldlist_data, mapper%weight_identifier)
-             if (ierr .ne. 0) then
-                write(logunit,*) subname,' error in applying weights (data fields, dual-map CAAS)'
-                call shr_sys_abort(subname//' ERROR in applying weights (data fields, dual-map CAAS)')
-             endif
-             if (mbnorm) then
-                ! Map norm8wt low-order only — gives target norm8wt = row sum
-                ! of the low-order map (≈ 1 for full coverage, < 1 for partial).
+             ! seq_nlmap_avNormArr exactly we split the data fields by
+             ! whether they appear in the namelist nlmaps_exclude_fields list:
+             !
+             !   (a) NON-EXCLUDED data fields (`fldlist_caas`): high-order
+             !       interpolation with low-order CAAS bounds via the dual-map
+             !       call. filter_type must be != CAAS_NONE for
+             !       ApplyWeightsWithDualMap to actually run (otherwise iMOAB
+             !       falls through to plain high-order without bounds —
+             !       produces OOB values that crash icepack).
+             !   (b) EXCLUDED data fields (`fldlist_lo_only`): low-order map
+             !       only, matching MCT seq_nlmap_avNormArr's behavior at
+             !       lines 691-698 of driver-mct/main/seq_nlmap_mod.F90 — for
+             !       these fields avp_o keeps the low-order mct_sMat_avMult
+             !       result and is NOT overwritten with the nonlinear-fixer
+             !       output. Examples: Faxa_rainc/rainl/snowc/snowl.
+             !   (c) `norm8wt` (when mbnorm): low-order map only, joined into
+             !       the same low-order pass as (b) since both use the same
+             !       weight matrix. Gives target norm8wt = low-order row sum.
+             !       The post-norm divide below then divides data by this
+             !       low-order row-sum, restoring correct normalization at
+             !       partial-coverage cells (matches MCT outer
+             !       seq_map_avNormArr post-divide).
+             call build_nlmap_sublists( fldlist_data, mbnorm, &
+                                        fldlist_caas, ncaas_fields, &
+                                        fldlist_lo_only, nlo_fields )
+
+             if (ncaas_fields > 0) then
+                filter_type = 2 ! CAAS_LOCAL
+                ierr = iMOAB_ApplyScalarProjectionWeights ( mapper%intx_mbid, filter_type, &
+                       mapper%howeight_identifier, fldlist_caas, fldlist_caas, &
+                       mapper%weight_identifier )
+                if (ierr .ne. 0) then
+                   write(logunit,*) subname,' error in applying weights (data fields, dual-map CAAS)'
+                   call shr_sys_abort(subname//' ERROR in applying weights (data fields, dual-map CAAS)')
+                endif
+             end if
+
+             if (nlo_fields > 0) then
+                ! Excluded data fields + (optionally) norm8wt — plain low-order.
                 ! lo_weights_identifier is empty so iMOAB takes the plain
                 ! ApplyWeights branch (no dual-map CAAS) regardless of
                 ! filter_type.
                 filter_type = 0
-                ierr = iMOAB_ApplyScalarProjectionWeights ( mapper%intx_mbid, filter_type, mapper%weight_identifier, &
-                  norm8wt_only, norm8wt_only, lo_weights_identifier)
+                ierr = iMOAB_ApplyScalarProjectionWeights ( mapper%intx_mbid, filter_type, &
+                       mapper%weight_identifier, fldlist_lo_only, fldlist_lo_only, &
+                       lo_weights_identifier )
                 if (ierr .ne. 0) then
-                   write(logunit,*) subname,' error in applying weights (norm8wt, low-order)'
-                   call shr_sys_abort(subname//' ERROR in applying weights (norm8wt, low-order)')
+                   write(logunit,*) subname,' error in applying weights (excluded fields + norm8wt, low-order)'
+                   call shr_sys_abort(subname//' ERROR in applying weights (excluded fields + norm8wt, low-order)')
                 endif
-             endif
+             end if
           endif
 
           !*** MOAB: Post-normalization (target side)
@@ -1308,6 +1326,119 @@ contains
        endif
 
   end subroutine seq_map_cart3d
+
+  !=======================================================================
+  ! build_nlmap_sublists -- split a colon-separated tag list into two
+  ! sub-lists for the dual-map nlmap path:
+  !
+  !   fldlist_caas    : data fields NOT in the nlmaps_exclude_fields list,
+  !                     which go through the high-order CAAS dual-map call.
+  !   fldlist_lo_only : data fields IN the exclude list, plus the special
+  !                     "norm8wt" tag when mbnorm is true. These are mapped
+  !                     with the LOW-order weight matrix only — same as MCT
+  !                     seq_nlmap_avNormArr's behavior of leaving avp_o at
+  !                     the mct_sMat_avMult result for excluded fields, and
+  !                     of mapping the norm8wt column via the low-order map.
+  !
+  ! Both output strings are colon-separated, terminated with C_NULL_CHAR
+  ! (so they can be passed straight to iMOAB). The corresponding field
+  ! counts are also returned. The input fldlist must be C_NULL-terminated.
+  !=======================================================================
+  subroutine build_nlmap_sublists(fldlist_in, mbnorm, &
+                                  fldlist_caas, ncaas, &
+                                  fldlist_lo_only, nlo)
+    use iso_c_binding, only : C_NULL_CHAR
+    use seq_nlmap_mod, only : seq_nlmap_field_is_excluded
+
+    character(len=*), intent(in)  :: fldlist_in
+    logical,          intent(in)  :: mbnorm
+    character(len=*), intent(out) :: fldlist_caas
+    integer,          intent(out) :: ncaas
+    character(len=*), intent(out) :: fldlist_lo_only
+    integer,          intent(out) :: nlo
+
+    integer :: i, n, start, ipos
+    character(len=128) :: name
+    character(len=*), parameter :: subname = '(build_nlmap_sublists) '
+
+    fldlist_caas    = ''
+    fldlist_lo_only = ''
+    ncaas = 0
+    nlo   = 0
+
+    ! Trim trailing C_NULL_CHAR(s) before parsing.
+    n = len_trim(fldlist_in)
+    do while (n > 0)
+       if (fldlist_in(n:n) /= C_NULL_CHAR) exit
+       n = n - 1
+    end do
+    if (n <= 0) then
+       fldlist_caas    = C_NULL_CHAR
+       fldlist_lo_only = C_NULL_CHAR
+       if (mbnorm) then
+          fldlist_lo_only = 'norm8wt'//C_NULL_CHAR
+          nlo = 1
+       end if
+       return
+    end if
+
+    ! Walk the colon-separated list.
+    start = 1
+    do i = 1, n+1
+       if (i == n+1 .or. fldlist_in(i:i) == ':') then
+          if (i > start) then
+             name = fldlist_in(start:i-1)
+             if (seq_nlmap_field_is_excluded(name)) then
+                if (nlo > 0) then
+                   ipos = len_trim(fldlist_lo_only)
+                   fldlist_lo_only(ipos+1:ipos+1) = ':'
+                   fldlist_lo_only(ipos+2:) = trim(name)
+                else
+                   fldlist_lo_only = trim(name)
+                end if
+                nlo = nlo + 1
+             else
+                if (ncaas > 0) then
+                   ipos = len_trim(fldlist_caas)
+                   fldlist_caas(ipos+1:ipos+1) = ':'
+                   fldlist_caas(ipos+2:) = trim(name)
+                else
+                   fldlist_caas = trim(name)
+                end if
+                ncaas = ncaas + 1
+             end if
+          end if
+          start = i + 1
+       end if
+    end do
+
+    ! Append norm8wt to the low-order list when normalization is requested.
+    if (mbnorm) then
+       if (nlo > 0) then
+          ipos = len_trim(fldlist_lo_only)
+          fldlist_lo_only(ipos+1:ipos+1) = ':'
+          fldlist_lo_only(ipos+2:) = 'norm8wt'
+       else
+          fldlist_lo_only = 'norm8wt'
+       end if
+       nlo = nlo + 1
+    end if
+
+    ! Null-terminate for iMOAB.
+    if (ncaas > 0) then
+       ipos = len_trim(fldlist_caas)
+       fldlist_caas(ipos+1:ipos+1) = C_NULL_CHAR
+    else
+       fldlist_caas = C_NULL_CHAR
+    end if
+
+    if (nlo > 0) then
+       ipos = len_trim(fldlist_lo_only)
+       fldlist_lo_only(ipos+1:ipos+1) = C_NULL_CHAR
+    else
+       fldlist_lo_only = C_NULL_CHAR
+    end if
+  end subroutine build_nlmap_sublists
 
   !=======================================================================
 

--- a/driver-moab/main/seq_map_mod.F90
+++ b/driver-moab/main/seq_map_mod.F90
@@ -210,8 +210,7 @@ contains
     integer(IN)                 :: mapid
     character(CL)               :: nlmap_id
     character(len=128)          :: nl_label
-    logical                     :: nl_found, nl_conservative
-    character(len=*),parameter  :: nl_strategy = 'X'
+    logical                     :: nl_found
     integer                     :: ierr
 
     character(len=*),parameter  :: subname = "(moab_map_init_rcfile) "
@@ -250,23 +249,15 @@ contains
        call shr_sys_abort(subname//' ERROR in loading map file - ' // mapfile)
     endif
 
-   mapper%nl_available = .false.
-!  Look for nonlinear map
+    mapper%nl_available = .false.
+    ! Look for an optional nonlinear (high-order) map paired with this one.
     nl_label = maprcname(1:len(maprcname)-1)//'_nonlinear:'
     call shr_mct_queryConfigFile(mpicom, maprcfile, trim(nl_label), nl_mapfile, &
           Label1Found=nl_found)
     if (nl_found) nl_found = nl_mapfile /= "idmap_ignore"
-    nl_conservative = .false.
 
-    ! initially any fmap will be set to be conservative
-    ! this can be overriden by the the nlmaps_atm2srf_conserve namelist variable
-    if (nl_found) nl_conservative = seq_map_should_nonlinear_map_conserve(maprcname)
-
-    mapper%nl_available = nl_found
     if (nl_found) then
          mapper%nl_available = .true.
-         mapper%nl_conservative = nl_conservative
-         mapper%nl_mapfile = trim(nl_mapfile)
          nlmap_id = 'ho'//map_identifier
          mapper%howeight_identifier = nlmap_id
          mapfile_term = trim(nl_mapfile)//CHAR(0)
@@ -282,13 +273,12 @@ contains
        write(logunit,'(2A,I6,4A)') subname,' mapper counter, strategy, mapfile = ', &
             mapper%counter,' ',trim(mapper%strategy),' ',trim(mapper%mapfile)
        if (mapper%nl_available) then
-          write(logunit,'(2A,I6,3A,L1,2A)') subname, &
-               ' mapper counter, nl_strategy, nl_conservative, nlmap_id,  nl_mapfile = ', &
-               mapper%counter,' ',nl_strategy,' ',nl_conservative,' ',trim(nlmap_id),' ',trim(mapper%nl_mapfile)
+          write(logunit,'(2A,I6,3A)') subname, &
+               ' mapper counter, nlmap_id = ', &
+               mapper%counter,' ',trim(nlmap_id)
        end if
        call shr_sys_flush(logunit)
     endif
-
 
   end subroutine moab_map_init_rcfile
 

--- a/driver-moab/main/seq_map_mod.F90
+++ b/driver-moab/main/seq_map_mod.F90
@@ -174,7 +174,7 @@ contains
   end subroutine seq_map_init_rcfile
 
 
-  subroutine moab_map_init_rcfile( mbsrc, mbtgt, mbintx, discretization_type, &
+  subroutine moab_map_init_rcfile( mapper, discretization_type, &
                    maprcfile, maprcname, maprctype, samegrid, arearead, map_identifier, &
                    description_string, esmf_map, fallback_map_identifier )
 
@@ -184,9 +184,7 @@ contains
     !
     ! Arguments
     !
-    type(integer)        ,intent(in)            :: mbsrc  ! moab source app id
-    type(integer)        ,intent(in)            :: mbtgt  ! moab target app id
-    type(integer)        ,intent(in)            :: mbintx  ! moab intersection app id, identifing the map from source to target
+    type(seq_map)        ,intent(inout)         :: mapper  ! mapper being initialized (src_mbid, tgt_mbid, intx_mbid must be set)
     type(integer)        ,intent(in)            :: discretization_type ! 1 for SE, 2 for PC, 3 for FV; should be a member data
     ! type(component_type) ,intent(inout)         :: comp_s
     ! type(component_type) ,intent(inout)         :: comp_d
@@ -237,7 +235,7 @@ contains
          write(logunit,*) subname,' reading map file with iMOAB: ', trim(mapfile_term)
       endif
 
-      ierr = iMOAB_LoadMapFile( mbsrc, mbtgt, mbintx, discretization_type, &
+      ierr = iMOAB_LoadMapFile( mapper%src_mbid, mapper%tgt_mbid, mapper%intx_mbid, discretization_type, &
                                  discretization_type, arearead, map_identifier, mapfile_term)
       if (ierr .ne. 0) then
          write(logunit,*) subname,' error in loading map file - ' // mapfile
@@ -245,7 +243,7 @@ contains
       endif
       if (seq_comm_iamroot(CPLID)) then
          write(logunit,'(2A,I10,6A)') subname, ': iMOAB appID: ', &
-            mbintx, ', maptype: ', trim(maptype), ', mapfile: ', &
+            mapper%intx_mbid, ', maptype: ', trim(maptype), ', mapfile: ', &
             trim(mapfile), ', identifier: ', trim(map_identifier)
          call shr_sys_flush(logunit)
       endif

--- a/driver-moab/main/seq_map_mod.F90
+++ b/driver-moab/main/seq_map_mod.F90
@@ -330,7 +330,7 @@ contains
   !=======================================================================
 
   subroutine seq_map_map( mapper, av_s, av_d, fldlist, norm, avwts_s, avwtsfld_s, &
-       string, msgtag )
+       string, msgtag, omit_nonlinear  )
 
     use iso_c_binding
     use iMOAB, only: iMOAB_GetMeshInfo, iMOAB_GetDoubleTagStorage, iMOAB_SetDoubleTagStorage, &
@@ -352,6 +352,7 @@ contains
     character(len=*),intent(in),optional :: avwtsfld_s
     character(len=*),intent(in),optional :: string
     integer(IN)     ,intent(in),optional :: msgtag
+    logical         ,intent(in),optional :: omit_nonlinear
     logical  :: valid_moab_context
     integer  :: ierr, nfields, lsize_src, lsize_tgt, arrsize_tgt, j, arrsize_src
     character(len=CXX) :: fldlist_moab
@@ -368,6 +369,7 @@ contains
     !
     logical :: lnorm  ! true if normalization is to be done
     logical :: mbnorm ! moab copy of lnorm
+    logical :: use_nonlinear_map
     logical :: mbpresent ! moab logical for presence of norm weight string
     integer(IN),save :: ltag    ! message tag for rearrange
     character(len=*),parameter :: subname = "(seq_map_map) "
@@ -376,6 +378,14 @@ contains
     if (seq_comm_iamroot(CPLID) .and. present(string)) then
        write(logunit,'(A)') subname//' called for '//trim(string)
     endif
+
+    use_nonlinear_map = .false.
+    if (mapper%nl_available) then
+       use_nonlinear_map = .true.
+       if (present(omit_nonlinear)) then
+          if (omit_nonlinear) use_nonlinear_map = .false.
+       end if
+    end if
 
     lnorm = .true.
     if (present(norm)) then
@@ -675,10 +685,12 @@ contains
           !***   fldlist_moab: Input and output field names (can be different)
           filter_type = 0 ! no filter
 
-          if(.not.mapper%nl_available) then
+          if(.not.use_nonlinear_map) then
              ierr = iMOAB_ApplyScalarProjectionWeights ( mapper%intx_mbid, filter_type, mapper%weight_identifier, fldlist_moab, fldlist_moab)
           else
-             ierr = iMOAB_ApplyScalarProjectionWeights ( mapper%intx_mbid, filter_type, mapper%howeight_identifier, fldlist_moab, fldlist_moab)
+             ! no difference until high order map is working
+             ierr = iMOAB_ApplyScalarProjectionWeights ( mapper%intx_mbid, filter_type, mapper%weight_identifier, fldlist_moab, fldlist_moab)
+             !ierr = iMOAB_ApplyScalarProjectionWeights ( mapper%intx_mbid, filter_type, mapper%howeight_identifier, fldlist_moab, fldlist_moab)
           endif
           if (ierr .ne. 0) then
              write(logunit,*) subname,' error in applying weights '

--- a/driver-moab/main/seq_map_mod.F90
+++ b/driver-moab/main/seq_map_mod.F90
@@ -356,7 +356,10 @@ contains
     logical  :: valid_moab_context
     integer  :: ierr, nfields, lsize_src, lsize_tgt, arrsize_tgt, j, arrsize_src
     character(len=CXX) :: fldlist_moab
+    character(len=CXX) :: fldlist_data    ! data fields only (no norm8wt) for nlmap CAAS path
+    character(len=CXX) :: norm8wt_only    ! "norm8wt" alone, for separate low-order pass
     character(len=CXX) :: tagname
+    character(len=CXX) :: lo_weights_identifier
     integer    :: nvert(3), nvise(3), nbl(3), nsurf(3), nvisBC(3) ! for moab info
     type(mct_list) :: temp_list
     integer, dimension(:), allocatable  :: globalIds
@@ -452,6 +455,15 @@ contains
           fldlist_moab = ''
           if ( nfields /= 0 ) fldlist_moab = trim(mct_aVect_exportRList2c(av_s))
        endif
+
+       ! Snapshot the data-only field list (no norm8wt). Used in the nlmap
+       ! path so the dual-map CAAS only sees real data fields. norm8wt has to
+       ! be mapped LOW-order separately (see Step 5 below) — putting it in the
+       ! CAAS list mishandles it: the high-order map of constant 1.0 is not
+       ! row-sum-1, so the CAAS-clipped result no longer matches MCT's
+       ! mct_sMat_avMult-mapped target norm8wt that the post-divide expects.
+       fldlist_data = trim(fldlist_moab)//C_NULL_CHAR
+       norm8wt_only = "norm8wt"//C_NULL_CHAR
 
        if (mbnorm) then
           fldlist_moab = trim(fldlist_moab)//":norm8wt"//C_NULL_CHAR
@@ -683,18 +695,52 @@ contains
           !***   filter_type: 0=no filter, other values for CAAS projection
           !***   weight_identifier: Name of the weight matrix (e.g., "scalar", "flux")
           !***   fldlist_moab: Input and output field names (can be different)
-          filter_type = 0 ! no filter
+          lo_weights_identifier = ''//C_NULL_CHAR
 
           if(.not.use_nonlinear_map) then
-             ierr = iMOAB_ApplyScalarProjectionWeights ( mapper%intx_mbid, filter_type, mapper%weight_identifier, fldlist_moab, fldlist_moab)
+             filter_type = 0 ! CAAS_NONE: plain low-order projection
+             ierr = iMOAB_ApplyScalarProjectionWeights ( mapper%intx_mbid, filter_type, mapper%weight_identifier, &
+               fldlist_moab, fldlist_moab, lo_weights_identifier)
+             if (ierr .ne. 0) then
+                write(logunit,*) subname,' error in applying weights '
+                call shr_sys_abort(subname//' ERROR in applying weights')
+             endif
           else
-             ! no difference until high order map is working
-             ierr = iMOAB_ApplyScalarProjectionWeights ( mapper%intx_mbid, filter_type, mapper%weight_identifier, fldlist_moab, fldlist_moab)
-             !ierr = iMOAB_ApplyScalarProjectionWeights ( mapper%intx_mbid, filter_type, mapper%howeight_identifier, fldlist_moab, fldlist_moab)
-          endif
-          if (ierr .ne. 0) then
-             write(logunit,*) subname,' error in applying weights '
-             call shr_sys_abort(subname//' ERROR in applying weights')
+             ! Dual-map nonlinear remapping path. To match MCT's
+             ! seq_nlmap_avNormArr exactly we split the work in two:
+             !   (a) DATA fields go through the dual-map CAAS so they get the
+             !       high-order interpolation with low-order CAAS bounds.
+             !       filter_type must be != CAAS_NONE for ApplyWeightsWithDualMap
+             !       to actually run (otherwise iMOAB falls through to plain
+             !       high-order without bounds — produces OOB values that
+             !       crash icepack).
+             !   (b) norm8wt goes through a SEPARATE low-order projection so
+             !       the target norm8wt = row-sum of the low-order map
+             !       (matching MCT's mct_sMat_avMult on the appended ffld
+             !       column). The post-norm divide below then divides data by
+             !       this low-order row-sum, which is what MCT does and what
+             !       restores correct normalization at partial-coverage cells.
+             filter_type = 2 ! CAAS_LOCAL
+             ierr = iMOAB_ApplyScalarProjectionWeights ( mapper%intx_mbid, filter_type, mapper%howeight_identifier, &
+               fldlist_data, fldlist_data, mapper%weight_identifier)
+             if (ierr .ne. 0) then
+                write(logunit,*) subname,' error in applying weights (data fields, dual-map CAAS)'
+                call shr_sys_abort(subname//' ERROR in applying weights (data fields, dual-map CAAS)')
+             endif
+             if (mbnorm) then
+                ! Map norm8wt low-order only — gives target norm8wt = row sum
+                ! of the low-order map (≈ 1 for full coverage, < 1 for partial).
+                ! lo_weights_identifier is empty so iMOAB takes the plain
+                ! ApplyWeights branch (no dual-map CAAS) regardless of
+                ! filter_type.
+                filter_type = 0
+                ierr = iMOAB_ApplyScalarProjectionWeights ( mapper%intx_mbid, filter_type, mapper%weight_identifier, &
+                  norm8wt_only, norm8wt_only, lo_weights_identifier)
+                if (ierr .ne. 0) then
+                   write(logunit,*) subname,' error in applying weights (norm8wt, low-order)'
+                   call shr_sys_abort(subname//' ERROR in applying weights (norm8wt, low-order)')
+                endif
+             endif
           endif
 
           !*** MOAB: Post-normalization (target side)

--- a/driver-moab/main/seq_map_mod.F90
+++ b/driver-moab/main/seq_map_mod.F90
@@ -258,7 +258,7 @@ contains
 
     if (nl_found) then
          mapper%nl_available = .true.
-         nlmap_id = 'ho'//map_identifier
+         nlmap_id = 'ho_'//map_identifier
          mapper%howeight_identifier = nlmap_id
          mapfile_term = trim(nl_mapfile)//CHAR(0)
          ierr = iMOAB_LoadMapFile( mapper%src_mbid, mapper%tgt_mbid, mapper%intx_mbid, discretization_type, &
@@ -351,7 +351,6 @@ contains
     character(len=CXX) :: fldlist_lo_only ! excluded data + norm8wt → low-order projection
     integer            :: ncaas_fields, nlo_fields  ! field counts for the two sub-lists
     character(len=CXX) :: tagname
-    character(len=CXX) :: lo_weights_identifier
     integer    :: nvert(3), nvise(3), nbl(3), nsurf(3), nvisBC(3) ! for moab info
     type(mct_list) :: temp_list
     integer, dimension(:), allocatable  :: globalIds
@@ -686,12 +685,10 @@ contains
           !***   filter_type: 0=no filter, other values for CAAS projection
           !***   weight_identifier: Name of the weight matrix (e.g., "scalar", "flux")
           !***   fldlist_moab: Input and output field names (can be different)
-          lo_weights_identifier = ''//C_NULL_CHAR
-
           if(.not.use_nonlinear_map) then
              filter_type = 0 ! CAAS_NONE: plain low-order projection
              ierr = iMOAB_ApplyScalarProjectionWeights ( mapper%intx_mbid, filter_type, mapper%weight_identifier, &
-               fldlist_moab, fldlist_moab, lo_weights_identifier)
+               fldlist_moab, fldlist_moab)
              if (ierr .ne. 0) then
                 write(logunit,*) subname,' error in applying weights '
                 call shr_sys_abort(subname//' ERROR in applying weights')
@@ -727,8 +724,7 @@ contains
              if (ncaas_fields > 0) then
                 filter_type = 2 ! CAAS_LOCAL
                 ierr = iMOAB_ApplyScalarProjectionWeights ( mapper%intx_mbid, filter_type, &
-                       mapper%howeight_identifier, fldlist_caas, fldlist_caas, &
-                       mapper%weight_identifier )
+                       mapper%howeight_identifier, fldlist_caas, fldlist_caas )
                 if (ierr .ne. 0) then
                    write(logunit,*) subname,' error in applying weights (data fields, dual-map CAAS)'
                    call shr_sys_abort(subname//' ERROR in applying weights (data fields, dual-map CAAS)')
@@ -737,13 +733,10 @@ contains
 
              if (nlo_fields > 0) then
                 ! Excluded data fields + (optionally) norm8wt — plain low-order.
-                ! lo_weights_identifier is empty so iMOAB takes the plain
-                ! ApplyWeights branch (no dual-map CAAS) regardless of
-                ! filter_type.
+                ! iMOAB takes the plain ApplyWeights branch (no dual-map CAAS)
                 filter_type = 0
                 ierr = iMOAB_ApplyScalarProjectionWeights ( mapper%intx_mbid, filter_type, &
-                       mapper%weight_identifier, fldlist_lo_only, fldlist_lo_only, &
-                       lo_weights_identifier )
+                       mapper%weight_identifier, fldlist_lo_only, fldlist_lo_only )
                 if (ierr .ne. 0) then
                    write(logunit,*) subname,' error in applying weights (excluded fields + norm8wt, low-order)'
                    call shr_sys_abort(subname//' ERROR in applying weights (excluded fields + norm8wt, low-order)')

--- a/driver-moab/main/seq_map_mod.F90
+++ b/driver-moab/main/seq_map_mod.F90
@@ -21,6 +21,7 @@ module seq_map_mod
   use seq_comm_mct
   use component_type_mod
   use seq_map_type_mod
+  use seq_nlmap_mod
   use shr_moab_mod
 
   implicit none
@@ -203,10 +204,14 @@ contains
     !type(mct_gsmap), pointer    :: gsmap_s ! temporary pointers
     !type(mct_gsmap), pointer    :: gsmap_d ! temporary pointers
     integer(IN)                 :: mpicom
-    character(CX)               :: mapfile
+    character(CX)               :: mapfile, nl_mapfile
     character(CX)               :: mapfile_term
     character(CL)               :: maptype
     integer(IN)                 :: mapid
+    character(CL)               :: nlmap_id
+    character(len=128)          :: nl_label
+    logical                     :: nl_found, nl_conservative
+    character(len=*),parameter  :: nl_strategy = 'X'
     integer                     :: ierr
 
     character(len=*),parameter  :: subname = "(moab_map_init_rcfile) "
@@ -218,36 +223,72 @@ contains
 
     call seq_comm_setptrs(CPLID, mpicom=mpicom)
 
-   ! --- Initialize Smatp
-   call shr_mct_queryConfigFile(mpicom,maprcfile,maprcname,mapfile,maprctype,maptype)
-   if (mapfile == 'idmap' .or. mapfile == 'idmap_ignore') then
+    ! --- Initialize Smatp
+    call shr_mct_queryConfigFile(mpicom,maprcfile,maprcname,mapfile,maprctype,maptype)
+
+    ! if this routine is called, there should be a mapfile present
+    if (mapfile == 'idmap' .or. mapfile == 'idmap_ignore') then
       if (present(fallback_map_identifier)) then
          map_identifier = fallback_map_identifier
-         write(logunit,*) subname,' do not want to load backup identifier - ' // mapfile
-         call shr_sys_abort(subname//' ERROR in not wanting to load backup identifier - ' // mapfile)
+         write(logunit,*) subname,' got idmap. do not want to load backup identifier - ' // maprcname
+         call shr_sys_abort(subname//' ERROR in not wanting to load backup identifier - ' // maprcname)
       else
-         write(logunit,*) subname,' error in loading map file - ' // mapfile
-         call shr_sys_abort(subname//' ERROR in loading map file - ' // mapfile)
+         write(logunit,*) subname,' got idmap. expecting map file name for - ' // maprcname
+         call shr_sys_abort(subname//' ERROR in finding map file - ' // maprcname)
       end if
-   else
-      mapfile_term = trim(mapfile)//CHAR(0)
-      if (seq_comm_iamroot(CPLID)) then
-         write(logunit,*) subname,' reading map file with iMOAB: ', trim(mapfile_term)
-      endif
-
-      ierr = iMOAB_LoadMapFile( mapper%src_mbid, mapper%tgt_mbid, mapper%intx_mbid, discretization_type, &
-                                 discretization_type, arearead, map_identifier, mapfile_term)
-      if (ierr .ne. 0) then
-         write(logunit,*) subname,' error in loading map file - ' // mapfile
-         call shr_sys_abort(subname//' ERROR in loading map file - ' // mapfile)
-      endif
-      if (seq_comm_iamroot(CPLID)) then
-         write(logunit,'(2A,I10,6A)') subname, ': iMOAB appID: ', &
-            mapper%intx_mbid, ', maptype: ', trim(maptype), ', mapfile: ', &
-            trim(mapfile), ', identifier: ', trim(map_identifier)
-         call shr_sys_flush(logunit)
-      endif
     endif
+
+    mapfile_term = trim(mapfile)//CHAR(0)
+    if (seq_comm_iamroot(CPLID)) then
+        write(logunit,*) subname,' reading map file with iMOAB: ', trim(mapfile_term)
+    endif
+
+    ierr = iMOAB_LoadMapFile( mapper%src_mbid, mapper%tgt_mbid, mapper%intx_mbid, discretization_type, &
+                                 discretization_type, arearead, map_identifier, mapfile_term)
+    if (ierr .ne. 0) then
+       write(logunit,*) subname,' error in loading map file - ' // mapfile
+       call shr_sys_abort(subname//' ERROR in loading map file - ' // mapfile)
+    endif
+
+   mapper%nl_available = .false.
+!  Look for nonlinear map
+    nl_label = maprcname(1:len(maprcname)-1)//'_nonlinear:'
+    call shr_mct_queryConfigFile(mpicom, maprcfile, trim(nl_label), nl_mapfile, &
+          Label1Found=nl_found)
+    if (nl_found) nl_found = nl_mapfile /= "idmap_ignore"
+    nl_conservative = .false.
+
+    ! initially any fmap will be set to be conservative
+    ! this can be overriden by the the nlmaps_atm2srf_conserve namelist variable
+    if (nl_found) nl_conservative = seq_map_should_nonlinear_map_conserve(maprcname)
+
+    mapper%nl_available = nl_found
+    if (nl_found) then
+         mapper%nl_available = .true.
+         mapper%nl_conservative = nl_conservative
+         mapper%nl_mapfile = trim(nl_mapfile)
+         nlmap_id = 'ho'//map_identifier
+         mapper%howeight_identifier = nlmap_id
+         mapfile_term = trim(nl_mapfile)//CHAR(0)
+         ierr = iMOAB_LoadMapFile( mapper%src_mbid, mapper%tgt_mbid, mapper%intx_mbid, discretization_type, &
+                                 discretization_type, 0, nlmap_id, mapfile_term)
+         if (ierr .ne. 0) then
+           write(logunit,*) subname,' error in loading nlmap file - ' // nl_mapfile
+           call shr_sys_abort(subname//' ERROR in loading nlmap file - ' // nl_mapfile)
+         endif
+    endif
+
+    if (seq_comm_iamroot(CPLID)) then
+       write(logunit,'(2A,I6,4A)') subname,' mapper counter, strategy, mapfile = ', &
+            mapper%counter,' ',trim(mapper%strategy),' ',trim(mapper%mapfile)
+       if (mapper%nl_available) then
+          write(logunit,'(2A,I6,3A,L1,2A)') subname, &
+               ' mapper counter, nl_strategy, nl_conservative, nlmap_id,  nl_mapfile = ', &
+               mapper%counter,' ',nl_strategy,' ',nl_conservative,' ',trim(nlmap_id),' ',trim(mapper%nl_mapfile)
+       end if
+       call shr_sys_flush(logunit)
+    endif
+
 
   end subroutine moab_map_init_rcfile
 
@@ -633,7 +674,12 @@ contains
           !***   weight_identifier: Name of the weight matrix (e.g., "scalar", "flux")
           !***   fldlist_moab: Input and output field names (can be different)
           filter_type = 0 ! no filter
-          ierr = iMOAB_ApplyScalarProjectionWeights ( mapper%intx_mbid, filter_type, mapper%weight_identifier, fldlist_moab, fldlist_moab)
+
+          if(.not.mapper%nl_available) then
+             ierr = iMOAB_ApplyScalarProjectionWeights ( mapper%intx_mbid, filter_type, mapper%weight_identifier, fldlist_moab, fldlist_moab)
+          else
+             ierr = iMOAB_ApplyScalarProjectionWeights ( mapper%intx_mbid, filter_type, mapper%howeight_identifier, fldlist_moab, fldlist_moab)
+          endif
           if (ierr .ne. 0) then
              write(logunit,*) subname,' error in applying weights '
              call shr_sys_abort(subname//' ERROR in applying weights')

--- a/driver-moab/main/seq_map_type_mod.F90
+++ b/driver-moab/main/seq_map_type_mod.F90
@@ -59,8 +59,7 @@ module seq_map_type_mod
      real(R8), pointer       :: clat_d_moab(:)
      !
      !---- optional nonlinear map; see seq_nlmap_mod.F90
-     logical                 :: nl_available, nl_conservative
-     character(CX)           :: nl_mapfile
+     logical                 :: nl_available
      real(R8), allocatable   :: frac_s(:), frac_d(:)
 
   end type seq_map
@@ -224,18 +223,5 @@ contains
     endif
 
   end subroutine seq_map_gsmapcheck
-
-  function seq_map_should_nonlinear_map_conserve(maprcname) result(conserve)
-    character(len=*),intent(in) :: maprcname
-
-    logical :: conserve
-    integer :: idx
-
-    ! smap and vmap do not conserve.
-    idx = index(maprcname, 'smap')
-    if (idx == 0) idx = index(maprcname, 'vmap')
-    ! Conserve if not an smap or vmap, meaning this is an fmap.
-    conserve = idx == 0
-  end function seq_map_should_nonlinear_map_conserve
 
 end module seq_map_type_mod

--- a/driver-moab/main/seq_map_type_mod.F90
+++ b/driver-moab/main/seq_map_type_mod.F90
@@ -223,4 +223,17 @@ contains
 
   end subroutine seq_map_gsmapcheck
 
+  function seq_map_should_nonlinear_map_conserve(maprcname) result(conserve)
+    character(len=*),intent(in) :: maprcname
+
+    logical :: conserve
+    integer :: idx
+
+    ! smap and vmap do not conserve.
+    idx = index(maprcname, 'smap')
+    if (idx == 0) idx = index(maprcname, 'vmap')
+    ! Conserve if not an smap or vmap, meaning this is an fmap.
+    conserve = idx == 0
+  end function seq_map_should_nonlinear_map_conserve
+
 end module seq_map_type_mod

--- a/driver-moab/main/seq_map_type_mod.F90
+++ b/driver-moab/main/seq_map_type_mod.F90
@@ -43,6 +43,7 @@ module seq_map_type_mod
      ! source and target app ids also make sense only on the coupler pes
      integer                 :: src_mbid, tgt_mbid, intx_mbid, src_context, intx_context
      character*32            :: weight_identifier ! 'state' OR 'flux'
+     character*32            :: howeight_identifier ! high order flux
      character*16            :: mbname
      integer                 :: tag_entity_type
      integer                 :: nentities ! this should be used only if copy_only is true
@@ -173,6 +174,7 @@ contains
     mapper%intx_mbid = -1
     mapper%tag_entity_type = 1 ! cells most of the time when we need it
     mapper%mbname    = "undefined"
+    mapper%howeight_identifier = "undefined"
     ! Initialize MOAB coordinate pointers
     nullify(mapper%slon_s_moab)
     nullify(mapper%clon_s_moab)

--- a/driver-moab/main/seq_map_type_mod.F90
+++ b/driver-moab/main/seq_map_type_mod.F90
@@ -57,6 +57,10 @@ module seq_map_type_mod
      real(R8), pointer       :: slat_d_moab(:)
      real(R8), pointer       :: clat_d_moab(:)
      !
+     !---- optional nonlinear map; see seq_nlmap_mod.F90
+     logical                 :: nl_available, nl_conservative
+     character(CX)           :: nl_mapfile
+     real(R8), allocatable   :: frac_s(:), frac_d(:)
 
   end type seq_map
   public seq_map

--- a/driver-moab/main/seq_nlmap_mod.F90
+++ b/driver-moab/main/seq_nlmap_mod.F90
@@ -169,6 +169,7 @@ module seq_nlmap_mod
   public :: seq_nlmap_init_a2oi_cons
   public :: seq_nlmap_init_a2l_cons
   public :: seq_nlmap_check_matrices
+  public :: seq_nlmap_field_is_excluded
 
   ! Measure and print information about nonlinearly mapped fields. 0 means no
   ! analysis is done or printed. >= 1 triggers analysis written to cpl.log.
@@ -221,6 +222,36 @@ contains
     end if
 
   end subroutine seq_nlmap_setopts
+
+  function seq_nlmap_field_is_excluded(fldname) result(is_excluded)
+    ! True if fldname appears in the namelist nlmaps_exclude_fields list, in
+    ! which case the nonlinear map must NOT be applied (the LOW-order map
+    ! result is kept). This mirrors the loop in MCT's seq_nlmap_avNormArr at
+    ! driver-mct/main/seq_nlmap_mod.F90 lines 691-698: for excluded fields
+    ! avp_o keeps the mct_sMat_avMult low-order value rather than being
+    ! overwritten with the nonlinear-fixer result.
+    !
+    ! When nlmaps_atm2srf_conserve is on, the exclude list is ignored
+    ! (matches MCT's warning at the end of seq_nlmap_setopts).
+    character(len=*), intent(in) :: fldname
+    logical :: is_excluded
+
+    integer :: i, n
+
+    is_excluded = .false.
+    if (atm2srf_conserve) return
+    if (nlmaps_exclude_n_fields <= 0) return
+
+    n = len_trim(fldname)
+    if (n <= 0) return
+
+    do i = 1, nlmaps_exclude_n_fields
+       if ( trim(fldname) == trim(nlmaps_exclude_fields(i)) ) then
+          is_excluded = .true.
+          return
+       end if
+    end do
+  end function seq_nlmap_field_is_excluded
 
   subroutine seq_nlmap_init_a2oi_cons(mapper, fractions_ax)
     ! Initialize frac_s, frac_d for the atm2ocn map.

--- a/driver-moab/main/seq_nlmap_mod.F90
+++ b/driver-moab/main/seq_nlmap_mod.F90
@@ -3,8 +3,7 @@ module seq_nlmap_mod
   !-----------------------------------------------------------------------------
   !
   ! Purpose: Apply a high-order linear map followed by a property restoring
-  ! nonlinear global fixer. This module adds to the capabilities of seq_map_mod
-  ! and extends its seq_map_avNormArr subroutine. The objective is to improve
+  ! nonlinear global fixer.  The objective is to improve
   ! coarse-to-fine, conservative, monotone maps. Area-averaged (aave) maps
   ! produce grid imprint on the target fine grid because each coarse source cell
   ! has a constant field. This module applies a high-order linear map that
@@ -20,19 +19,20 @@ module seq_nlmap_mod
   !   In practice, SRC2TGT_TMAPFILE should be an area-averaged map ('aave', aka
   ! 'mono'). This map provides the reference global mass on the target grid and
   ! the non-0 target cells. SRC2TGT_TMAPFILE_NONLINEAR can be anything, but its
-  ! non-0 pattern must be a superset of SRC2TGT_TMAPFILE's. An initialization-
-  ! time check of this requirement is performed; if it is not satisfied, the run
-  ! exits. This requirement assures that SRC2TGT_TMAPFILE_NONLINEAR provides
+  ! This requirement assures that SRC2TGT_TMAPFILE_NONLINEAR provides
   ! data in any target cell that SRC2TGT_TMAPFILE does. In the opposite
   ! direction, at runtime, any target cell that SRC2TGT_TMAPFILE does not affect
   ! is zeroed after SRC2TGT_TMAPFILE_NONLINEAR is applied.
-  !   Optionally, this module provides an algorithm variant to obtains exact
+  !
+  ! Optionally, there is an algorithm variant to obtains exact
   ! mass conservation for atmosphere-to-surface flux maps in the case of
   ! overlapping surface grids with a nontrivial common refinement. (A unified
   ! surface grid permits conservation without the variant.) This variant is
   ! controlled by the boolean option NLMAPS_ATM2SRF_CONSERVE in the coupler
   ! options. If this option is true, both the atm2lnd and atm2ocn maps must be
-  ! nonlinear; if they aren't, the module calls abort.
+  ! nonlinear; if they aren't, the module calls abort.  NOT YET IMPLMENTED IN MOAB
+  !
+  ! Algorithm is now implementd inside MOAB in src/Remapping/TempestOnlineMap.cpp
   !
   ! Following is a description of the algorithm and its properties,
   ! specializations of Alg. 3.1 of the following reference for this use case:
@@ -121,7 +121,7 @@ module seq_nlmap_mod
   !   0 <= (dM / (t g)'w) <= 1,
   ! permitting the final line to hold.
   !
-  ! nlmas_atm2srf_conserve variant.
+  ! Conservative variant:  NOT YET IMPLEMENTED IN MOAB
   !   Some modifications are made for this case.
   !   f, the vector of area fractions, is not used. That is because it is atm
   ! fractions, which are uniformly and globally 1.
@@ -140,6 +140,7 @@ module seq_nlmap_mod
   !
   ! Author: A.M. Bradley, Mar,Apr-2023
   ! Update: A.M. Bradley, Mar-2025. a2s_cons feature.
+  ! Update: MOAB Team, May 2026. MOAB version modifed from MCT original
   !
   !-----------------------------------------------------------------------------
   

--- a/driver-moab/main/seq_nlmap_mod.F90
+++ b/driver-moab/main/seq_nlmap_mod.F90
@@ -1,0 +1,308 @@
+module seq_nlmap_mod
+
+  !-----------------------------------------------------------------------------
+  !
+  ! Purpose: Apply a high-order linear map followed by a property restoring
+  ! nonlinear global fixer. This module adds to the capabilities of seq_map_mod
+  ! and extends its seq_map_avNormArr subroutine. The objective is to improve
+  ! coarse-to-fine, conservative, monotone maps. Area-averaged (aave) maps
+  ! produce grid imprint on the target fine grid because each coarse source cell
+  ! has a constant field. This module applies a high-order linear map that
+  ! produces smooth data on the fine target grid, then applies a nonlinear
+  ! global fixer to restore conservation and bounds.
+  !
+  ! Usage:
+  !   For any existing (area-averaged; see the next paragraph) mapfile
+  ! SRC2TGT_TMAPFILE, where T is 'F' or 'S', optionally provide a second,
+  ! high-order map by specifying SRC2TGT_TMAPFILE_NONLINEAR. If T is 'F', then
+  ! the fixer restores global mass, as defined by the SRC2TGT_TMAPFILE map, and
+  ! local bounds. If T is 'S', then the fixer restores the bounds.
+  !   In practice, SRC2TGT_TMAPFILE should be an area-averaged map ('aave', aka
+  ! 'mono'). This map provides the reference global mass on the target grid and
+  ! the non-0 target cells. SRC2TGT_TMAPFILE_NONLINEAR can be anything, but its
+  ! non-0 pattern must be a superset of SRC2TGT_TMAPFILE's. An initialization-
+  ! time check of this requirement is performed; if it is not satisfied, the run
+  ! exits. This requirement assures that SRC2TGT_TMAPFILE_NONLINEAR provides
+  ! data in any target cell that SRC2TGT_TMAPFILE does. In the opposite
+  ! direction, at runtime, any target cell that SRC2TGT_TMAPFILE does not affect
+  ! is zeroed after SRC2TGT_TMAPFILE_NONLINEAR is applied.
+  !   Optionally, this module provides an algorithm variant to obtains exact
+  ! mass conservation for atmosphere-to-surface flux maps in the case of
+  ! overlapping surface grids with a nontrivial common refinement. (A unified
+  ! surface grid permits conservation without the variant.) This variant is
+  ! controlled by the boolean option NLMAPS_ATM2SRF_CONSERVE in the coupler
+  ! options. If this option is true, both the atm2lnd and atm2ocn maps must be
+  ! nonlinear; if they aren't, the module calls abort.
+  !
+  ! Following is a description of the algorithm and its properties,
+  ! specializations of Alg. 3.1 of the following reference for this use case:
+  !   Bradley, A. M., Bosler, P. A., Guba, O., Taylor, M. A., and Barnett,
+  !   G. A. (2019). Communication-efficient property preservation in tracer
+  !   transport. SIAM Journal on Scientific Computing, 41(3), C161-C193.
+  !
+  ! Notation:
+  !   A x is the matrix-vector product A times x.
+  !   a x is a scalar times a vector.
+  !   x'y is the dot product of x and y.
+  !   non-zero-pattern(A) is a matrix of size A with 1 where A(i,j) /= 0
+  !     and 0 otherwise.
+  !   (In)equalities and / are applied element-wise.
+  !   In practice:
+  !     Am is the area-average conservative and monotone linear map.
+  !     A  is the high-order linear map.
+  !     f  is a vector of area fractions.
+  ! On input:
+  !   1. Am is a monotone and conservative linear operator, where s is the
+  !      vector of src areas; t, tgt areas.
+  !   2. non-zero-pattern(Am) in non-zero-pattern(A).
+  !   3. 0 <= f <= 1.
+  ! Definition of conservative:
+  !   t'Am x = s'x
+  ! Definition of monotone:
+  !   l, u := bounds(Am, x)
+  !     => l(i) := min(x where Am(i,:) /= 0)
+  !        u(i) similarly
+  !   l <= Am x <= u
+  !   => 4. 0 <= Am(i,j) <= 1
+  ! With fractions:
+  !   g := Am f
+  !   ym := (Am (f x)) / g
+  !   l, u := bounds(Am, x)
+  !   Conservative:
+  !     5. t'(g y) = t'(Am (f x)) = s'(f x)
+  !   Monotone:
+  !     c(j) := Am(i,j) f(j)
+  !     0 <= c(j) <= 1 by 3 and 4.
+  !     Let j vary over non-0s of Am(i,:).
+  !     ym(i) = sum_j Am(i,j) f(j) x(j) / sum_j Am(i,j) f(j)
+  !           = sum_j c(j) x(j) / sum_j c(j)
+  !          <= max_j x(j) sum_j c(j) / sum_j c(j)
+  !           = max_j x(j)
+  !           = u(j)
+  !     and similarly for l(j).
+  !     => 6. l <= ym <= u
+  ! Bounds:
+  !   2 => 7. bounds(Am, x) in bounds(A, x)
+  ! CAAS (Alg. 3.1 in doi:10.1137/18M1165414) applied to this case:
+  !   CAAS(Am, A, f, x)
+  !     g := Am f
+  !     gym := Am (f x)
+  !     M := t'gym
+  !     y0 := (A (f x)) / g
+  !     l, u := bounds(A, x)
+  !     zero y0, l, u in any cell in which gym is 0
+  !     y1 := max(l, min(u, y0))
+  !     dM := M - t'(g y1)
+  !     if dM >= 0
+  !       w := u - y1
+  !     else
+  !       w := y1 - l
+  !     y2 := y1 + (dM / (t g)'w) w
+  !     return y2
+  ! This algorithm has a nonempty constraint set because, by 5 and 6,
+  !   ym := (Am (f x)) / g is conservative and in bounds.
+  ! CAAS finds a solution if the constraint set is nonempty, proving y2 is
+  ! conservative and in bounds. We can prove this in detail, as follows:
+  !   y2 is conservative:
+  !     t'(g y2) = t'(g y1 + (dM / (t g)'w) g w)
+  !              = M - dM + (dM / (t g)'w) t'(g w)
+  !              = M
+  !   y2 is in bounds:
+  !     w >= 0 by construction.
+  !     Assume dM >= 0; the other case is similar.
+  !     8. M <= t'(g u):
+  !       M = t'(Am (f x)) = t'(g ym) <= t'(g u) by 6 and 7
+  !     dM <= (t g)'w:
+  !       (t g)'w = (t g)'u - (t g)'y1 = (t g)'u + dM - M
+  !         = dM + [(t g)'u - M] >= dM by 8
+  !     => y2 = y1 + (dM / (t g)'w) w <= y1 + w = u => y2 <= u.
+  ! In this proof, the crucial part is point 8; it is equivalent to the
+  ! statement that the constraint set is nonempty. This in turn makes
+  !   0 <= (dM / (t g)'w) <= 1,
+  ! permitting the final line to hold.
+  !
+  ! nlmas_atm2srf_conserve variant.
+  !   Some modifications are made for this case.
+  !   f, the vector of area fractions, is not used. That is because it is atm
+  ! fractions, which are uniformly and globally 1.
+  !   Instead, we need nontrivial fraction fields. We use the notation of the
+  ! documentation in seq_frac_mct.F90.
+  !   For atm2lnd, on the atmosphere we use frac_s = fractions_a(lfrac); on the
+  ! land we set frac_d to the 'frac' field in dom_cx_d.
+  !   For atm2ocn, on the atmosphere we use frac_s = 1 - fractions_a(lfrac); on
+  ! the ocn grid we again set frac_d to the 'frac' field in dom_cx_d, which is
+  ! the sum of the ocn and ice fractions in the fractions_ox structure.
+  !   Then in the above statement of the CAAS algorithm, these lines are used
+  !  instead of the original ones:
+  !     (1) M := sum( frac_s * area_s * x )
+  !     (2) zero y0, l, u in any cell in which frac_d is 0
+  !     (3) dM := M - sum( frac_d * area_d * y1 )
+  !
+  ! Author: A.M. Bradley, Mar,Apr-2023
+  ! Update: A.M. Bradley, Mar-2025. a2s_cons feature.
+  !
+  !-----------------------------------------------------------------------------
+  
+  use shr_kind_mod     , only: R8 => SHR_KIND_R8, IN => SHR_KIND_IN, I8 => SHR_KIND_I8, &
+                               SHR_KIND_CS, CX => SHR_KIND_CX
+  use shr_sys_mod
+  use shr_const_mod
+  use mct_mod
+  use seq_comm_mct
+  use component_type_mod
+  use seq_map_type_mod
+  use shr_reprosum_mod , only: shr_reprosum_calc
+  use shr_infnan_mod   , only: shr_infnan_isnan, shr_infnan_isinf
+  use seq_infodata_mod , only: nlmaps_exclude_max_number, nlmaps_exclude_nchar
+  use shr_moab_mod     , only: mbGetnCells
+  use iMOAB            , only: iMOAB_GetDoubleTagStorage
+  use iso_c_binding    , only: C_NULL_CHAR
+  use perf_mod
+
+  implicit none
+  save
+  private
+#include <mpif.h>
+
+  ! All routines are intended to be called on the cpl pes.
+  public :: seq_nlmap_setopts
+  public :: seq_nlmap_init_a2oi_cons
+  public :: seq_nlmap_init_a2l_cons
+  public :: seq_nlmap_check_matrices
+
+  ! Measure and print information about nonlinearly mapped fields. 0 means no
+  ! analysis is done or printed. >= 1 triggers analysis written to cpl.log.
+  integer :: nlmaps_verbosity
+  ! List of fields that are to be excluded from the set that are nonlinearly
+  ! mapped. For these excluded fields, the low-order linear map is used,
+  ! instead.
+  character(nlmaps_exclude_nchar) :: nlmaps_exclude_fields(nlmaps_exclude_max_number)
+  integer :: nlmaps_exclude_n_fields, nlmaps_exclude_max_nchar
+  logical :: atm2srf_conserve
+  logical :: atm2srf_a2oi_inited = .false., atm2srf_a2l_inited = .false.
+
+contains
+
+  subroutine seq_nlmap_setopts(nlmaps_verbosity_in, nlmaps_exclude_fields_in, &
+       nlmaps_atm2srf_conserve_in)
+    ! Options in drv_in.
+    
+    integer, optional, intent(in) :: nlmaps_verbosity_in
+    character(nlmaps_exclude_nchar), optional, intent(in) :: &
+         nlmaps_exclude_fields_in(nlmaps_exclude_max_number)
+    logical, optional, intent(in) :: nlmaps_atm2srf_conserve_in
+
+    integer :: i, n
+
+    if (present(nlmaps_verbosity_in)) nlmaps_verbosity = nlmaps_verbosity_in
+
+    nlmaps_exclude_n_fields = 0
+    nlmaps_exclude_max_nchar = 0
+    if (present(nlmaps_exclude_fields_in)) then
+       do i = 1, nlmaps_exclude_max_number
+          n = len(trim(nlmaps_exclude_fields_in(i)))
+          if (n > 0) then
+             nlmaps_exclude_n_fields = nlmaps_exclude_n_fields + 1
+             nlmaps_exclude_fields(nlmaps_exclude_n_fields) = nlmaps_exclude_fields_in(i)
+             nlmaps_exclude_max_nchar = max(nlmaps_exclude_max_nchar, n)
+          end if
+       end do
+    end if
+
+    if (present(nlmaps_atm2srf_conserve_in)) then
+       atm2srf_conserve = nlmaps_atm2srf_conserve_in
+    end if
+
+    if (atm2srf_conserve .and. nlmaps_exclude_n_fields > 0) then
+       if (seq_comm_iamroot(CPLID)) then
+          write(logunit,'(a)') 'nlmap> WARNING: When nlmaps_atm2srf_conserve is ON,&
+               & the field exclusion list is ignored.'
+       end if
+    end if
+
+  end subroutine seq_nlmap_setopts
+
+  subroutine seq_nlmap_init_a2oi_cons(mapper, fractions_ax)
+    ! Initialize frac_s, frac_d for the atm2ocn map.
+    
+    type(seq_map), pointer, intent(inout) :: mapper ! Fa2o
+    type(mct_aVect)       , intent(in)    :: fractions_ax(:)
+
+    integer(IN) :: k_sfrac, lsize_s, lsize_d, j
+    integer :: ierr, ent_type, arrsize
+    character(len=128) :: tagname
+
+    if (.not. atm2srf_conserve) return
+
+    if (.not. mapper%nl_available) then
+       call shr_sys_abort('seq_nlmap_init_a2oi_cons ERROR: Nonlinear map not set.')
+    end if
+
+    k_sfrac = mct_aVect_indexRA(fractions_ax(1), 'lfrac')
+    lsize_s = mct_aVect_lsize(fractions_ax(1))
+    lsize_d = mbGetnCells(mapper%tgt_mbid)
+    
+    allocate(mapper%frac_s(lsize_s), mapper%frac_d(lsize_d))
+
+    do j = 1,lsize_s
+       mapper%frac_s(j) = 1 - fractions_ax(1)%rAttr(k_sfrac,j)
+    end do
+    ent_type = mapper%tag_entity_type
+    arrsize = lsize_d
+    tagname = 'frac'//C_NULL_CHAR
+    ierr = iMOAB_GetDoubleTagStorage(mapper%tgt_mbid, tagname, arrsize, ent_type, mapper%frac_d)
+    if (ierr /= 0) then
+       call shr_sys_abort('seq_nlmap_init_a2oi_cons ERROR: Failed to get frac tag from target MOAB mesh.')
+    end if
+
+    atm2srf_a2oi_inited = .true.
+    
+  end subroutine seq_nlmap_init_a2oi_cons
+
+  subroutine seq_nlmap_init_a2l_cons(mapper, fractions_ax)
+    ! Initialize frac_s, frac_d for the atm2lnd map.
+
+    type(seq_map), pointer, intent(inout) :: mapper ! Fa2l
+    type(mct_aVect)       , intent(in)    :: fractions_ax(:)
+
+    integer(IN) :: k_sfrac, lsize_s, lsize_d, j
+    integer :: ierr, ent_type, arrsize
+    character(len=128) :: tagname
+
+    if (.not. atm2srf_conserve) return
+
+    if (.not. mapper%nl_available) then
+       call shr_sys_abort('seq_nlmap_init_a2l_cons ERROR: Nonlinear map not set.')
+    end if
+
+    k_sfrac = mct_aVect_indexRA(fractions_ax(1), 'lfrac')
+    lsize_s = mct_aVect_lsize(fractions_ax(1))
+    lsize_d = mbGetnCells(mapper%tgt_mbid)
+    
+    allocate(mapper%frac_s(lsize_s), mapper%frac_d(lsize_d))
+
+    do j = 1,lsize_s
+       mapper%frac_s(j) = fractions_ax(1)%rAttr(k_sfrac,j)
+    end do
+    ent_type = mapper%tag_entity_type
+    arrsize = lsize_d
+    tagname = 'frac'//C_NULL_CHAR
+    ierr = iMOAB_GetDoubleTagStorage(mapper%tgt_mbid, tagname, arrsize, ent_type, mapper%frac_d)
+    if (ierr /= 0) then
+       call shr_sys_abort('seq_nlmap_init_a2l_cons ERROR: Failed to get frac tag from target MOAB mesh.')
+    end if
+
+    atm2srf_a2l_inited = .true.
+
+  end subroutine seq_nlmap_init_a2l_cons
+
+  subroutine seq_nlmap_check_matrices(m)
+    ! Check that m%sMatp%Matrix's non-0 pattern is a subset of the pattern of
+    ! m%nl_sMatp%Matrix. This assures that the second will provide data to every
+    ! target index that the first does, regardless of source mask.
+    
+    type(seq_map), intent(in) :: m
+
+  end subroutine seq_nlmap_check_matrices
+
+end module seq_nlmap_mod

--- a/driver-moab/main/seq_nlmap_mod.F90
+++ b/driver-moab/main/seq_nlmap_mod.F90
@@ -259,7 +259,13 @@ contains
     k_sfrac = mct_aVect_indexRA(fractions_ax(1), 'lfrac')
     lsize_s = mct_aVect_lsize(fractions_ax(1))
     lsize_d = mbGetnCells(mapper%tgt_mbid)
-    
+
+    ! Guard against double-allocate on mapper re-init (would abort otherwise).
+    ! mapper points into the static seq_maps(:) array (seq_map_type_mod), so
+    ! it has program lifetime; releasing/re-claiming here also avoids a leak
+    ! if a caller re-initializes the same mapper with a different source size.
+    if (allocated(mapper%frac_s)) deallocate(mapper%frac_s)
+    if (allocated(mapper%frac_d)) deallocate(mapper%frac_d)
     allocate(mapper%frac_s(lsize_s), mapper%frac_d(lsize_d))
 
     do j = 1,lsize_s
@@ -294,7 +300,11 @@ contains
     k_sfrac = mct_aVect_indexRA(fractions_ax(1), 'lfrac')
     lsize_s = mct_aVect_lsize(fractions_ax(1))
     lsize_d = mbGetnCells(mapper%tgt_mbid)
-    
+
+    ! Guard against double-allocate on mapper re-init; see comment in
+    ! seq_nlmap_init_a2oi_cons.
+    if (allocated(mapper%frac_s)) deallocate(mapper%frac_s)
+    if (allocated(mapper%frac_d)) deallocate(mapper%frac_d)
     allocate(mapper%frac_s(lsize_s), mapper%frac_d(lsize_d))
 
     do j = 1,lsize_s

--- a/driver-moab/main/seq_nlmap_mod.F90
+++ b/driver-moab/main/seq_nlmap_mod.F90
@@ -143,7 +143,7 @@ module seq_nlmap_mod
   !
   !-----------------------------------------------------------------------------
   
-  use shr_kind_mod     , only: R8 => SHR_KIND_R8, IN => SHR_KIND_IN, I8 => SHR_KIND_I8, &
+  use shr_kind_mod     , only: R8 => SHR_KIND_R8, IN => SHR_KIND_IN, &
                                SHR_KIND_CS, CX => SHR_KIND_CX
   use shr_sys_mod
   use shr_const_mod
@@ -151,13 +151,10 @@ module seq_nlmap_mod
   use seq_comm_mct
   use component_type_mod
   use seq_map_type_mod
-  use shr_reprosum_mod , only: shr_reprosum_calc
-  use shr_infnan_mod   , only: shr_infnan_isnan, shr_infnan_isinf
   use seq_infodata_mod , only: nlmaps_exclude_max_number, nlmaps_exclude_nchar
   use shr_moab_mod     , only: mbGetnCells
   use iMOAB            , only: iMOAB_GetDoubleTagStorage
   use iso_c_binding    , only: C_NULL_CHAR
-  use perf_mod
 
   implicit none
   save
@@ -168,44 +165,34 @@ module seq_nlmap_mod
   public :: seq_nlmap_setopts
   public :: seq_nlmap_init_a2oi_cons
   public :: seq_nlmap_init_a2l_cons
-  public :: seq_nlmap_check_matrices
   public :: seq_nlmap_field_is_excluded
 
-  ! Measure and print information about nonlinearly mapped fields. 0 means no
-  ! analysis is done or printed. >= 1 triggers analysis written to cpl.log.
-  integer :: nlmaps_verbosity
   ! List of fields that are to be excluded from the set that are nonlinearly
   ! mapped. For these excluded fields, the low-order linear map is used,
   ! instead.
   character(nlmaps_exclude_nchar) :: nlmaps_exclude_fields(nlmaps_exclude_max_number)
-  integer :: nlmaps_exclude_n_fields, nlmaps_exclude_max_nchar
+  integer :: nlmaps_exclude_n_fields
   logical :: atm2srf_conserve
-  logical :: atm2srf_a2oi_inited = .false., atm2srf_a2l_inited = .false.
 
 contains
 
-  subroutine seq_nlmap_setopts(nlmaps_verbosity_in, nlmaps_exclude_fields_in, &
+  subroutine seq_nlmap_setopts(nlmaps_exclude_fields_in, &
        nlmaps_atm2srf_conserve_in)
     ! Options in drv_in.
-    
-    integer, optional, intent(in) :: nlmaps_verbosity_in
+
     character(nlmaps_exclude_nchar), optional, intent(in) :: &
          nlmaps_exclude_fields_in(nlmaps_exclude_max_number)
     logical, optional, intent(in) :: nlmaps_atm2srf_conserve_in
 
     integer :: i, n
 
-    if (present(nlmaps_verbosity_in)) nlmaps_verbosity = nlmaps_verbosity_in
-
     nlmaps_exclude_n_fields = 0
-    nlmaps_exclude_max_nchar = 0
     if (present(nlmaps_exclude_fields_in)) then
        do i = 1, nlmaps_exclude_max_number
           n = len(trim(nlmaps_exclude_fields_in(i)))
           if (n > 0) then
              nlmaps_exclude_n_fields = nlmaps_exclude_n_fields + 1
              nlmaps_exclude_fields(nlmaps_exclude_n_fields) = nlmaps_exclude_fields_in(i)
-             nlmaps_exclude_max_nchar = max(nlmaps_exclude_max_nchar, n)
           end if
        end do
     end if
@@ -286,8 +273,6 @@ contains
        call shr_sys_abort('seq_nlmap_init_a2oi_cons ERROR: Failed to get frac tag from target MOAB mesh.')
     end if
 
-    atm2srf_a2oi_inited = .true.
-    
   end subroutine seq_nlmap_init_a2oi_cons
 
   subroutine seq_nlmap_init_a2l_cons(mapper, fractions_ax)
@@ -323,17 +308,6 @@ contains
        call shr_sys_abort('seq_nlmap_init_a2l_cons ERROR: Failed to get frac tag from target MOAB mesh.')
     end if
 
-    atm2srf_a2l_inited = .true.
-
   end subroutine seq_nlmap_init_a2l_cons
-
-  subroutine seq_nlmap_check_matrices(m)
-    ! Check that m%sMatp%Matrix's non-0 pattern is a subset of the pattern of
-    ! m%nl_sMatp%Matrix. This assures that the second will provide data to every
-    ! target index that the first does, regardless of source mask.
-    
-    type(seq_map), intent(in) :: m
-
-  end subroutine seq_nlmap_check_matrices
 
 end module seq_nlmap_mod


### PR DESCRIPTION
Add support for nonlinear map capability in driver-moab originally added to driver-mct in 8e31009 and b03c25e.
This is the original nlmaps algorithm with the ability to exclude fields with nlmaps_exclude_fields.  This option
is conservative relative to the reference linear map but can be non-conservative overall because of inherent 
non-conservation in the coupler.

The control mechanism is the same as driver-mct:  nonlinear maps are applied if the NONLINEAR entries in
seq_maps.rc have a path to a mapping file and are not "idmap" or "idmap-ignore".

The actual CAAS algorithm is implemented inside MOAB. The main supporting change in driver-moab is processing 
the NONLINEAR entires in seq_maps.rc and nlmap namelist vars, how the `iMOAB_ApplyScalarProjectionWeights` 
call is made and if the `filter_type` argument is non-zero.

Because the algorithm details are in MOAB, nlmaps_verbosity is not implemented.  nlmaps_atm2srf_conserve is also
not implemented.  The algorithm changes to compensate for the non-conservation in the coupler in the atmosphere-
to-surface direction by adjusting masses using information from the coupler introduced in 126504a will be 
implemented in a future PR and will be always on.

This has been verified to be BFB with driver-mct as detailed below.

Other related changes:  Refactored calls to `moab_map_init_rcfile` to consistently use mapper objects (e.g., 
`mapper_Fa2o`, `mapper_Sa2l`, etc.) as arguments, and ensured that key fields (`src_mbid`, `tgt_mbid`, 
`intx_mbid`) are set prior to initialization. This change affects multiple initialization routines for atmosphere, ocean, 
land, ice, and runoff components.  This was needed to optionally read the nonlinear map.
Added the `omit_nonlinear=.true.` argument to several calls to `seq_map_map` for area mapping between 
components, ensuring that nonlinear mapping is omitted during initialization of area fields.
Ensured both flux and scalar mappers are initialized and logged for various component pairs, and improved log 
messages for clarity.

[BFB]

---

NOTE:  first needs MOAB PR https://bitbucket.org/fathomteam/moab/pull-requests/759/ to be integrated and MOAB installs to be updated.   

driver-mct PRs:  https://github.com/E3SM-Project/E3SM/pull/5691 https://github.com/E3SM-Project/E3SM/pull/6094  https://github.com/E3SM-Project/E3SM/pull/7111

Details from AI.

**Refactoring and standardization of MOAB mapper initialization:**

* Refactored calls to `moab_map_init_rcfile` to consistently use mapper objects (e.g., `mapper_Fa2o`, `mapper_Sa2l`, etc.) as arguments, and ensured that key fields (`src_mbid`, `tgt_mbid`, `intx_mbid`) are set prior to initialization. This change affects multiple initialization routines for atmosphere, ocean, land, ice, and runoff components. [[1]](diffhunk://#diff-444a740d7ee30a29ae77d667f7c6d6e3bc8f61fb21445ae8b8a2e106fe86d9b9L379-R379) [[2]](diffhunk://#diff-444a740d7ee30a29ae77d667f7c6d6e3bc8f61fb21445ae8b8a2e106fe86d9b9R440-R448) [[3]](diffhunk://#diff-444a740d7ee30a29ae77d667f7c6d6e3bc8f61fb21445ae8b8a2e106fe86d9b9L472-L474) [[4]](diffhunk://#diff-444a740d7ee30a29ae77d667f7c6d6e3bc8f61fb21445ae8b8a2e106fe86d9b9L696-R696) [[5]](diffhunk://#diff-444a740d7ee30a29ae77d667f7c6d6e3bc8f61fb21445ae8b8a2e106fe86d9b9L733-R736) [[6]](diffhunk://#diff-444a740d7ee30a29ae77d667f7c6d6e3bc8f61fb21445ae8b8a2e106fe86d9b9L805-R817) [[7]](diffhunk://#diff-444a740d7ee30a29ae77d667f7c6d6e3bc8f61fb21445ae8b8a2e106fe86d9b9L914-R929) [[8]](diffhunk://#diff-444a740d7ee30a29ae77d667f7c6d6e3bc8f61fb21445ae8b8a2e106fe86d9b9L974) [[9]](diffhunk://#diff-60b4cc4b82410bd2ec9d838988e8c6d284a57c3672f8281d65a4f24747385473R320-L330) [[10]](diffhunk://#diff-bdeaa96226d3835f1e4a8b05bf97bd4ba121009ccd18af4d94f630671d41c69eL371-R371) [[11]](diffhunk://#diff-bdeaa96226d3835f1e4a8b05bf97bd4ba121009ccd18af4d94f630671d41c69eL578-R578) [[12]](diffhunk://#diff-bdeaa96226d3835f1e4a8b05bf97bd4ba121009ccd18af4d94f630671d41c69eL587-R590) [[13]](diffhunk://#diff-0bedcb152cda812b72588558f11aa5d51cc000a32072a1e2feda52e899084121L409-R412) [[14]](diffhunk://#diff-0bedcb152cda812b72588558f11aa5d51cc000a32072a1e2feda52e899084121L563-R571) [[15]](diffhunk://#diff-0bedcb152cda812b72588558f11aa5d51cc000a32072a1e2feda52e899084121L609)

**Improved area mapping control:**

* Added the `omit_nonlinear=.true.` argument to several calls to `seq_map_map` for area mapping between components, ensuring that nonlinear mapping is omitted during initialization of area fields. [[1]](diffhunk://#diff-4a45c115001f51491985343ca1d4018786139b728d2b5c806f4c5e1093e42314L481-R481) [[2]](diffhunk://#diff-4a45c115001f51491985343ca1d4018786139b728d2b5c806f4c5e1093e42314L490-R490) [[3]](diffhunk://#diff-4a45c115001f51491985343ca1d4018786139b728d2b5c806f4c5e1093e42314L506-R506) [[4]](diffhunk://#diff-4a45c115001f51491985343ca1d4018786139b728d2b5c806f4c5e1093e42314L515-R515)

**Initialization and logging improvements:**

* Ensured both flux and scalar mappers are initialized and logged for various component pairs, and improved log messages for clarity (e.g., "Initializing a2o mappers", "Initializing l2a mappers"). [[1]](diffhunk://#diff-0bedcb152cda812b72588558f11aa5d51cc000a32072a1e2feda52e899084121L409-R412) [[2]](diffhunk://#diff-444a740d7ee30a29ae77d667f7c6d6e3bc8f61fb21445ae8b8a2e106fe86d9b9L805-R817)

**Code maintenance and cleanup:**

* Removed redundant or misplaced assignments and initialization calls, and ensured that mapper objects are properly configured before use. [[1]](diffhunk://#diff-444a740d7ee30a29ae77d667f7c6d6e3bc8f61fb21445ae8b8a2e106fe86d9b9L472-L474) [[2]](diffhunk://#diff-0bedcb152cda812b72588558f11aa5d51cc000a32072a1e2feda52e899084121L609) [[3]](diffhunk://#diff-444a740d7ee30a29ae77d667f7c6d6e3bc8f61fb21445ae8b8a2e106fe86d9b9L974) [[4]](diffhunk://#diff-60b4cc4b82410bd2ec9d838988e8c6d284a57c3672f8281d65a4f24747385473R320-L330)

These changes collectively improve the robustness, maintainability, and mass conservation properties of the coupler's mapping infrastructure.