### PR TITLE
Add S2D-required pressure-level diagnostics and small bug fix to maint-3.0

### DIFF
--- a/cime_config/config_archive.xml
+++ b/cime_config/config_archive.xml
@@ -59,7 +59,7 @@
     <rest_file_extension>r</rest_file_extension>
     <rest_file_extension>rh\d*</rest_file_extension>
     <hist_file_extension>h\d*</hist_file_extension>
-    <rest_history_varname>unset</rest_history_varname>
+    <rest_history_varname>locfnh</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.rof$NINST_STRING</rpointer_file>
       <rpointer_content>$CASE.mosart$NINST_STRING.r.$DATENAME.nc</rpointer_content>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -267,8 +267,6 @@
       <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
       <env name="PERL5LIB">/global/cfs/cdirs/e3sm/perl/lib/perl5-only-switch</env>
       <env name="FI_MR_CACHE_MONITOR">kdreg2</env>
-      <env name="FI_CXI_RX_MATCH_MODE">software</env> 
-      <env name="FI_CXI_DEFAULT_CQ_SIZE">131072</env>
       <env name="MPICH_COLL_SYNC">MPI_Bcast</env>
       <env name="NETCDF_PATH">$ENV{CRAY_NETCDF_HDF5PARALLEL_PREFIX}</env>
       <env name="PNETCDF_PATH">$ENV{CRAY_PARALLEL_NETCDF_PREFIX}</env>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -267,6 +267,8 @@
       <env name="HDF5_USE_FILE_LOCKING">FALSE</env>
       <env name="PERL5LIB">/global/cfs/cdirs/e3sm/perl/lib/perl5-only-switch</env>
       <env name="FI_MR_CACHE_MONITOR">kdreg2</env>
+      <env name="FI_CXI_RX_MATCH_MODE">software</env> 
+      <env name="FI_CXI_DEFAULT_CQ_SIZE">131072</env>
       <env name="MPICH_COLL_SYNC">MPI_Bcast</env>
       <env name="NETCDF_PATH">$ENV{CRAY_NETCDF_HDF5PARALLEL_PREFIX}</env>
       <env name="PNETCDF_PATH">$ENV{CRAY_PARALLEL_NETCDF_PREFIX}</env>

--- a/components/eam/src/physics/cam/cam_diagnostics.F90
+++ b/components/eam/src/physics/cam/cam_diagnostics.F90
@@ -1875,6 +1875,10 @@ end subroutine diag_conv_tend_ini
        call vertinterp(ncol, pcols, pver, state%pmid, 20000._r8, state%v, p_surf)
        call outfld('V200    ', p_surf, pcols, lchnk )
     end if
+    if (hist_fld_active('V150')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 15000._r8, state%v, p_surf)
+       call outfld('V150    ', p_surf, pcols, lchnk )
+    end if
     if (hist_fld_active('V100')) then
        call vertinterp(ncol, pcols, pver, state%pmid, 10000._r8, state%v, p_surf)
        call outfld('V100    ', p_surf, pcols, lchnk )

--- a/components/eam/src/physics/cam/cam_diagnostics.F90
+++ b/components/eam/src/physics/cam/cam_diagnostics.F90
@@ -1073,8 +1073,12 @@ end subroutine diag_conv_tend_ini
     lchnk = state%lchnk
     ncol  = state%ncol
 
-    call cnst_get_ind('CLDLIQ', ixcldliq)
-    call cnst_get_ind('CLDICE', ixcldice)
+    ixcldliq = -1
+    ixcldice = -1
+    if (moist_physics) then
+       call cnst_get_ind('CLDLIQ', ixcldliq)
+       call cnst_get_ind('CLDICE', ixcldice)
+    end if
 
     ! Output NSTEP for debugging
     nstep = get_nstep()

--- a/components/eam/src/physics/cam/cam_diagnostics.F90
+++ b/components/eam/src/physics/cam/cam_diagnostics.F90
@@ -219,9 +219,14 @@ subroutine diag_init()
    call addfld ('Z500',horiz_only,    'A','m','Geopotential Z at 500 mbar pressure surface')
    call addfld ('Z400',horiz_only,    'A','m','Geopotential Z at 400 mbar pressure surface')
    call addfld ('Z300',horiz_only,    'A','m','Geopotential Z at 300 mbar pressure surface')
+   call addfld ('Z250',horiz_only,    'A','m','Geopotential Z at 250 mbar pressure surface')
    call addfld ('Z200',horiz_only,    'A','m','Geopotential Z at 200 mbar pressure surface')
+   call addfld ('Z150',horiz_only,    'A','m','Geopotential Z at 150 mbar pressure surface')
    call addfld ('Z100',horiz_only,    'A','m','Geopotential Z at 100 mbar pressure surface')
    call addfld ('Z050',horiz_only,    'A','m','Geopotential Z at 50 mbar pressure surface')
+   call addfld ('Z030',horiz_only,    'A','m','Geopotential Z at 30 mbar pressure surface')
+   call addfld ('Z025',horiz_only,    'A','m','Geopotential Z at 25 mbar pressure surface')
+   call addfld ('Z020',horiz_only,    'A','m','Geopotential Z at 20 mbar pressure surface')
    call addfld ('Z010',horiz_only,    'A','m','Geopotential Z at 10 mbar pressure surface')
 
    call addfld ('ZZ',(/ 'lev' /), 'A','m2','Eddy height variance' )
@@ -397,7 +402,6 @@ subroutine diag_init()
    call addfld ('V250',horiz_only,    'A','m/s','Meridional wind at 250 mbar pressure surface')
    call addfld ('V200',horiz_only,    'A','m/s','Meridional wind at 200 mbar pressure surface')
    call addfld ('V100',horiz_only,    'A','m/s','Meridional wind at 100 mbar pressure surface')
-   call addfld ('V050',horiz_only,    'A','m/s','Meridional wind at  50 mbar pressure surface')
    call addfld ('V010',horiz_only,    'A','m/s','Meridional wind at  10 mbar pressure surface')
 
    call addfld ('TT',(/ 'lev' /), 'A','K2','Eddy temperature variance' )
@@ -452,18 +456,32 @@ subroutine diag_init()
    call addfld ('T250',horiz_only,   'A', 'K',   'Temperature at 250 mbar pressure surface')
    call addfld ('T150',horiz_only,   'A', 'K',   'Temperature at 150 mbar pressure surface')
    call addfld ('T050',horiz_only,   'A', 'K',   'Temperature at 50 mbar pressure surface')
+   call addfld ('T030',horiz_only,   'A', 'K',   'Temperature at 30 mbar pressure surface')
    call addfld ('T025',horiz_only,   'A', 'K',   'Temperature at 25 mbar pressure surface')
+   call addfld ('T020',horiz_only,   'A', 'K',   'Temperature at 20 mbar pressure surface')
    call addfld ('T005',horiz_only,   'A', 'K',   'Temperature at 5 mbar pressure surface')
    call addfld ('T002',horiz_only,   'A', 'K',   'Temperature at 2 mbar pressure surface')
    call addfld ('T001',horiz_only,   'A', 'K',   'Temperature at 1 mbar pressure surface')
    call addfld ('TTOP',horiz_only,   'A', 'K',   'Highest model level temperature')
    call addfld ('U150',horiz_only,   'A', 'm/s', 'Zonal wind at 150 mbar pressure surface')
    call addfld ('U050',horiz_only,   'A', 'm/s', 'Zonal wind at 50 mbar pressure surface')
+   call addfld ('U030',horiz_only,   'A', 'm/s', 'Zonal wind at 30 mbar pressure surface')
    call addfld ('U025',horiz_only,   'A', 'm/s', 'Zonal wind at 25 mbar pressure surface')
+   call addfld ('U020',horiz_only,   'A', 'm/s', 'Zonal wind at 20 mbar pressure surface')
    call addfld ('U005',horiz_only,   'A', 'm/s', 'Zonal wind at 5 mbar pressure surface')
    call addfld ('U002',horiz_only,   'A', 'm/s', 'Zonal wind at 2 mbar pressure surface')
    call addfld ('U001',horiz_only,   'A', 'm/s', 'Zonal wind at 1 mbar pressure surface')
    call addfld ('UTOP',horiz_only,   'A', 'm/s', 'Highest model level zonal wind')
+   ! Also add V at levels consistent with T and U 
+   call addfld ('V150',horiz_only,   'A', 'm/s', 'Meridional wind at 150 mbar pressure surface')
+   call addfld ('V050',horiz_only,   'A', 'm/s', 'Meridional wind at  50 mbar pressure surface')
+   call addfld ('V030',horiz_only,   'A', 'm/s', 'Meridional wind at  30 mbar pressure surface')
+   call addfld ('V025',horiz_only,   'A', 'm/s', 'Meridional wind at  25 mbar pressure surface')
+   call addfld ('V020',horiz_only,   'A', 'm/s', 'Meridional wind at  20 mbar pressure surface')
+   call addfld ('V005',horiz_only,   'A', 'm/s', 'Meridional wind at   5 mbar pressure surface')
+   call addfld ('V002',horiz_only,   'A', 'm/s', 'Meridional wind at   2 mbar pressure surface')
+   call addfld ('V001',horiz_only,   'A', 'm/s', 'Meridional wind at   1 mbar pressure surface')
+   call addfld ('VTOP',horiz_only,   'A', 'm/s', 'Highest model level meridional wind')
 
    call addfld ('U90M',horiz_only,    'A','m/s','Zonal wind at turbine hub height (90m above surface)')
    call addfld ('V90M',horiz_only,    'A','m/s','Meridional wind at turbine hub height (90m above surface)')
@@ -1153,9 +1171,17 @@ end subroutine diag_conv_tend_ini
        call vertinterp(ncol, pcols, pver, state%pmid, 30000._r8, z3, p_surf)
        call outfld('Z300    ', p_surf, pcols, lchnk)
     end if
+    if (hist_fld_active('Z250')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 25000._r8, z3, p_surf)
+       call outfld('Z250    ', p_surf, pcols, lchnk)
+    end if
     if (hist_fld_active('Z200')) then
        call vertinterp(ncol, pcols, pver, state%pmid, 20000._r8, z3, p_surf)
        call outfld('Z200    ', p_surf, pcols, lchnk)
+    end if
+    if (hist_fld_active('Z150')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 15000._r8, z3, p_surf)
+       call outfld('Z150    ', p_surf, pcols, lchnk)
     end if
     if (hist_fld_active('Z100')) then
        call vertinterp(ncol, pcols, pver, state%pmid, 10000._r8, z3, p_surf)
@@ -1164,6 +1190,18 @@ end subroutine diag_conv_tend_ini
     if (hist_fld_active('Z050')) then
        call vertinterp(ncol, pcols, pver, state%pmid,  5000._r8, z3, p_surf)
        call outfld('Z050    ', p_surf, pcols, lchnk)
+    end if
+    if (hist_fld_active('Z030')) then
+       call vertinterp(ncol, pcols, pver, state%pmid,  3000._r8, z3, p_surf)
+       call outfld('Z030    ', p_surf, pcols, lchnk)
+    end if
+    if (hist_fld_active('Z025')) then
+       call vertinterp(ncol, pcols, pver, state%pmid,  2500._r8, z3, p_surf)
+       call outfld('Z025    ', p_surf, pcols, lchnk)
+    end if
+    if (hist_fld_active('Z020')) then
+       call vertinterp(ncol, pcols, pver, state%pmid,  2000._r8, z3, p_surf)
+       call outfld('Z020    ', p_surf, pcols, lchnk)
     end if
     if (hist_fld_active('Z010')) then
        call vertinterp(ncol, pcols, pver, state%pmid,  1000._r8, z3, p_surf)
@@ -1811,10 +1849,6 @@ end subroutine diag_conv_tend_ini
        call vertinterp(ncol, pcols, pver, state%pmid, 10000._r8, state%u, p_surf)
        call outfld('U100    ', p_surf, pcols, lchnk )
     end if
-    if (hist_fld_active('U050')) then
-       call vertinterp(ncol, pcols, pver, state%pmid,  5000._r8, state%u, p_surf)
-       call outfld('U050    ', p_surf, pcols, lchnk )
-    end if
     if (hist_fld_active('U010')) then
        call vertinterp(ncol, pcols, pver, state%pmid,  1000._r8, state%u, p_surf)
        call outfld('U010    ', p_surf, pcols, lchnk )
@@ -1875,17 +1909,9 @@ end subroutine diag_conv_tend_ini
        call vertinterp(ncol, pcols, pver, state%pmid, 20000._r8, state%v, p_surf)
        call outfld('V200    ', p_surf, pcols, lchnk )
     end if
-    if (hist_fld_active('V150')) then
-       call vertinterp(ncol, pcols, pver, state%pmid, 15000._r8, state%v, p_surf)
-       call outfld('V150    ', p_surf, pcols, lchnk )
-    end if
     if (hist_fld_active('V100')) then
        call vertinterp(ncol, pcols, pver, state%pmid, 10000._r8, state%v, p_surf)
        call outfld('V100    ', p_surf, pcols, lchnk )
-    end if
-    if (hist_fld_active('V050')) then
-       call vertinterp(ncol, pcols, pver, state%pmid, 5000._r8, state%v, p_surf)
-       call outfld('V050    ', p_surf, pcols, lchnk )
     end if
     if (hist_fld_active('V010')) then
        call vertinterp(ncol, pcols, pver, state%pmid, 1000._r8, state%v, p_surf)
@@ -2065,9 +2091,17 @@ end subroutine diag_conv_tend_ini
        call vertinterp(ncol, pcols, pver, state%pmid, 5000._r8, state%t, p_surf)
        call outfld('T050           ', p_surf, pcols, lchnk )
     end if
+    if (hist_fld_active('T030')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 3000._r8, state%t, p_surf)
+       call outfld('T030           ', p_surf, pcols, lchnk )
+    end if
     if (hist_fld_active('T025')) then
        call vertinterp(ncol, pcols, pver, state%pmid, 2500._r8, state%t, p_surf)
        call outfld('T025           ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('T020')) then
+       call vertinterp(ncol, pcols, pver, state%pmid, 2000._r8, state%t, p_surf)
+       call outfld('T020           ', p_surf, pcols, lchnk )
     end if
     if (hist_fld_active('T010')) then
        call vertinterp(ncol, pcols, pver, state%pmid, 1000._r8, state%t, p_surf)
@@ -2094,9 +2128,17 @@ end subroutine diag_conv_tend_ini
        call vertinterp(ncol, pcols, pver, state%pmid,  5000._r8, state%u, p_surf)
        call outfld('U050    ', p_surf, pcols, lchnk )
     end if
+    if (hist_fld_active('U030')) then
+       call vertinterp(ncol, pcols, pver, state%pmid,  3000._r8, state%u, p_surf)
+       call outfld('U030    ', p_surf, pcols, lchnk )
+    end if
     if (hist_fld_active('U025')) then
        call vertinterp(ncol, pcols, pver, state%pmid,  2500._r8, state%u, p_surf)
        call outfld('U025    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('U020')) then
+       call vertinterp(ncol, pcols, pver, state%pmid,  2000._r8, state%u, p_surf)
+       call outfld('U020    ', p_surf, pcols, lchnk )
     end if
     if (hist_fld_active('U005')) then
        call vertinterp(ncol, pcols, pver, state%pmid,  500._r8, state%u, p_surf)
@@ -2111,7 +2153,6 @@ end subroutine diag_conv_tend_ini
        call outfld('U001    ', p_surf, pcols, lchnk )
     end if
     call outfld ('UTOP    ', state%u(:,1)  ,  pcols, lchnk)
-
     ! Extra levels for Meridional Wind 
     if (hist_fld_active('V150')) then
        call vertinterp(ncol, pcols, pver, state%pmid,  15000._r8, state%v, p_surf)
@@ -2121,9 +2162,17 @@ end subroutine diag_conv_tend_ini
        call vertinterp(ncol, pcols, pver, state%pmid,  5000._r8, state%v, p_surf)
        call outfld('V050    ', p_surf, pcols, lchnk )
     end if
+    if (hist_fld_active('V030')) then
+       call vertinterp(ncol, pcols, pver, state%pmid,  3000._r8, state%v, p_surf)
+       call outfld('V030    ', p_surf, pcols, lchnk )
+    end if
     if (hist_fld_active('V025')) then
        call vertinterp(ncol, pcols, pver, state%pmid,  2500._r8, state%v, p_surf)
        call outfld('V025    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('V020')) then
+       call vertinterp(ncol, pcols, pver, state%pmid,  2000._r8, state%v, p_surf)
+       call outfld('V020    ', p_surf, pcols, lchnk )
     end if
     if (hist_fld_active('V005')) then
        call vertinterp(ncol, pcols, pver, state%pmid,  500._r8, state%v, p_surf)
@@ -2137,6 +2186,7 @@ end subroutine diag_conv_tend_ini
        call vertinterp(ncol, pcols, pver, state%pmid,  100._r8, state%v, p_surf)
        call outfld('V001    ', p_surf, pcols, lchnk )
     end if
+    call outfld ('VTOP    ', state%v(:,1)  ,  pcols, lchnk)
 
   !---------------------------------------------------------
   ! WACCM tidal diagnostics 

--- a/components/eam/src/physics/cam/cam_diagnostics.F90
+++ b/components/eam/src/physics/cam/cam_diagnostics.F90
@@ -303,6 +303,40 @@ subroutine diag_init()
    call addfld ('RH100',horiz_only,    'A','%','Relative humidity at 100 mbar pressure surface')
    call addfld ('RHBOT',horiz_only,    'A','%','Lowest model level relative humidity')
 
+   call addfld ('CLDLIQ100', horiz_only,    'A','kg/kg','Cloud liquid water at 100 mbar pressure surface')
+   call addfld ('CLDLIQ150', horiz_only,    'A','kg/kg','Cloud liquid water at 150 mbar pressure surface')
+   call addfld ('CLDLIQ200', horiz_only,    'A','kg/kg','Cloud liquid water at 200 mbar pressure surface')
+   call addfld ('CLDLIQ250', horiz_only,    'A','kg/kg','Cloud liquid water at 250 mbar pressure surface')
+   call addfld ('CLDLIQ300', horiz_only,    'A','kg/kg','Cloud liquid water at 300 mbar pressure surface')
+   call addfld ('CLDLIQ400', horiz_only,    'A','kg/kg','Cloud liquid water at 400 mbar pressure surface')
+   call addfld ('CLDLIQ500', horiz_only,    'A','kg/kg','Cloud liquid water at 500 mbar pressure surface')
+   call addfld ('CLDLIQ600', horiz_only,    'A','kg/kg','Cloud liquid water at 600 mbar pressure surface')
+   call addfld ('CLDLIQ700', horiz_only,    'A','kg/kg','Cloud liquid water at 700 mbar pressure surface')
+   call addfld ('CLDLIQ800', horiz_only,    'A','kg/kg','Cloud liquid water at 800 mbar pressure surface')
+   call addfld ('CLDLIQ850', horiz_only,    'A','kg/kg','Cloud liquid water at 850 mbar pressure surface')
+   call addfld ('CLDLIQ900', horiz_only,    'A','kg/kg','Cloud liquid water at 900 mbar pressure surface')
+   call addfld ('CLDLIQ925', horiz_only,    'A','kg/kg','Cloud liquid water at 925 mbar pressure surface')
+   call addfld ('CLDLIQ950', horiz_only,    'A','kg/kg','Cloud liquid water at 950 mbar pressure surface')
+   call addfld ('CLDLIQ975', horiz_only,    'A','kg/kg','Cloud liquid water at 975 mbar pressure surface')
+   call addfld ('CLDLIQ1000',horiz_only,    'A','kg/kg','Cloud liquid water at 1000 mbar pressure surface')
+
+   call addfld ('CLDICE100', horiz_only,    'A','kg/kg','Cloud ice water at 100 mbar pressure surface')
+   call addfld ('CLDICE150', horiz_only,    'A','kg/kg','Cloud ice water at 150 mbar pressure surface')
+   call addfld ('CLDICE200', horiz_only,    'A','kg/kg','Cloud ice water at 200 mbar pressure surface')
+   call addfld ('CLDICE250', horiz_only,    'A','kg/kg','Cloud ice water at 250 mbar pressure surface')
+   call addfld ('CLDICE300', horiz_only,    'A','kg/kg','Cloud ice water at 300 mbar pressure surface')
+   call addfld ('CLDICE400', horiz_only,    'A','kg/kg','Cloud ice water at 400 mbar pressure surface')
+   call addfld ('CLDICE500', horiz_only,    'A','kg/kg','Cloud ice water at 500 mbar pressure surface')
+   call addfld ('CLDICE600', horiz_only,    'A','kg/kg','Cloud ice water at 600 mbar pressure surface')
+   call addfld ('CLDICE700', horiz_only,    'A','kg/kg','Cloud ice water at 700 mbar pressure surface')
+   call addfld ('CLDICE800', horiz_only,    'A','kg/kg','Cloud ice water at 800 mbar pressure surface')
+   call addfld ('CLDICE850', horiz_only,    'A','kg/kg','Cloud ice water at 850 mbar pressure surface')
+   call addfld ('CLDICE900', horiz_only,    'A','kg/kg','Cloud ice water at 900 mbar pressure surface')
+   call addfld ('CLDICE925', horiz_only,    'A','kg/kg','Cloud ice water at 925 mbar pressure surface')
+   call addfld ('CLDICE950', horiz_only,    'A','kg/kg','Cloud ice water at 950 mbar pressure surface')
+   call addfld ('CLDICE975', horiz_only,    'A','kg/kg','Cloud ice water at 975 mbar pressure surface')
+   call addfld ('CLDICE1000',horiz_only,    'A','kg/kg','Cloud ice water at 1000 mbar pressure surface')
+
    call addfld ('MQ',(/ 'lev' /), 'A','kg/m2','Water vapor mass in layer')
    call addfld ('TMQ',horiz_only,    'A','kg/m2','Total (vertically integrated) precipitable water', &
    standard_name='atmosphere_mass_content_of_water_vapor')
@@ -1013,11 +1047,16 @@ end subroutine diag_conv_tend_ini
     integer  plon             ! number of longitudes
 
     integer i, k, m, lchnk, ncol, nstep
+    integer ixcldice, ixcldliq ! constituent indices for cloud liquid and ice water.
+
 !
 !-----------------------------------------------------------------------
 !
     lchnk = state%lchnk
     ncol  = state%ncol
+
+    call cnst_get_ind('CLDLIQ', ixcldliq)
+    call cnst_get_ind('CLDICE', ixcldice)
 
     ! Output NSTEP for debugging
     nstep = get_nstep()
@@ -1368,6 +1407,122 @@ end subroutine diag_conv_tend_ini
     call outfld ('TVH     ',ftem, pcols   ,lchnk     )
 
     if (moist_physics) then
+
+      ! Cloud liquid water mixing ratio
+      if (hist_fld_active('CLDLIQ1000')) then
+         call vertinterp(ncol, pcols, pver, state%pmid, 100000._r8, state%q(1,1,ixcldliq), p_surf)
+         call outfld('CLDLIQ1000    ', p_surf, pcols, lchnk )
+      end if
+      if (hist_fld_active('CLDLIQ975')) then
+         call vertinterp(ncol, pcols, pver, state%pmid, 97500._r8, state%q(1,1,ixcldliq), p_surf)
+         call outfld('CLDLIQ975    ', p_surf, pcols, lchnk )
+      end if
+      if (hist_fld_active('CLDLIQ950')) then
+         call vertinterp(ncol, pcols, pver, state%pmid, 95000._r8, state%q(1,1,ixcldliq), p_surf)
+         call outfld('CLDLIQ950    ', p_surf, pcols, lchnk )
+      end if
+      if (hist_fld_active('CLDLIQ925')) then
+         call vertinterp(ncol, pcols, pver, state%pmid, 92500._r8, state%q(1,1,ixcldliq), p_surf)
+         call outfld('CLDLIQ925    ', p_surf, pcols, lchnk )
+      end if
+      if (hist_fld_active('CLDLIQ900')) then
+         call vertinterp(ncol, pcols, pver, state%pmid, 90000._r8, state%q(1,1,ixcldliq), p_surf)
+         call outfld('CLDLIQ900    ', p_surf, pcols, lchnk )
+      end if
+      if (hist_fld_active('CLDLIQ850')) then
+         call vertinterp(ncol, pcols, pver, state%pmid, 85000._r8, state%q(1,1,ixcldliq), p_surf)
+         call outfld('CLDLIQ850    ', p_surf, pcols, lchnk )
+      end if
+      if (hist_fld_active('CLDLIQ800')) then
+         call vertinterp(ncol, pcols, pver, state%pmid, 80000._r8, state%q(1,1,ixcldliq), p_surf)
+         call outfld('CLDLIQ800    ', p_surf, pcols, lchnk )
+      end if
+      if (hist_fld_active('CLDLIQ700')) then
+         call vertinterp(ncol, pcols, pver, state%pmid, 70000._r8, state%q(1,1,ixcldliq), p_surf)
+         call outfld('CLDLIQ700    ', p_surf, pcols, lchnk )
+      end if
+      if (hist_fld_active('CLDLIQ600')) then
+         call vertinterp(ncol, pcols, pver, state%pmid, 60000._r8, state%q(1,1,ixcldliq), p_surf)
+         call outfld('CLDLIQ600    ', p_surf, pcols, lchnk )
+      end if
+      if (hist_fld_active('CLDLIQ500')) then
+         call vertinterp(ncol, pcols, pver, state%pmid, 50000._r8, state%q(1,1,ixcldliq), p_surf)
+         call outfld('CLDLIQ500    ', p_surf, pcols, lchnk )
+      end if
+      if (hist_fld_active('CLDLIQ400')) then
+         call vertinterp(ncol, pcols, pver, state%pmid, 40000._r8, state%q(1,1,ixcldliq), p_surf)
+         call outfld('CLDLIQ400    ', p_surf, pcols, lchnk )
+      end if
+      if (hist_fld_active('CLDLIQ300')) then
+         call vertinterp(ncol, pcols, pver, state%pmid, 30000._r8, state%q(1,1,ixcldliq), p_surf)
+         call outfld('CLDLIQ300    ', p_surf, pcols, lchnk )
+      end if
+      if (hist_fld_active('CLDLIQ200')) then
+         call vertinterp(ncol, pcols, pver, state%pmid, 20000._r8, state%q(1,1,ixcldliq), p_surf)
+         call outfld('CLDLIQ200    ', p_surf, pcols, lchnk )
+      end if
+      if (hist_fld_active('CLDLIQ100')) then
+         call vertinterp(ncol, pcols, pver, state%pmid, 10000._r8, state%q(1,1,ixcldliq), p_surf)
+         call outfld('CLDLIQ100    ', p_surf, pcols, lchnk )
+      end if
+
+      ! Cloud ice water mixing ratio
+      if (hist_fld_active('CLDICE1000')) then
+         call vertinterp(ncol, pcols, pver, state%pmid, 100000._r8, state%q(1,1,ixcldice), p_surf)
+         call outfld('CLDICE1000    ', p_surf, pcols, lchnk )
+      end if
+      if (hist_fld_active('CLDICE975')) then
+         call vertinterp(ncol, pcols, pver, state%pmid, 97500._r8, state%q(1,1,ixcldice), p_surf)
+         call outfld('CLDICE975    ', p_surf, pcols, lchnk )
+      end if
+      if (hist_fld_active('CLDICE950')) then
+         call vertinterp(ncol, pcols, pver, state%pmid, 95000._r8, state%q(1,1,ixcldice), p_surf)
+         call outfld('CLDICE950    ', p_surf, pcols, lchnk )
+      end if
+      if (hist_fld_active('CLDICE925')) then
+         call vertinterp(ncol, pcols, pver, state%pmid, 92500._r8, state%q(1,1,ixcldice), p_surf)
+         call outfld('CLDICE925    ', p_surf, pcols, lchnk )
+      end if
+      if (hist_fld_active('CLDICE900')) then
+         call vertinterp(ncol, pcols, pver, state%pmid, 90000._r8, state%q(1,1,ixcldice), p_surf)
+         call outfld('CLDICE900    ', p_surf, pcols, lchnk )
+      end if
+      if (hist_fld_active('CLDICE850')) then
+         call vertinterp(ncol, pcols, pver, state%pmid, 85000._r8, state%q(1,1,ixcldice), p_surf)
+         call outfld('CLDICE850    ', p_surf, pcols, lchnk )
+      end if
+      if (hist_fld_active('CLDICE800')) then
+         call vertinterp(ncol, pcols, pver, state%pmid, 80000._r8, state%q(1,1,ixcldice), p_surf)
+         call outfld('CLDICE800    ', p_surf, pcols, lchnk )
+      end if
+      if (hist_fld_active('CLDICE700')) then
+         call vertinterp(ncol, pcols, pver, state%pmid, 70000._r8, state%q(1,1,ixcldice), p_surf)
+         call outfld('CLDICE700    ', p_surf, pcols, lchnk )
+      end if
+      if (hist_fld_active('CLDICE600')) then
+         call vertinterp(ncol, pcols, pver, state%pmid, 60000._r8, state%q(1,1,ixcldice), p_surf)
+         call outfld('CLDICE600    ', p_surf, pcols, lchnk )
+      end if
+      if (hist_fld_active('CLDICE500')) then
+         call vertinterp(ncol, pcols, pver, state%pmid, 50000._r8, state%q(1,1,ixcldice), p_surf)
+         call outfld('CLDICE500    ', p_surf, pcols, lchnk )
+      end if
+      if (hist_fld_active('CLDICE400')) then
+         call vertinterp(ncol, pcols, pver, state%pmid, 40000._r8, state%q(1,1,ixcldice), p_surf)
+         call outfld('CLDICE400    ', p_surf, pcols, lchnk )
+      end if
+      if (hist_fld_active('CLDICE300')) then
+         call vertinterp(ncol, pcols, pver, state%pmid, 30000._r8, state%q(1,1,ixcldice), p_surf)
+         call outfld('CLDICE300    ', p_surf, pcols, lchnk )
+      end if
+      if (hist_fld_active('CLDICE200')) then
+         call vertinterp(ncol, pcols, pver, state%pmid, 20000._r8, state%q(1,1,ixcldice), p_surf)
+         call outfld('CLDICE200    ', p_surf, pcols, lchnk )
+      end if
+      if (hist_fld_active('CLDICE100')) then
+         call vertinterp(ncol, pcols, pver, state%pmid, 10000._r8, state%q(1,1,ixcldice), p_surf)
+         call outfld('CLDICE100    ', p_surf, pcols, lchnk )
+      end if
 
       ! Mass of saturated q vertically integrated
        call qsat(state%t(:ncol,:), state%pmid(:ncol,:), tem2(:ncol,:), ftem(:ncol,:))
@@ -1953,6 +2108,31 @@ end subroutine diag_conv_tend_ini
     end if
     call outfld ('UTOP    ', state%u(:,1)  ,  pcols, lchnk)
 
+    ! Extra levels for Meridional Wind 
+    if (hist_fld_active('V150')) then
+       call vertinterp(ncol, pcols, pver, state%pmid,  15000._r8, state%v, p_surf)
+       call outfld('V150    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('V050')) then
+       call vertinterp(ncol, pcols, pver, state%pmid,  5000._r8, state%v, p_surf)
+       call outfld('V050    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('V025')) then
+       call vertinterp(ncol, pcols, pver, state%pmid,  2500._r8, state%v, p_surf)
+       call outfld('V025    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('V005')) then
+       call vertinterp(ncol, pcols, pver, state%pmid,  500._r8, state%v, p_surf)
+       call outfld('V005    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('V002')) then
+       call vertinterp(ncol, pcols, pver, state%pmid,  200._r8, state%v, p_surf)
+       call outfld('V002    ', p_surf, pcols, lchnk )
+    end if
+    if (hist_fld_active('V001')) then
+       call vertinterp(ncol, pcols, pver, state%pmid,  100._r8, state%v, p_surf)
+       call outfld('V001    ', p_surf, pcols, lchnk )
+    end if
 
   !---------------------------------------------------------
   ! WACCM tidal diagnostics 

--- a/components/eam/src/physics/cam/cam_diagnostics.F90
+++ b/components/eam/src/physics/cam/cam_diagnostics.F90
@@ -1553,9 +1553,17 @@ end subroutine diag_conv_tend_ini
          call vertinterp(ncol, pcols, pver, state%pmid, 30000._r8, state%q(1,1,ixcldice), p_surf)
          call outfld('CLDICE300    ', p_surf, pcols, lchnk )
       end if
+      if (hist_fld_active('CLDICE250')) then
+         call vertinterp(ncol, pcols, pver, state%pmid, 25000._r8, state%q(1,1,ixcldice), p_surf)
+         call outfld('CLDICE250    ', p_surf, pcols, lchnk )
+      end if
       if (hist_fld_active('CLDICE200')) then
          call vertinterp(ncol, pcols, pver, state%pmid, 20000._r8, state%q(1,1,ixcldice), p_surf)
          call outfld('CLDICE200    ', p_surf, pcols, lchnk )
+      end if
+      if (hist_fld_active('CLDICE150')) then
+         call vertinterp(ncol, pcols, pver, state%pmid, 15000._r8, state%q(1,1,ixcldice), p_surf)
+         call outfld('CLDICE150    ', p_surf, pcols, lchnk )
       end if
       if (hist_fld_active('CLDICE100')) then
          call vertinterp(ncol, pcols, pver, state%pmid, 10000._r8, state%q(1,1,ixcldice), p_surf)

--- a/components/eam/src/physics/cam/cam_diagnostics.F90
+++ b/components/eam/src/physics/cam/cam_diagnostics.F90
@@ -1499,9 +1499,17 @@ end subroutine diag_conv_tend_ini
          call vertinterp(ncol, pcols, pver, state%pmid, 30000._r8, state%q(1,1,ixcldliq), p_surf)
          call outfld('CLDLIQ300    ', p_surf, pcols, lchnk )
       end if
+      if (hist_fld_active('CLDLIQ250')) then
+         call vertinterp(ncol, pcols, pver, state%pmid, 25000._r8, state%q(1,1,ixcldliq), p_surf)
+         call outfld('CLDLIQ250    ', p_surf, pcols, lchnk )
+      end if
       if (hist_fld_active('CLDLIQ200')) then
          call vertinterp(ncol, pcols, pver, state%pmid, 20000._r8, state%q(1,1,ixcldliq), p_surf)
          call outfld('CLDLIQ200    ', p_surf, pcols, lchnk )
+      end if
+      if (hist_fld_active('CLDLIQ150')) then
+         call vertinterp(ncol, pcols, pver, state%pmid, 15000._r8, state%q(1,1,ixcldliq), p_surf)
+         call outfld('CLDLIQ150    ', p_surf, pcols, lchnk )
       end if
       if (hist_fld_active('CLDLIQ100')) then
          call vertinterp(ncol, pcols, pver, state%pmid, 10000._r8, state%q(1,1,ixcldliq), p_surf)

--- a/components/mpas-ocean/cime_config/buildnml
+++ b/components/mpas-ocean/cime_config/buildnml
@@ -882,7 +882,7 @@ def buildnml(case, caseroot, compname):
             lines.append('        filename_interval="00-01-00_00:00:00"')
             lines.append('        reference_time="01-01-01_00:00:00"')
             lines.append('        output_interval="none"')
-            lines.append('        ulobber_mode="truncate"')
+            lines.append('        clobber_mode="truncate"')
             lines.append('        packages="zonalMeanAMPKG">')
             lines.append('')
             lines.append('    <var name="xtime"/>')


### PR DESCRIPTION
This PR adds several pressure-level atmospheric diagnostics needed for the BruteForce S2D simulations based on the refined S2D model output variable list.

Main changes include:

- Add missing geopotential height diagnostics at selected pressure levels: Z250, Z150, Z030, Z025, Z020

- Add pressure-level cloud liquid and cloud ice water diagnostics:
1. CLDLIQ from 1000 hPa to 100 hPa, consistent with the existing U, V, T, and Q pressure-level fields. Levels above 100 hPa are excluded because they are not expected to contain meaningful cloud liquid water information.
2. CLDICE from 1000 hPa to 100 hPa, consistent with the existing U, V, T, and Q pressure-level fields. Levels above 100 hPa are excluded because they are not expected to contain meaningful cloud ice water information.

- Add missing and more consistent upper-level wind diagnostics, useful for analyzing stratospheric features such as the QBO and SSW: U030, U020, V150, V050, V030, V025, V020, V005, V002, V001, VTOP

- Add the corresponding interpolation/output logic in diag_phys_writeout.

- Fix a typo in the MPAS-Ocean buildnml stream setting: ulobber_mode → clobber_mode

- Fix a potential MOSART restart/archive issue by setting MOSART rest_history_varname from unset to locfnh in config_archive.xml. When this value is unset, high-frequency MOSART history files such as mosart.h1 may not be properly saved into the restart directory during archiving, which can cause restart runs to fail because the required MOSART history files are missing.

These changes are intended to support the requested S2D output variables and restart workflow while keeping the updates limited to the maint-3.0 branch used for the S2D simulations.

[BFB]