### PR TITLE
Add extra_debug testmod

### DIFF
--- a/cime_config/testmods_dirs/allactive/extra_debug/shell_commands
+++ b/cime_config/testmods_dirs/allactive/extra_debug/shell_commands
@@ -1,0 +1,2 @@
+./xmlchange DEBUG=TRUE
+./xmlchange EXTRA_DEBUG=TRUE

--- a/components/eamxx/cime_config/buildlib_cmake
+++ b/components/eamxx/cime_config/buildlib_cmake
@@ -32,6 +32,13 @@ def buildlib(bldroot, installpath, case):
     for item in it:
         cmake_args_dict[item] = next(it)
 
+    # When EXTRA_DEBUG is set, enable FPE and pack size 1 for thorough debugging.
+    # These override any values already present in SCREAM_CMAKE_OPTIONS.
+    if case.get_value("EXTRA_DEBUG"):
+        expect(case.get_value("DEBUG"), "EXTRA_DEBUG is On but DEBUG is Off? Makes no sense.")
+        cmake_args_dict["SCREAM_FPE"] = "True"
+        cmake_args_dict["SCREAM_PACK_SIZE"] = "1"
+
     cmake_args = ""
     for k,v in cmake_args_dict.items():
         cmake_args += f" -D{k}={v}"

--- a/components/eamxx/cime_config/buildlib_cmake
+++ b/components/eamxx/cime_config/buildlib_cmake
@@ -32,12 +32,13 @@ def buildlib(bldroot, installpath, case):
     for item in it:
         cmake_args_dict[item] = next(it)
 
-    # When EXTRA_DEBUG is set, enable FPE and pack size 1 for thorough debugging.
-    # These override any values already present in SCREAM_CMAKE_OPTIONS.
     if case.get_value("EXTRA_DEBUG"):
         expect(case.get_value("DEBUG"), "EXTRA_DEBUG is On but DEBUG is Off? Makes no sense.")
-        cmake_args_dict["SCREAM_FPE"] = "True"
-        cmake_args_dict["SCREAM_PACK_SIZE"] = "1"
+
+        # Extension point for EXTRA_DEBUG if we want to change additional cmake
+        # settings. The comments below provide an example.
+        # cmake_args_dict["SCREAM_FPE"] = "True"
+        # cmake_args_dict["SCREAM_PACK_SIZE"] = "1"
 
     cmake_args = ""
     for k,v in cmake_args_dict.items():

--- a/driver-mct/cime_config/config_component.xml
+++ b/driver-mct/cime_config/config_component.xml
@@ -705,6 +705,20 @@
       runs (i.e., non-DEBUG), due to performance penalties associated with turning on these flags.</desc>
   </entry>
 
+  <entry id="EXTRA_DEBUG">
+    <type>logical</type>
+    <valid_values>TRUE,FALSE</valid_values>
+    <default_value>FALSE</default_value>
+    <group>build_def</group>
+    <file>env_build.xml</file>
+    <desc>TRUE implies turning on extra debugging features beyond what DEBUG enables.
+      Currently enables Kokkos bounds checking (Kokkos_ENABLE_DEBUG_BOUNDS_CHECK),
+      floating point exceptions (SCREAM_FPE), and pack size 1 (SCREAM_PACK_SIZE=1)
+      for EAMxx builds. Other components may extend what EXTRA_DEBUG will do for them.
+      Only has effect when DEBUG is also TRUE. These features are
+      too expensive for routine debug builds but useful for targeted debugging.</desc>
+  </entry>
+
   <entry id="FORCE_BUILD_SMP">
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>

--- a/share/build/buildlib.ekat
+++ b/share/build/buildlib.ekat
@@ -135,7 +135,7 @@ def buildlib(bldroot, installpath, case):
     if debug:
         ekat_cmake_options += " -DCMAKE_BUILD_TYPE=Debug"
         # Kokkos bounds checking is too expensive to always turn on
-        if "E3SM_ENABLE_KOKKOS_BOUNDS_CHECKING" in os.environ:
+        if case.get_value("EXTRA_DEBUG"):
             ekat_cmake_options += " -DKokkos_ENABLE_DEBUG_BOUNDS_CHECK=On"
 
     gen_makefile_cmd = f"cmake {kokkos_options} {cc} {cxx} -DCMAKE_CXX_STANDARD=17 {ekat_cmake_options} -DCMAKE_INSTALL_PREFIX={installpath} {ekat_dir}"


### PR DESCRIPTION
Interacts with a new env XML setting 'EXTRA_DEBUG'.

Other components can extend this feature too.

Replaces the some of what env var "E3SM_ENABLE_KOKKOS_BOUNDS_CHECKING" was doing for us.

[BFB]