### PR TITLE
Add the modified Leith viscosity scheme to MPAS-Ocean

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -307,6 +307,7 @@ _TESTS = {
             "SMS_D_Ld1.T62_oQU240.GMPAS-IAF.mpaso-upwind_advection",
             "SMS_D_Ld1.T62_oQU240.GMPAS-IAF.mpaso-freshwater_tracers",
             "SMS_D_Ld1.T62_oQU240.GMPAS-IAF.mpaso-lat_dep_diffusivity",
+            "SMS_D_Ld1.T62_oQU240.GMPAS-IAF.mpaso-leith_viscosity",
             "ERS_Ld5_D.T62_oQU240.GMPAS-IAF.mpaso-conservation_check",
             "ERS_Ld5_PS.ne30pg2_r05_IcoswISC30E3r5.CRYO1850-DISMF.mpaso-scaled_dib_dismf",
             "SMS_PS.ne30pg2_r05_IcoswISC30E3r5.WCYCL1850.mpaso-frazil_ice_porosity",

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -569,9 +569,9 @@ add_default($nl, 'config_use_Leith_del2');
 add_default($nl, 'config_use_Leith_del4');
 add_default($nl, 'config_Leith_del2_parameter');
 add_default($nl, 'config_Leith_del4_parameter');
-add_default($nl, 'config_Leith_dx');
 add_default($nl, 'config_Leith_del2_div_scaler');
 add_default($nl, 'config_Leith_del4_div_scaler');
+add_default($nl, 'config_Leith_dx');
 add_default($nl, 'config_Leith_visc2_max');
 add_default($nl, 'config_Leith_visc4_max');
 

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -566,9 +566,14 @@ add_default($nl, 'config_tracer_del4');
 ##############################
 
 add_default($nl, 'config_use_Leith_del2');
-add_default($nl, 'config_Leith_parameter');
+add_default($nl, 'config_use_Leith_del4');
+add_default($nl, 'config_Leith_del2_parameter');
+add_default($nl, 'config_Leith_del4_parameter');
 add_default($nl, 'config_Leith_dx');
+add_default($nl, 'config_Leith_del2_div_scaler');
+add_default($nl, 'config_Leith_del4_div_scaler');
 add_default($nl, 'config_Leith_visc2_max');
+add_default($nl, 'config_Leith_visc4_max');
 
 #########################################
 # Namelist group: Redi_isopycnal_mixing #

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -571,7 +571,6 @@ add_default($nl, 'config_Leith_del2_parameter');
 add_default($nl, 'config_Leith_del4_parameter');
 add_default($nl, 'config_Leith_del2_div_scaler');
 add_default($nl, 'config_Leith_del4_div_scaler');
-add_default($nl, 'config_Leith_dx');
 add_default($nl, 'config_Leith_visc2_max');
 add_default($nl, 'config_Leith_visc4_max');
 

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -88,9 +88,14 @@ add_default($nl, 'config_tracer_del4');
 ##############################
 
 add_default($nl, 'config_use_Leith_del2');
-add_default($nl, 'config_Leith_parameter');
+add_default($nl, 'config_use_Leith_del4');
+add_default($nl, 'config_Leith_del2_parameter');
+add_default($nl, 'config_Leith_del4_parameter');
+add_default($nl, 'config_Leith_del2_div_scaler');
+add_default($nl, 'config_Leith_del4_div_scaler');
 add_default($nl, 'config_Leith_dx');
 add_default($nl, 'config_Leith_visc2_max');
+add_default($nl, 'config_Leith_visc4_max');
 
 #########################################
 # Namelist group: Redi_isopycnal_mixing #

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -174,9 +174,14 @@
 
 <!-- hmix_Leith -->
 <config_use_Leith_del2>.false.</config_use_Leith_del2>
-<config_Leith_parameter>1.0</config_Leith_parameter>
-<config_Leith_dx>15000.0</config_Leith_dx>
-<config_Leith_visc2_max>2.5e3</config_Leith_visc2_max>
+<config_use_Leith_del4>.false.</config_use_Leith_del4>
+<config_Leith_del2_parameter>2.2</config_Leith_del2_parameter>
+<config_Leith_del4_parameter>2.2</config_Leith_del4_parameter>
+<config_Leith_dx>30000.0</config_Leith_dx>
+<config_Leith_del2_div_scaler>1.0</config_Leith_del2_div_scaler>
+<config_Leith_del4_div_scaler>1.0</config_Leith_del4_div_scaler>
+<config_Leith_visc2_max>1000.0</config_Leith_visc2_max>
+<config_Leith_visc4_max>1.2e11</config_Leith_visc4_max>
 
 <!-- Redi_isopycnal_mixing -->
 <config_use_Redi>.true.</config_use_Redi>

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -177,9 +177,9 @@
 <config_use_Leith_del4>.false.</config_use_Leith_del4>
 <config_Leith_del2_parameter>2.2</config_Leith_del2_parameter>
 <config_Leith_del4_parameter>2.2</config_Leith_del4_parameter>
-<config_Leith_dx>30000.0</config_Leith_dx>
 <config_Leith_del2_div_scaler>1.0</config_Leith_del2_div_scaler>
 <config_Leith_del4_div_scaler>1.0</config_Leith_del4_div_scaler>
+<config_Leith_dx>30000.0</config_Leith_dx>
 <config_Leith_visc2_max>1000.0</config_Leith_visc2_max>
 <config_Leith_visc4_max>1.2e11</config_Leith_visc4_max>
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -179,7 +179,6 @@
 <config_Leith_del4_parameter>2.2</config_Leith_del4_parameter>
 <config_Leith_del2_div_scaler>1.0</config_Leith_del2_div_scaler>
 <config_Leith_del4_div_scaler>1.0</config_Leith_del4_div_scaler>
-<config_Leith_dx>30000.0</config_Leith_dx>
 <config_Leith_visc2_max>1000.0</config_Leith_visc2_max>
 <config_Leith_visc4_max>1.2e11</config_Leith_visc4_max>
 

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -350,24 +350,25 @@ Default: Defined in namelist_defaults.xml
 
 
 <!-- hmix_Leith -->
+
 <entry id="config_use_Leith_del2" type="logical"
-        category="hmix_Leith" group="hmix_Leith">
-If true, harmonic Leith horizontal mixing is used on the momentum equation.
+	category="hmix_Leith" group="hmix_Leith">
+If true, the modified del2 Leith enstrophy-cascade closure is turned on
 
 Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml
 </entry>
 
 <entry id="config_use_Leith_del4" type="logical"
-        category="hmix_Leith" group="hmix_Leith">
-If true, biharmonic Leith horizontal mixing is used on the momentum equation.
+	category="hmix_Leith" group="hmix_Leith">
+If true, the modified del4 Leith enstrophy-cascade closure is turned on
 
 Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml
 </entry>
 
 <entry id="config_Leith_del2_parameter" type="real"
-        category="hmix_Leith" group="hmix_Leith">
+	category="hmix_Leith" group="hmix_Leith">
 Non-dimensional Leith del2 closure parameter
 
 Valid values: any positive real
@@ -375,48 +376,48 @@ Default: Defined in namelist_defaults.xml
 </entry>
 
 <entry id="config_Leith_del4_parameter" type="real"
-        category="hmix_Leith" group="hmix_Leith">
+	category="hmix_Leith" group="hmix_Leith">
 Non-dimensional Leith del4 closure parameter
 
 Valid values: any positive real
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_Leith_dx" type="real"
-        category="hmix_Leith" group="hmix_Leith">
-Characteristic length scale, usually the smallest dx in the mesh
-
-Valid values: any positive real
-Default: Defined in namelist_defaults.xml
-</entry>
-
 <entry id="config_Leith_del2_div_scaler" type="real"
-        category="hmix_Leith" group="hmix_Leith">
-The divergence portion of the Leith del4 viscosity is scaled by this factor.
+	category="hmix_Leith" group="hmix_Leith">
+Non-dimensional Leith del2 closure divergence scaler
 
 Valid values: any positive real
 Default: Defined in namelist_defaults.xml
 </entry>
 
 <entry id="config_Leith_del4_div_scaler" type="real"
-        category="hmix_Leith" group="hmix_Leith">
-The divergence portion of the Leith del4 viscosity is scaled by this factor.
+	category="hmix_Leith" group="hmix_Leith">
+Non-dimensional Leith del4 closure divergence scaler
+
+Valid values: any positive real
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_Leith_dx" type="real"
+	category="hmix_Leith" group="hmix_Leith">
+Characteristic length scale, usually the smallest dx in the mesh
 
 Valid values: any positive real
 Default: Defined in namelist_defaults.xml
 </entry>
 
 <entry id="config_Leith_visc2_max" type="real"
-        category="hmix_Leith" group="hmix_Leith">
-Upper bound on the allowable value of Leith-computed del2 viscosity
+	category="hmix_Leith" group="hmix_Leith">
+Upper bound on the allowable value of Leith-computed viscosity
 
 Valid values: any positive real
 Default: Defined in namelist_defaults.xml
 </entry>
 
 <entry id="config_Leith_visc4_max" type="real"
-        category="hmix_Leith" group="hmix_Leith">
-Upper bound on the allowable value of Leith-computed del4 viscosity
+	category="hmix_Leith" group="hmix_Leith">
+Upper bound on the allowable value of Leith-computed viscosity
 
 Valid values: any positive real
 Default: Defined in namelist_defaults.xml

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -350,34 +350,73 @@ Default: Defined in namelist_defaults.xml
 
 
 <!-- hmix_Leith -->
-
 <entry id="config_use_Leith_del2" type="logical"
-	category="hmix_Leith" group="hmix_Leith">
-If true, the Leith enstrophy-cascade closure is turned on
+        category="hmix_Leith" group="hmix_Leith">
+If true, harmonic Leith horizontal mixing is used on the momentum equation.
 
 Valid values: .true. or .false.
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_Leith_parameter" type="real"
-	category="hmix_Leith" group="hmix_Leith">
-Non-dimensional Leith closure parameter
+<entry id="config_use_Leith_del4" type="logical"
+        category="hmix_Leith" group="hmix_Leith">
+If true, biharmonic Leith horizontal mixing is used on the momentum equation.
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_Leith_del2_parameter" type="real"
+        category="hmix_Leith" group="hmix_Leith">
+Non-dimensional Leith del2 closure parameter
+
+Valid values: any positive real
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_Leith_del4_parameter" type="real"
+        category="hmix_Leith" group="hmix_Leith">
+Non-dimensional Leith del4 closure parameter
 
 Valid values: any positive real
 Default: Defined in namelist_defaults.xml
 </entry>
 
 <entry id="config_Leith_dx" type="real"
-	category="hmix_Leith" group="hmix_Leith">
+        category="hmix_Leith" group="hmix_Leith">
 Characteristic length scale, usually the smallest dx in the mesh
 
 Valid values: any positive real
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_Leith_del2_div_scaler" type="real"
+        category="hmix_Leith" group="hmix_Leith">
+The divergence portion of the Leith del4 viscosity is scaled by this factor.
+
+Valid values: any positive real
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_Leith_del4_div_scaler" type="real"
+        category="hmix_Leith" group="hmix_Leith">
+The divergence portion of the Leith del4 viscosity is scaled by this factor.
+
+Valid values: any positive real
+Default: Defined in namelist_defaults.xml
+</entry>
+
 <entry id="config_Leith_visc2_max" type="real"
-	category="hmix_Leith" group="hmix_Leith">
-Upper bound on the allowable value of Leith-computed viscosity
+        category="hmix_Leith" group="hmix_Leith">
+Upper bound on the allowable value of Leith-computed del2 viscosity
+
+Valid values: any positive real
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_Leith_visc4_max" type="real"
+        category="hmix_Leith" group="hmix_Leith">
+Upper bound on the allowable value of Leith-computed del4 viscosity
 
 Valid values: any positive real
 Default: Defined in namelist_defaults.xml

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -399,14 +399,6 @@ Valid values: any positive real
 Default: Defined in namelist_defaults.xml
 </entry>
 
-<entry id="config_Leith_dx" type="real"
-	category="hmix_Leith" group="hmix_Leith">
-Characteristic length scale, usually the smallest dx in the mesh
-
-Valid values: any positive real
-Default: Defined in namelist_defaults.xml
-</entry>
-
 <entry id="config_Leith_visc2_max" type="real"
 	category="hmix_Leith" group="hmix_Leith">
 Upper bound on the allowable value of Leith-computed viscosity

--- a/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/leith_viscosity/README
+++ b/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/leith_viscosity/README
@@ -1,0 +1,13 @@
+This testdef is used to test a stealth feature in mpaso introduced by
+PR #8417. It uses mpaso namelist variables to turn on the modified
+Leith viscosity:
+    config_use_leith_del2
+    config_use_leith_del4
+from its default value of .false. to .true.. It also sets associated
+variables,
+    config_leith_visc2_max
+    config_leith_visc4_max
+    config_leith_dx
+    config_use_mom_del2
+    config_use_mom_del4
+for testing. It will have an impact on all mpaso runs.

--- a/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/leith_viscosity/README
+++ b/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/leith_viscosity/README
@@ -7,7 +7,6 @@ from its default value of .false. to .true.. It also sets associated
 variables,
     config_leith_visc2_max
     config_leith_visc4_max
-    config_leith_dx
     config_use_mom_del2
     config_use_mom_del4
 for testing. It will have an impact on all mpaso runs.

--- a/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/leith_viscosity/user_nl_mpaso
+++ b/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/leith_viscosity/user_nl_mpaso
@@ -1,0 +1,7 @@
+ config_use_leith_del2 = .true.
+ config_use_leith_del4 = .true.
+ config_leith_visc2_max = 1000.0
+ config_leith_visc4_max = 2.0e14
+ config_leith_dx = 240000.0
+ config_use_mom_del2 = .false.
+ config_use_mom_del4 = .false.

--- a/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/leith_viscosity/user_nl_mpaso
+++ b/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/leith_viscosity/user_nl_mpaso
@@ -2,6 +2,5 @@
  config_use_leith_del4 = .true.
  config_leith_visc2_max = 1000.0
  config_leith_visc4_max = 2.0e14
- config_leith_dx = 240000.0
  config_use_mom_del2 = .false.
  config_use_mom_del4 = .false.

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -290,22 +290,42 @@
 		/>
 	</nml_record>
 	<nml_record name="hmix_Leith" mode="forward">
-		<nml_option name="config_use_Leith_del2" type="logical" default_value=".false."
-					description="If true, the Leith enstrophy-cascade closure is turned on"
-					possible_values=".true. or .false."
-		/>
-		<nml_option name="config_Leith_parameter" type="real" default_value="1.0" units="non-dimensional"
-					description="Non-dimensional Leith closure parameter"
-					possible_values="any positive real"
-		/>
-		<nml_option name="config_Leith_dx" type="real" default_value="15000.0" units="m"
-					description="Characteristic length scale, usually the smallest dx in the mesh"
-					possible_values="any positive real"
-		/>
-		<nml_option name="config_Leith_visc2_max" type="real" default_value="2.5e3" units="m^2 s^-1"
-					description="Upper bound on the allowable value of Leith-computed viscosity"
-					possible_values="any positive real"
-		/>
+                <nml_option name="config_use_Leith_del2" type="logical" default_value=".false."
+                                        description="If true, the modified del2 Leith enstrophy-cascade closure is turned on"
+                                        possible_values=".true. or .false."
+                />
+                <nml_option name="config_use_Leith_del4" type="logical" default_value=".false."
+                                        description="If true, the modified del4 Leith enstrophy-cascade closure is turned on"
+                                        possible_values=".true. or .false."
+                />
+                <nml_option name="config_Leith_del2_parameter" type="real" default_value="2.2" units="non-dimensional"
+                                        description="Non-dimensional Leith del2 closure parameter"
+                                        possible_values="any positive real"
+                />
+                <nml_option name="config_Leith_del4_parameter" type="real" default_value="2.2" units="non-dimensional"
+                                        description="Non-dimensional Leith del4 closure parameter"
+                                        possible_values="any positive real"
+                />
+                <nml_option name="config_Leith_del2_div_scaler" type="real" default_value="1.0" units="non-dimensional"
+                                        description="Non-dimensional Leith del2 closure divergence scaler"
+                                        possible_values="any positive real"
+                />
+                <nml_option name="config_Leith_del4_div_scaler" type="real" default_value="1.0" units="non-dimensional"
+                                        description="Non-dimensional Leith del4 closure divergence scaler"
+                                        possible_values="any positive real"
+                />
+                <nml_option name="config_Leith_dx" type="real" default_value="15000.0" units="m"
+                                        description="Characteristic length scale, usually the smallest dx in the mesh"
+                                        possible_values="any positive real"
+                />
+                <nml_option name="config_Leith_visc2_max" type="real" default_value="1.0e3" units="m^2 s^-1"
+                                        description="Upper bound on the allowable value of Leith-computed viscosity"
+                                        possible_values="any positive real"
+                />
+                <nml_option name="config_Leith_visc4_max" type="real" default_value="1.2e11" units="m^4 s^-1"
+                                        description="Upper bound on the allowable value of Leith-computed viscosity"
+                                        possible_values="any positive real"
+                />
 	</nml_record>
 	<nml_record name="Redi_isopycnal_mixing" mode="forward">
 		<nml_option name="config_use_Redi" type="logical" default_value=".false."
@@ -2174,7 +2194,7 @@
 			<var name="SSHinitial" packages="scaledSFWFPKG"/>
 			<var name="SSHfinal" packages="scaledSFWFPKG"/>
 			<var name="nValidTotalfwFluxHistory" packages="scaledSFWFPKG"/>
-			<var name="SFWFScalingFactor" packages="scaledSFWFPKG"/> 
+			<var name="SFWFScalingFactor" packages="scaledSFWFPKG"/>
 		</stream>
 
 		<stream name="output"

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -314,7 +314,7 @@
                                         description="Non-dimensional Leith del4 closure divergence scaler"
                                         possible_values="any positive real"
                 />
-                <nml_option name="config_Leith_dx" type="real" default_value="15000.0" units="m"
+                <nml_option name="config_Leith_dx" type="real" default_value="30000.0" units="m"
                                         description="Characteristic length scale, usually the smallest dx in the mesh"
                                         possible_values="any positive real"
                 />

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_hmix.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_hmix.F
@@ -128,10 +128,13 @@ contains
       call ocn_vel_hmix_del2_tend(div, relVort, tend, err1)
       err = ior(err1, err)
 
-      call ocn_vel_hmix_leith_tend(div, relVort, tend, err1)
+      call ocn_vel_hmix_leith_del2_tend(div, relVort, tend, err1)
       err = ior(err1, err)
 
       call ocn_vel_hmix_del4_tend(div, relVort, tend, err1)
+      err = ior(err1, err)
+
+      call ocn_vel_hmix_leith_del4_tend(div, relVort, tend, err1)
       err = ior(err1, err)
 
       call mpas_timer_stop("vel hmix")

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_hmix_leith.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_hmix_leith.F
@@ -42,7 +42,8 @@ module ocn_vel_hmix_leith
    !
    !--------------------------------------------------------------------
 
-   public :: ocn_vel_hmix_leith_tend, &
+   public :: ocn_vel_hmix_leith_del2_tend, &
+             ocn_vel_hmix_leith_del4_tend, &
              ocn_vel_hmix_leith_init
 
    !-------------------------------------------------------------------
@@ -52,13 +53,18 @@ module ocn_vel_hmix_leith
    !--------------------------------------------------------------------
 
    logical :: &
-      hmixLeithOff  !< on/off switch to determine whether leith chosen
+      hmixLeith2Off, & !< on/off switch to determine whether leith del2 chosen
+      hmixLeith4Off    !< on/off switch to determine whether leith del4 chosen
 
    real (kind=RKIND) :: &
-      leithParam,       &!< Leith parameter
-      dxLeith,          &!< Leith length scale
-      viscMaxLeith,     &!< maximum viscosity
-      sqrt3fact          !< sqrt(3)
+      leithParam2,     &!< Leith del2 parameter
+      leithParam4,     &!< Leith del4 parameter
+      leithDivScaler2, &!< Leith del4 divergence scale factor
+      leithDivScaler4, &!< Leith del4 divergence scale factor
+      dxLeith,         &!< Leith length scale
+      visc2MaxLeith,   &!< maximum del2 viscosity
+      visc4MaxLeith,   &!< maximum del4 viscosity
+      sqrt3fact         !< sqrt(3)
 
 !***********************************************************************
 
@@ -77,7 +83,7 @@ contains
 !> enstrophy-cascade analogy to the Smagorinsky (1963) energy-cascade
 !> closure, i.e. Leith (1996) assumes an inertial range of enstrophy
 !> flux moving toward the mesh scale. The assumption of an enstrophy
-!> cascade and dimensional analysis produces right-hand-side 
+!> cascade and dimensional analysis produces right-hand-side
 !> dissipation, $\bf{D}$, of velocity of the form
 !> $ {\bf D} = \nabla \cdot \left( \nu_\ast \nabla {\bf u} \right)
 !>    = \nabla \cdot \left( \gamma \left| \nabla \omega  \right|
@@ -87,7 +93,11 @@ contains
 !
 !-----------------------------------------------------------------------
 
-   subroutine ocn_vel_hmix_leith_tend(div, relVort, tend, err)!{{{
+!***********************************************************************
+!  routine ocn_vel_hmix_leith_del2_tend
+!***********************************************************************
+
+   subroutine ocn_vel_hmix_leith_del2_tend(div, relVort, tend, err)!{{{
 
       !-----------------------------------------------------------------
       ! input variables
@@ -134,8 +144,8 @@ contains
       !*** start timer if chosen
 
       err = 0
-      if (hmixLeithOff) return
-      call mpas_timer_start("vel leith")
+      if (hmixLeith2Off) return
+      call mpas_timer_start("vel leith del2")
 
 #ifdef MPAS_OPENACC
       !$acc parallel loop &
@@ -159,15 +169,15 @@ contains
          dcEdgeInv = 1.0_RKIND / dcEdge(iEdge)
          dvEdgeInv = 1.0_RKIND / dvEdge(iEdge)
 
-         visc2tmp = (leithParam*dxLeith*meshScalingDel2(iEdge)/pi)**3
+         visc2tmp = (leithParam2*dxLeith*meshScalingDel2(iEdge)/pi)**3
 
          do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
 
-            ! Here -( relativeVorticity(k,vertex2) - 
+            ! Here -( relativeVorticity(k,vertex2) -
             !         relativeVorticity(k,vertex1) ) / dvEdge(iEdge)
-            ! is - \nabla relativeVorticity pointing from vertex 2 to 
+            ! is - \nabla relativeVorticity pointing from vertex 2 to
             ! vertex 1, or equivalently
-            ! + k \times \nabla relativeVorticity pointing from cell1 
+            ! + k \times \nabla relativeVorticity pointing from cell1
             ! to cell2.
 
             uDiff = (div(k,cell2)  - div(k,cell1))*dcEdgeInv &
@@ -177,9 +187,12 @@ contains
             ! the second line is |\nabla \omega|
             ! and u_diffusion is \nabla^2 u (see formula for $\bf{D}$ above).
             visc2 = visc2tmp &
-                   *abs(relVort(k,vertex2) - relVort(k,vertex1))* &
-                    dcEdgeInv*sqrt3fact
-            visc2 = min(visc2, viscMaxLeith)
+                   *sqrt( (abs(relVort(k,vertex2) - relVort(k,vertex1))* &
+                           dcEdgeInv*sqrt3fact)**2.0 + &
+                           leithDivScaler2 * &
+                           abs((div(k,cell2)  - div(k,cell1))*dcEdgeInv)**2.0 )
+            !visc2 = min(visc2, viscMaxLeith)
+            visc2 = min(visc2, visc2MaxLeith)
 
             tend(k,iEdge) = tend(k,iEdge) + &
                             edgeMask(k,iEdge)*visc2*uDiff
@@ -191,11 +204,266 @@ contains
       !$omp end parallel
 #endif
 
-      call mpas_timer_stop("vel leith")
+      call mpas_timer_stop("vel leith del2")
+
+   !--------------------------------------------------------------------
+   end subroutine ocn_vel_hmix_leith_del2_tend!}}}
+
+
+!***********************************************************************
+!  routine ocn_vel_hmix_leith_del4_tend
+!***********************************************************************
+
+   !--------------------------------------------------------------------
+   subroutine ocn_vel_hmix_leith_del4_tend(div, relVort, tend, err)!{{{
+
+      !-----------------------------------------------------------------
+      ! input variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(in) :: &
+         div,           &!< [in] velocity divergence
+         relVort         !< [in] relative vorticity
+
+      !-----------------------------------------------------------------
+      ! input/output variables
+      !-----------------------------------------------------------------
+
+      real (kind=RKIND), dimension(:,:), intent(inout) :: &
+         tend             !< [inout] accumulated velocity tendency
+
+      !-----------------------------------------------------------------
+      ! output variables
+      !-----------------------------------------------------------------
+
+      integer, intent(out) :: err !< [out] error flag
+
+
+      !-----------------------------------------------------------------
+      ! local variables
+      !-----------------------------------------------------------------
+
+      integer ::                      &
+         iEdge, iCell, iVertex, k, i, &! loop counters
+         cell1, cell2,     &! neighbor cell addresses across edge
+         vertex1, vertex2, &! neighbor vertex addresses along edge
+         nEdges, nCells, nVertices ! num edges,cells,vertices incl halos
+
+      real (kind=RKIND) ::      &
+         uDiff,                 &! diffusion operator temporary
+         cellWidth,             &! diffusion operator temporary
+         areaCellInv,           &! 1/area of cell
+         areaTriInv,            &! 1/area of triangle
+         dcEdgeInv,             &! 1/dcEdge
+         dvEdgeInv,             &! 1/dvEdge
+         leithDel2relVortEdge,  &! del2relVort on Edges
+         leithDel2divEdge,      &! del2div on Edges
+         visc4tmp,              &! common factor for visc4
+         visc4                   ! scaled biharmonic viscosity coeff
+
+
+      ! Scratch Arrays
+      real (kind=RKIND), dimension(:,:), allocatable :: &
+         del2div,     &!
+         del2relVort, &!
+         del2u
+
+      integer :: kmin, kmax
+
+      ! End preamble
+      !-----------------------------------------------------------------
+      ! Begin code
+
+      !*** initialize return code and exit if Leith not chosen
+      !*** start timer if chosen
+
+      err = 0
+      if (hmixLeith4Off) return
+      call mpas_timer_start("vel leith del4")
+
+
+      !*** allocate temporaries
+
+      allocate(del2u(nVertLevels, nEdgesAll + 1), &
+               del2div(nVertLevels, nCellsAll + 1), &
+               del2relVort(nVertLevels, nVerticesAll + 1))
+      !$acc enter data create(del2u, del2div, del2relVort)
+
+      nEdges = nEdgesHalo(2)
+
+      !Compute Laplacian of velocity
+#ifdef MPAS_OPENACC
+      !$acc parallel loop &
+      !$acc    present(cellsOnEdge, verticesOnEdge, minLevelEdgeBot, maxLevelEdgeTop, &
+      !$acc            dvEdge, dcEdge, del2u, div, relVort) &
+      !$acc    private(k, cell1, cell2, vertex1, vertex2, &
+      !$acc            dcEdgeInv, dvEdgeInv, kmin, kmax)
+#else
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp    private(k, cell1, cell2, vertex1, vertex2, &
+      !$omp            dcEdgeInv, dvEdgeInv, kmin, kmax)
+#endif
+      do iEdge = 1, nEdges
+         del2u(:, iEdge) = 0.0_RKIND
+         cell1 = cellsOnEdge(1,iEdge)
+         cell2 = cellsOnEdge(2,iEdge)
+
+         kmin = minLevelEdgeBot(iEdge)
+         kmax = maxLevelEdgeTop(iEdge)
+
+         vertex1 = verticesOnEdge(1,iEdge)
+         vertex2 = verticesOnEdge(2,iEdge)
+
+         dcEdgeInv = 1.0_RKIND / dcEdge(iEdge)
+         dvEdgeInv = 1.0_RKIND / max(dvEdge(iEdge), 0.25_RKIND*dcEdge(iEdge))
+
+         do k=kmin, kmax
+            ! Compute \nabla^2 u = \nabla divergence + k \times \nabla relativeVorticity
+            del2u(k,iEdge) = (div(k,cell2) - div(k,cell1))*dcEdgeInv &
+                            -(relVort(k,vertex2) - relVort(k,vertex1))*&
+                                                           dvEdgeInv
+         end do
+      end do
+#ifndef MPAS_OPENACC
+      !$omp end do
+      !$omp end parallel
+#endif
+
+      nVertices = nVerticesHalo(1)
+
+      ! Compute del2 of relative vorticity
+#ifdef MPAS_OPENACC
+      !$acc parallel loop &
+      !$acc    present(edgesOnVertex, minLevelVertexBot, maxLevelVertexTop, dcEdge, &
+      !$acc            areaTriangle, edgeSignOnVertex, del2u, &
+      !$acc            del2relVort) &
+      !$acc    private(i, k, iEdge, areaTriInv, kmin, kmax)
+#else
+      !$omp parallel
+      !$omp do schedule(runtime) private(i, k, iEdge, areaTriInv, kmin, kmax)
+#endif
+      do iVertex = 1, nVertices
+         kmin = minLevelVertexBot(iVertex)
+         kmax = maxLevelVertexTop(iVertex)
+         del2relVort(:, iVertex) = 0.0_RKIND
+         areaTriInv = 1.0_RKIND/areaTriangle(iVertex)
+         do i = 1, vertexDegree
+            iEdge = edgesOnVertex(i, iVertex)
+            do k = kmin, kmax
+               del2relVort(k,iVertex) = del2relVort(k,iVertex) &
+                                      + edgeSignOnVertex(i,iVertex) &
+                                       *dcEdge(iEdge)*del2u(k,iEdge)*areaTriInv
+            end do
+         end do
+      end do
+#ifndef MPAS_OPENACC
+      !$omp end do
+      !$omp end parallel
+#endif
+
+      nCells = nCellsHalo(1)
+
+      ! Compute del2 of divergence
+#ifdef MPAS_OPENACC
+      !$acc parallel loop &
+      !$acc    present(nEdgesOnCell, edgesOnCell, minLevelCell, maxLevelCell, dvEdge,&
+      !$acc            edgeSignOnCell, areaCell, del2u, del2div) &
+      !$acc    private(i, k, iEdge, areaCellInv, kmin, kmax)
+#else
+      !$omp parallel
+      !$omp do schedule(runtime) private(i, k, iEdge, areaCellInv, kmin, kmax)
+#endif
+      do iCell = 1, nCells
+         kmin = minLevelCell(iCell)
+         kmax = maxLevelCell(iCell)
+         del2div(:, iCell) = 0.0_RKIND
+         areaCellInv = 1.0_RKIND / areaCell(iCell)
+         do i = 1, nEdgesOnCell(iCell)
+            iEdge = edgesOnCell(i, iCell)
+            do k = kmin, kmax
+               del2div(k,iCell) = del2div(k,iCell) - &
+                                  edgeSignOnCell(i,iCell)*dvEdge(iEdge) &
+                                 *del2u(k,iEdge)*areaCellInv
+            end do
+         end do
+      end do
+#ifndef MPAS_OPENACC
+      !$omp end do
+      !$omp end parallel
+#endif
+
+      ! Compute final tendency \kappa \nabla^4 u
+      ! as  \nabla div(\nabla^2 u) + k \times
+      !     \nabla ( k \cross curl(\nabla^2 u) )
+
+#ifdef MPAS_OPENACC
+      !$acc parallel loop &
+      !$acc    present(cellsOnEdge, verticesOnEdge, minLevelEdgeBot, maxLevelEdgeTop, &
+      !$acc            dcEdge, dvEdge, meshScalingDel4, edgeMask, &
+      !$acc            del2div, del2relVort, tend) &
+      !$acc private(k, cell1, cell2, vertex1, vertex2, del2relVortEdge, del2divEdge, &
+      !$acc         dcEdgeInv, dvEdgeInv, visc4, visc4tmp uDiff, kmin, kmax)
+#else
+      !$omp parallel
+      !$omp do schedule(runtime) &
+      !$omp private(k, cell1, cell2, vertex1, vertex2, &
+      !$omp         dcEdgeInv, dvEdgeInv, visc4, uDiff, kmin, kmax)
+#endif
+      do iEdge = 1, nEdgesOwned
+         kmin = minLevelEdgeBot(iEdge)
+         kmax = maxLevelEdgeTop(iEdge)
+
+         cell1 = cellsOnEdge(1,iEdge)
+         cell2 = cellsOnEdge(2,iEdge)
+         vertex1 = verticesOnEdge(1,iEdge)
+         vertex2 = verticesOnEdge(2,iEdge)
+
+         dcEdgeInv = 1.0_RKIND / dcEdge(iEdge)
+         dvEdgeInv = 1.0_RKIND / dvEdge(iEdge)
+
+         cellWidth = 2.0_RKIND* &
+                     sqrt((areaCell(cell1) + areaCell(cell2))/2.0_RKIND/pi)
+
+         visc4tmp = (leithParam4*cellWidth/pi)**12
+
+         do k = kmin, kmax
+            uDiff = (del2div(k,cell2) - del2div(k,cell1))* &
+                                                dcEdgeInv  &
+                  - (del2relVort(k,vertex2) - del2relVort(k,vertex1))* &
+                                                          dvEdgeInv
+
+            leithDel2relVortEdge = abs(0.5_RKIND * &
+                                 (del2relVort(k,vertex1)+del2relVort(k,vertex2)))**2.0
+
+            leithDel2divEdge = abs(0.5_RKIND * &
+                             (del2div(k,cell1)+del2div(k,cell2)))**2.0
+
+            visc4 = visc4tmp &
+                   *sqrt(visc4tmp * leithDel2relVortEdge + &
+                         visc4tmp * leithDivScaler4 * leithDel2divEdge)
+
+            visc4 = min(visc4, visc4MaxLeith*meshScalingDel4(iEdge))
+
+            tend(k,iEdge) = tend(k,iEdge) - &
+                            edgeMask(k,iEdge)*uDiff*visc4
+         end do
+      end do
+#ifndef MPAS_OPENACC
+      !$omp end do
+      !$omp end parallel
+#endif
+
+      !$acc exit data delete(del2u, del2div, del2relVort)
+      deallocate(del2u, &
+                 del2div, &
+                 del2relVort)
+
+      call mpas_timer_stop("vel leith del4")
 
    !--------------------------------------------------------------------
 
-   end subroutine ocn_vel_hmix_leith_tend!}}}
+   end subroutine ocn_vel_hmix_leith_del4_tend!}}}
 
 !***********************************************************************
 !
@@ -225,19 +493,33 @@ contains
       !*** initialize return flag and set default values
 
       err = 0
-      hmixLeithOff = .true.
-      leithParam   = 0.0_RKIND
-      dxLeith      = 0.0_RKIND
-      viscMaxLeith = 0.0_RKIND
-      sqrt3fact    = sqrt(3.0_RKIND)
+      hmixLeith2Off   = .true.
+      hmixLeith4Off   = .true.
+      leithParam2     = 0.0_RKIND
+      leithParam4     = 0.0_RKIND
+      leithDivScaler2 = 0.0_RKIND
+      leithDivScaler4 = 0.0_RKIND
+      dxLeith         = 0.0_RKIND
+      visc2MaxLeith   = 0.0_RKIND
+      visc4MaxLeith   = 0.0_RKIND
+      sqrt3fact       = sqrt(3.0_RKIND)
 
       !*** reset values based on input configuration
 
       if (config_use_leith_del2) then
-         hmixLeithOff = .false.
-         leithParam   = config_leith_parameter
-         dxLeith      = config_leith_dx
-         viscMaxLeith = config_leith_visc2_max
+         hmixLeith2Off   = .false.
+         leithParam2     = config_leith_del2_parameter
+         leithDivScaler2 = config_leith_del2_div_scaler ** 6.0
+         dxLeith         = config_leith_dx
+         visc2MaxLeith   = config_leith_visc2_max
+      endif
+
+      if (config_use_leith_del4) then
+         hmixLeith4Off   = .false.
+         leithParam4     = config_leith_del4_parameter
+         leithDivScaler4 = config_leith_del4_div_scaler ** 12.0
+         dxLeith         = config_leith_dx
+         visc4MaxLeith   = config_leith_visc4_max
       endif
 
       !-----------------------------------------------------------------

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_hmix_leith.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_hmix_leith.F
@@ -191,7 +191,6 @@ contains
                            dcEdgeInv*sqrt3fact)**2.0 + &
                            leithDivScaler2 * &
                            abs((div(k,cell2)  - div(k,cell1))*dcEdgeInv)**2.0 )
-            !visc2 = min(visc2, viscMaxLeith)
             visc2 = min(visc2, visc2MaxLeith)
 
             tend(k,iEdge) = tend(k,iEdge) + &

--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_hmix_leith.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_hmix_leith.F
@@ -61,7 +61,6 @@ module ocn_vel_hmix_leith
       leithParam4,     &!< Leith del4 parameter
       leithDivScaler2, &!< Leith del4 divergence scale factor
       leithDivScaler4, &!< Leith del4 divergence scale factor
-      dxLeith,         &!< Leith length scale
       visc2MaxLeith,   &!< maximum del2 viscosity
       visc4MaxLeith,   &!< maximum del4 viscosity
       sqrt3fact         !< sqrt(3)
@@ -134,6 +133,7 @@ contains
          dcEdgeInv,        &! 1/dcEdge
          dvEdgeInv,        &! 1/dvEdge
          visc2tmp,         &! common factor for visc2
+         visc2MaxTmp,      &! max factor for visc2
          visc2              ! scaled viscosity coeff
 
       ! End preamble
@@ -153,12 +153,12 @@ contains
       !$acc            dcEdge, dvEdge, meshScalingDel2, div, relVort, &
       !$acc            tend, edgeMask) &
       !$acc    private(k, cell1, cell2, vertex1, vertex2, dcEdgeInv, &
-      !$acc            dvEdgeInv, uDiff, visc2, visc2tmp)
+      !$acc            dvEdgeInv, uDiff, visc2, visc2tmp,visc2MaxTmp)
 #else
       !$omp parallel
       !$omp do schedule(runtime) &
       !$omp    private(k, cell1, cell2, vertex1, vertex2, dcEdgeInv, &
-      !$omp            dvEdgeInv, uDiff, visc2, visc2tmp)
+      !$omp            dvEdgeInv, uDiff, visc2, visc2tmp,visc2MaxTmp)
 #endif
       do iEdge = 1, nEdgesOwned
          cell1 = cellsOnEdge(1,iEdge)
@@ -169,7 +169,8 @@ contains
          dcEdgeInv = 1.0_RKIND / dcEdge(iEdge)
          dvEdgeInv = 1.0_RKIND / dvEdge(iEdge)
 
-         visc2tmp = (leithParam2*dxLeith*meshScalingDel2(iEdge)/pi)**3
+         visc2tmp = (leithParam2*dcEdge(iEdge)/pi)**3
+         visc2MaxTmp = visc2MaxLeith*meshScalingDel2(iEdge)
 
          do k = minLevelEdgeBot(iEdge), maxLevelEdgeTop(iEdge)
 
@@ -191,7 +192,7 @@ contains
                            dcEdgeInv*sqrt3fact)**2.0 + &
                            leithDivScaler2 * &
                            abs((div(k,cell2)  - div(k,cell1))*dcEdgeInv)**2.0 )
-            visc2 = min(visc2, visc2MaxLeith)
+            visc2 = min(visc2, visc2MaxTmp)
 
             tend(k,iEdge) = tend(k,iEdge) + &
                             edgeMask(k,iEdge)*visc2*uDiff
@@ -250,7 +251,6 @@ contains
 
       real (kind=RKIND) ::      &
          uDiff,                 &! diffusion operator temporary
-         cellWidth,             &! diffusion operator temporary
          areaCellInv,           &! 1/area of cell
          areaTriInv,            &! 1/area of triangle
          dcEdgeInv,             &! 1/dcEdge
@@ -258,6 +258,7 @@ contains
          leithDel2relVortEdge,  &! del2relVort on Edges
          leithDel2divEdge,      &! del2div on Edges
          visc4tmp,              &! common factor for visc4
+         visc4MaxTmp,           &! max factor for visc4
          visc4                   ! scaled biharmonic viscosity coeff
 
 
@@ -402,12 +403,12 @@ contains
       !$acc            dcEdge, dvEdge, meshScalingDel4, edgeMask, &
       !$acc            del2div, del2relVort, tend) &
       !$acc private(k, cell1, cell2, vertex1, vertex2, del2relVortEdge, del2divEdge, &
-      !$acc         dcEdgeInv, dvEdgeInv, visc4, visc4tmp uDiff, kmin, kmax)
+      !$acc         dcEdgeInv, dvEdgeInv, visc4, visc4tmp, visc4MaxTmp, uDiff, kmin, kmax)
 #else
       !$omp parallel
       !$omp do schedule(runtime) &
       !$omp private(k, cell1, cell2, vertex1, vertex2, &
-      !$omp         dcEdgeInv, dvEdgeInv, visc4, uDiff, kmin, kmax)
+      !$omp         dcEdgeInv, dvEdgeInv, visc4, visc4tmp, visc4MaxTmp, uDiff, kmin, kmax)
 #endif
       do iEdge = 1, nEdgesOwned
          kmin = minLevelEdgeBot(iEdge)
@@ -421,10 +422,8 @@ contains
          dcEdgeInv = 1.0_RKIND / dcEdge(iEdge)
          dvEdgeInv = 1.0_RKIND / dvEdge(iEdge)
 
-         cellWidth = 2.0_RKIND* &
-                     sqrt((areaCell(cell1) + areaCell(cell2))/2.0_RKIND/pi)
-
-         visc4tmp = (leithParam4*cellWidth/pi)**12
+         visc4tmp = (leithParam4*dcEdge(iEdge)/pi)**12.0_RKIND
+         visc4MaxTmp = visc4MaxLeith*meshScalingDel4(iEdge)
 
          do k = kmin, kmax
             uDiff = (del2div(k,cell2) - del2div(k,cell1))* &
@@ -442,7 +441,7 @@ contains
                    *sqrt(visc4tmp * leithDel2relVortEdge + &
                          visc4tmp * leithDivScaler4 * leithDel2divEdge)
 
-            visc4 = min(visc4, visc4MaxLeith*meshScalingDel4(iEdge))
+            visc4 = min(visc4, visc4MaxTmp)
 
             tend(k,iEdge) = tend(k,iEdge) - &
                             edgeMask(k,iEdge)*uDiff*visc4
@@ -498,7 +497,6 @@ contains
       leithParam4     = 0.0_RKIND
       leithDivScaler2 = 0.0_RKIND
       leithDivScaler4 = 0.0_RKIND
-      dxLeith         = 0.0_RKIND
       visc2MaxLeith   = 0.0_RKIND
       visc4MaxLeith   = 0.0_RKIND
       sqrt3fact       = sqrt(3.0_RKIND)
@@ -509,7 +507,6 @@ contains
          hmixLeith2Off   = .false.
          leithParam2     = config_leith_del2_parameter
          leithDivScaler2 = config_leith_del2_div_scaler ** 6.0
-         dxLeith         = config_leith_dx
          visc2MaxLeith   = config_leith_visc2_max
       endif
 
@@ -517,7 +514,6 @@ contains
          hmixLeith4Off   = .false.
          leithParam4     = config_leith_del4_parameter
          leithDivScaler4 = config_leith_del4_div_scaler ** 12.0
-         dxLeith         = config_leith_dx
          visc4MaxLeith   = config_leith_visc4_max
       endif
 


### PR DESCRIPTION
This PR adds the modified Leith viscosity in both harmonic and biharmonic forms.

- This feature provides a flow-aware viscosity formulation.
- The implementation follows Fox-Kemper and Menemenlis (2008): https://doi.org/10.1029/177GM19.
- This viscosity option (`config_use_Leith_del2` and `config_use_Leith_del4`) is a stealth feature in MPAS-Ocean.

[BFB] - stealth feature