### PR TITLE
Remove an extraneous comma after Fortran WRITE statements

### DIFF
--- a/components/data_comps/dice/src/ice_comp_mct.F90
+++ b/components/data_comps/dice/src/ice_comp_mct.F90
@@ -162,7 +162,7 @@ CONTAINS
 #ifdef HAVE_MOAB
     if (my_task == master_task) then
        ! send path of ice domain to MOAB coupler.
-       write(logunit,*), ' file used for ice domain ', SDICE%domainFile
+       write(logunit,*) ' file used for ice domain ', SDICE%domainFile
        call seq_infodata_PutData( infodata, ice_domain=SDICE%domainFile)
     endif
 #endif

--- a/components/data_comps/dlnd/src/lnd_comp_mct.F90
+++ b/components/data_comps/dlnd/src/lnd_comp_mct.F90
@@ -168,7 +168,7 @@ CONTAINS
      if (my_task == master_task) then
           call seq_infodata_PutData( infodata, lnd_domain=SDLND%domainFile) ! we use the same one for regular case
           ! in regular case, it is copied from fatmlndfrc ; so we don't know if it is data land or not
-          write(logunit,*), ' use this land domain file: ', SDLND%domainFile
+          write(logunit,*) ' use this land domain file: ', SDLND%domainFile
      endif
 #endif
     !----------------------------------------------------------------------------

--- a/components/data_comps/drof/src/rof_comp_mct.F90
+++ b/components/data_comps/drof/src/rof_comp_mct.F90
@@ -176,7 +176,7 @@ CONTAINS
        call shr_stream_getFile(filePath,fileName)
        ! send path of river domain to MOAB coupler.
        call seq_infodata_PutData( infodata, rof_domain=fileName)
-       write(logunit,*), ' filename: ', filename
+       write(logunit,*) ' filename: ', filename
     endif
 #endif
     !----------------------------------------------------------------------------


### PR DESCRIPTION
In `ice_comp_mct.F90`, `lnd_comp_mct.F90`, and `rof_comp_mct.F90`, there is a Fortran WRITE statement with an extraneous comma.
```
write(logunit,*), '...'
```

This statement is not valid according to the Fortran standard. While gfortran accepts it without error,
other compilers, such as the Cray ftn compiler on Frontier, report it as a compilation error.