### PR TITLE
EAMxx: fix bug related to saving geo data

### DIFF
--- a/components/eamxx/src/share/io/eamxx_output_manager.cpp
+++ b/components/eamxx/src/share/io/eamxx_output_manager.cpp
@@ -140,6 +140,8 @@ setup (const std::shared_ptr<fm_type>& field_mgr,
     // to avoid clashes of names.
     bool use_suffix = grids.size()>1;
     for (const auto& [gname,grid] : grids) {
+      auto& geo_data = m_grid_name_to_geo_data[grid->name()];
+      geo_data.grid = grid;
       for (const auto& fn : grid->get_geometry_data_names()) {
         const auto& f = grid->get_geometry_data(fn);
 
@@ -158,7 +160,7 @@ setup (const std::shared_ptr<fm_type>& field_mgr,
         }
 
         auto alias_name = f.name() + (use_suffix ? grid->m_disambiguation_suffix : "");
-        m_grid_to_geo_data_fields[grid].push_back(f.alias(alias_name,gname));
+        geo_data.fields.push_back(f.alias(alias_name,gname));
       }
     }
   }
@@ -874,9 +876,11 @@ setup_file (      IOFileSpecs& filespecs,
     // By this point all regular output streams have already defined their dims.
     // So if a field is conditional to a certain dim being in the output file,
     // we can immediately check whether we should output it or not.
-    // Note: m_grid_to_geo_data_field is reset to empty after this loop, so the loop runs ONCE,
+    // Note: m_grid_name_to_geo_data is reset to empty after this loop, so the loop runs ONCE,
     //       which means geo streams are lazy-inited on the first setup_file call
-    for (auto& [grid, fields] : m_grid_to_geo_data_fields) {
+    for (auto& kv : m_grid_name_to_geo_data) {
+      auto& geo_data = kv.second;
+      auto& fields = geo_data.fields;
       for (auto it=fields.begin(); it!=fields.end(); ) {
         if (it->get_header().has_extra_data("io_output_if_dim_exists")) {
           // If the required dim is not in the output file, this field is not needed
@@ -892,12 +896,12 @@ setup_file (      IOFileSpecs& filespecs,
       if (fields.size()==0)
         continue; // No grid data to save here (unlikely, but we may as well)
 
-      auto output = std::make_shared<output_type>(m_io_comm, fields, grid);
+      auto output = std::make_shared<output_type>(m_io_comm, fields, geo_data.grid);
       m_geo_data_streams.push_back(output);
     }
 
     // Ensure that the above block runs only once (the 1st time we run this function)
-    m_grid_to_geo_data_fields = {};
+    m_grid_name_to_geo_data.clear();
 
     for (auto& it : m_geo_data_streams) {
       it->setup_output_file(filename,fp_precision,mode);

--- a/components/eamxx/src/share/io/eamxx_output_manager.hpp
+++ b/components/eamxx/src/share/io/eamxx_output_manager.hpp
@@ -149,7 +149,11 @@ protected:
   // m_geo_data_streams on the first call to setup_file(). When geo streams are created,
   // we add these fields ONLY IF they don't have the io_output_if_dim_exists extra data
   // set, or if the corresponding dim is ALREADY in the output file.
-  std::map<std::shared_ptr<const AbstractGrid>,std::vector<Field>>  m_grid_to_geo_data_fields;
+  struct GeoData {
+    std::shared_ptr<const AbstractGrid> grid;
+    std::vector<Field>                  fields;
+  };
+  std::map<std::string,GeoData> m_grid_name_to_geo_data;
 
   globals_map_t                  m_globals;
 


### PR DESCRIPTION
Ensure that the geo data streams are added in the same order across ranks.

[BFB]

---

This was a nasty bug. We had a map ptr->vector, which seemed innocuous, but the value of each ptr is completely unpredictable across ranks. In a particular test case with both gll and pg2 output on the same file, we were getting some ranks processing pg2 first and others processig gll first. This caused absolute mayhem in pnetcdf when it was time to sync stuff, since ranks disagreed on the var names.

The fix was simple: use a map where the key is the grid name, on which all ranks will agree.

Now to calm the fears: first, this is NOT affecting restart files (which always have 2 grids in it), since it is 100% confined to geo data (which is only added to output streams). Second, this is a _very_ recent bug, introduced by #8349 yesterday, so hopefully no major run was affected. We'll merge this asap.