### PR TITLE
EAMxx: support Ninja generator in test-all-eamxx

### DIFF
--- a/components/eamxx/cmake/ctest_script.cmake
+++ b/components/eamxx/cmake/ctest_script.cmake
@@ -17,6 +17,10 @@ set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
 
 ctest_start(${dashboard_model} TRACK ${dashboard_track})
 
+if (USE_NINJA)
+  set (CTEST_CMAKE_GENERATOR Ninja)
+endif()
+
 separate_arguments(OPTIONS_LIST UNIX_COMMAND "${CMAKE_COMMAND}")
 ctest_configure(OPTIONS "${OPTIONS_LIST}" RETURN_VALUE CONFIG_ERROR_CODE)
 

--- a/components/eamxx/scripts/machines_specs.py
+++ b/components/eamxx/scripts/machines_specs.py
@@ -73,6 +73,7 @@ class Machine(object):
     c_compiler   = "mpicc"
     ftn_compiler = "mpifort"
     baselines_dir = ""
+    use_ninja = False
 
     @classmethod
     def setup_base(cls,name,num_bld_res=-1,num_run_res=-1):

--- a/components/eamxx/scripts/test_all_eamxx.py
+++ b/components/eamxx/scripts/test_all_eamxx.py
@@ -314,6 +314,9 @@ class TestAllScream(object):
         # Ctest only needs config options, and doesn't need the leading 'cmake '
         result  = f"{'' if for_ctest else 'cmake '}-C {self._machine.mach_file}"
 
+        if self._machine.use_ninja and not for_ctest:
+            result  += " -G Ninja"
+
         # Netcdf should be available. But if the user is doing a testing session
         # where all netcdf-related code is disabled, he/she should be able to run
         # even if no netcdf is available
@@ -472,6 +475,9 @@ class TestAllScream(object):
         for key, value in extra_configs:
             result += f"-D{key}={value} "
 
+        if self._machine.use_ninja:
+            result += "-DUSE_NINJA=TRUE "
+
         work_dir = self._work_dir/str(test)
         result += f"-DBUILD_WORK_DIR={work_dir} "
 
@@ -526,7 +532,10 @@ class TestAllScream(object):
             print (f"WARNING: Failed to create baselines (config phase):\n{err}")
             return False
 
-        cmd = f"make -j{test.compile_res_count}"
+        if self._machine.use_ninja:
+            cmd = f"ninja -j{test.compile_res_count}"
+        else:
+            cmd = f"make -j{test.compile_res_count}"
         if self._parallel:
             resources = self.get_taskset_resources(test)
             cmd = f"taskset -c {','.join([str(r) for r in resources])} sh -c '{cmd}'"


### PR DESCRIPTION
Off by default, turn on setting the machine spec 'use_ninja' to True.

[BFB]

---

This feature is not yet enabled on any machine, though I verified it works on my laptop. I will try it next week on the CI machines. My hope is that it can speed up compilation when we're waiting for the last file of an eamxx tgt to build, blocking all downstream tgt from starting. E.g., a p3 function file (blocking all downstream tests from starting to build), or a field ETI file. This is especially true for GPU machines.