### PR TITLE
EAMxx: fix bug in Field::get_view

### DIFF
--- a/components/eamxx/src/share/field/field.hpp
+++ b/components/eamxx/src/share/field/field.hpp
@@ -173,13 +173,13 @@ public:
   template<typename ST, HostOrDevice HD = Device>
   ST* get_internal_view_data () const {
     // Check that the scalar type is correct
-    using nonconst_ST = typename std::remove_const<ST>::type;
-    EKAT_REQUIRE_MSG ((field_valid_data_types().at<nonconst_ST>()==m_header->get_identifier().data_type()
-                       or std::is_same<nonconst_ST,char>::value),
+    using scalar_t = typename ekat::ScalarTraits<ST>::scalar_type;
+    EKAT_REQUIRE_MSG (field_valid_data_types().has_t<scalar_t>() and
+                      get_data_type<scalar_t>()==m_header->get_identifier().data_type(),
         "Error! Attempt to access raw field pointer with the wrong scalar type.\n"
         " - field name: " + name() + "\n"
-        " - field data type: " + e2str(data_type()) + "\n"
-        " - requested type : " + e2str(field_valid_data_types().at<nonconst_ST>()) + "\n");
+        " - field data type: " + e2str(data_type()) + "\n");
+
     EKAT_REQUIRE_MSG (not m_is_read_only || std::is_const<ST>::value,
         "Error! Cannot get a non-const raw pointer to the field data if the field is read-only.\n"
         " - field name: " + name() + "\n");
@@ -197,14 +197,13 @@ public:
   template<typename ST, HostOrDevice HD = Device>
   ST* get_internal_view_data_unsafe () const {
     // Check that the scalar type is correct
-    using nonconst_ST = typename std::remove_const<ST>::type;
-    EKAT_REQUIRE_MSG ((std::is_same<nonconst_ST,char>::value or std::is_same<nonconst_ST,void>::value or
-                       (field_valid_data_types().has_t<nonconst_ST>() and
-                        get_data_type<nonconst_ST>()==m_header->get_identifier().data_type())),
-        "Error! Attempt to access raw field pointer with the wrong scalar type.\n"
-        " - field name: " + name() + "\n"
-        " - field data type: " + e2str(data_type()) + "\n"
-        " - requested type : " + e2str(field_valid_data_types().at<nonconst_ST>()) + "\n");
+    using scalar_t = typename ekat::ScalarTraits<ST>::scalar_type;
+    EKAT_REQUIRE_MSG (field_valid_data_types().has_t<scalar_t>() and
+                      get_data_type<scalar_t>()==m_header->get_identifier().data_type(),
+      "Error! Attempt to access raw field pointer with the wrong scalar type.\n"
+      " - field name: " + name() + "\n"
+      " - field data type: " + e2str(data_type()) + "\n"
+      " - requested type : " + e2str(field_valid_data_types().at<scalar_t>()) + "\n");
 
     return reinterpret_cast<ST*>(get_view_impl<HD>().data());
   }

--- a/components/eamxx/src/share/field/field_get_view_impl.hpp
+++ b/components/eamxx/src/share/field/field_get_view_impl.hpp
@@ -204,10 +204,9 @@ auto Field::get_ND_view () const
       num_values = fl.dim(i)==0 ? 0 : num_values/fl.dim(i);
     }
   }
-  auto ptr = reinterpret_cast<T*>(get_view_impl<HD>().data());
 
+  auto ptr = get_internal_view_data<T,HD>();
   using ret_type = get_view_type<data_nd_t<T,N>,HD>;
-
   return ret_type (ptr,kl);
 }
 
@@ -235,8 +234,8 @@ auto Field::get_ND_view () const
     num_values /= fl.dim(i);
   }
   kl.dimension[N-1] = num_values;
-  auto ptr = reinterpret_cast<T*>(get_view_impl<HD>().data());
 
+  auto ptr = get_internal_view_data<T,HD>();
   using ret_type = get_view_type<data_nd_t<T,N>,HD>;
   return ret_type (ptr,kl);
 }

--- a/components/eamxx/src/share/field/tests/field_tests.cpp
+++ b/components/eamxx/src/share/field/tests/field_tests.cpp
@@ -36,6 +36,10 @@ TEST_CASE("field", "") {
 
     f1.allocate_view();
 
+    // Cannot get view using wrong scalar type (even if of same sizeof)
+    using same_sz_int = std::conditional_t<sizeof(Real)==8,std::int64_t,int>;
+    REQUIRE_THROWS(f1.get_view<same_sz_int**>());
+
     // Reshape should work with both dynamic and static dims
     auto v1 = f1.get_view<Real[3][24]>();
     auto v2 = f1.get_view<Real**>();


### PR DESCRIPTION
Do not allow to call `get_view<double*>` on an `IntType` field.

[BFB]

---

Also, we were technically allowing to call `get_internal_view_data<T>()` with `T=char` or `T=void`, to retrieve a generic pointer. I grepped through the code, and did not see a single use case of this, so I removed this capability, so that one needs to use the correct type. If this turns out to be a pb, we can reinstate the generic `char` (but no `void`, as it'd be redundant I think).