### PR TITLE
EAMxx: upgrade Field::clone to allow copying less stuff

### DIFF
--- a/components/eamxx/src/share/algorithm/eamxx_data_interpolation.cpp
+++ b/components/eamxx/src/share/algorithm/eamxx_data_interpolation.cpp
@@ -660,13 +660,13 @@ void DataInterpolation::register_fields_in_remappers ()
 
   for (int i=0; i<m_nfields; ++i) {
     const auto& f = m_vert_remapper->get_src_field(i);
-    m_horiz_remapper_beg->register_field_from_tgt(f.clone(f.name(), m_horiz_remapper_beg->get_src_grid()->name()));
-    m_horiz_remapper_end->register_field_from_tgt(f.clone(f.name(), m_horiz_remapper_end->get_src_grid()->name()));
+    m_horiz_remapper_beg->register_field_from_tgt(f.clone(f.name(), m_horiz_remapper_beg->get_src_grid()->name(), CloneFlags::MatchPacking));
+    m_horiz_remapper_end->register_field_from_tgt(f.clone(f.name(), m_horiz_remapper_end->get_src_grid()->name(), CloneFlags::MatchPacking));
   }
   if (m_vr_type==Dynamic3D or m_vr_type==Dynamic3DRef) {
     const auto& data_p = m_helper_pressure_fields["p_file"];
-    m_horiz_remapper_beg->register_field_from_tgt(data_p.clone(data_p.name(), m_horiz_remapper_beg->get_src_grid()->name()));
-    m_horiz_remapper_end->register_field_from_tgt(data_p.clone(data_p.name(), m_horiz_remapper_end->get_src_grid()->name()));
+    m_horiz_remapper_beg->register_field_from_tgt(data_p.clone(data_p.name(), m_horiz_remapper_beg->get_src_grid()->name(), CloneFlags::MatchPacking));
+    m_horiz_remapper_end->register_field_from_tgt(data_p.clone(data_p.name(), m_horiz_remapper_end->get_src_grid()->name(), CloneFlags::MatchPacking));
   }
   m_horiz_remapper_beg->registration_ends();
   m_horiz_remapper_end->registration_ends();

--- a/components/eamxx/src/share/algorithm/tests/data_interpolation_tests.cpp
+++ b/components/eamxx/src/share/algorithm/tests/data_interpolation_tests.cpp
@@ -82,8 +82,8 @@ void run_tests (const std::shared_ptr<const AbstractGrid>& grid,
     f.deep_copy(1);
   }
 
-  auto model_pmid = base[2].clone("pmid");
-  auto model_pint = base[4].clone("pint");
+  auto model_pmid = base[2].clone("pmid", CloneFlags::All);
+  auto model_pint = base[4].clone("pint", CloneFlags::All);
   if (vr_type==P1D) {
     // It's complicated to test the static profile, since we'd have to really do
     // a manual interpolation. But setting all model pressure equal to the 1st col

--- a/components/eamxx/src/share/algorithm/tests/data_interpolation_tests.hpp
+++ b/components/eamxx/src/share/algorithm/tests/data_interpolation_tests.hpp
@@ -148,7 +148,7 @@ create_fields (const std::shared_ptr<const AbstractGrid>& grid,
     v3d_i.sync_to_dev();
   }
 
-  auto p1d = s3d_m.subfield(0,0).clone("p1d");
+  auto p1d = s3d_m.subfield(0,0).clone("p1d", CloneFlags::All);
   auto comm = grid->get_comm();
   comm.broadcast(p1d.get_internal_view_data<Real,Host>(),nlevs,0);
   p1d.sync_to_dev();

--- a/components/eamxx/src/share/algorithm/tests/time_interpolation_tests.cpp
+++ b/components/eamxx/src/share/algorithm/tests/time_interpolation_tests.cpp
@@ -239,7 +239,7 @@ bool views_are_approx_equal(const Field& f0, const Field& f1, const Real tol)
   EKAT_REQUIRE_MSG(l0==l1,"Error! views_are_approx_equal - the two fields don't have matching layouts.");
   // Take advantage of field utils update, min and max to assess the max difference between the two fields
   // simply.
-  auto ft = f0.clone();
+  auto ft = f0.clone(CloneFlags::CopyData);
   ft.update(f1,1.0,-1.0);
   auto d_min = field_min(ft).as<Real>();
   auto d_max = field_max(ft).as<Real>();

--- a/components/eamxx/src/share/data_managers/IOPDataManager.cpp
+++ b/components/eamxx/src/share/data_managers/IOPDataManager.cpp
@@ -48,11 +48,12 @@ void read_fields (const std::string& filename,
         " - field name: " + f.name() + "\n"
         " - parent field name: " + f.get_header().get_parent()->get_identifier().name() + "\n");
 
-    if (f.get_header().get_alloc_properties().get_padding()==0) {
+    if (f.get_header().get_alloc_properties().get_padding()==0 and
+        f.get_header().get_alloc_properties().contiguous()) {
       scorpio::read_var(filename,f.name(),f.get_internal_view_data<Real,Host>());
       f.sync_to_dev();
     } else {
-      // Create non-padded clone
+      // Create non-padded, contiguous clone
       auto f_no_padding = f.clone();
       scorpio::read_var(filename,f.name(),f_no_padding.get_internal_view_data<Real,Host>());
       f_no_padding.sync_to_dev();

--- a/components/eamxx/src/share/data_managers/IOPDataManager.cpp
+++ b/components/eamxx/src/share/data_managers/IOPDataManager.cpp
@@ -53,8 +53,7 @@ void read_fields (const std::string& filename,
       f.sync_to_dev();
     } else {
       // Create non-padded clone
-      Field f_no_padding(f.get_header().get_identifier());
-      f_no_padding.allocate_view();
+      auto f_no_padding = f.clone();
       scorpio::read_var(filename,f.name(),f_no_padding.get_internal_view_data<Real,Host>());
       f_no_padding.sync_to_dev();
       f.deep_copy(f_no_padding);

--- a/components/eamxx/src/share/diagnostics/conditional_sampling.cpp
+++ b/components/eamxx/src/share/diagnostics/conditional_sampling.cpp
@@ -153,15 +153,14 @@ void ConditionalSampling::initialize_impl()
 {
   if (m_diag_is_mask) {
     if (m_lhs_is_lev) {
-      m_diagnostic_output = m_lev_mask.clone(m_diag_name);
+      m_diagnostic_output = m_lev_mask.alias(m_diag_name);
     } else {
       auto dfid = m_fields_in.at(m_condition_lhs).get_header().get_identifier().clone(m_diag_name);
       dfid.reset_dtype(DataType::IntType).reset_units(ekat::units::none);
       m_diagnostic_output = Field(dfid,true);
     }
   } else {
-    auto xfid = m_fields_in.at(m_input_f).get_header().get_identifier();
-    m_diagnostic_output = Field(xfid.clone(m_diag_name),true);
+    m_diagnostic_output = m_fields_in.at(m_input_f).clone(m_diag_name);
     m_diagnostic_output.create_valid_mask();
   }
 

--- a/components/eamxx/src/share/diagnostics/horiz_avg.cpp
+++ b/components/eamxx/src/share/diagnostics/horiz_avg.cpp
@@ -59,7 +59,7 @@ void HorizAvg::initialize_impl()
     // the area sum, and set weight = area/sum(area), so that we avoid
     // one loop at runtime.
     // NOTE: clone m_area, since the field from the grid is read-only
-    m_area = m_area.clone("scaled_area");
+    m_area = m_area.clone("scaled_area", CloneFlags::CopyData);
 
     m_denom = m_area.subfield(COL,0).clone(); // This should create a 0d field
     m_ones = m_area.clone("ones");

--- a/components/eamxx/src/share/diagnostics/tests/atm_backtend_test.cpp
+++ b/components/eamxx/src/share/diagnostics/tests/atm_backtend_test.cpp
@@ -91,8 +91,7 @@ TEST_CASE("atm_backtend") {
   qc.get_header().get_tracking().update_time_stamp(ts);
   for (int itest = 2; itest < ntests; itest++) {
     // Save current qc before advancing
-    auto qc_old = qc.clone();
-    qc_old.deep_copy(qc);
+    auto qc_old = qc.clone(CloneFlags::CopyData);
     qc_old.sync_to_host();
 
     // init_timestep: FieldPrev stores current qc; FieldOverDt saves start ts
@@ -116,11 +115,11 @@ TEST_CASE("atm_backtend") {
     auto qc_old_v = qc_old.get_view<Real**, Host>();
     auto res_v    = result.get_view<Real**, Host>();
 
-    auto manual = qc.clone();
+    auto manual = qc.clone(CloneFlags::CopyData);
     manual.update(qc_old,-1,1);
     manual.scale(1/a_day);
 
-    auto diff = result.clone();
+    auto diff = result.clone(CloneFlags::CopyData);
     diff.update(manual,-1,1);
     REQUIRE_THAT (inf_norm(diff).as<Real>(), Catch::WithinAbs(0,tol));
   }

--- a/components/eamxx/src/share/diagnostics/tests/binary_ops_test.cpp
+++ b/components/eamxx/src/share/diagnostics/tests/binary_ops_test.cpp
@@ -110,7 +110,7 @@ TEST_CASE("binary_ops") {
 
   // field+field diag
   REQUIRE (plus_diag_f.has_valid_mask());
-  auto tgt_mask = qc.get_valid_mask().clone();
+  auto tgt_mask = qc.get_valid_mask().clone(CloneFlags::CopyData);
   tgt_mask.scale(qv.get_valid_mask());
   REQUIRE (views_are_equal(tgt_mask,plus_diag_f.get_valid_mask()));
 

--- a/components/eamxx/src/share/diagnostics/tests/field_at_height_tests.cpp
+++ b/components/eamxx/src/share/diagnostics/tests/field_at_height_tests.cpp
@@ -325,7 +325,7 @@ bool views_are_approx_equal(const Field& f0, const Field& f1, const Real tol, co
   EKAT_REQUIRE_MSG(l0==l1,"Error! views_are_approx_equal - the two fields don't have matching layouts.");
   // Take advantage of field utils update, min and max to assess the max difference between the two fields
   // simply.
-  auto ft = f0.clone();
+  auto ft = f0.clone(CloneFlags::CopyData);
   ft.update(f1,1.0,-1.0);
   auto d_min = field_min(ft).as<Real>();
   auto d_max = field_max(ft).as<Real>();

--- a/components/eamxx/src/share/diagnostics/tests/field_over_dt_test.cpp
+++ b/components/eamxx/src/share/diagnostics/tests/field_over_dt_test.cpp
@@ -53,8 +53,7 @@ TEST_CASE("field_over_dt") {
   auto diag_f = diag->get();
   for (int itest = 2; itest < ntests; itest++) {
     // Save qc before advancing
-    auto qc_prev = qc.clone();
-    qc_prev.deep_copy(qc);
+    auto qc_prev = qc.clone(CloneFlags::CopyData);
 
     // init_timestep saves start of step
     diag->init_timestep(ts);

--- a/components/eamxx/src/share/diagnostics/tests/field_prev_test.cpp
+++ b/components/eamxx/src/share/diagnostics/tests/field_prev_test.cpp
@@ -74,8 +74,7 @@ TEST_CASE("field_prev") {
   tgt_mask.deep_copy(1);
   for (int itest = 2; itest < ntests; itest++) {
     // Save current qc before we advance
-    auto qc_prev = qc.clone();
-    qc_prev.deep_copy(qc);
+    auto qc_prev = qc.clone(CloneFlags::CopyData);
 
     // init_timestep stores the current qc as the "previous" value
     diag->init_timestep(ts);

--- a/components/eamxx/src/share/diagnostics/tests/horiz_avg_test.cpp
+++ b/components/eamxx/src/share/diagnostics/tests/horiz_avg_test.cpp
@@ -60,13 +60,13 @@ TEST_CASE("horiz_avg") {
     auto diag_f = diag->get();
 
     auto manual = diag_f.clone("manual");
-    auto area_scaled = area.clone();
+    auto area_scaled = area.clone(CloneFlags::CopyData);
     area_scaled.scale(1/area_sum);
 
     horiz_contraction(manual,scl_x,area_scaled,comm);
 
     // Compare
-    auto diff = diag_f.clone();
+    auto diff = diag_f.clone(CloneFlags::CopyData);
     diff.update(manual,-1,1);
     auto diff_norm = inf_norm(diff,&comm).as<Real>();
     REQUIRE_THAT (diff_norm, Catch::WithinAbs(0,tol));
@@ -113,7 +113,7 @@ TEST_CASE("horiz_avg") {
     manual.scale_inv(manual_den,tgt_mask);
 
     // Compare where valid; zero out fill_value entries before norm
-    auto diff = diag_f.clone("diff");
+    auto diff = diag_f.clone("diff", CloneFlags::CopyData);
     diff.update(manual,-1,1,d_mask);
     diff.deep_copy(0,d_mask,true);
     auto diff_norm = inf_norm(diff,&comm).as<Real>();
@@ -173,7 +173,7 @@ TEST_CASE("horiz_avg") {
     manual.deep_copy(c);
 
     // Compare
-    auto diff = diag_f.clone();
+    auto diff = diag_f.clone(CloneFlags::CopyData);
     diff.update(manual,-1,1);
     auto diff_norm = inf_norm(diff,&comm).as<Real>();
     REQUIRE_THAT (diff_norm, Catch::WithinAbs(0,tol));

--- a/components/eamxx/src/share/diagnostics/tests/relative_humidity_tests.cpp
+++ b/components/eamxx/src/share/diagnostics/tests/relative_humidity_tests.cpp
@@ -83,7 +83,7 @@ void run()
     const auto& qv_v = qv_f.get_view<Pack**>();
 
     // Run diagnostic and compare with manual calculation
-    Field rh_f = T_mid_f.clone();
+    Field rh_f = T_mid_f.clone(CloneFlags::MatchPacking);
     rh_f.deep_copy(0);
     const auto& rh_v = rh_f.get_view<Pack**>();
     auto manual = KOKKOS_LAMBDA(const int icol, const int jpack) {

--- a/components/eamxx/src/share/diagnostics/tests/vert_contract_test.cpp
+++ b/components/eamxx/src/share/diagnostics/tests/vert_contract_test.cpp
@@ -76,7 +76,7 @@ TEST_CASE("vert_contract") {
     auto diag_f = diag->get();
 
     // Manual reference: ref(col,cmp) = sum_lev( (dp/g)(col,lev) * f(col,cmp,lev) )
-    auto dp_scaled = dp.clone("dp_scaled");
+    auto dp_scaled = dp.clone("dp_scaled", CloneFlags::CopyData);
     dp_scaled.scale(1 / physics::Constants<Real>::gravit.value);
     auto ref = diag_f.clone("ref");
     vert_contraction(ref, fin, dp_scaled);
@@ -113,7 +113,7 @@ TEST_CASE("vert_contract") {
     //   num(col) = sum_lev( (dp/g)(col,lev) * f(col,lev) )
     //   den(col) = sum_lev( (dp/g)(col,lev) )
     //   ref(col) = num(col) / den(col)
-    auto dp_scaled = dp.clone("dp_scaled");
+    auto dp_scaled = dp.clone("dp_scaled", CloneFlags::CopyData);
     dp_scaled.scale(1 / physics::Constants<Real>::gravit.value);
     auto dp_ones = dp_scaled.clone("ones");
     dp_ones.deep_copy(1);

--- a/components/eamxx/src/share/diagnostics/tests/water_path_tests.cpp
+++ b/components/eamxx/src/share/diagnostics/tests/water_path_tests.cpp
@@ -214,11 +214,11 @@ void run(std::mt19937_64& engine)
     // Test 2: If the cell-wise mass is scaled by constant alpha then the water
     //         path should also be scaled by alpha.
     {
-      Field vwp_copy_f = diags["vwp"]->get().clone();
-      Field lwp_copy_f = diags["lwp"]->get().clone();
-      Field iwp_copy_f = diags["iwp"]->get().clone();
-      Field mwp_copy_f = diags["mwp"]->get().clone();
-      Field rwp_copy_f = diags["rwp"]->get().clone();
+      Field vwp_copy_f = diags["vwp"]->get().clone(CloneFlags::CopyData);
+      Field lwp_copy_f = diags["lwp"]->get().clone(CloneFlags::CopyData);
+      Field iwp_copy_f = diags["iwp"]->get().clone(CloneFlags::CopyData);
+      Field mwp_copy_f = diags["mwp"]->get().clone(CloneFlags::CopyData);
+      Field rwp_copy_f = diags["rwp"]->get().clone(CloneFlags::CopyData);
       const auto& vwp_copy_v = vwp_copy_f.get_view<Real*>();
       const auto& lwp_copy_v = lwp_copy_f.get_view<Real*>();
       const auto& iwp_copy_v = iwp_copy_f.get_view<Real*>();

--- a/components/eamxx/src/share/diagnostics/vert_contract.cpp
+++ b/components/eamxx/src/share/diagnostics/vert_contract.cpp
@@ -71,13 +71,12 @@ void VertContract::initialize_impl()
   auto w_units = none;
   // set up the weighting field
   if (m_weighting_method == "dp") {
-    m_weight = m_fields_in.at("pseudo_density").clone("vert_contract_wts");
+    m_weight = m_fields_in.at("pseudo_density").clone("vert_contract_wts", CloneFlags::CopyData);
     constexpr auto g_units = physics::Constants<Real>::gravit.units;
     w_units = m_weight.get_header().get_identifier().get_units() / g_units;
   } else if (m_weighting_method == "dz") {
     // TODO: for some reason the dz field keeps getting set to 0
     // TODO: as a workaround, just calculate dz here (sigh...)
-    // m_weight = get_field_in("dz").clone("vert_contract_wts");
     m_weight = m_fields_in.at("pseudo_density").clone("vert_contract_wts");
     w_units = m;
   } else {

--- a/components/eamxx/src/share/diagnostics/zonal_avg.cpp
+++ b/components/eamxx/src/share/diagnostics/zonal_avg.cpp
@@ -229,7 +229,7 @@ void ZonalAvg::initialize_impl()
     compute_zonal_sum(m_zonal_area,m_ones,m_area,m_bin_to_cols,&m_comm);
 
     // Create a copy of area which is scaled by 1 / zonal area
-    m_scaled_area = m_area.clone("scaled_area");
+    m_scaled_area = m_area.clone("scaled_area", CloneFlags::CopyData);
     auto zonal_area_view  = m_zonal_area.get_view<const Real *>();
     auto scaled_area_view = m_scaled_area.get_view<Real *>();
     Kokkos::parallel_for("scale_area_by_zonal_area_" + field.name(),

--- a/components/eamxx/src/share/field/field.cpp
+++ b/components/eamxx/src/share/field/field.cpp
@@ -1,6 +1,8 @@
 #include "share/field/field.hpp"
 #include "share/util/eamxx_utils.hpp"
 
+#include <bitset>
+
 namespace scream
 {
 
@@ -138,9 +140,61 @@ Field::get_const() const {
 }
 
 Field
-Field::clone() const {
-  return clone(name());
+Field::clone(const int flags) const {
+  return clone(name(),flags);
 }
+
+Field
+Field::clone(const std::string& name, const int flags) const {
+  return clone(name, get_header().get_identifier().get_grid_name(),flags);
+}
+
+Field
+Field::clone(const std::string& name, const std::string& grid_name, const int flags) const
+{
+  const int invalid_flags = flags & ~CloneFlags::All;
+  constexpr int nbits = std::numeric_limits<unsigned int>::digits;
+  EKAT_REQUIRE_MSG(invalid_flags == 0,
+                   "[Field::clone] Error! Input flags contain unrecognized or invalid bits.\n"
+                   " - input flags provided : 0b" + std::bitset<nbits>(flags).to_string() + " (" + std::to_string(flags) + ")\n"
+                   " - invalid bits detected: 0b" + std::bitset<nbits>(invalid_flags).to_string() + "\n"
+                   " - valid individual options include:\n"
+                   "     CloneFlags::None          (0b" + std::bitset<nbits>(CloneFlags::None).to_string() + ") [Default]\n"
+                   "     CloneFlags::MatchPacking  (0b" + std::bitset<nbits>(CloneFlags::MatchPacking).to_string() + ")\n"
+                   "     CloneFlags::CopyTimeStamp (0b" + std::bitset<nbits>(CloneFlags::CopyTimeStamp).to_string() + ")\n"
+                   "     CloneFlags::CopyData      (0b" + std::bitset<nbits>(CloneFlags::CopyData).to_string() + ")\n"
+                   " - maximum combined mask: 0b" + std::bitset<nbits>(CloneFlags::All).to_string() + "\n");
+
+  // Create new field
+  const auto& my_fid = get_header().get_identifier();
+  auto fid = my_fid.clone(name).reset_grid(grid_name);
+  Field f(fid);
+
+  if (flags & CloneFlags::MatchPacking) {
+    // Ensure alloc props match
+    const auto&  ap = get_header().get_alloc_properties();
+          auto& fap = f.get_header().get_alloc_properties();
+    fap.request_allocation(ap.get_largest_pack_size());
+  }
+
+  // Allocate
+  f.allocate_view();
+
+  if (flags & CloneFlags::CopyTimeStamp) {
+    // Set correct time stamp
+    const auto& ts = get_header().get_tracking().get_time_stamp();
+    f.get_header().get_tracking().update_time_stamp(ts);
+  }
+
+  if (flags & CloneFlags::CopyData) {
+    // Deep copy
+    f.deep_copy(*this);
+    f.sync_to_host();
+  }
+
+  return f;
+}
+
 
 Field
 Field::alias (const std::string& name) const {
@@ -167,37 +221,6 @@ Field::alias (const std::string& name, const std::string& grid_name, const std::
   f.m_header = get_header().alias(name, grid_name, tag_names);
   f.m_data = m_data;
   f.m_is_read_only = m_is_read_only;
-  return f;
-}
-
-Field
-Field::clone(const std::string& name) const {
-  return clone(name, get_header().get_identifier().get_grid_name());
-}
-
-Field
-Field::clone(const std::string& name, const std::string& grid_name) const {
-  // Create new field
-  const auto& my_fid = get_header().get_identifier();
-  auto fid = my_fid.clone(name).reset_grid(grid_name);
-  Field f(fid);
-
-  // Ensure alloc props match
-  const auto&  ap = get_header().get_alloc_properties();
-        auto& fap = f.get_header().get_alloc_properties();
-  fap.request_allocation(ap.get_largest_pack_size());
-
-  // Allocate
-  f.allocate_view();
-
-  // Set correct time stamp
-  const auto& ts = get_header().get_tracking().get_time_stamp();
-  f.get_header().get_tracking().update_time_stamp(ts);
-
-  // Deep copy
-  f.deep_copy(*this);
-  f.sync_to_host();
-
   return f;
 }
 

--- a/components/eamxx/src/share/field/field.hpp
+++ b/components/eamxx/src/share/field/field.hpp
@@ -26,6 +26,15 @@ enum HostOrDevice {
 #endif
 };
 
+// Used to specify different behavior in the clone operation
+namespace CloneFlags {
+  constexpr int None          = 0;
+  constexpr int MatchPacking  = 1 << 0; // Preserves allocation properties
+  constexpr int CopyTimeStamp = 1 << 1; // Copies current timestamp
+  constexpr int CopyData      = 1 << 2; // Copies the data
+  constexpr int All           = MatchPacking | CopyTimeStamp | CopyData;
+}
+
 // ======================== FIELD ======================== //
 
 // A field is composed of metadata info (the header) and a pointer to a view.
@@ -109,11 +118,14 @@ public:
 
   bool is_read_only () const { return m_is_read_only; }
 
-  // Creates a deep copy version of this field.
-  // It is created with a pristine header (no providers/customers)
-  Field clone () const;
-  Field clone (const std::string& name) const;
-  Field clone (const std::string& name, const std::string& grid_name) const;
+  // Creates a new field with a pristine header (no providers/customers).
+  // Clone behavior is controlled by flags: by default (CloneFlags::None),
+  // timestamp, packing, and data are not copied.
+  // Use CopyTimeStamp/CopyData/MatchPacking to copy the current
+  // timestamp and/or packing and/or field data into the clone.
+  Field clone (const int flags = CloneFlags::None) const;
+  Field clone (const std::string& name, const int flags = CloneFlags::None) const;
+  Field clone (const std::string& name, const std::string& grid_name, const int flags = CloneFlags::None) const;
 
   Field alias (const std::string& name) const;
   Field alias (const std::string& name, const std::string& grid_name) const;

--- a/components/eamxx/src/share/field/tests/contractions.cpp
+++ b/components/eamxx/src/share/field/tests/contractions.cpp
@@ -67,7 +67,7 @@ TEST_CASE("field_contractions") {
     REQUIRE_THROWS(horiz_contraction(scl, scl_x, vec_x)); // incompatible weight layout
 
     SECTION ("scl_x") {
-      auto f_in = scl_x.clone();
+      auto f_in = scl_x.clone(CloneFlags::CopyData);
       auto f_out = scl.clone();
 
       horiz_contraction(f_out, f_in, w);
@@ -84,7 +84,7 @@ TEST_CASE("field_contractions") {
     }
 
     SECTION ("scl_x_masked") {
-      auto f_in = scl_x.clone();
+      auto f_in = scl_x.clone(CloneFlags::CopyData);
       auto f_out = scl.clone();
       auto mask = f_in.create_valid_mask("mask",Field::MaskInit::Valid);
       mask.sync_to_host();
@@ -112,7 +112,7 @@ TEST_CASE("field_contractions") {
     }
 
     SECTION ("vec_xz") {
-      auto f_in  = vec_xz.clone();
+      auto f_in  = vec_xz.clone(CloneFlags::CopyData);
       auto f_out = vec_z.clone();
       auto mask = f_in.create_valid_mask();
       randomize_uniform(mask,seed++);
@@ -181,7 +181,7 @@ TEST_CASE("field_contractions") {
       REQUIRE_THROWS(vert_contraction(scl, scl_z, vec_xz)); // incompatible weight layout
 
       SECTION ("scl_z") {
-        auto f_in = scl_z.clone();
+        auto f_in = scl_z.clone(CloneFlags::CopyData);
         auto f_out = scl.clone();
         auto w = scl_z.clone();
         randomize_uniform (w,seed++);
@@ -201,7 +201,7 @@ TEST_CASE("field_contractions") {
       }
 
       SECTION ("scl_z_masked") {
-        auto f_in = scl_z.clone();
+        auto f_in = scl_z.clone(CloneFlags::CopyData);
         auto f_out = scl.clone();
         auto w = scl_z.clone();
         randomize_uniform (w,seed++);
@@ -231,7 +231,7 @@ TEST_CASE("field_contractions") {
       }
 
       SECTION ("scl_xz_w_z") {
-        auto f_in = scl_xz.clone();
+        auto f_in = scl_xz.clone(CloneFlags::CopyData);
         auto f_out = scl_x.clone();
         auto w = scl_z.clone();
         randomize_uniform (w,seed++);
@@ -258,7 +258,7 @@ TEST_CASE("field_contractions") {
       }
 
       SECTION ("vec_xz_w_xz") {
-        auto f_in = vec_xz.clone();
+        auto f_in = vec_xz.clone(CloneFlags::CopyData);
         auto f_out = vec_x.clone();
         auto w = scl_xz.clone();
         randomize_uniform (w,seed++);

--- a/components/eamxx/src/share/field/tests/field_masked_ops_tests.cpp
+++ b/components/eamxx/src/share/field/tests/field_masked_ops_tests.cpp
@@ -154,10 +154,10 @@ TEST_CASE ("masked_ops") {
   SECTION ("masked_scale_scalar") {
     auto mask = make_col_mask(f_real, f_int, ncol);
 
-    auto f2 = f_real.clone();   // starts as a copy of f_real
+    auto f2 = f_real.clone(CloneFlags::CopyData);   // starts as a copy of f_real
     f2.scale(2, mask);        // only masked cols multiplied by 2
 
-    auto f_ref = f_real.clone();
+    auto f_ref = f_real.clone(CloneFlags::CopyData);
     f_ref.scale(2);           // reference: 2*f_real everywhere
 
     for (int icol = 0; icol < ncol; ++icol) {
@@ -171,12 +171,12 @@ TEST_CASE ("masked_ops") {
   SECTION ("masked_scale_field") {
     auto mask = make_col_mask(f_real, f_int, ncol);
 
-    auto f2     = f_real.clone();
+    auto f2     = f_real.clone(CloneFlags::CopyData);
     auto f_twos = f_real.clone();
     f_twos.deep_copy(2);
     f2.scale(f_twos, mask);
 
-    auto f_ref = f_real.clone();
+    auto f_ref = f_real.clone(CloneFlags::CopyData);
     f_ref.scale(2);
 
     for (int icol = 0; icol < ncol; ++icol) {
@@ -191,12 +191,12 @@ TEST_CASE ("masked_ops") {
     auto mask = make_col_mask(f_real, f_int, ncol);
 
     // Integer scale by field of twos, only on masked cols
-    auto f2     = f_int.clone();
+    auto f2     = f_int.clone(CloneFlags::CopyData);
     auto f_twos = f_int.clone();
     f_twos.deep_copy(2);
     f2.scale(f_twos, mask);
 
-    auto f_ref = f_int.clone();
+    auto f_ref = f_int.clone(CloneFlags::CopyData);
     f_ref.scale(f_twos);
 
     for (int icol = 0; icol < ncol; ++icol) {
@@ -210,12 +210,12 @@ TEST_CASE ("masked_ops") {
   SECTION ("masked_scale_inv") {
     auto mask = make_col_mask(f_real, f_int, ncol);
 
-    auto f2     = f_real.clone();
+    auto f2     = f_real.clone(CloneFlags::CopyData);
     auto f_twos = f_real.clone();
     f_twos.deep_copy(2);
     f2.scale_inv(f_twos, mask);
 
-    auto f_ref = f_real.clone();
+    auto f_ref = f_real.clone(CloneFlags::CopyData);
     f_ref.scale(0.5);   // f_real/2
 
     for (int icol = 0; icol < ncol; ++icol) {
@@ -323,7 +323,7 @@ TEST_CASE ("masked_ops") {
     REQUIRE(views_are_equal(dst, ref));
 
     // scale with zero mask: f should remain unchanged
-    auto f2 = f_real.clone();
+    auto f2 = f_real.clone(CloneFlags::CopyData);
     f2.scale(10, mask);
     REQUIRE(views_are_equal(f2, f_real));
 

--- a/components/eamxx/src/share/field/tests/field_tests.cpp
+++ b/components/eamxx/src/share/field/tests/field_tests.cpp
@@ -93,11 +93,35 @@ TEST_CASE("field", "") {
     fap1.request_allocation(16);
     f1.allocate_view();
     f1.deep_copy(3.0);
+    auto ts = util::TimeStamp(2022,1,2,3,4,5);
+    f1.get_header().get_tracking().update_time_stamp(ts);
 
-    Field f2 = f1.clone();
+    Field f_none = f1.clone();
+    REQUIRE(f_none.is_allocated());
+    REQUIRE(f_none.get_header().get_alloc_properties().get_largest_pack_size()==1);
+    REQUIRE(!f_none.get_header().get_tracking().get_time_stamp().is_valid());
+
+    Field f_alloc = f1.clone(CloneFlags::MatchPacking);
+    REQUIRE(f_alloc.is_allocated());
+    REQUIRE(f_alloc.get_header().get_alloc_properties().get_largest_pack_size()==16);
+    REQUIRE(!f_alloc.get_header().get_tracking().get_time_stamp().is_valid());
+
+    Field f_ts = f1.clone(CloneFlags::CopyTimeStamp);
+    REQUIRE(f_ts.is_allocated());
+    REQUIRE(f_ts.get_header().get_tracking().get_time_stamp()==ts);
+    REQUIRE(f_ts.get_header().get_alloc_properties().get_largest_pack_size()==1);
+
+    Field f_data = f1.clone(CloneFlags::MatchPacking | CloneFlags::CopyData);
+    REQUIRE(f_data.is_allocated());
+    REQUIRE(f_data.get_header().get_alloc_properties().get_largest_pack_size()==16);
+    REQUIRE(!f_data.get_header().get_tracking().get_time_stamp().is_valid());
+    REQUIRE(views_are_equal(f1,f_data));
+
+    Field f2 = f1.clone(CloneFlags::All);
     auto& fap2 = f2.get_header().get_alloc_properties();
     REQUIRE(f2.is_allocated());
     REQUIRE(fap2.get_alloc_size()==fap1.get_alloc_size());
+    REQUIRE(f2.get_header().get_tracking().get_time_stamp()==ts);
     REQUIRE(views_are_equal(f1,f2));
 
     // Changing f2 should leave f1 unchanged

--- a/components/eamxx/src/share/field/tests/field_update_tests.cpp
+++ b/components/eamxx/src/share/field/tests/field_update_tests.cpp
@@ -36,7 +36,7 @@ TEST_CASE ("update") {
   randomize_uniform (f_int, seed++, 0, 100);
 
   SECTION ("data_type_checks") {
-    Field f2 = f_int.clone();
+    Field f2 = f_int.clone(CloneFlags::CopyData);
 
     // Coeffs have wrong data type (precision loss casting to field's data type)
     REQUIRE_THROWS (f2.update (f_int,1.0,1.0));
@@ -67,7 +67,7 @@ TEST_CASE ("update") {
   SECTION ("scale") {
     SECTION ("real") {
       Field f1 = f_real.clone();
-      Field f2 = f_real.clone();
+      Field f2 = f_real.clone(CloneFlags::CopyData);
 
       // x=2, x*y = 2*y
       f1.deep_copy(2.0);
@@ -96,13 +96,13 @@ TEST_CASE ("update") {
       one.deep_copy(1.0);
       two.deep_copy(2.0);
 
-      Field f1 = one.clone();
-      Field f2 = two.clone();
+      Field f1 = one.clone(CloneFlags::CopyData);
+      Field f2 = two.clone(CloneFlags::CopyData);
       f1.max(f2);
       REQUIRE (views_are_equal(f1, f2));
 
-      Field f3 = one.clone();
-      Field f4 = two.clone();
+      Field f3 = one.clone(CloneFlags::CopyData);
+      Field f4 = two.clone(CloneFlags::CopyData);
       f4.min(f3);
       REQUIRE (views_are_equal(f3, f4));
 
@@ -120,13 +120,13 @@ TEST_CASE ("update") {
       one.deep_copy(1);
       two.deep_copy(2);
 
-      Field f1 = one.clone();
-      Field f2 = two.clone();
+      Field f1 = one.clone(CloneFlags::CopyData);
+      Field f2 = two.clone(CloneFlags::CopyData);
       f1.max(f2);
       REQUIRE (views_are_equal(f1, f2));
 
-      Field f3 = one.clone();
-      Field f4 = two.clone();
+      Field f3 = one.clone(CloneFlags::CopyData);
+      Field f4 = two.clone(CloneFlags::CopyData);
       f4.min(f3);
       REQUIRE (views_are_equal(f3, f4));
 
@@ -141,8 +141,8 @@ TEST_CASE ("update") {
 
   SECTION ("scale_inv") {
     SECTION ("real") {
-      Field f1 = f_real.clone();
-      Field f2 = f_real.clone();
+      Field f1 = f_real.clone(CloneFlags::CopyData);
+      Field f2 = f_real.clone(CloneFlags::CopyData);
       Field f3 = f_real.clone();
 
       f3.deep_copy(2.0);
@@ -165,8 +165,8 @@ TEST_CASE ("update") {
 
   SECTION ("update") {
     SECTION ("real") {
-      Field f2 = f_real.clone();
-      Field f3 = f_real.clone();
+      Field f2 = f_real.clone(CloneFlags::CopyData);
+      Field f3 = f_real.clone(CloneFlags::CopyData);
 
       // x+x == 2*x
       f2.update(f_real,1,1);
@@ -200,8 +200,8 @@ TEST_CASE ("update") {
     }
 
     SECTION ("int") {
-      Field f2 = f_int.clone();
-      Field f3 = f_int.clone();
+      Field f2 = f_int.clone(CloneFlags::CopyData);
+      Field f3 = f_int.clone(CloneFlags::CopyData);
 
       // x+x == 2*x
       f2.update(f_int,1,1);

--- a/components/eamxx/src/share/grid/abstract_grid.cpp
+++ b/components/eamxx/src/share/grid/abstract_grid.cpp
@@ -199,7 +199,7 @@ bool AbstractGrid::is_unique () const {
     // Get a copy of gids on host. CAREFUL: do not use the stored dofs,
     // since we need to sort dofs in order to call unique, and we don't
     // want to alter the order of gids in this grid.
-    auto dofs = m_dofs_gids.clone();
+    auto dofs = m_dofs_gids.clone(CloneFlags::CopyData);
     auto dofs_h = dofs.get_view<gid_type*,Host>();
 
     std::sort(dofs_h.data(),dofs_h.data()+m_num_local_dofs);
@@ -764,21 +764,21 @@ void AbstractGrid::copy_data (const AbstractGrid& src, const bool shallow)
     m_dofs_gids = src.m_dofs_gids;
     m_partitioned_dim_gids = src.m_partitioned_dim_gids;
   } else {
-    m_dofs_gids = src.m_dofs_gids.clone();
-    m_partitioned_dim_gids = src.m_partitioned_dim_gids.clone();
+    m_dofs_gids = src.m_dofs_gids.clone(CloneFlags::CopyData);
+    m_partitioned_dim_gids = src.m_partitioned_dim_gids.clone(CloneFlags::CopyData);
   }
 
   if (shallow) {
     m_lid_to_idx = src.m_lid_to_idx;
   } else {
-    m_lid_to_idx = src.m_lid_to_idx.clone();
+    m_lid_to_idx = src.m_lid_to_idx.clone(CloneFlags::CopyData);
   }
 
   for (const auto& name : src.get_geometry_data_names()) {
     if (shallow) {
       m_geo_fields[name] = src.m_geo_fields.at(name);
     } else {
-      m_geo_fields[name] = src.m_geo_fields.at(name).clone();
+      m_geo_fields[name] = src.m_geo_fields.at(name).clone(CloneFlags::CopyData);
     }
   }
 

--- a/components/eamxx/src/share/grid/grid_import_export.cpp
+++ b/components/eamxx/src/share/grid/grid_import_export.cpp
@@ -22,8 +22,8 @@ GridImportExport (const std::shared_ptr<const AbstractGrid>& unique,
   // Note: we can't use the gids views from the grids, since we need to pass pointers
   //       to MPI bcast routines, which require pointers to nonconst data.
   //       Hence, create a clone, and grab a non-const pointer from it.
-  const auto unique_gids_f = unique->get_dofs_gids().clone();
-  const auto overlap_gids_f = overlapped->get_dofs_gids().clone();
+  const auto unique_gids_f = unique->get_dofs_gids().clone(CloneFlags::CopyData);
+  const auto overlap_gids_f = overlapped->get_dofs_gids().clone(CloneFlags::CopyData);
   const auto    gids = unique_gids_f.get_view<gid_type*,Host>();
   const auto ov_gids = overlap_gids_f.get_view<gid_type*,Host>();
 

--- a/components/eamxx/src/share/grid/se_grid.cpp
+++ b/components/eamxx/src/share/grid/se_grid.cpp
@@ -140,7 +140,7 @@ std::shared_ptr<AbstractGrid> SEGrid::clone (const std::string& clone_name, cons
     if (shallow) {
       grid->m_cg_dofs_gids = m_cg_dofs_gids;
     } else {
-      grid->m_cg_dofs_gids = m_cg_dofs_gids.clone();
+      grid->m_cg_dofs_gids = m_cg_dofs_gids.clone(CloneFlags::CopyData);
     }
   }
 

--- a/components/eamxx/src/share/io/eamxx_output_manager.cpp
+++ b/components/eamxx/src/share/io/eamxx_output_manager.cpp
@@ -159,14 +159,14 @@ setup (const std::shared_ptr<fm_type>& field_mgr,
           continue;
         }
         if (use_suffix) {
-          fields.push_back(f.clone(f.name() + grid->m_disambiguation_suffix, gname));
+          fields.push_back(f.clone(f.name() + grid->m_disambiguation_suffix, gname, CloneFlags::All));
 
           // Adjust long/std name, as the default metadata does not recognize the names with suffix
           auto& str_atts = fields.back().get_header().get_extra_data<stratts_t>("io: string attributes");
           str_atts["long_name"] = meta.get_longname(f.name());
           str_atts["standard_name"] = meta.get_standardname(f.name());
         } else {
-          fields.push_back(f.clone(f.name(), gname));
+          fields.push_back(f.clone(f.name(), gname, CloneFlags::All));
         }
 
         // Transfer io: string attributes from original field (e.g., "bounds" attribute).

--- a/components/eamxx/src/share/io/scorpio_input.cpp
+++ b/components/eamxx/src/share/io/scorpio_input.cpp
@@ -138,11 +138,7 @@ set_field_manager (const std::shared_ptr<const fm_type>& field_mgr)
     } else {
       // We have padding, or the field is a subfield (or both).
       // Either way, we need a temporary.
-      // NOTE: Field::clone honors the max pack size for the allocation,
-      //       which would defy one of the reason for cloning it...
-      Field copy (f.get_header().get_identifier());
-      copy.allocate_view();
-      m_fm_for_scorpio->add_field(copy);
+      m_fm_for_scorpio->add_field(f.clone());
     }
   }
 

--- a/components/eamxx/src/share/io/tests/io_basic.cpp
+++ b/components/eamxx/src/share/io/tests/io_basic.cpp
@@ -244,7 +244,7 @@ void read (const std::string& avg_type, const std::string& freq_units,
   for (int n=0; n<num_writes; ++n) {
     reader.read_variables(n);
     for (const auto& fn : fnames) {
-      auto f0 = fm0->get_field(fn).clone();
+      auto f0 = fm0->get_field(fn).clone(CloneFlags::CopyData);
       auto f  = fm->get_field(fn);
       if (avg_type=="MIN") {
         // The 1st snap in the avg window (the smallest)

--- a/components/eamxx/src/share/io/tests/io_diags.cpp
+++ b/components/eamxx/src/share/io/tests/io_diags.cpp
@@ -221,7 +221,7 @@ void read (const int seed, const ekat::Comm& comm)
     }
   }
 
-  auto f0 = fm0->get_field(f_name).clone();
+  auto f0 = fm0->get_field(f_name).clone(CloneFlags::CopyData);
   auto f  = fm->get_field(f_name);
 
   // Sanity check
@@ -251,7 +251,7 @@ void read (const int seed, const ekat::Comm& comm)
     const auto t = t0+i*get_dt();
     const double dt = t-t0;
     auto d = fm->get_field("MyDiag");
-    auto d0 = f0.clone();
+    auto d0 = f0.clone(CloneFlags::CopyData);
     d0.update(one,dt,2.0);
     REQUIRE (views_are_equal(d,d0));
 

--- a/components/eamxx/src/share/io/tests/io_filled.cpp
+++ b/components/eamxx/src/share/io/tests/io_filled.cpp
@@ -219,7 +219,7 @@ void read (const std::string& avg_type, const std::string& freq_units,
   for (int n=0; n<num_writes; ++n) {
     reader.read_variables(n);
     for (const auto& fn : fnames) {
-      auto f0 = fm0->get_field(fn).clone();
+      auto f0 = fm0->get_field(fn).clone(CloneFlags::CopyData);
       auto f  = fm->get_field(fn);
       if (avg_type=="MIN") {
         Real test_val = ((n+1)*freq%2==0) ? n*freq+1 : n*freq+2;

--- a/components/eamxx/src/share/io/tests/io_monthly.cpp
+++ b/components/eamxx/src/share/io/tests/io_monthly.cpp
@@ -194,7 +194,7 @@ void read (const int seed, const ekat::Comm& comm)
     reader.read_variables();
 
     for (const auto& fn : fnames) {
-      auto f0 = fm0->get_field(fn).clone();
+      auto f0 = fm0->get_field(fn).clone(CloneFlags::CopyData);
       auto f  = fm->get_field(fn);
       add(f0,n);
       REQUIRE (views_are_equal(f,f0));

--- a/components/eamxx/src/share/io/tests/output_restart.cpp
+++ b/components/eamxx/src/share/io/tests/output_restart.cpp
@@ -200,7 +200,7 @@ std::shared_ptr<FieldManager>
 clone_fm(const std::shared_ptr<const FieldManager>& src) {
   auto copy = std::make_shared<FieldManager>(src->get_grid(),RepoState::Closed);
   for (auto it : src->get_repo()) {
-    copy->add_field(it.second->clone());
+    copy->add_field(it.second->clone(CloneFlags::All));
   }
 
   return copy;

--- a/components/eamxx/src/share/property_checks/mass_and_energy_conservation_check.cpp
+++ b/components/eamxx/src/share/property_checks/mass_and_energy_conservation_check.cpp
@@ -341,7 +341,7 @@ void MassAndEnergyConservationCheck::global_fixer(const bool air_sea_surface_wat
 
   auto field_view_s1 = field_version_s1.get_view<Real*>();
 
-  auto area = m_grid->get_geometry_data("area").clone();
+  auto area = m_grid->get_geometry_data("area");
   auto area_view = area.get_view<const Real*>();
 
   //reprosum vars

--- a/components/eamxx/src/share/remap/tests/coarsening_remapper_tests.cpp
+++ b/components/eamxx/src/share/remap/tests/coarsening_remapper_tests.cpp
@@ -295,8 +295,8 @@ TEST_CASE("coarsening_remap")
   // -------------------------------------- //
 
   Real w = 0.5;
-  auto gids_tgt = all_gather_field(tgt_grid->get_dofs_gids().clone(),comm); // Need clone to be able to extract writable
-  auto gids_src = all_gather_field(src_grid->get_dofs_gids().clone(),comm); // pointers to pass to MPI's broadcast
+  auto gids_tgt = all_gather_field(tgt_grid->get_dofs_gids().clone(CloneFlags::CopyData),comm); // Need clone to be able to extract writable
+  auto gids_src = all_gather_field(src_grid->get_dofs_gids().clone(CloneFlags::CopyData),comm); // pointers to pass to MPI's broadcast
   auto gids_src_v = gids_src.get_view<const AbstractGrid::gid_type*,Host>();
   auto gids_tgt_v = gids_tgt.get_view<const AbstractGrid::gid_type*,Host>();
 

--- a/components/eamxx/src/share/remap/tests/vertical_remapper_tests.cpp
+++ b/components/eamxx/src/share/remap/tests/vertical_remapper_tests.cpp
@@ -554,7 +554,7 @@ TEST_CASE ("vertical_remapper") {
             Real tol = 10*std::numeric_limits<Real>::epsilon();
 
             auto check = [&](const Field& computed, Field& expected) {
-              auto rel_diff = computed.clone("rel_diff");
+              auto rel_diff = computed.clone("rel_diff", CloneFlags::CopyData);
               rel_diff.update(expected,1,-1);
               // By construction, expected fields are always > 0, so we can divide
               rel_diff.scale_inv(expected);


### PR DESCRIPTION
Allow to copy only the desired data/metadata during a Field::clone operation.

[BFB]

---

Before this PR, in order to create an unpadded clone of the field, one had to do
```cpp
Field f2 (f1.get_header().get_identifier(),true);
```
while now we can do
```cpp
auto f2 = f1.clone(CloneFlag);
```

This PR also changes the default behavior of `Field::clone`: before, it copied _everything_ (alloc props, timestamp, data), while now it creates a pristine clone without any alloc props, timestamp, or data. All existing call sites have been updated to pass `CloneFlags::All` to preserve the previous behavior.

Unit tests for the new clone flavors have been added to `field_tests.cpp`, with a dedicated catch2 `SECTION` for each flag combination: `All`, `None` (default), `PreserveAlloc`, `CopyTS`, `CopyData`, and `PreserveAlloc|CopyData`.