### PR TITLE
Fix CICE CIME_cppdefs missing BLCK defines after buildnml -nodecomp configure

### DIFF
--- a/components/cice/cime_config/buildnml
+++ b/components/cice/cime_config/buildnml
@@ -97,6 +97,14 @@ def buildnml(case, caseroot, compname):
 
     case.flush()
 
+    # write the complete cppdefs (including BLCK values) back to CIME_cppdefs so that
+    # the cmake build system picks up the correct defines if it re-configures.
+    # The cice configure script writes CIME_cppdefs without BLCK values (because it is
+    # called with -nodecomp), so we must update the file here after appending them.
+    if os.path.isfile(os.path.join(ciceconf_dir, "CIME_cppdefs")):
+        with open(os.path.join(ciceconf_dir, "CIME_cppdefs"), "w") as fd:
+            fd.write(cppdefs + "\n")
+
     # write out cppdefs to CICE_cppdefs.new
     # this will force gmake to rebuild when $CASE.buildexe is called
 


### PR DESCRIPTION
Fix missing BLCK defines in CIME_cppdefs: CICE configure script is called with
`-nodecomp`, so it writes `CIME_cppdefs` without the BLCK decomposition defines.
After buildnml appends those BLCK values to `cppdefs`, it now writes the complete
string back to `CIME_cppdefs`. Without this, a subsequent CMake reconfigure (e.g.,
after changing the pe-layout or rebuilding an existing case without cleaning) would
read an incomplete `CIME_cppdefs` and produce a broken build.

The fix is in the Python buildnml script and runs before any compilation. All machines
and compilers are affected equally.

This is specifically relevant when modifying and rebuilding an existing case without
cleaning: the first build succeeds because `CICE_cppdefs.new` triggers a full rebuild,
but a subsequent reconfigure reads the stale `CIME_cppdefs` and misses the BLCK defines.

[bfb]
