### PR TITLE
EAMxx: create lightwieght FieldReader class (and free-functions)

### DIFF
--- a/components/eamxx/src/share/field/CMakeLists.txt
+++ b/components/eamxx/src/share/field/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(eamxx_field
   field.cpp
   field_group.cpp
   field_sync.cpp
+  field_reader.cpp
   eti/field_get_strided_view_double_device.cpp
   eti/field_get_strided_view_float_device.cpp
   eti/field_get_strided_view_int_device.cpp
@@ -66,7 +67,8 @@ endif()
 
 target_link_libraries (eamxx_field PUBLIC
   eamxx_core
-  eamxx_utils)
+  eamxx_utils
+  eamxx_scorpio_interface)
 
 if (NOT SCREAM_LIB_ONLY)
   add_subdirectory(tests)

--- a/components/eamxx/src/share/field/field.cpp
+++ b/components/eamxx/src/share/field/field.cpp
@@ -81,7 +81,7 @@ void update_checks (const std::string& caller,
 
   const auto& y_l = y.get_header().get_identifier().get_layout();
   const auto& x_l = x.get_header().get_identifier().get_layout();
-  EKAT_REQUIRE_MSG (y_l==x_l,
+  EKAT_REQUIRE_MSG (y_l.congruent(x_l),
       "[" + caller + "] Error! Incompatible fields layouts.\n"
       " - rhs name: " + x.name() + "\n"
       " - lhs name: " + y.name() + "\n"
@@ -217,6 +217,20 @@ Field::alias (const std::string& name, const std::map<FieldTag,std::string>& tag
 
 Field
 Field::alias (const std::string& name, const std::string& grid_name, const std::map<FieldTag,std::string>& tag_names) const {
+  Field f;
+  f.m_header = get_header().alias(name, grid_name, tag_names);
+  f.m_data = m_data;
+  f.m_is_read_only = m_is_read_only;
+  return f;
+}
+
+Field
+Field::alias (const std::string& name, const std::map<std::string,std::string>& tag_names) const {
+  return alias(name, get_header().get_identifier().get_grid_name(), tag_names);
+}
+
+Field
+Field::alias (const std::string& name, const std::string& grid_name, const std::map<std::string,std::string>& tag_names) const {
   Field f;
   f.m_header = get_header().alias(name, grid_name, tag_names);
   f.m_data = m_data;

--- a/components/eamxx/src/share/field/field.hpp
+++ b/components/eamxx/src/share/field/field.hpp
@@ -131,6 +131,8 @@ public:
   Field alias (const std::string& name, const std::string& grid_name) const;
   Field alias (const std::string& name, const std::map<FieldTag,std::string>& tag_names) const;
   Field alias (const std::string& name, const std::string& grid_name, const std::map<FieldTag,std::string>& tag_names) const;
+  Field alias (const std::string& name, const std::map<std::string,std::string>& tag_names) const;
+  Field alias (const std::string& name, const std::string& grid_name, const std::map<std::string,std::string>& tag_names) const;
 
   // Allows to get the underlying view, reshaped for a different data type.
   // The class will check that the requested data type is compatible with the

--- a/components/eamxx/src/share/field/field_header.cpp
+++ b/components/eamxx/src/share/field/field_header.cpp
@@ -69,6 +69,27 @@ std::shared_ptr<FieldHeader> FieldHeader::alias(const std::string& name, const s
   return fh;
 }
 
+std::shared_ptr<FieldHeader> FieldHeader::alias(const std::string& name, const std::map<std::string,std::string>& tag_names) const {
+  return alias(name, m_identifier.get_grid_name(), tag_names);
+}
+
+std::shared_ptr<FieldHeader> FieldHeader::alias(const std::string& name, const std::string& grid_name, const std::map<std::string,std::string>& tag_names) const {
+  auto layout = get_identifier().get_layout().clone();
+  layout.rename_dims(tag_names);
+  auto fid = get_identifier().clone(name);
+  fid.reset_grid(grid_name);
+  fid.reset_layout(layout);
+  auto fh = std::make_shared<FieldHeader>(fid);
+  if (get_parent() != nullptr) {
+    // If we're aliasing, we MUST keep track of the parent
+    fh->create_parent_child_link(get_parent());
+  }
+  fh->m_tracking = m_tracking;
+  fh->m_alloc_prop = m_alloc_prop;
+  fh->m_extra_data = m_extra_data;
+  return fh;
+}
+
 bool FieldHeader::is_aliasing (const FieldHeader& rhs) const
 {
   if (this==&rhs)

--- a/components/eamxx/src/share/field/field_header.hpp
+++ b/components/eamxx/src/share/field/field_header.hpp
@@ -84,6 +84,8 @@ public:
   std::shared_ptr<FieldHeader> alias (const std::string& name, const std::string& grid_name) const;
   std::shared_ptr<FieldHeader> alias (const std::string& name, const std::map<FieldTag,std::string>& tag_names) const;
   std::shared_ptr<FieldHeader> alias (const std::string& name, const std::string& grid_name, const std::map<FieldTag,std::string>& tag_names) const;
+  std::shared_ptr<FieldHeader> alias (const std::string& name, const std::map<std::string,std::string>& tag_names) const;
+  std::shared_ptr<FieldHeader> alias (const std::string& name, const std::string& grid_name, const std::map<std::string,std::string>& tag_names) const;
 
   // Two headers alias each other if either
   //   - they are the same obj

--- a/components/eamxx/src/share/field/field_layout.cpp
+++ b/components/eamxx/src/share/field/field_layout.cpp
@@ -259,6 +259,16 @@ FieldLayout& FieldLayout::rename_dims (const std::map<FieldTag,std::string>& new
   return *this;
 }
 
+FieldLayout& FieldLayout::rename_dims (const std::map<std::string,std::string>& new_names)
+{
+  for (int i=0; i<m_rank; ++i) {
+    if (new_names.count(m_names[i]))
+      m_names[i] = new_names.at(m_names[i]);
+  }
+
+  return *this;
+}
+
 FieldLayout& FieldLayout::reset_dim (const int idim, const int extent)
 {
   EKAT_REQUIRE_MSG(idim>=0 && idim<m_rank, "Error! Index out of bounds.");

--- a/components/eamxx/src/share/field/field_layout.hpp
+++ b/components/eamxx/src/share/field/field_layout.hpp
@@ -147,6 +147,7 @@ public:
   // These overload allow to remove/rename dims *if found*. They won't throw if layout does not have them
   FieldLayout& strip_dims (const std::vector<FieldTag>& tags); // Does not throw if not found
   FieldLayout& rename_dims (const std::map<FieldTag,std::string>& new_names); // Does not throw if not found
+  FieldLayout& rename_dims (const std::map<std::string,std::string>& new_names); // Does not throw if not found
 
   FieldLayout clone() const;
   FieldLayout transpose () const;

--- a/components/eamxx/src/share/field/field_reader.cpp
+++ b/components/eamxx/src/share/field/field_reader.cpp
@@ -144,9 +144,13 @@ void FieldReader::set_dim_decomp(const Field& gids, const ekat::Comm& comm)
 void FieldReader::setup_internals ()
 {
   if (m_dim_decomp_name!="" and m_reader_state & (NEW_FILE | NEW_DECOMP)) {
-    EKAT_REQUIRE_MSG ((std::is_same_v<std::int64_t,scorpio::offset_t>),
-        "[FieldReader::setup_internals] Error! scorpio::offset_t no longer compatible with int64_t.\n");
-    scorpio::set_dim_decomp(m_filename, m_dim_decomp_name, m_dim_decomp_offsets);
+    if (std::is_same_v<std::int64_t,scorpio::offset_t>) {
+      scorpio::set_dim_decomp(m_filename, m_dim_decomp_name, m_dim_decomp_offsets);
+    } else {
+      std::vector<scorpio::offset_t> offsets(m_dim_decomp_offsets.begin(),
+                                             m_dim_decomp_offsets.end());
+      scorpio::set_dim_decomp(m_filename, m_dim_decomp_name, offsets);
+    }
   }
 
   if (m_reader_state & (NEW_FIELDS | NEW_FILE)) {

--- a/components/eamxx/src/share/field/field_reader.cpp
+++ b/components/eamxx/src/share/field/field_reader.cpp
@@ -1,0 +1,282 @@
+#include "share/field/field_reader.hpp"
+#include "share/field/field_utils.hpp"
+#include "share/scorpio_interface/eamxx_scorpio_interface.hpp"
+
+#include <ekat_string_utils.hpp>
+#include <ekat_zip.hpp>
+
+#include <memory>
+#include <numeric>
+
+namespace scream
+{
+
+FieldReader::
+~FieldReader ()
+{
+  clean_up ();
+}
+
+void FieldReader::
+set_fields (const std::vector<Field>& fields)
+{
+  m_fields = fields;
+  m_reader_state |= NEW_FIELDS;
+}
+
+void FieldReader::
+set_file_specs (const std::string& filename,
+                const std::string& io_type)
+{
+  set_file_specs(filename,{},io_type);
+}
+
+void FieldReader::
+set_file_specs (const std::string& filename,
+                const std::map<std::string,std::string>& tag_rename,
+                const std::string& io_type)
+
+{
+  EKAT_REQUIRE_MSG (filename!="",
+      "[FieldReader::set_file_specs] Error! Input filename is empty.\n");
+
+  if (filename!=m_filename) {
+    if (m_filename!="") {
+      scorpio::release_file(m_filename);
+    }
+
+    m_filename = filename;
+    m_tag_rename = tag_rename;
+
+    scorpio::register_file(m_filename,scorpio::FileMode::Read,scorpio::str2iotype(io_type));
+
+    // Some input files have the "time" dimension as non-unlimited. This can sometime mess up
+    // our interfaces, which stores a pointer to a "time" dim to be used to read/write
+    // the desired time slices. This ptr is automatically inited to the unlimited dim in the file.
+    // If there is no unlimited dim, this ptr remains uninited, which means that the
+    // eamxx scorpio interface will treat "time" like any other dim (yielding n+1-dim fields)
+    if (not scorpio::has_time_dim(m_filename) and scorpio::has_dim(m_filename,"time")) {
+      scorpio::mark_dim_as_time(m_filename,"time");
+    }
+
+    m_reader_state |= NEW_FILE;
+  } else {
+    EKAT_REQUIRE_MSG (tag_rename==m_tag_rename,
+        "[FieldReader::set_file_specs] Error! Filename did not change, but tag_rename did.\n"
+        " - file name: " + filename + "\n");
+  }
+}
+
+void FieldReader::read (const int time_index)
+{
+  if (m_reader_state!=CLEAN)
+    setup_internals ();
+
+  for (const auto& [f, f_io] : ekat::zip(m_fields,m_io_fields)) {
+    switch (f_io.data_type()) {
+      case DataType::DoubleType:
+        scorpio::read_var(m_filename,f.name(),f_io.get_internal_view_data<double,Host>(),time_index);
+        break;
+      case DataType::FloatType:
+        scorpio::read_var(m_filename,f.name(),f_io.get_internal_view_data<float,Host>(),time_index);
+        break;
+      case DataType::IntType:
+        scorpio::read_var(m_filename,f.name(),f_io.get_internal_view_data<int,Host>(),time_index);
+        break;
+      default:
+        EKAT_ERROR_MSG (
+            "Error! Unsupported/unrecognized data type while reading field from file.\n"
+            " - file name : " + m_filename + "\n"
+            " - field name: " + f.name() + "\n");
+    }
+
+    f_io.sync_to_dev();
+    f.deep_copy(f_io); // If f_io is aliasing f, this is a no-op
+  }
+}
+
+void FieldReader::clean_up ()
+{
+  if (m_filename!="")
+    scorpio::release_file(m_filename);
+
+  m_fields = {};
+  m_io_fields = {};
+
+  m_filename = "";
+  m_tag_rename = {};
+
+  m_dim_decomp_offsets = {};
+  m_dim_decomp_name = "";
+
+  m_reader_state = CLEAN;
+}
+
+void FieldReader::set_dim_decomp(const Field& gids, const ekat::Comm& comm)
+{
+  const auto& layout = gids.get_header().get_identifier().get_layout();
+
+  EKAT_REQUIRE_MSG (gids.is_allocated(),
+      "[FieldReader::set_dim_decomp] Error! Invalid gids field.\n"
+      " - gids field name: " + gids.name() + "\n");
+  EKAT_REQUIRE_MSG (gids.rank()==1,
+      "[FieldReader::set_dim_decomp] Error! GIDs field must have rank 1.\n"
+      " - field name: " + gids.name() + "\n"
+      " - field layout: " + layout.to_string() + "\n");
+  EKAT_REQUIRE_MSG (gids.data_type()==DataType::IntType,
+      "[FieldReader::set_dim_decomp] Error! GIDs field must have data type IntType.\n"
+      " - field name : " + gids.name() + "\n"
+      " - field dtype: " + e2str(gids.data_type()) + "\n");
+
+  // Set the decomposition for the partitioned dimension
+  const int local_dim = layout.size();
+  auto gids_h = gids.get_view<const int*,Host>();
+  auto min_gid = field_min(gids,&comm).as<int>();
+  m_dim_decomp_offsets.resize(local_dim);
+  for (int idof=0; idof<local_dim; ++idof) {
+    m_dim_decomp_offsets[idof] = gids_h[idof] - min_gid;
+  }
+  m_dim_decomp_name = layout.name(0);
+
+  m_reader_state |= NEW_DECOMP;
+}
+
+void FieldReader::setup_internals ()
+{
+  if (m_dim_decomp_name!="" and m_reader_state & (NEW_FILE | NEW_DECOMP)) {
+    EKAT_REQUIRE_MSG ((std::is_same_v<std::int64_t,scorpio::offset_t>),
+        "[FieldReader::setup_internals] Error! scorpio::offset_t no longer compatible with int64_t.\n");
+    scorpio::set_dim_decomp(m_filename, m_dim_decomp_name, m_dim_decomp_offsets);
+  }
+
+  if (m_reader_state & (NEW_FIELDS | NEW_FILE)) {
+    // First, check fields are in the file, with correct layout
+    for (const auto & f : m_fields) {
+      // Check that the variable is in the file.
+      EKAT_REQUIRE_MSG (scorpio::has_var(m_filename,f.name()),
+          "Error! Input file does not store a required variable.\n"
+          " - filename: " + m_filename + "\n"
+          " - varname : " + f.name() + "\n");
+
+      const auto& layout = f.get_header().get_identifier().get_layout();
+      auto io_dims = layout.names();
+      for (int i=0; i<layout.rank(); ++i) {
+        if (io_dims[i]=="dim")
+          io_dims[i] += std::to_string(layout.dim(i));
+        if (m_tag_rename.count(io_dims[i])>0) {
+          io_dims[i] = m_tag_rename.at(io_dims[i]);
+        }
+      }
+
+      const auto& var = scorpio::get_var(m_filename,f.name());
+      EKAT_REQUIRE_MSG (var.dim_names()==io_dims,
+          "Error! Layout mismatch for input file variable.\n"
+          " - filename: " + m_filename + "\n"
+          " - varname : " + f.name() + "\n"
+          " - expected dim names: " + ekat::join(io_dims,",") + "\n"
+          " - dims from file    : " + ekat::join(var.dim_names(),",") + "\n");
+
+      for (int i=0; i<layout.rank(); ++i) {
+        if (io_dims[i]!=m_dim_decomp_name) {
+          const int file_len  = scorpio::get_dimlen(m_filename,io_dims[i]);
+          EKAT_REQUIRE_MSG (layout.dim(i)==file_len,
+              "Error! Dimension mismatch for input file variable.\n"
+            " - filename : " + m_filename + "\n"
+            " - varname  : " + f.name() + "\n"
+            " - var dims : " + ekat::join(io_dims,",") + "\n"
+            " - dim name : " + io_dims[i] + "\n"
+            " - expected extent : " + std::to_string(layout.dim(i)) + "\n"
+            " - extent from file: " + std::to_string(file_len) + "\n");
+        }
+      }
+    }
+
+    // Now create io_fields
+    // IO fields MUST be contiguous, so if padded or with parent, create a new one.
+    // Otherwise, we can alias input field, possibly with renamed tags
+    m_io_fields = {};
+    auto io_map = m_layout_to_io_field;
+    m_layout_to_io_field.clear();
+    for (const auto& f : m_fields) {
+      const auto& fh  = f.get_header();
+      const auto& fap = fh.get_alloc_properties();
+
+      const auto& fid    = fh.get_identifier();
+      const auto& layout = fid.get_layout();
+      auto key = e2str(fid.data_type()) + "_" + ekat::join(layout.dims(),"_");
+      if (fh.get_parent() or fap.get_padding()>0) {
+        auto it = io_map.try_emplace(key,fid.clone(key),true);
+        m_io_fields.push_back(it.first->second.alias(f.name(),m_tag_rename));
+        m_layout_to_io_field[key] = it.first->second;
+      } else {
+        m_io_fields.push_back(f.alias(f.name(),m_tag_rename));
+        m_layout_to_io_field[key] = m_io_fields.back();
+      }
+    }
+  }
+
+  m_reader_state = CLEAN;
+}
+
+// ------ Free functions ------- //
+
+void read_fields (const std::string& filename,
+                  const std::vector<Field>& fields,
+                  const int time_index)
+{
+  // FieldReader reader(filename,fields);
+  FieldReader reader;
+  reader.set_file_specs(filename);
+  reader.set_fields(fields);
+  reader.read(time_index);
+}
+void read_fields (const std::string& filename,
+                  const std::initializer_list<Field>& fields,
+                  const int time_index)
+{
+  read_fields(filename,std::vector<Field>(fields),time_index);
+}
+void read_fields (const std::string& filename,
+                  const std::map<std::string,Field>& fields,
+                  const int time_index)
+{
+  std::vector<Field> fields_vec;
+  for (const auto& [name,f] : fields)
+    fields_vec.push_back(f.alias(name));
+  read_fields(filename,fields_vec,time_index);
+}
+
+void read_fields (const std::string& filename,
+                  const std::vector<Field>& fields,
+                  const Field& decomp_gids,
+                  const ekat::Comm& comm,
+                  const int time_index)
+{
+  // FieldReader reader(filename,fields,decomp_gids,comm);
+  FieldReader reader;
+  reader.set_file_specs(filename);
+  reader.set_dim_decomp(decomp_gids,comm);
+  reader.set_fields(fields);
+  reader.read(time_index);
+}
+void read_fields (const std::string& filename,
+                  const std::initializer_list<Field>& fields,
+                  const Field& decomp_gids,
+                  const ekat::Comm& comm,
+                  const int time_index)
+{
+  read_fields(filename,std::vector<Field>(fields),decomp_gids,comm,time_index);
+}
+void read_fields (const std::string& filename,
+                  const std::map<std::string,Field>& fields,
+                  const Field& decomp_gids,
+                  const ekat::Comm& comm,
+                  const int time_index)
+{
+  std::vector<Field> fields_vec;
+  for (const auto& [name,f] : fields)
+    fields_vec.push_back(f.alias(name));
+  read_fields(filename,fields_vec,decomp_gids,comm,time_index);
+}
+
+} // namespace scream

--- a/components/eamxx/src/share/field/field_reader.hpp
+++ b/components/eamxx/src/share/field/field_reader.hpp
@@ -1,0 +1,103 @@
+#ifndef EAMXX_FIELD_READER_HPP
+#define EAMXX_FIELD_READER_HPP
+
+#include "share/field/field.hpp"
+
+#include <ekat_comm.hpp>
+
+#include <string>
+#include <map>
+
+namespace scream
+{
+
+class FieldReader
+{
+public:
+  // --- Constructor(s) & Destructor --- //
+  FieldReader () = default;
+  ~FieldReader ();
+
+  // Due to resource acquisition (in scorpio), avoid copies
+  FieldReader (const FieldReader&) = delete;
+  FieldReader& operator= (const FieldReader&) = delete;
+
+  // --- Methods --- //
+
+  // Expose the ability to set/reset fields or filename for cases like data interpolation,
+  // where we swap pointers but all the scorpio data structures are unchanged.
+  void set_fields (const std::vector<Field>& fields);
+  void set_file_specs(const std::string& filename, const std::string& io_type = "default");
+  void set_file_specs(const std::string& filename, const std::map<std::string,std::string>& tag_rename, const std::string& io_type = "default");
+  void set_dim_decomp (const Field& gids, const ekat::Comm& comm);
+
+  // Read fields that were required via parameter list.
+  void read (const int time_index = -1);
+
+  // Cleans up the reader and closes scorpio stuff
+  // NOTE: mostly useful for tests, when scorpio::finalize_session is in the same scope
+  //       as the reader, and we MUST close all files before finalizing scorpio
+  void clean_up ();
+
+protected:
+
+  // Flags to determine if anything needs to be re-inited before we read
+  static constexpr int CLEAN      = 0;
+  static constexpr int NEW_FILE   = 1;
+  static constexpr int NEW_FIELDS = 2;
+  static constexpr int NEW_DECOMP = 4;
+
+  // Called lazily at the beginning of read if m_reader_state!=CLEAN
+  void setup_internals ();
+
+  std::string         m_filename;
+
+  // Entries in m_io_fields may alias entries in m_fields if there is no padding, they are not subfields,
+  // and the data type matches what's on the file.
+  std::vector<Field>  m_fields;
+  std::vector<Field>  m_io_fields;
+
+  // Store info about the decomposed dim (if any), so if the file changes
+  // we can replay it in the new file
+  std::string          m_dim_decomp_name;
+  std::vector<int64_t> m_dim_decomp_offsets;
+
+  std::map<std::string,Field> m_layout_to_io_field;
+
+  // If the input file has non-standard names, we store them here, so we can alias the fields
+  std::map<std::string, std::string> m_tag_rename;
+
+  // When read is called, if this is not READER_CLEAN, we must proceed to setup some things
+  int m_reader_state = CLEAN;
+};
+
+// Shorthand functions if you don't need to keep the reader around and the default io type is ok
+void read_fields (const std::string& filename,
+                  const std::vector<Field>& fields,
+                  const int time_index = -1);
+void read_fields (const std::string& filename,
+                  const std::initializer_list<Field>& fields,
+                  const int time_index = -1);
+void read_fields (const std::string& filename,
+                  const std::map<std::string,Field>& fields,
+                  const int time_index = -1);
+
+void read_fields (const std::string& filename,
+                  const std::vector<Field>& fields,
+                  const Field& decomp_gids,
+                  const ekat::Comm& comm,
+                  const int time_index = -1);
+void read_fields (const std::string& filename,
+                  const std::initializer_list<Field>& fields,
+                  const Field& decomp_gids,
+                  const ekat::Comm& comm,
+                  const int time_index = -1);
+void read_fields (const std::string& filename,
+                  const std::map<std::string,Field>& fields,
+                  const Field& decomp_gids,
+                  const ekat::Comm& comm,
+                  const int time_index = -1);
+
+} //namespace scream
+
+#endif // EAMXX_FIELD_READER_HPP

--- a/components/eamxx/src/share/field/tests/CMakeLists.txt
+++ b/components/eamxx/src/share/field/tests/CMakeLists.txt
@@ -64,6 +64,12 @@ if (NOT SCREAM_ONLY_GENERATE_BASELINES)
     MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}
   )
 
+  # Test field_reader
+  CreateUnitTest(field_reader
+    SOURCES field_reader_tests.cpp
+    LIBS eamxx_field
+    MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS})
+
   if (EAMXX_ENABLE_PYTHON)
     CreateUnitTest(pyfield
       SOURCES pyfield.cpp

--- a/components/eamxx/src/share/field/tests/field_reader_tests.cpp
+++ b/components/eamxx/src/share/field/tests/field_reader_tests.cpp
@@ -1,0 +1,295 @@
+#include <catch2/catch.hpp>
+
+#include "share/field/field_reader.hpp"
+#include "share/field/field.hpp"
+#include "share/scorpio_interface/eamxx_scorpio_interface.hpp"
+
+#include <ekat_comm.hpp>
+
+#include <numeric>
+
+// ============================================================ //
+//  Helpers
+// ============================================================ //
+
+namespace scream {
+
+namespace {
+
+// Build and allocate a field with a given layout and data type.
+Field make_field (const std::string& name,
+                  const FieldLayout& layout,
+                  const DataType dtype = DataType::RealType)
+{
+  return Field(FieldIdentifier(name, layout, ekat::units::none, "grid", dtype),true);
+}
+
+// Fill a field with sequentially increasing values starting from `start`.
+void iota (Field& f, const ScalarWrapper& init)
+{
+  const int n = f.get_header().get_alloc_properties().get_num_scalars();
+  switch (f.data_type()) {
+    case DataType::IntType:
+    {
+      auto* ptr = f.get_internal_view_data<int, Host>();
+      std::iota(ptr, ptr + n, init.as<int>());
+      break;
+    }
+    case DataType::FloatType:
+    {
+      auto* ptr = f.get_internal_view_data<float, Host>();
+      std::iota(ptr, ptr + n, init.as<float>());
+      break;
+    }
+    case DataType::DoubleType:
+    {
+      auto* ptr = f.get_internal_view_data<double, Host>();
+      std::iota(ptr, ptr + n, init.as<double>());
+      break;
+    }
+    default:
+      EKAT_ERROR_MSG ("Unrecognized/unsupported data type.\n"
+                      " - field name: " + f.name() + "\n"
+                      " - data type : " + e2str(f.data_type()) + "\n");
+  }
+  f.sync_to_dev();
+}
+
+// Write a single variable to an already-open (and enddef'd) scorpio file.
+template <typename ST>
+void write_field_to_file (const std::string& filename, const Field& f)
+{
+  f.sync_to_host();
+  scorpio::write_var(filename, f.name(),
+                     f.get_internal_view_data<const ST, Host>());
+}
+
+} // anonymous namespace
+
+// ============================================================ //
+//  Test: non-decomposed read
+// ============================================================ //
+
+TEST_CASE ("read_fields_no_decomp")
+{
+  using namespace ShortFieldTagsNames;
+
+  ekat::Comm comm(MPI_COMM_WORLD);
+  scorpio::init_subsystem(comm);
+
+  const std::string filename =
+      "field_io_test_no_decomp_np" + std::to_string(comm.size()) + ".nc";
+
+  // Layouts
+  const int ncols = 4;
+  const int nlevs = 6;
+  FieldLayout lay2d({COL, LEV}, {ncols, nlevs});
+  FieldLayout lay1d({LEV},      {nlevs});
+
+  // ---- Write phase ---- //
+  {
+    scorpio::register_file(filename, scorpio::Write);
+    scorpio::define_dim(filename, "ncol", ncols);
+    scorpio::define_dim(filename, "lev",  nlevs);
+    scorpio::define_var(filename, "f2d", {"ncol", "lev"}, "real", false);
+    scorpio::define_var(filename, "f1d", {"lev"},         "int",  false);
+    scorpio::enddef(filename);
+
+    Field f2d = make_field("f2d", lay2d);
+    Field f1d = make_field("f1d", lay1d, DataType::IntType);
+    iota(f2d,0);
+    iota(f1d,100);
+
+    write_field_to_file<Real>(filename, f2d);
+    write_field_to_file<int>(filename, f1d);
+
+    scorpio::release_file(filename);
+  }
+
+  // ---- Read phase ---- //
+  {
+    Field f2d = make_field("f2d", lay2d);
+    Field f1d = make_field("f1d", lay1d, DataType::IntType);
+    f2d.deep_copy(-1);
+    f1d.deep_copy(-1);
+
+    read_fields(filename, {f2d, f1d});
+
+    // Verify
+    f2d.sync_to_host();
+    f1d.sync_to_host();
+
+    auto v2d = f2d.get_view<const Real**, Host>();
+    auto v1d = f1d.get_view<const int*,  Host>();
+
+    int idx = 0;
+    for (int i = 0; i < ncols; ++i) {
+      for (int j = 0; j < nlevs; ++j, ++idx) {
+        REQUIRE (v2d(i, j) == Real(idx));
+      }
+    }
+    for (int j = 0; j < nlevs; ++j) {
+      REQUIRE (v1d(j) == 100 + j);
+    }
+  }
+
+  scorpio::finalize_subsystem();
+}
+
+// ============================================================ //
+//  Test: decomposed read (distributed column dimension)
+// ============================================================ //
+
+TEST_CASE ("read_fields_with_decomp", "[field_utils][io]")
+{
+  using namespace ShortFieldTagsNames;
+  using namespace ekat::units;
+
+  ekat::Comm comm(MPI_COMM_WORLD);
+  scorpio::init_subsystem(comm);
+
+  const std::string filename =
+      "field_io_test_decomp_np" + std::to_string(comm.size()) + ".nc";
+
+  // Global sizes: use a multiple of comm.size() so decomp divides evenly
+  const int lcols_per_rank = 3;
+  const int ncols_global   = lcols_per_rank * comm.size();
+  const int nlevs          = 4;
+
+  FieldLayout lay2d({COL, LEV}, {lcols_per_rank, nlevs});
+  FieldLayout lay1d({COL},      {lcols_per_rank});
+
+  // GIDs owned by this rank (1-based)
+  auto my_gids = make_field("gids",lay1d,DataType::IntType);
+  auto my_gids_beg = my_gids.get_internal_view_data<int,Host>();
+  auto my_gids_end = my_gids_beg + lcols_per_rank;
+  std::iota(my_gids_beg,my_gids_end, 1 + comm.rank() * lcols_per_rank);
+  my_gids.sync_to_dev();
+
+  // ---- Write phase (rank 0 writes full data) ---- //
+  {
+    scorpio::register_file(filename, scorpio::Write);
+    scorpio::define_dim(filename, "ncol", ncols_global);
+    scorpio::define_dim(filename, "lev",  nlevs);
+
+    // Decomposition offsets
+    std::vector<scorpio::offset_t> offsets(lcols_per_rank);
+    for (int i = 0; i < lcols_per_rank; ++i) {
+      offsets[i] = my_gids_beg[i] - 1;
+    }
+    scorpio::set_dim_decomp(filename, "ncol", offsets);
+
+    scorpio::define_var(filename, "f2d", {"ncol", "lev"}, "real", false);
+    scorpio::define_var(filename, "f1d", {"ncol"},        "int",  false);
+    scorpio::enddef(filename);
+
+    // Fill: global value at (gcol, lev) = gcol*nlevs + lev
+    //       global value at (gcol)      = gcol
+    Field f2d = make_field("f2d", lay2d);
+    Field f1d = make_field("f1d", lay1d, DataType::IntType);
+    f2d.sync_to_host();
+    f1d.sync_to_host();
+
+    auto v2d = f2d.get_view<Real**, Host>();
+    auto v1d = f1d.get_view<int*,  Host>();
+    for (int li = 0; li < lcols_per_rank; ++li) {
+      const int gcol = my_gids_beg[li];
+      v1d(li) = gcol;
+      for (int j = 0; j < nlevs; ++j) {
+        v2d(li, j) = Real(gcol * nlevs + j);
+      }
+    }
+    f2d.sync_to_dev();
+    f1d.sync_to_dev();
+
+    write_field_to_file<Real>(filename, f2d);
+    write_field_to_file<int>(filename, f1d);
+
+    scorpio::release_file(filename);
+  }
+
+  // ---- Read phase ---- //
+  {
+    Field f2d = make_field("f2d", lay2d);
+    Field f1d = make_field("f1d", lay1d, DataType::IntType);
+    f2d.deep_copy(-1);
+    f1d.deep_copy(-1);
+
+    read_fields(filename, {f2d, f1d}, my_gids, comm);
+
+    // Verify local data
+    f2d.sync_to_host();
+    f1d.sync_to_host();
+
+    auto v2d = f2d.get_view<const Real**, Host>();
+    auto v1d = f1d.get_view<const int*,  Host>();
+
+    for (int li = 0; li < lcols_per_rank; ++li) {
+      const int gcol = my_gids_beg[li];
+      REQUIRE (v1d(li) == gcol);
+      for (int j = 0; j < nlevs; ++j) {
+        REQUIRE (v2d(li, j) == Real(gcol * nlevs + j));
+      }
+    }
+  }
+
+  scorpio::finalize_subsystem();
+}
+
+// ============================================================ //
+//  Test: reading a specific time slice
+// ============================================================ //
+
+TEST_CASE ("read_fields_time_slice")
+{
+  using namespace ShortFieldTagsNames;
+
+  ekat::Comm comm(MPI_COMM_WORLD);
+  scorpio::init_subsystem(comm);
+
+  const std::string filename =
+      "field_io_test_time_np" + std::to_string(comm.size()) + ".nc";
+
+  const int nlevs  = 5;
+  const int ntimes = 3;
+  FieldLayout lay1d({LEV}, {nlevs});
+
+  // ---- Write phase ---- //
+  {
+    scorpio::register_file(filename, scorpio::Write);
+    scorpio::define_time(filename, "s");
+    scorpio::define_dim(filename, "lev", nlevs);
+    scorpio::define_var(filename, "f1d", {"lev"}, "real", true);
+    scorpio::enddef(filename);
+
+    Field f1d = make_field("f1d", lay1d);
+
+    for (int t = 0; t < ntimes; ++t) {
+      scorpio::update_time(filename, double(t));
+      f1d.deep_copy(Real(t * 10));
+      write_field_to_file<Real>(filename, f1d);
+    }
+
+    scorpio::release_file(filename);
+  }
+
+  // ---- Read phase: request middle time slice ---- //
+  {
+    const int target_t = 1;
+
+    Field f1d = make_field("f1d", lay1d);
+    f1d.deep_copy(Real(-1));
+
+    read_fields(filename, {f1d}, target_t);
+
+    f1d.sync_to_host();
+    auto v = f1d.get_view<const Real*, Host>();
+    for (int j = 0; j < nlevs; ++j) {
+      REQUIRE (v(j) == Real(target_t * 10));
+    }
+  }
+
+  scorpio::finalize_subsystem();
+}
+
+} // namespace scream


### PR DESCRIPTION
Add small infrastructure to wrap `scorpio::read_var` calls for reading into `Field` objects, without having to link the heavy IO machinery.

[BFB]

---

I originally had a single PR to replace atm input with this, but I realized it's easier to integrate smaller PRs. This adds the class (with its testing). I will follow up with PRs that replace atm input with the lightweight reader in individual parts of eamxx. The goal is to turn eamxx_io into a eamxx_model_output library.

Note: I had to add the aliases overloads, since I was foreseeing someone reading a field with layout `(ncol,nmodes,nbands)` (or something along that line, from a file where the dims have a different name (e.g., `num_modes` and `num_bands`). Since both `nmodes` and `nbands` will have tag `CMP`, we would not be able to provide the file dim names via a `FieldTag->std::string` map. So I had to allow using a string->string map to create aliases. Long term, I think I would like to support ONLY the oldname->newname version (rather than providing a tag->newname map). But I did not want to add mods to the grids classes (which are the big customers of this) just yet. Hopefully, as the IO reorg gets underway, we will be able to remove the special tags names from the grids altogether.