### PR TITLE
EAMxx: better sync cosp and rrtmgp

### DIFF
--- a/components/eamxx/src/physics/cosp/eamxx_cosp.cpp
+++ b/components/eamxx/src/physics/cosp/eamxx_cosp.cpp
@@ -205,7 +205,7 @@ void Cosp::run_impl (const double dt)
   // Make sure cosp frequency is multiple of rad frequency?
 
   // Compare frequency in steps with current timestep
-  auto update_cosp = cosp_do(cosp_freq_in_steps, end_of_step_ts().get_num_steps());
+  auto update_cosp = cosp_do(cosp_freq_in_steps, start_of_step_ts().get_num_steps());
 
   // Call COSP wrapper routines
   if (update_cosp) {

--- a/components/eamxx/src/physics/rrtmgp/eamxx_rrtmgp_process_interface.cpp
+++ b/components/eamxx/src/physics/rrtmgp/eamxx_rrtmgp_process_interface.cpp
@@ -614,8 +614,6 @@ void RRTMGPRadiation::run_impl (const double dt) {
   auto d_dtau105 = get_field_out("dtau105").get_view<Real**>();
   auto d_sunlit = get_field_out("sunlit_mask").get_view<int*>();
 
-  Kokkos::deep_copy(d_dtau067,0.0);
-  Kokkos::deep_copy(d_dtau105,0.0);
   // Outputs for AeroCom cloud-top diagnostics
   auto d_T_mid_at_cldtop = get_field_out("T_mid_at_cldtop").get_view<Real *>();
   auto d_p_mid_at_cldtop = get_field_out("p_mid_at_cldtop").get_view<Real *>();


### PR DESCRIPTION
makes targeted adjustments to the COSP and RRTMGP physics modules to improve the timing logic for COSP updates and to clean up unnecessary code in the RRTMGP process interface.

Fixes #8410

[BFB] for everything except eamxx cosp