### PR TITLE
Fix issues with testing after driver-moab switch

### DIFF
--- a/cime_config/config_grids.xml
+++ b/cime_config/config_grids.xml
@@ -1443,7 +1443,7 @@
       <grid name="rof">r05</grid>
       <grid name="glc">null</grid>
       <grid name="wav">null</grid>
-      <mask>gx1v6</mask>
+      <mask>oEC60to30v3</mask>
     </model_grid>
 
     <model_grid alias="ne30_r05_ne30" compset="(DOCN|XOCN|SOCN|AQP1)">

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -385,7 +385,7 @@ _TESTS = {
             "SMS_Ld2.ne30pg2_r05_IcoswISC30E3r5.BGCEXP_CNTL_CNPRDCTC_1850.elm-bgcexp",
             "SMS_D_Ld3.T62_oQU120.CMPASO-IAF",
             "SMS_Ln5.ne30pg2_ne30pg2.F2010-SCREAM-LR-DYAMOND2",
-            "ERS_Ld3.ne30pg2_r05_IcoswISC30E3r5.WCYCL1850.allactive-nlmaps",
+            "ERS_Vmct_Ld3.ne30pg2_r05_IcoswISC30E3r5.WCYCL1850.allactive-nlmaps",
             "SMS_D_Ld1.ne30pg2_r05_IcoswISC30E3r5.CRYO1850-DISMF",
             "ERS.hcru_hcru.I20TRGSWCNPRDCTCBC.elm-erosion",
             "ERS.ne30pg2_r05_IcoswISC30E3r5.GPMPAS-JRA.mosart-rof_ocn_2way",

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -799,8 +799,8 @@ _TESTS = {
         "inherit" : (
         ),
         "tests" : (
-            "RCS_C4.ne30pg2_ne30pg2.F2010-SCREAMv1.eamxx-perturb",  # 8 nodes, about 1.9 hours on pm-gpu
-            "RCS_C4.ne4pg2_ne4pg2.F2010-SCREAMv1.eamxx-perturb",    # 1 node, about 22min on pm-gpu
+            "RCS_Vmct_C4.ne30pg2_ne30pg2.F2010-SCREAMv1.eamxx-perturb",  # 8 nodes, about 1.9 hours on pm-gpu
+            "RCS_Vmct_C4.ne4pg2_ne4pg2.F2010-SCREAMv1.eamxx-perturb",    # 1 node, about 22min on pm-gpu
             "ERP_D_Lh182.ne4pg2_ne4pg2.F2010-SCREAMv1",
             "ERS_Ln362.ne30pg2_ne30pg2.F2010-SCREAMv1"
             )

--- a/components/elm/src/cpl/lnd_comp_mct.F90
+++ b/components/elm/src/cpl/lnd_comp_mct.F90
@@ -703,9 +703,9 @@ contains
     ! fill this in
 #ifdef HAVE_MOAB
     ! deallocate moab fields arrays
-      deallocate (l2x_lm)
-      if (allocated(l2x_lm_t)) deallocate (l2x_lm_t)
-      deallocate (x2l_lm)
+    if (allocated(l2x_lm)) deallocate (l2x_lm)
+    if (allocated(l2x_lm_t)) deallocate (l2x_lm_t)
+    if (allocated(x2l_lm))  deallocate (x2l_lm)
 #endif
     call final()
 

--- a/driver-moab/main/prep_ocn_mod.F90
+++ b/driver-moab/main/prep_ocn_mod.F90
@@ -1844,7 +1844,7 @@ subroutine prep_ocn_mrg_moab(infodata, xao_ox, timer_mrg)
 
        if (rof_c2_ocn_saved) then
          x2o_om(n,index_x2o_Foxx_rofl) = (r2x_om(n,index_r2x_Forr_rofl ) + &
-            r2x_om(n,index_r2x_Flrr_flood) )
+            r2x_om(n,index_r2x_Flrr_flood) ) * flux_epbalfact
            ! g2x_om(n,index_g2x_Fogg_rofl )) * flux_epbalfact
          x2o_om(n,index_x2o_Foxx_rofi) = (r2x_om(n,index_r2x_Forr_rofi ) ) * flux_epbalfact
           !  g2x_om(n,index_g2x_Fogg_rofi )) * flux_epbalfact

--- a/driver-moab/main/prep_ocn_mod.F90
+++ b/driver-moab/main/prep_ocn_mod.F90
@@ -1193,6 +1193,28 @@ subroutine prep_ocn_mrg_moab(infodata, xao_ox, timer_mrg)
     integer, save :: index_r2x_Flrr_flood
     integer, save :: index_g2x_Fogg_rofl
     integer, save :: index_g2x_Fogg_rofi
+    integer, save :: index_r2x_Forr_rofDIN
+    integer, save :: index_r2x_Forr_rofDIP
+    integer, save :: index_r2x_Forr_rofDON
+    integer, save :: index_r2x_Forr_rofDOP
+    integer, save :: index_r2x_Forr_rofDOC
+    integer, save :: index_r2x_Forr_rofPP
+    integer, save :: index_r2x_Forr_rofDSi
+    integer, save :: index_r2x_Forr_rofPOC
+    integer, save :: index_r2x_Forr_rofPN
+    integer, save :: index_r2x_Forr_rofDIC
+    integer, save :: index_r2x_Forr_rofFe
+    integer, save :: index_x2o_Foxx_rofDIN
+    integer, save :: index_x2o_Foxx_rofDIP
+    integer, save :: index_x2o_Foxx_rofDON
+    integer, save :: index_x2o_Foxx_rofDOP
+    integer, save :: index_x2o_Foxx_rofDOC
+    integer, save :: index_x2o_Foxx_rofPP
+    integer, save :: index_x2o_Foxx_rofDSi
+    integer, save :: index_x2o_Foxx_rofPOC
+    integer, save :: index_x2o_Foxx_rofPN
+    integer, save :: index_x2o_Foxx_rofDIC
+    integer, save :: index_x2o_Foxx_rofFe
     integer, save :: index_x2o_Foxx_swnet
     integer, save :: index_x2o_Faxa_snow
     integer, save :: index_x2o_Faxa_rain
@@ -1327,6 +1349,19 @@ subroutine prep_ocn_mrg_moab(infodata, xao_ox, timer_mrg)
        index_a2x_Faxa_rainl     = mct_aVect_indexRA(a2x_o,'Faxa_rainl')
        index_r2x_Forr_rofl      = mct_aVect_indexRA(r2x_o,'Forr_rofl')
        index_r2x_Forr_rofi      = mct_aVect_indexRA(r2x_o,'Forr_rofi')
+       if (rof2ocn_nutrients) then
+          index_r2x_Forr_rofDIN    = mct_aVect_indexRA(r2x_o,'Forr_rofDIN')
+          index_r2x_Forr_rofDIP    = mct_aVect_indexRA(r2x_o,'Forr_rofDIP')
+          index_r2x_Forr_rofDON    = mct_aVect_indexRA(r2x_o,'Forr_rofDON')
+          index_r2x_Forr_rofDOP    = mct_aVect_indexRA(r2x_o,'Forr_rofDOP')
+          index_r2x_Forr_rofDOC    = mct_aVect_indexRA(r2x_o,'Forr_rofDOC')
+          index_r2x_Forr_rofPP     = mct_aVect_indexRA(r2x_o,'Forr_rofPP')
+          index_r2x_Forr_rofDSi    = mct_aVect_indexRA(r2x_o,'Forr_rofDSi')
+          index_r2x_Forr_rofPOC    = mct_aVect_indexRA(r2x_o,'Forr_rofPOC')
+          index_r2x_Forr_rofPN     = mct_aVect_indexRA(r2x_o,'Forr_rofPN')
+          index_r2x_Forr_rofDIC    = mct_aVect_indexRA(r2x_o,'Forr_rofDIC')
+          index_r2x_Forr_rofFe     = mct_aVect_indexRA(r2x_o,'Forr_rofFe')
+       endif
        index_r2x_Flrr_flood     = mct_aVect_indexRA(r2x_o,'Flrr_flood')
        !index_g2x_Fogg_rofl      = mct_aVect_indexRA(g2x_o,'Fogg_rofl')
        !index_g2x_Fogg_rofi      = mct_aVect_indexRA(g2x_o,'Fogg_rofi')
@@ -1335,6 +1370,19 @@ subroutine prep_ocn_mrg_moab(infodata, xao_ox, timer_mrg)
        index_x2o_Faxa_prec      = mct_aVect_indexRA(x2o_o,'Faxa_prec')
        index_x2o_Foxx_rofl      = mct_aVect_indexRA(x2o_o,'Foxx_rofl')
        index_x2o_Foxx_rofi      = mct_aVect_indexRA(x2o_o,'Foxx_rofi')
+       if (rof2ocn_nutrients) then
+          index_x2o_Foxx_rofDIN    = mct_aVect_indexRA(x2o_o,'Foxx_rofDIN')
+          index_x2o_Foxx_rofDIP    = mct_aVect_indexRA(x2o_o,'Foxx_rofDIP')
+          index_x2o_Foxx_rofDON    = mct_aVect_indexRA(x2o_o,'Foxx_rofDON')
+          index_x2o_Foxx_rofDOP    = mct_aVect_indexRA(x2o_o,'Foxx_rofDOP')
+          index_x2o_Foxx_rofDOC    = mct_aVect_indexRA(x2o_o,'Foxx_rofDOC')
+          index_x2o_Foxx_rofPP     = mct_aVect_indexRA(x2o_o,'Foxx_rofPP')
+          index_x2o_Foxx_rofDSi    = mct_aVect_indexRA(x2o_o,'Foxx_rofDSi')
+          index_x2o_Foxx_rofPOC    = mct_aVect_indexRA(x2o_o,'Foxx_rofPOC')
+          index_x2o_Foxx_rofPN     = mct_aVect_indexRA(x2o_o,'Foxx_rofPN')
+          index_x2o_Foxx_rofDIC    = mct_aVect_indexRA(x2o_o,'Foxx_rofDIC')
+          index_x2o_Foxx_rofFe     = mct_aVect_indexRA(x2o_o,'Foxx_rofFe')
+       endif
 
        if (seq_flds_i2o_per_cat) then
           index_x2o_Sf_afrac          = mct_aVect_indexRA(x2o_o,'Sf_afrac')
@@ -1848,6 +1896,20 @@ subroutine prep_ocn_mrg_moab(infodata, xao_ox, timer_mrg)
            ! g2x_om(n,index_g2x_Fogg_rofl )) * flux_epbalfact
          x2o_om(n,index_x2o_Foxx_rofi) = (r2x_om(n,index_r2x_Forr_rofi ) ) * flux_epbalfact
           !  g2x_om(n,index_g2x_Fogg_rofi )) * flux_epbalfact
+
+         if (rof2ocn_nutrients) then
+            x2o_om(n,index_x2o_Foxx_rofDIN) = r2x_om(n,index_r2x_Forr_rofDIN)
+            x2o_om(n,index_x2o_Foxx_rofDIP) = r2x_om(n,index_r2x_Forr_rofDIP)
+            x2o_om(n,index_x2o_Foxx_rofDON) = r2x_om(n,index_r2x_Forr_rofDON)
+            x2o_om(n,index_x2o_Foxx_rofDOP) = r2x_om(n,index_r2x_Forr_rofDOP)
+            x2o_om(n,index_x2o_Foxx_rofDOC) = r2x_om(n,index_r2x_Forr_rofDOC)
+            x2o_om(n,index_x2o_Foxx_rofPP ) = r2x_om(n,index_r2x_Forr_rofPP )
+            x2o_om(n,index_x2o_Foxx_rofDSi) = r2x_om(n,index_r2x_Forr_rofDSi)
+            x2o_om(n,index_x2o_Foxx_rofPOC) = r2x_om(n,index_r2x_Forr_rofPOC)
+            x2o_om(n,index_x2o_Foxx_rofPN ) = r2x_om(n,index_r2x_Forr_rofPN )
+            x2o_om(n,index_x2o_Foxx_rofDIC) = r2x_om(n,index_r2x_Forr_rofDIC)
+            x2o_om(n,index_x2o_Foxx_rofFe)  = r2x_om(n,index_r2x_Forr_rofFe )
+         endif
        endif
 
        if ( index_x2o_Foxx_rofl_16O /= 0 .and. rof_c2_ocn_saved ) then

--- a/driver-moab/main/prep_rof_mod.F90
+++ b/driver-moab/main/prep_rof_mod.F90
@@ -140,6 +140,7 @@ module prep_rof_mod
   real (kind=R8) , allocatable, private :: x2r_rm (:,:) ! result of merge
   real (kind=R8) , allocatable, private :: a2x_rm (:,:)
   real (kind=R8) , allocatable, private :: l2x_rm (:,:)
+  real (kind=R8) , allocatable, private :: o2x_rm (:,:)
 
   logical :: no_match ! used to force a new mapper
   logical :: compute_maps_online_l2r, compute_maps_online_a2r, compute_maps_online_o2r
@@ -220,6 +221,7 @@ contains
          lnd_gnam=lnd_gnam             , &
          atm_gnam=atm_gnam             , &
          rof_gnam=rof_gnam             , &
+         ocn_gnam=ocn_gnam             , &
          cpl_compute_maps_online=cpl_compute_maps_online )
 
     wgtIdl2r = 'conservative_l2r'//C_NULL_CHAR
@@ -809,13 +811,13 @@ contains
               write(logunit,*) subname,' error in registering OCN-ROF intersection'
               call shr_sys_abort(subname//' ERROR in registering OCN-ROF intersection')
             endif
-            tagname = trim(seq_flds_o2x_fluxes_to_rof)//C_NULL_CHAR
+            tagname = trim(seq_flds_o2x_fields_to_rof)//C_NULL_CHAR
             tagtype = 1 ! dense
             numco = 1 !
             ierr = iMOAB_DefineTagStorage(mbrxid, tagname, tagtype, numco, tagindex )
             if (ierr .ne. 0) then
-               write(logunit,*) subname,' error in defining tags for seq_flds_a2x_fields on rof cpl'
-               call shr_sys_abort(subname//' ERROR in  defining tags for seq_flds_a2x_fields on rof cpl')
+               write(logunit,*) subname,' error in defining tags for seq_flds_o2x_fields_to_rof on rof cpl'
+               call shr_sys_abort(subname//' ERROR in  defining tags for seq_flds_o2x_fields_to_rof on rof cpl')
             endif
 
             ! If loading map from disk, then load the scalar map as well
@@ -1113,6 +1115,7 @@ subroutine prep_rof_accum_ocn_moab(timer)
     ! used for indexing
     type(mct_avect) , pointer   :: l2x_r
     type(mct_avect) , pointer   :: a2x_r
+    type(mct_avect) , pointer   :: o2x_r
     type(mct_avect) , pointer    :: fractions_r
     type(mct_avect) , pointer :: x2r_r
     !
@@ -1173,6 +1176,12 @@ subroutine prep_rof_accum_ocn_moab(timer)
     integer, save :: index_l2x_coszen_str
     integer, save :: index_x2r_coszen_str
 
+    integer, save :: index_o2x_So_ssh
+    integer, save :: index_x2r_So_ssh
+
+    integer, save :: index_l2x_Flrl_inundinf
+    integer, save :: index_x2r_Flrl_inundinf
+
     integer, save :: index_frac
     real(R8)      :: frac
     character(CL) :: fracstr
@@ -1188,7 +1197,7 @@ subroutine prep_rof_accum_ocn_moab(timer)
 
     character(CXX) ::tagname, mct_field
     integer :: ent_type, ierr, arrsize
-    integer, save :: naflds, nlflds ! these are saved the first time
+    integer, save :: naflds, nlflds, noflds ! these are saved the first time
 #ifdef MOABDEBUG
     character*32             :: outfile, wopts, lnum
 #endif
@@ -1218,6 +1227,12 @@ subroutine prep_rof_accum_ocn_moab(timer)
          a2x_r => a2r_rx(1)
          naflds = mct_aVect_nRattr(a2x_r)
          allocate(a2x_rm (lsize, naflds))
+      endif
+
+      if (ocn_rof_two_way) then
+         o2x_r => o2r_rx(1)
+         noflds = mct_aVect_nRattr(o2x_r)
+         allocate(o2x_rm (lsize, noflds))
       endif
 
       nlflds = mct_aVect_nRattr(l2x_r)
@@ -1357,6 +1372,18 @@ subroutine prep_rof_accum_ocn_moab(timer)
           mrgstr(index_x2r_Faxa_lwdn)  = trim(mrgstr(index_x2r_Faxa_lwdn))//' = '//'a2x%Faxa_lwdn'
        endif
 
+       if (ocn_rof_two_way) then
+          index_o2x_So_ssh = mct_aVect_indexRA(o2x_r,'So_ssh')
+          index_x2r_So_ssh = mct_aVect_indexRA(x2r_r,'So_ssh')
+          mrgstr(index_x2r_So_ssh) = trim(mrgstr(index_x2r_So_ssh))//' = '//'o2x%So_ssh'
+       endif
+
+       if (lnd_rof_two_way) then
+          index_l2x_Flrl_inundinf = mct_aVect_indexRA(l2x_r,'Flrl_inundinf')
+          index_x2r_Flrl_inundinf = mct_aVect_indexRA(x2r_r,'Flrl_inundinf')
+          mrgstr(index_x2r_Flrl_inundinf) = trim(mrgstr(index_x2r_Flrl_inundinf))//' = '//'l2x%Flrl_inundinf'
+       endif
+
     end if
 ! fill in with data from moab tags
 
@@ -1384,6 +1411,14 @@ subroutine prep_rof_accum_ocn_moab(timer)
        ierr = iMOAB_GetDoubleTagStorage ( mbrxid, tagname, arrsize , ent_type, a2x_rm)
        if (ierr .ne. 0) then
          call shr_sys_abort(subname//' error in getting a2x_rm array ')
+       endif
+    endif
+    if (ocn_rof_two_way) then
+       tagname = trim(seq_flds_o2x_fields_to_rof)//C_NULL_CHAR
+       arrsize = noflds * lsize !        allocate (o2x_rm (lsize, noflds))
+       ierr = iMOAB_GetDoubleTagStorage ( mbrxid, tagname, arrsize , ent_type, o2x_rm)
+       if (ierr .ne. 0) then
+         call shr_sys_abort(subname//' error in getting o2x_rm array ')
        endif
     endif
     !  l2x_rm
@@ -1419,6 +1454,10 @@ subroutine prep_rof_accum_ocn_moab(timer)
           x2r_rm(i,index_x2r_Flrl_rofi_HDO) = l2x_rm(i,index_l2x_Flrl_rofi_HDO) * frac
        end if
 
+       if (lnd_rof_two_way) then
+          x2r_rm(i,index_x2r_Flrl_inundinf) = l2x_rm(i,index_l2x_Flrl_inundinf)
+       endif
+
        if ( rof_heat ) then
           x2r_rm(i,index_x2r_Sa_tbot)    = a2x_rm(i,index_a2x_Sa_tbot)
           x2r_rm(i,index_x2r_Sa_pbot)    = a2x_rm(i,index_a2x_Sa_pbot)
@@ -1433,6 +1472,12 @@ subroutine prep_rof_accum_ocn_moab(timer)
        endif
 
     end do
+
+    if (ocn_rof_two_way) then
+       do i = 1,lsize
+          x2r_rm(i,index_x2r_So_ssh) = o2x_rm(i,index_o2x_So_ssh)
+       enddo
+    endif
     ! after we are done, set x2r_rm to the mbrxid
 
     tagname = trim(seq_flds_x2r_fields)//C_NULL_CHAR

--- a/driver-moab/main/seq_hist_mod.F90
+++ b/driver-moab/main/seq_hist_mod.F90
@@ -1281,6 +1281,7 @@ contains
              do ii = 1, nflds
                 call mct_list_get(mctOStr, ii, temp_list)
                 call mbGetCellTagVals(mbxid, mct_string_toChar(mctOStr), tag_data, numpts)
+                call mct_string_clean(mctOStr)
                 avavg(found)%data(:,ii) = (avavg(found)%data(:,ii) + tag_data(:)) / (avcnt(found) * 1.0_r8)
              enddo
           else
@@ -1288,6 +1289,7 @@ contains
              do ii = 1, nflds
                 call mct_list_get(mctOStr, ii, temp_list)
                 call mbGetCellTagVals(mbxid, mct_string_toChar(mctOStr), tag_data, numpts)
+                call mct_string_clean(mctOStr)
                 avavg(found)%data(:,ii) = avavg(found)%data(:,ii) + tag_data(:)
              enddo
           endif
@@ -1386,9 +1388,12 @@ contains
                          if (trim(mct_string_toChar(mctOStr)) == &
                              trim(mct_string_toChar(mctOStr2))) then
                             matrix_data(:,ii) = avavg(found)%data(:,jj)
+                            call mct_string_clean(mctOStr2)
                             exit
                          endif
+                         call mct_string_clean(mctOStr2)
                       enddo
+                      call mct_string_clean(mctOStr)
                    enddo
                    p_matrix => matrix_data
                    call seq_io_write(hist_file(found), mbxid, trim(aname), &

--- a/driver-moab/main/seq_map_mod.F90
+++ b/driver-moab/main/seq_map_mod.F90
@@ -822,6 +822,11 @@ contains
 
           endif ! end normalization
 
+          ! Defensive: targtags_ini is allocated under `if (mbpresent)` at line 596 but the
+          ! matching deallocate at line 820 sits inside `if (mbnorm)`. If a future caller ever
+          ! sets mbpresent=.true. with mbnorm=.false., the array would leak per mapping call.
+          if (allocated(targtags_ini)) deallocate(targtags_ini)
+
        endif
 
     endif ! end of mapping type if else


### PR DESCRIPTION
Fix test problems uncovered after switch to driver-moab as default.

Change nlmaps and RCS tests to Vmct
Change mask for ne30_ne30 to oEC60to30v3
adds all 11 river nutrient fields
Fix OCN merge issue
Add proper handling of lnd_rof_two_way and ocn_rof_two_way options
Deallocate temporaries

[non-BFB] for ne30_ne30 case.  