### PR TITLE
Updating to SCORPIO v2.0.2

### DIFF
--- a/components/eamxx/cmake/tpls/Scorpio.cmake
+++ b/components/eamxx/cmake/tpls/Scorpio.cmake
@@ -45,6 +45,9 @@ macro (CreateScorpioTargets)
     # This is the default, but just in case scorpio changes it
     option (PIO_ENABLE_FORTRAN "Enable the Fortran library builds" ON)
 
+    # Use malloc (instead of the custom bget) for mallocs
+    option (PIO_USE_MALLOC "Use native malloc (instead of bget package)" ON)
+
     add_subdirectory (${E3SM_EXTERNALS_DIR}/scorpio ${CMAKE_BINARY_DIR}/externals/scorpio)
 
     set (SCORPIO_Fortran_INCLUDE_DIRS ${CMAKE_BINARY_DIR}/externals/scorpio/src/flib CACHE INTERNAL "SCORPIO Fortran include dirs")

--- a/components/eamxx/scripts/machines_specs.py
+++ b/components/eamxx/scripts/machines_specs.py
@@ -414,6 +414,7 @@ class AnlGceUb22(Machine):
                          "module load gcc/12.1.0",
                          "export LD_LIBRARY_PATH=/nfs/gce/projects/climate/software/linux-ubuntu22.04-x86_64/mpich/4.1.2/gcc-12.1.0/lib:$LD_LIBRARY_PATH",
                          "export PATH=/nfs/gce/projects/climate/software/linux-ubuntu22.04-x86_64/mpich/4.1.2/gcc-12.1.0/bin:/nfs/gce/projects/climate/software/linux-ubuntu22.04-x86_64/netcdf/4.8.0c-4.3.1cxx-4.5.3f-serial/gcc-12.1.0/bin:$PATH",
+                          "export HDF5_ROOT=/nfs/gce/projects/climate/software/linux-ubuntu22.04-x86_64/hdf5/1.14.6/mpich-4.1.2/gcc-12.1.0-mt",
                          "export NetCDF_ROOT=/nfs/gce/projects/climate/software/linux-ubuntu22.04-x86_64/netcdf/4.8.0c-4.3.1cxx-4.5.3f-serial/gcc-12.1.0",
                          "export PERL5LIB=/nfs/gce/projects/climate/software/perl5/lib/perl5"
                         ]

--- a/components/eamxx/src/share/io/eamxx_output_manager.cpp
+++ b/components/eamxx/src/share/io/eamxx_output_manager.cpp
@@ -859,7 +859,6 @@ setup_file (      IOFileSpecs& filespecs,
       const auto& c = pc_dict.at(n);
       scorpio::define_var (filename, n, c.units.to_string(), {},
                            "real", "real", false);
-      scorpio::write_var (filename, n, &c.value);
     }
   }
 
@@ -905,6 +904,16 @@ setup_file (      IOFileSpecs& filespecs,
   }
 
   scorpio::enddef (filename);
+
+  // Write the constants to the output file
+  if (!m_resume_output_file) {
+    const auto& pc_names = m_params.get<std::vector<std::string>>("constants",{});
+    const auto& pc_dict = physics::Constants<Real>::dictionary();
+    for (const auto& n: pc_names) {
+      const auto& c = pc_dict.at(n);
+      scorpio::write_var (filename, n, &c.value);
+    }
+  }
 
   if (m_save_grid_data and not filespecs.is_restart_file() and not m_resume_output_file) {
     // Immediately run the geo data streams


### PR DESCRIPTION
Upgrading SCORPIO to version 2.0.2

SCORPIO version 2.0.0 includes,

* Asynchronous I/O support (for HDF5 iotypes)
* New Data rearranger (PIO_REARR_CONTIG)
* New I/O decomposition logger
* Moving to C++ data structures (lists etc)
* Major code refactoring (source/headers are refactored and moved)
* Bug fixes from maint/v1.9 branch
* Misc enhancements - datatype converter, capture stack trace,
   GPTL timers, more tests, C++ unit testing framework
* Configure settings for data compression and chunking
* Misc bug fixes

SCORPIO version 2.0.1 includes the following fixes,

* Turn bget off by default in configure
* In PIOc_initdecomp() allow compmap to be NULL when length is 0

SCORPIO v2.0.2 includes the following fixes,

* Remove pthread dependency for non-async builds and
  adding a config check for pthread lib
  (Fixes E3SM build issues on Aurora for non-async builds)

The PR also includes some minor changes to eamxx,
* Turn off bget for eamxx standalone tests
* Add paths to HDF5 libs for ANL compute nodes (for eamxx standalone tests)
* Ensure that eamxx output writes are done after ending define mode

[BFB]