### PR TITLE
EAMxx: Adding namelist option mam4_number_so4_monolayers_to_age_carbon

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -309,6 +309,7 @@ be lost if SCREAM_HACK_XML is not enabled.
     <!-- MAM4xx-Aerosol-Microphysics -->
     <mam4_aero_microphys inherit="mam4_atm_proc_base">
       <!--Aerosol Microphysics processes on/off switches -->
+      <mam4_number_so4_monolayers_to_age_carbon_particle type="integer" doc="number of so4 manolayers to age carbon particle">8</mam4_number_so4_monolayers_to_age_carbon_particle>	   
       <mam4_do_gas_phase_chemistry type="logical" doc="Switch to enable gas phase chemistry">true</mam4_do_gas_phase_chemistry>
       <mam4_do_aqueous_phase_chemistry type="logical" doc="Switch to enable aqueous chemistry (setsox)">true</mam4_do_aqueous_phase_chemistry>
       <extra_mam4_aero_microphys_diags type="logical" doc="Extra MAM4xx aerosol microphysics diagnostics">false</extra_mam4_aero_microphys_diags>


### PR DESCRIPTION
We are adding  `mam4_number_so4_monolayers_to_age_carbon` to the default EAMxx namelist.

[BFB]