### PR TITLE
Remove Perls Switch dependency

### DIFF
--- a/components/mpas-albany-landice/bld/build-namelist
+++ b/components/mpas-albany-landice/bld/build-namelist
@@ -1179,34 +1179,30 @@ sub valid_date {
 # $$month by 1 (also incrementing $$year if going from Dec to Jan) and 
 # then return 0.
 
-  use Switch;
-
   my $day = shift;
   my $month = shift;
   my $year = shift;
   my $cal = shift;
 
   my $maxday = -1;
-  switch ($$month) {
-    case 1 { $maxday = 31; }
-    case 2 {
-      if (($cal eq 'NO_LEAP') || (not leap($$year))) {
-        $maxday = 28;
-      } else {
-        $maxday = 29;
-      }
+  if    ($$month == 1)  { $maxday = 31; }
+  elsif ($$month == 2) {
+    if (($cal eq 'NO_LEAP') || (not leap($$year))) {
+      $maxday = 28;
+    } else {
+      $maxday = 29;
     }
-    case 3 { $maxday = 31; }
-    case 4 { $maxday = 30; }
-    case 5 { $maxday = 31; }
-    case 6 { $maxday = 30; }
-    case 7 { $maxday = 31; }
-    case 8 { $maxday = 31; }
-    case 9 { $maxday = 30; }
-    case 10 { $maxday = 31; }
-    case 11 { $maxday = 30; }
-    case 12 { $maxday = 31; }
   }
+  elsif ($$month == 3)  { $maxday = 31; }
+  elsif ($$month == 4)  { $maxday = 30; }
+  elsif ($$month == 5)  { $maxday = 31; }
+  elsif ($$month == 6)  { $maxday = 30; }
+  elsif ($$month == 7)  { $maxday = 31; }
+  elsif ($$month == 8)  { $maxday = 31; }
+  elsif ($$month == 9)  { $maxday = 30; }
+  elsif ($$month == 10) { $maxday = 31; }
+  elsif ($$month == 11) { $maxday = 30; }
+  elsif ($$month == 12) { $maxday = 31; }
   if ($maxday == -1) {
     die "ERROR: can not figure out what month $$month is";
   }


### PR DESCRIPTION
Remove a dependency that Perl installation have the Switch module, which is easy to replace with if/then logic.

[bfb]
