### PR TITLE
EAMxx: fix bug in iop remapper

### DIFF
--- a/components/eamxx/src/share/remap/iop_remapper.cpp
+++ b/components/eamxx/src/share/remap/iop_remapper.cpp
@@ -124,7 +124,7 @@ void IOPRemapper::remap_fwd_impl ()
   // 2. Rank root_id broadcasts the single-col fields
   for (int i=0; i<m_num_fields; ++i) {
     auto& f = m_single_col_fields[i];
-    int col_size = f.get_header().get_identifier().get_layout().size();
+    int col_size = f.get_header().get_alloc_properties().get_num_scalars();
 #if SCREAM_MPI_ON_DEVICE
     m_comm.broadcast(f.get_internal_view_data<Real>(),col_size,root_id);
 #else

--- a/components/eamxx/src/share/remap/tests/iop_remapper_tests.cpp
+++ b/components/eamxx/src/share/remap/tests/iop_remapper_tests.cpp
@@ -164,7 +164,7 @@ TEST_CASE("iop_remap")
     const auto& tgt = remap->get_tgt_field(i);
 
     auto col = src.subfield(COL,0).clone("col");
-    int col_size = col.get_header().get_identifier().get_layout().size();
+    int col_size = col.get_header().get_alloc_properties().get_num_scalars();
     if (comm.rank()==closest_rank) {
       col.deep_copy(src.subfield(COL,closest_lid));
     }


### PR DESCRIPTION
Broadcast correct number of Real's in IOP remapper.

[non-BFB] for eamxx cases with DP/IOP enabled, pack size > 1, and nlevs % pack_size != 0.

---

Note: this only affects iop fields with another dim other than the vert lev one (e.g., CCN3 is unaffected), since for 1d views the layout size is actually capturing all the scalars we need to bcast. But for fields like AER_SW_G (say, with nlev=72 and pack size=16) what we'd really have to bcast are 72 doubles, then skip 8, then 72 doubles, then skip 8... Or, as this PR does, bcast the total number of doubles in the view allocation (hence, bcasting also the zeros/garbage inside the padding).

Also, since on GPU the pack size is 1, any prod run on frontier/pm-gpu is fine. And since our CPU default pack size of 16 evenly divides 128 (hence, no padding), even on CPU things are fine for 128 levels cases.