### PR TITLE
EAMxx: set OMPI env var to avoid slow pnetcdf on ghci-snl-oneapi

### DIFF
--- a/components/eamxx/cmake/ctest_script.cmake
+++ b/components/eamxx/cmake/ctest_script.cmake
@@ -20,14 +20,9 @@ ctest_start(${dashboard_model} TRACK ${dashboard_track})
 # Add some exception rules for ctest automatic error detection
 # These are strings in the build output that ctest mistakenly
 # interprets as errors
-string(CONCAT FILE_CONTENT
-  "list(APPEND CTEST_CUSTOM_ERROR_EXCEPTION\n"
-  "  error_handler\n"
-  ")"
-)
-
-file(WRITE ${CTEST_BINARY_DIRECTORY}/CTestCustom.cmake
-  "${FILE_CONTENT}"
+list(APPEND CTEST_CUSTOM_ERROR_EXCEPTION
+  ".*error_handler.*"
+  ".*spdlog/fmt/bundled/format.h.*"
 )
 
 if (USE_NINJA)

--- a/components/eamxx/scripts/machines_specs.py
+++ b/components/eamxx/scripts/machines_specs.py
@@ -291,7 +291,8 @@ class GHCISNLOneAPI(Machine):
     def setup(cls):
         super().setup_base("ghci-snl-oneapi")
         cls.baselines_dir = "/projects/e3sm/baselines/scream/ghci-snl-oneapi"
-        cls.env_setup = ["export GATOR_INITIAL_MB=4000MB"]
+        cls.env_setup = ["export GATOR_INITIAL_MB=4000MB",
+                         "export OMPI_MCA_io=romio321"]
 
 ###############################################################################
 class GHCISNLCuda(Machine):


### PR DESCRIPTION
Fixes an issue causing VERY SLOW reads on this machine.

[BFB]

---

The reads were so slow that some tests would not complete in 30min...
