### PR TITLE
Fix null characters leaking into log files from MOAB coupler driver and component MCT drivers

### DIFF
--- a/components/cice/src/drivers/cpl/ice_comp_mct.F90
+++ b/components/cice/src/drivers/cpl/ice_comp_mct.F90
@@ -1544,7 +1544,7 @@ end function restart_filename
        call shr_sys_abort()
     endif
     if(iam == 0) then
-       write(nu_diag,*) "register MOAB app:", trim(appname), "  MPSIID=", MPSIID
+       write(nu_diag,*) "register MOAB app:", appname(1:index(appname,C_NULL_CHAR)-1), "  MPSIID=", MPSIID
     endif
 
     ! start describing the mesh to MOAB

--- a/components/eam/src/cpl/atm_comp_mct.F90
+++ b/components/eam/src/cpl/atm_comp_mct.F90
@@ -1477,7 +1477,7 @@ CONTAINS
        call endrun('Error: cannot register moab app for atm physics')
     if(masterproc) then
        write(iulog,*) " "
-       write(iulog,*) "register MOAB app:", trim(appname), "  mphaid=", mphaid
+       write(iulog,*) "register MOAB app:", appname(1:index(appname,C_NULL_CHAR)-1), "  mphaid=", mphaid
        write(iulog,*) " "
     endif
 

--- a/components/eam/src/dynamics/se/dyn_comp.F90
+++ b/components/eam/src/dynamics/se/dyn_comp.F90
@@ -181,7 +181,7 @@ CONTAINS
            call endrun('Error: cannot register moab app')
        if(par%masterproc) then
            write(iulog,*) " "
-           write(iulog,*) "register MOAB app:", trim(appname), "  MHID=", MHID
+           write(iulog,*) "register MOAB app:", appname(1:index(appname,C_NULL_CHAR)-1), "  MHID=", MHID
            write(iulog,*) " "
        endif
        appname="HM_FINE"//C_NULL_CHAR
@@ -191,7 +191,7 @@ CONTAINS
            call endrun('Error: cannot register moab app for fine mesh')
        if(par%masterproc) then
            write(iulog,*) " "
-           write(iulog,*) "register MOAB app:", trim(appname), "  MHFID=", MHFID
+           write(iulog,*) "register MOAB app:", appname(1:index(appname,C_NULL_CHAR)-1), "  MHFID=", MHFID
            write(iulog,*) " "
        endif
        if ( fv_nphys > 0 ) then
@@ -205,7 +205,7 @@ CONTAINS
              call endrun('Error: cannot register moab app for fine mesh')
          if(par%masterproc) then
              write(iulog,*) " "
-             write(iulog,*) "register MOAB app:", trim(appname), "  MHPGID=", mhpgid
+             write(iulog,*) "register MOAB app:", appname(1:index(appname,C_NULL_CHAR)-1), "  MHPGID=", mhpgid
              write(iulog,*) " "
          endif
        endif

--- a/components/elm/src/cpl/lnd_comp_mct.F90
+++ b/components/elm/src/cpl/lnd_comp_mct.F90
@@ -890,7 +890,7 @@ contains
        call endrun('Error: cannot register moab app')
     if(masterproc) then
        write(iulog,*) " "
-       write(iulog,*) "register MOAB app:", trim(appname), "  mlnid=", mlnid
+       write(iulog,*) "register MOAB app:", appname(1:index(appname,C_NULL_CHAR)-1), "  mlnid=", mlnid
        write(iulog,*) " "
     endif
 

--- a/components/elm/src/data_types/MOABGridType.F90
+++ b/components/elm/src/data_types/MOABGridType.F90
@@ -144,7 +144,7 @@ contains
          call endrun('Error: cannot register ELM-MOAB halo application')
     if(masterproc) then
        write(iulog,*) " "
-       write(iulog,*) "register MOAB application:", trim(appname), ", id=", mlndghostid
+       write(iulog,*) "register MOAB application:", appname(1:index(appname,C_NULL_CHAR)-1), ", id=", mlndghostid
        write(iulog,*) " "
     endif
 

--- a/components/mosart/src/cpl/rof_comp_mct.F90
+++ b/components/mosart/src/cpl/rof_comp_mct.F90
@@ -1007,7 +1007,7 @@ contains
           call shr_sys_abort( sub//' Error: cannot register moab app')
        if(masterproc) then
           write(iulog,*) " "
-          write(iulog,*) "register MOAB ROF app:", trim(appname), "  mrofid=", mrofid, " ROFID=", ROFID
+          write(iulog,*) "register MOAB ROF app:", appname(1:index(appname,C_NULL_CHAR)-1), "  mrofid=", mrofid, " ROFID=", ROFID
           write(iulog,*) " "
        endif
 

--- a/driver-moab/main/cplcomp_exchange_mod.F90
+++ b/driver-moab/main/cplcomp_exchange_mod.F90
@@ -341,8 +341,8 @@ subroutine  copy_aream_from_area(mbappid)
          !!!!  DATA ATM
          else
            ! we need to read the atm mesh on coupler, from domain file
-            infile = trim(atm_mesh)//C_NULL_CHAR
-            ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;REPARTITION;NO_CULLING'//C_NULL_CHAR
+            infile = trim(atm_mesh)
+            ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;REPARTITION;NO_CULLING'
             if (seq_comm_iamroot(CPLID)) then
                write(logunit,'(A)') subname//' loading atm domain mesh from file '//trim(atm_mesh) &
                 , ' with options ' // trim(ropts)
@@ -486,8 +486,8 @@ subroutine  copy_aream_from_area(mbappid)
  !!!!! DATA OCN
          else
            ! we need to read the ocean mesh on coupler, from domain file
-            infile = trim(ocn_domain)//C_NULL_CHAR
-            ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;NO_CULLING;REPARTITION'//C_NULL_CHAR
+            infile = trim(ocn_domain)
+            ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;NO_CULLING;REPARTITION'
             if (seq_comm_iamroot(CPLID)) then
                write(logunit,'(A)') subname//' loading ocn domain mesh from file '//trim(infile) &
                 , ' with options ' // trim(ropts)
@@ -555,8 +555,8 @@ subroutine  copy_aream_from_area(mbappid)
  !!!!! DATA OCN
          else
              ! we need to read the ocean mesh on coupler, from domain file
-            infile = trim(ocn_domain)//C_NULL_CHAR
-            ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;NO_CULLING;REPARTITION'//C_NULL_CHAR
+            infile = trim(ocn_domain)
+            ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;NO_CULLING;REPARTITION'
             if (seq_comm_iamroot(CPLID)) then
                write(logunit,'(A)') subname//' load ocn domain mesh from file for second ocn instance '//trim(ocn_domain) &
                , ' with options '//trim(ropts)
@@ -662,11 +662,11 @@ subroutine  copy_aream_from_area(mbappid)
                ! do not cull in case of data land, like all other data models
                ! for regular land model, cull, because the lnd component culls too
                if (lnd_prognostic) then
-                  ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;REPARTITION'//C_NULL_CHAR
+                  ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;REPARTITION'
                else
-                  ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;REPARTITION;NO_CULLING'//C_NULL_CHAR
+                  ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;REPARTITION;NO_CULLING'
                endif
-               outfile = trim(lnd_domain)//C_NULL_CHAR
+               outfile = trim(lnd_domain)
                nghlay = 0 ! no ghost layers
                if (seq_comm_iamroot(CPLID) ) then
                   write(logunit, *) "loading land domain file from file: ", trim(lnd_domain), &
@@ -810,10 +810,10 @@ subroutine  copy_aream_from_area(mbappid)
          else
             ! we need to read the mesh ice (domain file)
             ! we could be using cice model or data sea ice; in both cases ice_domain should be non-empty
-            ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;NO_CULLING;REPARTITION'//C_NULL_CHAR
-            infile = trim(ice_domain)//C_NULL_CHAR
+            ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;NO_CULLING;REPARTITION'
+            infile = trim(ice_domain)
             if (seq_comm_iamroot(CPLID)) then
-               write(logunit,'(A)') subname//' loading ice domain mesh from file '//infile &
+               write(logunit,'(A)') subname//' loading ice domain mesh from file '//trim(infile) &
                  , ' with options '//trim(ropts)
             endif
             call moab_load_mesh(mbixid, infile, ropts, 0, subname)
@@ -919,11 +919,11 @@ subroutine  copy_aream_from_area(mbappid)
                ! load mesh from scrip file passed from river model, if domain file is not available
                call seq_infodata_GetData(infodata,rof_mesh=rtm_mesh,rof_domain=rof_domain)
                if ( trim(rof_domain) == 'none' ) then
-                  outfile = trim(rtm_mesh)//C_NULL_CHAR
-                  ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=RCBZOLTAN'//C_NULL_CHAR
+                  outfile = trim(rtm_mesh)
+                  ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=RCBZOLTAN'
                else
-                  outfile = trim(rof_domain)//C_NULL_CHAR
-                  ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;REPARTITION'//C_NULL_CHAR
+                  outfile = trim(rof_domain)
+                  ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;REPARTITION'
                endif
                nghlay = 0 ! no ghost layers
                if (seq_comm_iamroot(CPLID)) then
@@ -1209,7 +1209,7 @@ subroutine  copy_aream_from_area(mbappid)
        if (mbAPPid1 .ge. 0) then !  we are on the sending pes
           ierr = iMOAB_SendElementTag(mbAPPid1, tagName, mpicom_join, target_id)
           if (ierr .ne. 0) then
-             call shr_sys_abort(subname//' cannot send element tag: '//trim(tagName))
+             call shr_sys_abort(subname//' cannot send element tag: '//tagName(1:index(tagName,C_NULL_CHAR)-1))
           endif
        endif
 
@@ -1220,7 +1220,7 @@ subroutine  copy_aream_from_area(mbappid)
        if ( mbAPPid2 .ge. 0 ) then !  we are on receiving end
           ierr = iMOAB_ReceiveElementTag(mbAPPid2, tagName, mpicom_join, source_id)
           if (ierr .ne. 0) then
-             call shr_sys_abort(subname//' cannot receive element tag: '//trim(tagName))
+             call shr_sys_abort(subname//' cannot receive element tag: '//tagName(1:index(tagName,C_NULL_CHAR)-1))
           endif
        endif
 
@@ -1285,7 +1285,7 @@ subroutine  copy_aream_from_area(mbappid)
 #ifdef MOABDEBUG
     write(lnum,"(I0.2)") num_moab_exports
     if (seq_comm_iamroot(CPLID) ) then
-       write(logunit,'(A)') subname//' '//comp%ntype//' at moab count '//trim(lnum)//' called in direction '//trim(direction)//' for fields '//trim(tagname)
+       write(logunit,'(A)') subname//' '//comp%ntype//' at moab count '//trim(lnum)//' called in direction '//trim(direction)//' for fields '//tagName(1:index(tagName,C_NULL_CHAR)-1)
     endif
 
     ! Write received mesh data to HDF5 file for visualization/debugging
@@ -1298,7 +1298,7 @@ subroutine  copy_aream_from_area(mbappid)
       wopts   = ';PARALLEL=WRITE_PART'//C_NULL_CHAR
       ierr = iMOAB_WriteMesh(mbAPPid2, trim(outfile), trim(wopts))
       if (ierr .ne. 0) then
-          call shr_sys_abort(subname//' cannot write file '// outfile)
+          call shr_sys_abort(subname//' cannot write file '// outfile(1:index(outfile,C_NULL_CHAR)-1))
        endif
     endif
 #endif

--- a/driver-moab/main/cplcomp_moab_helpers_mod.F90
+++ b/driver-moab/main/cplcomp_moab_helpers_mod.F90
@@ -90,7 +90,8 @@ contains
 
     integer :: ierr
 
-    ierr = iMOAB_LoadMesh(appid, trim(infile), trim(ropts), nghlay)
+    ! iMOAB_LoadMesh is a C API: append C_NULL_CHAR here so callers stay null-free
+    ierr = iMOAB_LoadMesh(appid, trim(infile)//C_NULL_CHAR, trim(ropts)//C_NULL_CHAR, nghlay)
     if (ierr /= 0) then
       call shr_sys_abort(trim(subctx)//' ERROR loading mesh from '//trim(infile))
     end if

--- a/driver-moab/main/seq_io_mod.F90
+++ b/driver-moab/main/seq_io_mod.F90
@@ -1117,7 +1117,7 @@ contains
                if (ns > 0 ) then
                   ierr = iMOAB_GetDoubleTagStorage (mbxid, tagname, ns, ent_type, data1)
                   if (ierr .ne. 0) then
-                     write(logunit,*) subname,' ERROR: cannot get tag data ', trim(tagname)
+                     write(logunit,*) subname,' ERROR: cannot get tag data ', trim(field)
                      call shr_sys_abort(subname//'cannot get tag data ')
                   endif
                endif
@@ -1635,18 +1635,12 @@ contains
             if (ns > 0) then
                ierr = iMOAB_SetDoubleTagStorage (mbxid, tagname, ns , ent_type, data_reorder)
                if (ierr .ne. 0) then
-                  write(logunit,*) subname,' ERROR: cannot set tag data ', trim(tagname)
+                  write(logunit,*) subname,' ERROR: cannot set tag data ', trim(field)
                   call shr_sys_abort(subname//'cannot set tag data ')
                endif
             endif
           endif
-         !  n = 0
-         !  do n1 = 1,ni
-         !     do n2 = 1,ns
-         !        n = n + 1
-         !        avs(:n1)%rAttr(k,n2) = data(n)
-         !     enddo
-         !  enddo
+
        else
           write(logunit,*)subname, ' warning: field ',trim(field), ' name1:', trim(name1),  ' is not on restart file'
           write(logunit,*)'for backwards compatibility will set it to 0'
@@ -1664,7 +1658,7 @@ contains
             if ( ns > 0 ) then
                ierr = iMOAB_SetDoubleTagStorage (mbxid, tagname, ns , ent_type, data_reorder)
                if (ierr .ne. 0) then
-                  write(logunit,*) subname,' ERROR: cannot set tag data ', trim(tagname)
+                write(logunit,*) subname,' ERROR: cannot set tag data ', trim(field)
                   call shr_sys_abort(subname//'cannot set tag data ')
                endif
             endif

--- a/driver-moab/main/seq_map_mod.F90
+++ b/driver-moab/main/seq_map_mod.F90
@@ -239,7 +239,7 @@ contains
 
     mapfile_term = trim(mapfile)//CHAR(0)
     if (seq_comm_iamroot(CPLID)) then
-        write(logunit,*) subname,' reading map file with iMOAB: ', trim(mapfile_term)
+        write(logunit,*) subname,' reading map file with iMOAB: ', trim(mapfile)
     endif
 
     ierr = iMOAB_LoadMapFile( mapper%src_mbid, mapper%tgt_mbid, mapper%intx_mbid, discretization_type, &
@@ -466,7 +466,7 @@ contains
 #ifdef MOABDEBUG
        if (seq_comm_iamroot(CPLID)) then
           write(logunit,*) subname, 'iMOAB mapper ',trim(mapper%mbname), ' iMOAB_mapper  nfields', &
-                nfields,  ' fldlist_moab=', trim(fldlist_moab), ' moab step ', num_moab_exports
+                nfields,  ' fldlist_moab=', fldlist_moab(1:index(fldlist_moab,C_NULL_CHAR)-1), ' moab step ', num_moab_exports
           call shr_sys_flush(logunit)
        endif
 #endif
@@ -489,7 +489,7 @@ contains
        if ( valid_moab_context ) then
 #ifdef MOABDEBUG
           if (seq_comm_iamroot(CPLID)) then
-             write(logunit, *) subname,' iMOAB mapper rearrange or copy ', mapper%mbname, ' send/recv tags ', trim(fldlist_moab), &
+             write(logunit, *) subname,' iMOAB mapper rearrange or copy ', mapper%mbname, ' send/recv tags ', fldlist_moab(1:index(fldlist_moab,C_NULL_CHAR)-1), &
                ' mbpresent=', mbpresent, ' mbnorm=', mbnorm, ' moab step:', num_moab_exports
              call shr_sys_flush(logunit)
           endif
@@ -502,7 +502,7 @@ contains
           !***   intx_context: Context ID for the intersection/target app
           ierr = iMOAB_SendElementTag( mapper%src_mbid, fldlist_moab, mapper%mpicom, mapper%intx_context );
           if (ierr .ne. 0) then
-             write(logunit, *) subname,' iMOAB mapper ', mapper%mbname, ' error in sending tags ', trim(fldlist_moab), ierr
+             write(logunit, *) subname,' iMOAB mapper ', mapper%mbname, ' error in sending tags ', fldlist_moab(1:index(fldlist_moab,C_NULL_CHAR)-1), ierr
              call shr_sys_flush(logunit)
              call shr_sys_abort(subname//' ERROR in sending tags')
           endif
@@ -514,7 +514,7 @@ contains
           !***   src_context: Context ID for the source app
           ierr = iMOAB_ReceiveElementTag( mapper%tgt_mbid, fldlist_moab, mapper%mpicom, mapper%src_context );
           if (ierr .ne. 0) then
-             write(logunit,*) subname,' error in receiving tags iMOAB mapper ', mapper%mbname,  trim(fldlist_moab)
+             write(logunit,*) subname,' error in receiving tags iMOAB mapper ', mapper%mbname,  fldlist_moab(1:index(fldlist_moab,C_NULL_CHAR)-1)
              call shr_sys_flush(logunit)
              call shr_sys_abort(subname//' ERROR in receiving tags')
           endif
@@ -522,7 +522,7 @@ contains
           !*** Must be called after receive completes to free memory.
           ierr = iMOAB_FreeSenderBuffers( mapper%src_mbid, mapper%intx_context )
           if (ierr .ne. 0) then
-             write(logunit,*) subname,' error in freeing buffers ', trim(fldlist_moab)
+             write(logunit,*) subname,' error in freeing buffers ', fldlist_moab(1:index(fldlist_moab,C_NULL_CHAR)-1)
              call shr_sys_abort(subname//' ERROR in freeing buffers') ! serious enough
           endif
        endif ! if (valid_moab_context)
@@ -568,7 +568,7 @@ contains
              !*** MOAB: iMOAB_SetDoubleTagStorage - Set tag values on mesh elements
              ierr = iMOAB_SetDoubleTagStorage (mapper%src_mbid, tagname, lsize_src , mapper%tag_entity_type, wghts)
              if (ierr .ne. 0) then
-                write(logunit,*) subname,' error setting init value for mapping norm factor ',ierr,trim(tagname)
+                 write(logunit,*) subname,' error setting init value for mapping norm factor ',ierr,'norm8wt'
                 call shr_sys_abort(subname//' ERROR setting norm init value') ! serious enough
              endif
 #ifdef MOABDEBUG
@@ -586,7 +586,7 @@ contains
                 tagname = avwtsfld_s//C_NULL_CHAR
                 ierr = iMOAB_GetDoubleTagStorage (mapper%src_mbid, tagname, lsize_src , mapper%tag_entity_type, wghts)
                 if (ierr .ne. 0) then
-                   write(logunit,*) subname,' error getting value for mapping norm factor ', trim(tagname)
+                    write(logunit,*) subname,' error getting value for mapping norm factor ', trim(avwtsfld_s)
                    call shr_sys_abort(subname//' ERROR getting norm factor') ! serious enough
                 endif
 
@@ -599,7 +599,7 @@ contains
                 !*** MOAB: iMOAB_GetDoubleTagStorage - Get current field values
                 ierr = iMOAB_GetDoubleTagStorage (mapper%src_mbid, fldlist_moab, arrsize_src , mapper%tag_entity_type, targtags)
                 if (ierr .ne. 0) then
-                   write(logunit,*) subname,' error getting source tag values ', mapper%mbname, mapper%src_mbid, trim(fldlist_moab), arrsize_src, mapper%tag_entity_type
+                    write(logunit,*) subname,' error getting source tag values ', mapper%mbname, mapper%src_mbid, fldlist_moab(1:index(fldlist_moab,C_NULL_CHAR)-1), arrsize_src, mapper%tag_entity_type
                    call shr_sys_abort(subname//' ERROR getting source tag values') ! serious enough
                 endif
 
@@ -637,7 +637,7 @@ contains
           !*** where projection weights will be applied.
           ierr = iMOAB_SendElementTag( mapper%src_mbid, fldlist_moab, mapper%mpicom, mapper%intx_context )
           if (ierr .ne. 0) then
-             write(logunit, *) subname,' iMOAB mapper error in sending tags ', mapper%mbname,  trim(fldlist_moab)
+             write(logunit, *) subname,' iMOAB mapper error in sending tags ', mapper%mbname,  fldlist_moab(1:index(fldlist_moab,C_NULL_CHAR)-1)
              call shr_sys_flush(logunit)
              call shr_sys_abort(subname//' ERROR in sending tags')
           endif
@@ -651,12 +651,12 @@ contains
 #ifdef MOABDEBUG
           if (seq_comm_iamroot(CPLID)) then
              write(logunit, *) subname,' iMOAB mapper receiving tags with intx and intx_mbid: ', &
-                mapper%mbname, trim(fldlist_moab), ' moab step:', num_moab_exports
+                mapper%mbname, fldlist_moab(1:index(fldlist_moab,C_NULL_CHAR)-1), ' moab step:', num_moab_exports
           endif
 #endif
           ierr = iMOAB_ReceiveElementTag( mapper%intx_mbid, fldlist_moab, mapper%mpicom, mapper%src_context )
           if (ierr .ne. 0) then
-             write(logunit,*) subname,' error in receiving tags ', mapper%mbname, 'recv:',  mapper%intx_mbid, trim(fldlist_moab)
+             write(logunit,*) subname,' error in receiving tags ', mapper%mbname, 'recv:',  mapper%intx_mbid, fldlist_moab(1:index(fldlist_moab,C_NULL_CHAR)-1)
              call shr_sys_flush(logunit)
              call shr_sys_abort(subname//' ERROR in receiving tags')
              !valid_moab_context = .false. ! do not attempt to project
@@ -664,7 +664,7 @@ contains
           !*** MOAB: iMOAB_FreeSenderBuffers - Release MPI send buffers
           ierr = iMOAB_FreeSenderBuffers( mapper%src_mbid, mapper%intx_context )
           if (ierr .ne. 0) then
-             write(logunit,*) subname,' error in freeing buffers ', trim(fldlist_moab)
+             write(logunit,*) subname,' error in freeing buffers ', fldlist_moab(1:index(fldlist_moab,C_NULL_CHAR)-1)
              call shr_sys_abort(subname//' ERROR in freeing buffers') ! serious enough
           endif
        endif
@@ -676,7 +676,7 @@ contains
 
 #ifdef MOABDEBUG
           if (seq_comm_iamroot(CPLID)) then
-             write(logunit, *) subname,' iMOAB projection mapper: ',trim(mapper%mbname), ' between ', mapper%src_mbid, ' and ',  mapper%tgt_mbid, trim(fldlist_moab), &
+             write(logunit, *) subname,' iMOAB projection mapper: ',trim(mapper%mbname), ' between ', mapper%src_mbid, ' and ',  mapper%tgt_mbid, fldlist_moab(1:index(fldlist_moab,C_NULL_CHAR)-1), &
                 ' moab step:', num_moab_exports
              call shr_sys_flush(logunit)
           endif
@@ -767,7 +767,7 @@ contains
              !*** MOAB: Get mapped normalization weights on target grid
              ierr = iMOAB_GetDoubleTagStorage (mapper%tgt_mbid, tagname, lsize_tgt , mapper%tag_entity_type, wghts)
              if (ierr .ne. 0) then
-                write(logunit,*) subname,' error getting value for mapping norm factor post-map ', ierr, trim(tagname)
+                 write(logunit,*) subname,' error getting value for mapping norm factor post-map ', ierr, 'norm8wt'
                 call shr_sys_abort(subname//' ERROR getting norm factor') ! serious enough
              endif
 


### PR DESCRIPTION
Fix null-terminated strings used for MOAB C API calls from leaking C_NULL_CHAR into log
files across the MOAB coupler driver and all component MCT drivers that register MOAB apps.
The null byte caused cpl.log and e3sm.log to be identified as binary data and broke
simple grep on those files.

---

## Summary

- Push `C_NULL_CHAR` into `moab_load_mesh` helper (`cplcomp_moab_helpers_mod.F90`) at the
  C interop boundary so all callers pass clean strings.
- Remove `//C_NULL_CHAR` from `infile`/`ropts`/`outfile` local assignments in
  `cplcomp_exchange_mod.F90`; use inline null-strip for `tagName` in log/abort calls.
- Use clean companion variables (`mapfile`, `avwtsfld_s`) in log statements in
  `seq_map_mod.F90` where they already exist; apply inline null-strip
  (`var(1:index(var,C_NULL_CHAR)-1)`) for `fldlist_moab` and `tagname` everywhere else.
- Fix `seq_io_mod.F90` log statements to use the clean `field` variable instead of the
  null-terminated `tagname` derived from it; remove dead commented-out code.
- Apply inline null-strip for `appname` log statements in all component MCT drivers that
  call `iMOAB_RegisterApplication`: `ice_comp_mct.F90`, `atm_comp_mct.F90`,
  `dyn_comp.F90` (3 locations), `lnd_comp_mct.F90`, `MOABGridType.F90`,
  `rof_comp_mct.F90`.

## Problem

In the MOAB coupler driver and component MCT drivers, Fortran strings are null-terminated
before being passed to C/C++ APIs (`iMOAB_RegisterApplication`, `iMOAB_LoadMesh`,
`iMOAB_LoadMapFile`, `iMOAB_SendElementTag`, etc.).  This is correct and necessary for C
interoperability.

The bug is that those same null-terminated variables were also passed to Fortran
`write(logunit,...)` statements.  Fortran's `trim()` strips trailing spaces (ASCII 32)
but not null characters (ASCII 0), so the null byte leaked into log output.  This caused
`file cpl.log` to report binary data and `grep` to fail without the `-a` flag.


## Fix

Ten files were changed:

| File | Approach |
|------|----------|
| `driver-moab/main/cplcomp_moab_helpers_mod.F90` | Append `C_NULL_CHAR` inside `moab_load_mesh` at the C call site; callers keep clean strings |
| `driver-moab/main/cplcomp_exchange_mod.F90` | Remove `//C_NULL_CHAR` from `infile`/`ropts`/`outfile`; inline null-strip for `tagName` in log/abort |
| `driver-moab/main/seq_map_mod.F90` | Use clean `mapfile`/`avwtsfld_s` where available; inline null-strip for `fldlist_moab` throughout |
| `driver-moab/main/seq_io_mod.F90` | Use `trim(field)` instead of `trim(tagname)` in error-path log statements; remove dead code |
| `components/cice/src/drivers/cpl/ice_comp_mct.F90` | Inline null-strip for `appname` in MOAB registration log |
| `components/eam/src/cpl/atm_comp_mct.F90` | Inline null-strip for `appname` in MOAB registration log |
| `components/eam/src/dynamics/se/dyn_comp.F90` | Inline null-strip for `appname` in 3 MOAB registration log statements |
| `components/elm/src/cpl/lnd_comp_mct.F90` | Inline null-strip for `appname` in MOAB registration log |
| `components/elm/src/data_types/MOABGridType.F90` | Inline null-strip for `appname` in MOAB halo-app registration log |
| `components/mosart/src/cpl/rof_comp_mct.F90` | Inline null-strip for `appname` in MOAB registration log |

C API calls are unchanged and continue to receive correctly null-terminated strings.

Closes #8461
