### PR TITLE
EAMxx: fix copy-paste error in print_field_hypeslab

### DIFF
--- a/components/eamxx/src/share/field/utils/print_hyperslab.cpp
+++ b/components/eamxx/src/share/field/utils/print_hyperslab.cpp
@@ -183,7 +183,7 @@ void print_field_hyperslab (const Field& f,
               for (int l=0; l<layout.dim(3); ++l) {
                 dims_str[dims_left[3]] = std::to_string(l);
                 out << "  " << f.name() << "(" << ekat::join(dims_str,",") << ")";
-                for (int m=0; m<layout.dim(3); ++m) {
+                for (int m=0; m<layout.dim(4); ++m) {
                   if (m%max_per_line==0) {
                     out << "\n    ";
                   }


### PR DESCRIPTION
Fix for loop upper bound for rank-5 fields.

[BFB]

---