### PR TITLE
Fix null bytes in log files by confining C_NULL_CHAR to MOAB C API call sites

### DIFF
--- a/components/cice/src/drivers/cpl/ice_comp_mct.F90
+++ b/components/cice/src/drivers/cpl/ice_comp_mct.F90
@@ -1536,9 +1536,9 @@ end function restart_filename
 
     call mpi_comm_rank(mpicom_ice_moab,iam,ierr)
     ! define a MOAB app for ELM
-    appname="CICEMB"//C_NULL_CHAR
+    appname="CICEMB"
     ! first cice instance, should be 13 ICEID is a private local variable
-    ierr = iMOAB_RegisterApplication(appname, mpicom_ice_moab, ICEID, MPSIID)
+    ierr = iMOAB_RegisterApplication(appname//C_NULL_CHAR, mpicom_ice_moab, ICEID, MPSIID)
     if (ierr > 0 )  then
        write(nu_diag, *) 'Error: cannot register moab app'
        call shr_sys_abort()

--- a/components/eam/src/cpl/atm_comp_mct.F90
+++ b/components/eam/src/cpl/atm_comp_mct.F90
@@ -1470,9 +1470,9 @@ CONTAINS
     call seq_cdata_setptrs(cdata_a, ID=ATMID, mpicom=mpicom_atm, &
          infodata=infodata)
 
-    appname="ATM_PHYS"//C_NULL_CHAR
+    appname="ATM_PHYS"
     ATM_PHYS = 200 + ATMID !
-    ierr = iMOAB_RegisterApplication(appname, mpicom_atm, ATM_PHYS, mphaid)
+    ierr = iMOAB_RegisterApplication(appname//C_NULL_CHAR, mpicom_atm, ATM_PHYS, mphaid)
     if (ierr > 0 )  &
        call endrun('Error: cannot register moab app for atm physics')
     if(masterproc) then

--- a/components/eam/src/dynamics/se/dyn_comp.F90
+++ b/components/eam/src/dynamics/se/dyn_comp.F90
@@ -170,13 +170,13 @@ CONTAINS
 
 
 #ifdef HAVE_MOAB
-       appname="HM_COARSE"//C_NULL_CHAR
+       appname="HM_COARSE"
        if (fv_nphys > 0 ) then ! in this case HM_COARSE will not be used for transfers ...
         ATM_ID1 = 120 ! 
        else
         ATM_ID1 = ATMID(1) ! first atmosphere instance; it should be 5
        endif
-       ierr = iMOAB_RegisterApplication(appname, par%comm, ATM_ID1, MHID)
+       ierr = iMOAB_RegisterApplication(appname//C_NULL_CHAR, par%comm, ATM_ID1, MHID)
        if (ierr > 0 )  &
            call endrun('Error: cannot register moab app')
        if(par%masterproc) then
@@ -184,9 +184,9 @@ CONTAINS
            write(iulog,*) "register MOAB app:", trim(appname), "  MHID=", MHID
            write(iulog,*) " "
        endif
-       appname="HM_FINE"//C_NULL_CHAR
+       appname="HM_FINE"
        ATM_ID1 = 119 ! this number should not conflict with other components IDs; how do we know?
-       ierr = iMOAB_RegisterApplication(appname, par%comm, ATM_ID1, MHFID)
+       ierr = iMOAB_RegisterApplication(appname//C_NULL_CHAR, par%comm, ATM_ID1, MHFID)
        if (ierr > 0 )  &
            call endrun('Error: cannot register moab app for fine mesh')
        if(par%masterproc) then
@@ -195,12 +195,12 @@ CONTAINS
            write(iulog,*) " "
        endif
        if ( fv_nphys > 0 ) then
-         appname="HM_PGX"//C_NULL_CHAR
+         appname="HM_PGX"
          ATM_ID1 =  ATMID(1) ! this number should not conflict with other components IDs; how do we know?
          !  
          ! in this case, we reuse the main atm id, mhid will not be used for intersection anymore
          ! still, need to be careful
-         ierr = iMOAB_RegisterApplication(appname, par%comm, ATM_ID1, mhpgid)
+         ierr = iMOAB_RegisterApplication(appname//C_NULL_CHAR, par%comm, ATM_ID1, mhpgid)
          if (ierr > 0 )  &
              call endrun('Error: cannot register moab app for fine mesh')
          if(par%masterproc) then

--- a/components/eamxx/src/dynamics/homme/interface/phys_grid_mod.F90
+++ b/components/eamxx/src/dynamics/homme/interface/phys_grid_mod.F90
@@ -389,9 +389,9 @@ contains
     call compute_local_area (pg)
 #ifdef HAVE_MOAB
     if (pgN > 0) then
-        appname="HM_COARSE"//C_NULL_CHAR
+        appname="HM_COARSE"
         ATM_ID1 = 120 !
-        ierr = iMOAB_RegisterApplication(appname, par%comm, ATM_ID1, MHID)
+        ierr = iMOAB_RegisterApplication(appname//C_NULL_CHAR, par%comm, ATM_ID1, MHID)
         if (ierr > 0 )  &
         call abortmp('Error: cannot register moab app')
         if(par%masterproc) then
@@ -399,9 +399,9 @@ contains
             write(iulog,*) "register MOAB app:", trim(appname), "  MHID=", MHID
             write(iulog,*) " "
         endif
-        appname="HM_FINE"//C_NULL_CHAR
+        appname="HM_FINE"
         ATM_ID1 = 119 ! this number should not conflict with other components IDs; how do we know?
-        ierr = iMOAB_RegisterApplication(appname, par%comm, ATM_ID1, MHFID)
+        ierr = iMOAB_RegisterApplication(appname//C_NULL_CHAR, par%comm, ATM_ID1, MHFID)
         if (ierr > 0 )  &
         call abortmp('Error: cannot register moab app for fine mesh')
         if(par%masterproc) then
@@ -409,12 +409,12 @@ contains
             write(iulog,*) "register MOAB app:", trim(appname), "  MHFID=", MHFID
             write(iulog,*) " "
         endif
-        appname="HM_PGX"//C_NULL_CHAR
+        appname="HM_PGX"
         ATM_ID1 =  ATMID(1) ! this number should not conflict with other components IDs; how do we know?
         !
         ! in this case, we reuse the main atm id, mhid will not be used for intersection anymore
         ! still, need to be careful
-        ierr = iMOAB_RegisterApplication(appname, par%comm, ATM_ID1, mhpgid)
+        ierr = iMOAB_RegisterApplication(appname//C_NULL_CHAR, par%comm, ATM_ID1, mhpgid)
         if (ierr > 0 )  &
             call abortmp('Error: cannot register moab app for fine mesh')
         if(par%masterproc) then

--- a/components/eamxx/src/mct_coupling/atm_comp_mct.F90
+++ b/components/eamxx/src/mct_coupling/atm_comp_mct.F90
@@ -556,9 +556,9 @@ CONTAINS
     real(r8)       :: latv, lonv
     !-------------------------------------------------------------------
 
-    appname="ATM_PHYS_SCREAM"//C_NULL_CHAR
+    appname="ATM_PHYS_SCREAM"
     ATM_PHYS = 200 + ATM_ID !
-    ierr = iMOAB_RegisterApplication(appname, mpicom_atm, ATM_PHYS, mphaid)
+    ierr = iMOAB_RegisterApplication(appname//C_NULL_CHAR, mpicom_atm, ATM_PHYS, mphaid)
     if (ierr > 0 )  then
       call mpi_abort(mpicom_atm,ierr,mpi_ierr)
     endif

--- a/components/elm/src/cpl/lnd_comp_mct.F90
+++ b/components/elm/src/cpl/lnd_comp_mct.F90
@@ -883,9 +883,9 @@ contains
     character*32  appname
 
     ! define a MOAB app for ELM
-    appname="LNDMB"//C_NULL_CHAR
+    appname="LNDMB"
     ! first land instance, should be 9
-    ierr = iMOAB_RegisterApplication(appname, mpicom_lnd_moab, LNDID, mlnid)
+    ierr = iMOAB_RegisterApplication(appname//C_NULL_CHAR, mpicom_lnd_moab, LNDID, mlnid)
     if (ierr > 0 )  &
        call endrun('Error: cannot register moab app')
     if(masterproc) then

--- a/components/elm/src/data_types/MOABGridType.F90
+++ b/components/elm/src/data_types/MOABGridType.F90
@@ -137,9 +137,9 @@ contains
 
     ! next define MOAB app for the ghosted one
     ! We do this so that coupling does not have to deal with halos
-    appname="MOAB_ELM_GHOSTED"//C_NULL_CHAR
+    appname="MOAB_ELM_GHOSTED"
     LNDGHOSTID = 55120 ! this is arbitrary (but needs to be unique)
-    ierr = iMOAB_RegisterApplication(appname, mpicom, LNDGHOSTID, mlndghostid)
+    ierr = iMOAB_RegisterApplication(appname//C_NULL_CHAR, mpicom, LNDGHOSTID, mlndghostid)
     if (ierr > 0 )  &
          call endrun('Error: cannot register ELM-MOAB halo application')
     if(masterproc) then

--- a/components/mosart/src/cpl/rof_comp_mct.F90
+++ b/components/mosart/src/cpl/rof_comp_mct.F90
@@ -1000,9 +1000,9 @@ contains
     character(len=32), parameter :: sub = 'init_moab_rof'
     character(len=*),  parameter :: format = "('("//trim(sub)//") :',A)"
 
-    appname="ROFMB"//C_NULL_CHAR ! only if rof_prognostic
+    appname="ROFMB" ! only if rof_prognostic
     ! first rof instance, should be
-    ierr = iMOAB_RegisterApplication(appname, mpicom_rof, ROFID, mrofid)
+    ierr = iMOAB_RegisterApplication(appname//C_NULL_CHAR, mpicom_rof, ROFID, mrofid)
        if (ierr > 0 )  &
           call shr_sys_abort( sub//' Error: cannot register moab app')
        if(masterproc) then

--- a/components/xcpl_comps/xwav/src/wav_comp_mct.F90
+++ b/components/xcpl_comps/xwav/src/wav_comp_mct.F90
@@ -81,6 +81,11 @@ CONTAINS
 
     call seq_infodata_getData(infodata, wav_phase=phase)
 
+    ! Determine instance information
+    inst_name   = seq_comm_name(compid)
+    inst_index  = seq_comm_inst(compid)
+    inst_suffix = seq_comm_suffix(compid)
+
     if (phase == 1) then
        ! Determine communicator group
        call mpi_comm_rank(mpicom, my_task, ierr)

--- a/driver-moab/main/cplcomp_exchange_mod.F90
+++ b/driver-moab/main/cplcomp_exchange_mod.F90
@@ -341,8 +341,8 @@ subroutine  copy_aream_from_area(mbappid)
          !!!!  DATA ATM
          else
            ! we need to read the atm mesh on coupler, from domain file
-            infile = trim(atm_mesh)//C_NULL_CHAR
-            ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;REPARTITION;NO_CULLING'//C_NULL_CHAR
+            infile = trim(atm_mesh)
+            ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;REPARTITION;NO_CULLING'
             if (seq_comm_iamroot(CPLID)) then
                write(logunit,'(A)') subname//' loading atm domain mesh from file '//trim(atm_mesh) &
                 , ' with options ' // trim(ropts)
@@ -486,8 +486,8 @@ subroutine  copy_aream_from_area(mbappid)
  !!!!! DATA OCN
          else
            ! we need to read the ocean mesh on coupler, from domain file
-            infile = trim(ocn_domain)//C_NULL_CHAR
-            ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;NO_CULLING;REPARTITION'//C_NULL_CHAR
+            infile = trim(ocn_domain)
+            ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;NO_CULLING;REPARTITION'
             if (seq_comm_iamroot(CPLID)) then
                write(logunit,'(A)') subname//' loading ocn domain mesh from file '//trim(infile) &
                 , ' with options ' // trim(ropts)
@@ -555,8 +555,8 @@ subroutine  copy_aream_from_area(mbappid)
  !!!!! DATA OCN
          else
              ! we need to read the ocean mesh on coupler, from domain file
-            infile = trim(ocn_domain)//C_NULL_CHAR
-            ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;NO_CULLING;REPARTITION'//C_NULL_CHAR
+            infile = trim(ocn_domain)
+            ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;NO_CULLING;REPARTITION'
             if (seq_comm_iamroot(CPLID)) then
                write(logunit,'(A)') subname//' load ocn domain mesh from file for second ocn instance '//trim(ocn_domain) &
                , ' with options '//trim(ropts)
@@ -662,11 +662,11 @@ subroutine  copy_aream_from_area(mbappid)
                ! do not cull in case of data land, like all other data models
                ! for regular land model, cull, because the lnd component culls too
                if (lnd_prognostic) then
-                  ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;REPARTITION'//C_NULL_CHAR
+                  ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;REPARTITION'
                else
-                  ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;REPARTITION;NO_CULLING'//C_NULL_CHAR
+                  ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;REPARTITION;NO_CULLING'
                endif
-               outfile = trim(lnd_domain)//C_NULL_CHAR
+               outfile = trim(lnd_domain)
                nghlay = 0 ! no ghost layers
                if (seq_comm_iamroot(CPLID) ) then
                   write(logunit, *) "loading land domain file from file: ", trim(lnd_domain), &
@@ -810,10 +810,10 @@ subroutine  copy_aream_from_area(mbappid)
          else
             ! we need to read the mesh ice (domain file)
             ! we could be using cice model or data sea ice; in both cases ice_domain should be non-empty
-            ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;NO_CULLING;REPARTITION'//C_NULL_CHAR
-            infile = trim(ice_domain)//C_NULL_CHAR
+            ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;NO_CULLING;REPARTITION'
+            infile = trim(ice_domain)
             if (seq_comm_iamroot(CPLID)) then
-               write(logunit,'(A)') subname//' loading ice domain mesh from file '//infile &
+               write(logunit,'(A)') subname//' loading ice domain mesh from file '//trim(infile) &
                  , ' with options '//trim(ropts)
             endif
             call moab_load_mesh(mbixid, infile, ropts, 0, subname)
@@ -919,11 +919,11 @@ subroutine  copy_aream_from_area(mbappid)
                ! load mesh from scrip file passed from river model, if domain file is not available
                call seq_infodata_GetData(infodata,rof_mesh=rtm_mesh,rof_domain=rof_domain)
                if ( trim(rof_domain) == 'none' ) then
-                  outfile = trim(rtm_mesh)//C_NULL_CHAR
-                  ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=RCBZOLTAN'//C_NULL_CHAR
+                  outfile = trim(rtm_mesh)
+                  ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=RCBZOLTAN'
                else
-                  outfile = trim(rof_domain)//C_NULL_CHAR
-                  ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;REPARTITION'//C_NULL_CHAR
+                  outfile = trim(rof_domain)
+                  ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;REPARTITION'
                endif
                nghlay = 0 ! no ghost layers
                if (seq_comm_iamroot(CPLID)) then
@@ -1171,8 +1171,8 @@ subroutine  copy_aream_from_area(mbappid)
        id_join = comp%cplcompid
        call seq_comm_getinfo(ID_join,mpicom=mpicom_join)
 
-       ! Prepare tag name with C null terminator for iMOAB interface
-       tagName = trim(fields)//C_NULL_CHAR
+       ! Keep tag name clean; C_NULL_CHAR is appended only at each iMOAB call site
+       tagName = trim(fields)
 
        !---------------------------------------------------------------------------
        ! Determine source and target IDs based on data flow direction
@@ -1207,7 +1207,7 @@ subroutine  copy_aream_from_area(mbappid)
        ! Only PEs with valid mbAPPid1 participate in sending
        !---------------------------------------------------------------------------
        if (mbAPPid1 .ge. 0) then !  we are on the sending pes
-          ierr = iMOAB_SendElementTag(mbAPPid1, tagName, mpicom_join, target_id)
+          ierr = iMOAB_SendElementTag(mbAPPid1, trim(tagName)//C_NULL_CHAR, mpicom_join, target_id)
           if (ierr .ne. 0) then
              call shr_sys_abort(subname//' cannot send element tag: '//trim(tagName))
           endif
@@ -1218,7 +1218,7 @@ subroutine  copy_aream_from_area(mbappid)
        ! Only PEs with valid mbAPPid2 participate in receiving
        !---------------------------------------------------------------------------
        if ( mbAPPid2 .ge. 0 ) then !  we are on receiving end
-          ierr = iMOAB_ReceiveElementTag(mbAPPid2, tagName, mpicom_join, source_id)
+          ierr = iMOAB_ReceiveElementTag(mbAPPid2, trim(tagName)//C_NULL_CHAR, mpicom_join, source_id)
           if (ierr .ne. 0) then
              call shr_sys_abort(subname//' cannot receive element tag: '//trim(tagName))
           endif
@@ -1291,14 +1291,14 @@ subroutine  copy_aream_from_area(mbappid)
     ! Write received mesh data to HDF5 file for visualization/debugging
     if (mbAPPid2 .ge. 0 ) then !  we are on receiving pes, for sure
       if (present(context_exch)) then
-         outfile = comp%ntype//'_'//trim(context_exch)//'_'//trim(direction)//'_'//trim(lnum)//'.h5m'//C_NULL_CHAR
+         outfile = comp%ntype//'_'//trim(context_exch)//'_'//trim(direction)//'_'//trim(lnum)//'.h5m'
       else
-         outfile = comp%ntype//'_'//trim(direction)//'_'//trim(lnum)//'.h5m'//C_NULL_CHAR
+         outfile = comp%ntype//'_'//trim(direction)//'_'//trim(lnum)//'.h5m'
       endif
-      wopts   = ';PARALLEL=WRITE_PART'//C_NULL_CHAR
-      ierr = iMOAB_WriteMesh(mbAPPid2, trim(outfile), trim(wopts))
+      wopts   = ';PARALLEL=WRITE_PART'
+      ierr = iMOAB_WriteMesh(mbAPPid2, trim(outfile)//C_NULL_CHAR, trim(wopts)//C_NULL_CHAR)
       if (ierr .ne. 0) then
-          call shr_sys_abort(subname//' cannot write file '// outfile)
+          call shr_sys_abort(subname//' cannot write file '// trim(outfile))
        endif
     endif
 #endif

--- a/driver-moab/main/cplcomp_exchange_mod.F90
+++ b/driver-moab/main/cplcomp_exchange_mod.F90
@@ -184,10 +184,8 @@ subroutine  copy_aream_from_area(mbappid)
             ent_type = 0 ! vertices
          endif
          allocate(tagValues(arrSize))
-         tagname = 'area'//C_NULL_CHAR
-         ierr  = iMOAB_GetDoubleTagStorage( mbappid, tagname, arrsize , ent_type, tagValues )
-         tagname = 'aream'//C_NULL_CHAR
-         ierr  = iMOAB_SetDoubleTagStorage( mbappid, tagname, arrsize , ent_type, tagValues )
+         ierr  = iMOAB_GetDoubleTagStorage( mbappid, 'area'//C_NULL_CHAR, arrsize , ent_type, tagValues )
+         ierr  = iMOAB_SetDoubleTagStorage( mbappid, 'aream'//C_NULL_CHAR, arrsize , ent_type, tagValues )
          deallocate(tagValues)
       endif
 
@@ -207,9 +205,7 @@ subroutine  copy_aream_from_area(mbappid)
       type(component_type), intent(inout) :: comp
       integer,              intent(in)    :: comp_appid, cpl_appid
       character(len=*),     intent(in)    :: domain_fields, dom_context
-      character(CXX) :: tagname
-      tagname = trim(domain_fields)//C_NULL_CHAR
-      call component_exch_moab(comp, comp_appid, cpl_appid, 'c2x', tagname, context_exch=dom_context)
+      call component_exch_moab(comp, comp_appid, cpl_appid, 'c2x', trim(domain_fields)//C_NULL_CHAR, context_exch=dom_context)
       call copy_aream_from_area(cpl_appid)
   end subroutine moab_exchange_domain_tags
 
@@ -329,7 +325,7 @@ subroutine  copy_aream_from_area(mbappid)
       endif ! atmosphere pes
 !!!!!!!!  ON ATM IN CPL
       if (MPI_COMM_NULL /= mpicom_new ) then !  we are on the coupler pes
-         appname = "COUPLE_ATM"//C_NULL_CHAR
+         appname = "COUPLE_ATM"
          ! migrated mesh gets another app id, moab atm to coupler (mbax)
          call moab_register_app(appname, mpicom_new, id_join, mbaxid, subname)
          !!!!  FULL ATM
@@ -477,7 +473,7 @@ subroutine  copy_aream_from_area(mbappid)
       endif
 !!!!!!  OCN ON CPL
       if (MPI_COMM_NULL /= mpicom_new ) then !  we are on the coupler pes
-         appname = "COUPLE_MPASO"//C_NULL_CHAR
+         appname = "COUPLE_MPASO"
          ! migrated mesh gets another app id, moab ocean to coupler (mbox)
          call moab_register_app(appname, mpicom_new, id_join, mboxid, subname)
  !!!!! FULL OCN
@@ -546,7 +542,7 @@ subroutine  copy_aream_from_area(mbappid)
 
 !!!!!!  ON 2nd OCN ON CPL
       if (MPI_COMM_NULL /= mpicom_new ) then !  we are on the coupler pes
-         appname = "COUPLE_MPASOF"//C_NULL_CHAR
+         appname = "COUPLE_MPASOF"
          ! migrated mesh gets another app id, moab ocean to coupler (mbox)
          call moab_register_app(appname, mpicom_new, id_join, mbofxid, subname)
  !!!!! FULL OCN
@@ -569,12 +565,11 @@ subroutine  copy_aream_from_area(mbappid)
          call moab_define_double_tag(mbofxid, trim(seq_flds_dom_fields)//":norm8wt", subname)
 
          ! copy domain data to mbofxid
-         tagname = 'lat:lon:area:frac:mask'//C_NULL_CHAR
          nloc = mbGetnCells(mbofxid)
          arrsize=nloc*5
          allocate(tagValues(arrsize))
-         call mbGetCellTagVals(mboxid,tagname,tagValues,arrsize)
-         call mbSetCellTagVals(mbofxid,tagname,tagValues,arrsize)
+         call mbGetCellTagVals(mboxid,'lat:lon:area:frac:mask'//C_NULL_CHAR,tagValues,arrsize)
+         call mbSetCellTagVals(mbofxid,'lat:lon:area:frac:mask'//C_NULL_CHAR,tagValues,arrsize)
          deallocate(tagValues)
 
       endif
@@ -638,7 +633,7 @@ subroutine  copy_aream_from_area(mbappid)
       call seq_infodata_GetData(infodata,lnd_domain=lnd_domain)
 
       if (MPI_COMM_NULL /= mpicom_new ) then !  we are on the coupler pes
-         appname = "COUPLE_LAND"//C_NULL_CHAR
+         appname = "COUPLE_LAND"
          ! migrated mesh gets another app id, moab land to coupler (mblx)
          call moab_register_app(appname, mpicom_new, id_join, mblxid, subname)
       endif
@@ -695,9 +690,8 @@ subroutine  copy_aream_from_area(mbappid)
                  ent_type = 1 ! cell
               endif
               allocate(tagValues(arrsize))
-              tagname = trim(newlist)//C_NULL_CHAR
               tagValues = 0.0_r8
-              ierr = iMOAB_SetDoubleTagStorage ( mblxid, tagname, arrsize, ent_type, tagValues)
+              ierr = iMOAB_SetDoubleTagStorage ( mblxid, trim(newlist)//C_NULL_CHAR, arrsize, ent_type, tagValues)
               if (ierr .ne. 0) then
                  write(logunit,*) subname,' error in zeroing Flrr tags on land', ierr
                  call shr_sys_abort(subname//' ERROR in zeroing Flrr tags land')
@@ -802,7 +796,7 @@ subroutine  copy_aream_from_area(mbappid)
          endif
       endif
       if (MPI_COMM_NULL /= mpicom_new ) then !  we are on the coupler pes
-         appname = "COUPLE_MPASSI"//C_NULL_CHAR
+         appname = "COUPLE_MPASSI"
          ! migrated mesh gets another app id, moab moab sea ice to coupler (mbix)
          call moab_register_app(appname, mpicom_new, id_join, mbixid, subname)
          if ( trim(ice_domain) == 'none' ) then ! regular ice model
@@ -900,7 +894,7 @@ subroutine  copy_aream_from_area(mbappid)
 
       ! Coupler side: register application and receive/load mesh
       if (MPI_COMM_NULL /= mpicom_new ) then !  we are on the coupler pes
-         appname = "COUPLE_MROF"//C_NULL_CHAR
+         appname = "COUPLE_MROF"
          call moab_register_app(appname, mpicom_new, id_join, mbrxid, subname)
 
          if (dead_comps) then

--- a/driver-moab/main/cplcomp_moab_helpers_mod.F90
+++ b/driver-moab/main/cplcomp_moab_helpers_mod.F90
@@ -90,7 +90,8 @@ contains
 
     integer :: ierr
 
-    ierr = iMOAB_LoadMesh(appid, trim(infile), trim(ropts), nghlay)
+    ! iMOAB_LoadMesh is a C API: append C_NULL_CHAR here so callers stay null-free
+    ierr = iMOAB_LoadMesh(appid, trim(infile)//C_NULL_CHAR, trim(ropts)//C_NULL_CHAR, nghlay)
     if (ierr /= 0) then
       call shr_sys_abort(trim(subctx)//' ERROR loading mesh from '//trim(infile))
     end if

--- a/driver-moab/main/cplcomp_moab_helpers_mod.F90
+++ b/driver-moab/main/cplcomp_moab_helpers_mod.F90
@@ -28,7 +28,8 @@ contains
 
     integer :: ierr
 
-    ierr = iMOAB_RegisterApplication(trim(appname), mpicom, id_join, appid)
+    ! iMOAB_RegisterApplication is a C API: append C_NULL_CHAR here so callers stay null-free
+    ierr = iMOAB_RegisterApplication(trim(appname)//C_NULL_CHAR, mpicom, id_join, appid)
     if (ierr /= 0) then
       call shr_sys_abort(trim(subctx)//' ERROR cannot register app '//trim(appname))
     end if

--- a/driver-moab/main/prep_atm_mod.F90
+++ b/driver-moab/main/prep_atm_mod.F90
@@ -222,12 +222,13 @@ contains
       if (trim(atm_gnam) /= trim(ocn_gnam)) samegrid_ao = .false.
 
       ! TODO: make these namelists
-      wgtIdSo2a = 'scalar_o2a'//C_NULL_CHAR
-      wgtIdFo2a = 'flux_o2a'//C_NULL_CHAR
-      wgtIdSi2a = 'scalar_i2a'//C_NULL_CHAR
-      wgtIdFi2a = 'flux_i2a'//C_NULL_CHAR
-      wgtIdSl2a = 'scalar_l2a'//C_NULL_CHAR
-      wgtIdFl2a = 'flux_l2a'//C_NULL_CHAR
+      ! C_NULL_CHAR is added at each iMOAB C API call site; keep variables clean for diagnostics.
+      wgtIdSo2a = 'scalar_o2a'
+      wgtIdFo2a = 'flux_o2a'
+      wgtIdSi2a = 'scalar_i2a'
+      wgtIdFi2a = 'flux_i2a'
+      wgtIdSl2a = 'scalar_l2a'
+      wgtIdFl2a = 'flux_l2a'
       compute_maps_online_o2a = cpl_compute_maps_online ! read from disk or compute online
       compute_maps_online_i2a = cpl_compute_maps_online ! read from disk or compute online
       compute_maps_online_l2a = cpl_compute_maps_online ! read from disk or compute online
@@ -261,10 +262,10 @@ contains
               write(logunit,*) ' '
               write(logunit,F00) 'Initializing MOAB mapper_So2a'
             endif
-            appname = "OCN_ATM_COU"//C_NULL_CHAR
+            appname = "OCN_ATM_COU"
             ! idintx is a unique number of MOAB app that takes care of intx between atm and ocn mesh
             idintx = 100*ocn(1)%cplcompid + atm(1)%cplcompid ! something different, to differentiate it
-            ierr = iMOAB_RegisterApplication(trim(appname), mpicom_CPLID, idintx, mbintxoa)
+            ierr = iMOAB_RegisterApplication(trim(appname)//C_NULL_CHAR, mpicom_CPLID, idintx, mbintxoa)
             if (ierr .ne. 0) then
               write(logunit,*) subname,' error in registering ATM-OCN intersection application'
               call shr_sys_abort(subname//' ERROR in registering ATM-OCN intersection application')
@@ -346,7 +347,7 @@ contains
                                                    noConserve, validate, &
                                                    trim(dofnameS), trim(dofnameT)
                   endif
-                  ierr = iMOAB_ComputeScalarProjectionWeights ( mbintxoa, wgtIdSo2a, &
+                  ierr = iMOAB_ComputeScalarProjectionWeights ( mbintxoa, trim(wgtIdSo2a)//C_NULL_CHAR, &
                                                    trim(dm1), orderS, trim(dm2), orderT, ''//C_NULL_CHAR, &
                                                    fNoBubble, monotonicity, volumetric, fInverseDistanceMap, &
                                                    noConserve, validate, &
@@ -584,10 +585,10 @@ contains
               write(logunit,*) ' '
               write(logunit,F00) 'Initializing ice atm coupler'
             endif
-            appname = "ICE_ATM_COU"//C_NULL_CHAR
+            appname = "ICE_ATM_COU"
             ! idintx is a unique number of MOAB app that takes care of intx between ice and atm mesh
             idintx = 100*ice(1)%cplcompid + atm(1)%cplcompid ! something different, to differentiate it
-            ierr = iMOAB_RegisterApplication(trim(appname), mpicom_CPLID, idintx, mbintxia)
+            ierr = iMOAB_RegisterApplication(trim(appname)//C_NULL_CHAR, mpicom_CPLID, idintx, mbintxia)
             if (ierr .ne. 0) then
               write(logunit,*) subname,' error in registering ICE-ATM intersection'
               call shr_sys_abort(subname//' ERROR in registering ICE-ATM intersection')
@@ -672,7 +673,7 @@ contains
                                               noConserve, validate, &
                                               trim(dofnameS), trim(dofnameT)
                endif
-               ierr = iMOAB_ComputeScalarProjectionWeights ( mbintxia, wgtIdSi2a, &
+               ierr = iMOAB_ComputeScalarProjectionWeights ( mbintxia, trim(wgtIdSi2a)//C_NULL_CHAR, &
                                                 trim(dm1), orderS, trim(dm2), orderT, ''//C_NULL_CHAR, &
                                                 fNoBubble, monotonicity, volumetric, fInverseDistanceMap, &
                                                 noConserve, validate, &
@@ -826,10 +827,10 @@ contains
               write(logunit,F00) 'Initializing MOAB mapper_Fl2a'
             endif
 
-            appname = "LND_ATM_COU"//C_NULL_CHAR
+            appname = "LND_ATM_COU"
             ! idintx is a unique number of MOAB app that takes care of intx between lnd and atm mesh
             idintx = 100*lnd(1)%cplcompid + atm(1)%cplcompid ! something different, to differentiate it
-            ierr = iMOAB_RegisterApplication(trim(appname), mpicom_CPLID, idintx, mbintxla)
+            ierr = iMOAB_RegisterApplication(trim(appname)//C_NULL_CHAR, mpicom_CPLID, idintx, mbintxla)
             if (ierr .ne. 0) then
               write(logunit,*) subname,' error in registering lnd atm intx '
               call shr_sys_abort(subname//' ERROR in registering lnd atm intx ')
@@ -903,7 +904,7 @@ contains
                                                    noConserve, validate, &
                                                    trim(dofnameS), trim(dofnameT)
                   endif
-                  ierr = iMOAB_ComputeScalarProjectionWeights ( mbintxla, wgtIdFl2a, &
+                  ierr = iMOAB_ComputeScalarProjectionWeights ( mbintxla, trim(wgtIdFl2a)//C_NULL_CHAR, &
                                                    trim(dm1), orderS, trim(dm2), orderT, ''//C_NULL_CHAR, &
                                                    fNoBubble, monotonicity, volumetric, fInverseDistanceMap, &
                                                    noConserve, validate, &

--- a/driver-moab/main/prep_ice_mod.F90
+++ b/driver-moab/main/prep_ice_mod.F90
@@ -308,10 +308,10 @@ contains
                write(logunit,F00) 'Initializing MOAB mapper_Rr2i'
             end if
 
-            appname = "ROF_ICE_COU"//C_NULL_CHAR
+            appname = "ROF_ICE_COU"
             ! idintx is a unique number of MOAB app that takes care of intx between lnd and rof mesh
             idintx = 100*rof(1)%cplcompid + ice(1)%cplcompid ! something different, to differentiate it
-            ierr = iMOAB_RegisterApplication(trim(appname), mpicom_CPLID, idintx, mbintxri)
+            ierr = iMOAB_RegisterApplication(trim(appname)//C_NULL_CHAR, mpicom_CPLID, idintx, mbintxri)
             if (ierr .ne. 0) then
               write(logunit,*) subname,' error in registering ROF-ICE intersection'
               call shr_sys_abort(subname//' ERROR in registering ROF-ICE intersection')

--- a/driver-moab/main/prep_lnd_mod.F90
+++ b/driver-moab/main/prep_lnd_mod.F90
@@ -195,9 +195,10 @@ contains
     allocate(mapper_Sg2l)
     allocate(mapper_Fg2l)
 
-      wgtIdFr2l = 'flux_r2l'//C_NULL_CHAR
-      wgtIdFa2l = 'flux_a2l'//C_NULL_CHAR
-      wgtIdSa2l = 'scalar_a2l'//C_NULL_CHAR
+      ! C_NULL_CHAR is added at each iMOAB C API call site; keep variables clean for diagnostics.
+      wgtIdFr2l = 'flux_r2l'
+      wgtIdFa2l = 'flux_a2l'
+      wgtIdSa2l = 'scalar_a2l'
       compute_maps_online_r2l = cpl_compute_maps_online ! read from disk or compute online
       compute_maps_online_a2l = cpl_compute_maps_online ! read from disk or compute online
       ! compute_maps_online_a2l = .false. ! Explicitly force read from disk
@@ -259,10 +260,10 @@ contains
                write(logunit,*) ' '
                write(logunit,F00) 'Initializing MOAB mapper_Fr2l'
             end if
-            appname = "ROF_LND_COU"//C_NULL_CHAR
+            appname = "ROF_LND_COU"
             ! idintx is a unique number of MOAB app that takes care of intx between rof and lnd mesh
             idintx = 100*rof(1)%cplcompid + lnd(1)%cplcompid ! something different, to differentiate it
-            ierr = iMOAB_RegisterApplication(trim(appname), mpicom_CPLID, idintx, mbintxrl)
+            ierr = iMOAB_RegisterApplication(trim(appname)//C_NULL_CHAR, mpicom_CPLID, idintx, mbintxrl)
             if (ierr .ne. 0) then
               write(logunit,*) subname,' error in registering  rof lnd intx'
               call shr_sys_abort(subname//' ERROR in registering rof lnd intx')
@@ -354,7 +355,7 @@ contains
                                                     noConserve, validate, &
                                                     trim(dofnameS), trim(dofnameT)
                   endif
-                  ierr = iMOAB_ComputeScalarProjectionWeights ( mbintxrl, wgtIdFr2l, &
+                  ierr = iMOAB_ComputeScalarProjectionWeights ( mbintxrl, trim(wgtIdFr2l)//C_NULL_CHAR, &
                                                     trim(dm1), orderS, trim(dm2), orderT, ''//C_NULL_CHAR, &
                                                     fNoBubble, monotonicity, volumetric, fInverseDistanceMap, &
                                                     noConserve, validate, &
@@ -466,10 +467,10 @@ contains
                write(logunit,*) ' '
                write(logunit,F00) 'Initializing MOAB mapper_Sa2l and mapper_Fa2l'
             end if
-            appname = "ATM_LND_COU"//C_NULL_CHAR
+            appname = "ATM_LND_COU"
             ! idintx is a unique number of MOAB app that takes care of intx between lnd and atm mesh
             idintx = 100*atm(1)%cplcompid + lnd(1)%cplcompid ! something different, to differentiate it
-            ierr = iMOAB_RegisterApplication(trim(appname), mpicom_CPLID, idintx, mbintxal)
+            ierr = iMOAB_RegisterApplication(trim(appname)//C_NULL_CHAR, mpicom_CPLID, idintx, mbintxal)
             if (ierr .ne. 0) then
               write(logunit,*) subname,' error in registering atm lnd intx '
               call shr_sys_abort(subname//' ERROR in registering atm lnd intx ')
@@ -551,7 +552,7 @@ contains
                                                       trim(dofnameS), trim(dofnameT)
                   endif
 
-                  ierr = iMOAB_ComputeScalarProjectionWeights( mbintxal, wgtIdSa2l, &
+                  ierr = iMOAB_ComputeScalarProjectionWeights( mbintxal, trim(wgtIdSa2l)//C_NULL_CHAR, &
                                                       trim(dm1), orderS, trim(dm2), orderT, 'bilin'//C_NULL_CHAR, &
                                                       fNoBubble, monotonicity, volumetric, fInverseDistanceMap, &
                                                       noConserve, validate, &
@@ -562,7 +563,7 @@ contains
                   endif
 
                   ! Next compute the conservative map for projection of flux fields
-                  ierr = iMOAB_ComputeScalarProjectionWeights( mbintxal, wgtIdFa2l, &
+                  ierr = iMOAB_ComputeScalarProjectionWeights( mbintxal, trim(wgtIdFa2l)//C_NULL_CHAR, &
                                                   trim(dm1), orderS, trim(dm2), orderT, C_NULL_CHAR, &
                                                   fNoBubble, monotonicity, volumetric, fInverseDistanceMap, &
                                                   noConserve, validate, &

--- a/driver-moab/main/prep_ocn_mod.F90
+++ b/driver-moab/main/prep_ocn_mod.F90
@@ -291,12 +291,13 @@ contains
 
     compute_maps_online_a2o = cpl_compute_maps_online  ! read from disk or compute online
     compute_maps_online_r2o = .false.  ! *always* read from disk
-    wgtIdFa2o = 'flux_a2o'//C_NULL_CHAR
-    wgtIdSa2o = 'bilinear_a2o'//C_NULL_CHAR
-    wgtIdVa2o = 'vector_a2o'//C_NULL_CHAR
-    wgtIdFr2ol = 'flux_r2o_liq'//C_NULL_CHAR
-    wgtIdFr2oi = 'flux_r2o_ice'//C_NULL_CHAR
-    wgtIdFr2o = 'flux_r2o'//C_NULL_CHAR
+    ! C_NULL_CHAR is added at each iMOAB C API call site; keep variables clean for diagnostics.
+    wgtIdFa2o = 'flux_a2o'
+    wgtIdSa2o = 'bilinear_a2o'
+    wgtIdVa2o = 'vector_a2o'
+    wgtIdFr2ol = 'flux_r2o_liq'
+    wgtIdFr2oi = 'flux_r2o_ice'
+    wgtIdFr2o = 'flux_r2o'
     no_match = .true. ! force to create a new mapper object
 
     allocate(mapper_Sa2o)
@@ -421,10 +422,10 @@ contains
                write(logunit,*) ' '
                write(logunit,F00) 'Initializing MOAB mapper_Fa2o and mapper_Sa2o'
             end if
-            appname = "ATM_OCN_COU"//C_NULL_CHAR
+            appname = "ATM_OCN_COU"
             ! idintx is a unique number of MOAB app that takes care of intx between ocn and atm mesh
             idintx = 100*atm(1)%cplcompid + ocn(1)%cplcompid ! something different, to differentiate it
-            ierr = iMOAB_RegisterApplication(trim(appname), mpicom_CPLID, idintx, mbintxao)
+            ierr = iMOAB_RegisterApplication(trim(appname)//C_NULL_CHAR, mpicom_CPLID, idintx, mbintxao)
             if (ierr .ne. 0) then
               write(logunit,*) subname,' error in registering ATM-OCN intersection application'
               call shr_sys_abort(subname//' ERROR in registering ATM-OCN intersection application')
@@ -530,7 +531,7 @@ contains
                         trim(dm1), orderS, trim(dofnameS), trim(dm2), orderT, trim(dofnameT), "bilinear", &
                         fNoBubble, monotonicity, volumetric, fInverseDistanceMap, noConserve, validate)
                   endif
-                  ierr = iMOAB_ComputeScalarProjectionWeights ( mbintxao, wgtIdSa2o, &
+                  ierr = iMOAB_ComputeScalarProjectionWeights ( mbintxao, trim(wgtIdSa2o)//C_NULL_CHAR, &
                                                    trim(dm1), orderS, trim(dm2), orderT, 'bilin'//C_NULL_CHAR, &
                                                    fNoBubble, monotonicity, volumetric, fInverseDistanceMap, &
                                                    noConserve, validate, &
@@ -548,7 +549,7 @@ contains
                         trim(dm1), orderS, trim(dofnameS), trim(dm2), orderT, trim(dofnameT), "", &
                         fNoBubble, monotonicity, volumetric, fInverseDistanceMap, noConserve, validate)
                   endif
-                  ierr = iMOAB_ComputeScalarProjectionWeights ( mbintxao, wgtIdFa2o, &
+                  ierr = iMOAB_ComputeScalarProjectionWeights ( mbintxao, trim(wgtIdFa2o)//C_NULL_CHAR, &
                                                    trim(dm1), orderS, trim(dm2), orderT, C_NULL_CHAR, &
                                                    fNoBubble, monotonicity, volumetric, fInverseDistanceMap, &
                                                    noConserve, validate, &
@@ -764,10 +765,10 @@ contains
           call seq_comm_getData(CPLID, mpicom=mpicom_CPLID, iamroot=iamroot_CPLID)
           call seq_comm_getData(CPLID, mpigrp=mpigrp_CPLID)   !  second group, the coupler group CPLID is global variable
 
-          appname = "ROF_OCN_COU"//CHAR(0)
+          appname = "ROF_OCN_COU"
             ! rmapid  is a unique external number of MOAB app that takes care of map between rof and ocn mesh
           rmapid = 100*rof(1)%cplcompid + ocn(1)%cplcompid ! something different, to differentiate it
-          ierr = iMOAB_RegisterApplication(trim(appname), mpicom_CPLID, rmapid, mbintxro)
+          ierr = iMOAB_RegisterApplication(trim(appname)//C_NULL_CHAR, mpicom_CPLID, rmapid, mbintxro)
           if (ierr .ne. 0) then
              write(logunit,*) subname,' error in registering rof 2 ocn moab map '
              call shr_sys_abort(subname//' ERROR in registering  rof 2 ocn moab map ')

--- a/driver-moab/main/prep_rof_mod.F90
+++ b/driver-moab/main/prep_rof_mod.F90
@@ -224,10 +224,11 @@ contains
          ocn_gnam=ocn_gnam             , &
          cpl_compute_maps_online=cpl_compute_maps_online )
 
-    wgtIdl2r = 'conservative_l2r'//C_NULL_CHAR
-    wgtIdFa2r = 'flux_a2r'//C_NULL_CHAR
-    wgtIdSa2r = 'scalar_a2r'//C_NULL_CHAR
-    wgtIdSo2r = 'scalar_o2r'//C_NULL_CHAR
+    ! C_NULL_CHAR is added at each iMOAB C API call site; keep variables clean for diagnostics.
+    wgtIdl2r = 'conservative_l2r'
+    wgtIdFa2r = 'flux_a2r'
+    wgtIdSa2r = 'scalar_a2r'
+    wgtIdSo2r = 'scalar_o2r'
     compute_maps_online_l2r = cpl_compute_maps_online ! read from disk or compute online
     compute_maps_online_a2r = cpl_compute_maps_online ! read from disk or compute online
     compute_maps_online_o2r = cpl_compute_maps_online ! read from disk or compute online
@@ -321,10 +322,10 @@ contains
                write(logunit,*) ' '
                write(logunit,F00) 'Initializing MOAB mapper_Fl2r'
             endif
-            appname = "LND_ROF_COU"//C_NULL_CHAR
+            appname = "LND_ROF_COU"
             ! idintx is a unique number of MOAB app that takes care of intx between lnd and rof mesh
             idintx = 100*lnd(1)%cplcompid + rof(1)%cplcompid ! something different, to differentiate it
-            ierr = iMOAB_RegisterApplication(trim(appname), mpicom_CPLID, idintx, mbintxlr)
+            ierr = iMOAB_RegisterApplication(trim(appname)//C_NULL_CHAR, mpicom_CPLID, idintx, mbintxlr)
             if (ierr .ne. 0) then
               write(logunit,*) subname,' error in registering LND-ROF intersection'
               call shr_sys_abort(subname//' ERROR in registering LND-ROF intersection')
@@ -429,7 +430,7 @@ contains
                                                    noConserve, validate, &
                                                    trim(dofnameS), trim(dofnameT)
                   endif
-                  ierr = iMOAB_ComputeScalarProjectionWeights ( mbintxlr, wgtIdl2r, &
+                  ierr = iMOAB_ComputeScalarProjectionWeights ( mbintxlr, trim(wgtIdl2r)//C_NULL_CHAR, &
                                                    trim(dm1), orderS, trim(dm2), orderT, ''//C_NULL_CHAR, &
                                                    fNoBubble, monotonicity, volumetric, fInverseDistanceMap, &
                                                    noConserve, validate, &
@@ -547,10 +548,10 @@ contains
                write(logunit,*) ' '
                write(logunit,F00) 'Initializing MOAB mapper_Fa2r'
             end if
-            appname = "ATM_ROF_COU"//C_NULL_CHAR
+            appname = "ATM_ROF_COU"
             ! idintx is a unique number of MOAB app that takes care of intx between rof and atm mesh
             idintx = 100*atm(1)%cplcompid + rof(1)%cplcompid ! something different, to differentiate it
-            ierr = iMOAB_RegisterApplication(trim(appname), mpicom_CPLID, idintx, mbintxar)
+            ierr = iMOAB_RegisterApplication(trim(appname)//C_NULL_CHAR, mpicom_CPLID, idintx, mbintxar)
             if (ierr .ne. 0) then
               write(logunit,*) subname,' error in registering ATM-ROF mesh intersection context'
               call shr_sys_abort(subname//' ERROR in registering ATM-ROF mesh intersection context')
@@ -641,7 +642,7 @@ contains
                                                    noConserve, validate, &
                                                    trim(dofnameS), trim(dofnameT)
                   endif
-                  ierr = iMOAB_ComputeScalarProjectionWeights ( mbintxar, wgtIdFa2r, &
+                  ierr = iMOAB_ComputeScalarProjectionWeights ( mbintxar, trim(wgtIdFa2r)//C_NULL_CHAR, &
                                                    trim(dm1), orderS, trim(dm2), orderT, ''//C_NULL_CHAR, &
                                                    fNoBubble, monotonicity, volumetric, fInverseDistanceMap, &
                                                    noConserve, validate, &
@@ -803,10 +804,10 @@ contains
                write(logunit,F00) 'Initializing MOAB mapper_So2r'
             end if
 
-            appname = "OCN_ROF_COU"//C_NULL_CHAR
+            appname = "OCN_ROF_COU"
             ! idintx is a unique number of MOAB app that takes care of intx between OCN and ROF mesh
             idintx = 100*ocn(1)%cplcompid + rof(1)%cplcompid ! something different, to differentiate it
-            ierr = iMOAB_RegisterApplication(trim(appname), mpicom_CPLID, idintx, mbintxor)
+            ierr = iMOAB_RegisterApplication(trim(appname)//C_NULL_CHAR, mpicom_CPLID, idintx, mbintxor)
             if (ierr .ne. 0) then
               write(logunit,*) subname,' error in registering OCN-ROF intersection'
               call shr_sys_abort(subname//' ERROR in registering OCN-ROF intersection')

--- a/driver-moab/main/seq_io_mod.F90
+++ b/driver-moab/main/seq_io_mod.F90
@@ -1115,9 +1115,9 @@ contains
              else
                tagname = trim(field)//C_NULL_CHAR
                if (ns > 0 ) then
-                  ierr = iMOAB_GetDoubleTagStorage (mbxid, tagname, ns, ent_type, data1)
-                  if (ierr .ne. 0) then
-                     write(logunit,*) subname,' ERROR: cannot get tag data ', trim(tagname)
+                   ierr = iMOAB_GetDoubleTagStorage (mbxid, tagname, ns, ent_type, data1)
+                   if (ierr .ne. 0) then
+                      write(logunit,*) subname,' ERROR: cannot get tag data ', trim(tagname)
                      call shr_sys_abort(subname//'cannot get tag data ')
                   endif
                endif
@@ -1640,13 +1640,7 @@ contains
                endif
             endif
           endif
-         !  n = 0
-         !  do n1 = 1,ni
-         !     do n2 = 1,ns
-         !        n = n + 1
-         !        avs(:n1)%rAttr(k,n2) = data(n)
-         !     enddo
-         !  enddo
+
        else
           write(logunit,*)subname, ' warning: field ',trim(field), ' name1:', trim(name1),  ' is not on restart file'
           write(logunit,*)'for backwards compatibility will set it to 0'

--- a/driver-moab/main/seq_io_mod.F90
+++ b/driver-moab/main/seq_io_mod.F90
@@ -1076,19 +1076,18 @@ contains
 
        ! note: size of dof is ns
        if (ns > 0) then
-          tagname = 'GLOBAL_ID'//C_NULL_CHAR
-          ierr = iMOAB_GetIntTagStorage ( mbxid, tagname, ns , ent_type, dof)
-          if (ierr .ne. 0) then
-            write(logunit,*) subname,' ERROR: cannot get dofs '
-            call shr_sys_abort(subname//'cannot get dofs ')
-          endif
+           ierr = iMOAB_GetIntTagStorage ( mbxid, 'GLOBAL_ID'//C_NULL_CHAR, ns , ent_type, dof)
+           if (ierr .ne. 0) then
+             write(logunit,*) subname,' ERROR: cannot get dofs '
+             call shr_sys_abort(subname//'cannot get dofs ')
+           endif
 
-          call IndexSet(ns, indx)
-          call IndexSort(ns, indx, dof, descend=.false.)
-          !      after sort, dof( indx(i)) < dof( indx(i+1) )
-          do ix=1,ns
-             dof_reorder(ix) = dof(indx(ix)) !
-          enddo
+           call IndexSet(ns, indx)
+           call IndexSort(ns, indx, dof, descend=.false.)
+           !      after sort, dof( indx(i)) < dof( indx(i+1) )
+           do ix=1,ns
+              dof_reorder(ix) = dof(indx(ix)) !
+           enddo
           ! so we know that dof_reorder(ix) < dof_reorder(ix+1)
        endif
        if (luse_float) then
@@ -1112,16 +1111,16 @@ contains
                do ix = 1, ns
                  data1(ix) = matrix(ix, index_list) !
                enddo
-             else
-               tagname = trim(field)//C_NULL_CHAR
-               if (ns > 0 ) then
-                   ierr = iMOAB_GetDoubleTagStorage (mbxid, tagname, ns, ent_type, data1)
-                   if (ierr .ne. 0) then
-                      write(logunit,*) subname,' ERROR: cannot get tag data ', trim(tagname)
-                     call shr_sys_abort(subname//'cannot get tag data ')
-                  endif
-               endif
-             endif
+              else
+                tagname = trim(field)
+                if (ns > 0 ) then
+                    ierr = iMOAB_GetDoubleTagStorage (mbxid, trim(tagname)//C_NULL_CHAR, ns, ent_type, data1)
+                    if (ierr .ne. 0) then
+                       write(logunit,*) subname,' ERROR: cannot get tag data ', trim(tagname)
+                      call shr_sys_abort(subname//'cannot get tag data ')
+                   endif
+                endif
+              endif
 
              ! remove MOAB default values
              ! This is needed to match MCT coupler history fields where data
@@ -1574,16 +1573,15 @@ contains
     allocate(dof(ns))
     allocate(dof_reorder(ns))
 
-   ! note: size of dof is ns
-    tagname = 'GLOBAL_ID'//C_NULL_CHAR
-    if (ns > 0 ) then
-       ierr = iMOAB_GetIntTagStorage ( mbxid, tagname, ns , ent_type, dof)
-       if (ierr .ne. 0) then
-          write(logunit,*) subname,' ERROR: cannot get dofs '
-          call shr_sys_abort(subname//'cannot get dofs ')
-       endif
-    endif
-   allocate(indx(ns))
+    ! note: size of dof is ns
+     if (ns > 0 ) then
+        ierr = iMOAB_GetIntTagStorage ( mbxid, 'GLOBAL_ID'//C_NULL_CHAR, ns , ent_type, dof)
+        if (ierr .ne. 0) then
+           write(logunit,*) subname,' ERROR: cannot get dofs '
+           call shr_sys_abort(subname//'cannot get dofs ')
+        endif
+     endif
+    allocate(indx(ns))
    call IndexSet(ns, indx)
    call IndexSort(ns, indx, dof, descend=.false.)
    !      after sort, dof( indx(i)) < dof( indx(i+1) )
@@ -1631,15 +1629,15 @@ contains
                matrix(ix, index_list)  = data_reorder(ix) !
             enddo
           else
-            tagname = trim(field)//C_NULL_CHAR
-            if (ns > 0) then
-               ierr = iMOAB_SetDoubleTagStorage (mbxid, tagname, ns , ent_type, data_reorder)
-               if (ierr .ne. 0) then
-                  write(logunit,*) subname,' ERROR: cannot set tag data ', trim(tagname)
-                  call shr_sys_abort(subname//'cannot set tag data ')
-               endif
-            endif
-          endif
+             tagname = trim(field)
+             if (ns > 0) then
+                ierr = iMOAB_SetDoubleTagStorage (mbxid, trim(tagname)//C_NULL_CHAR, ns , ent_type, data_reorder)
+                if (ierr .ne. 0) then
+                   write(logunit,*) subname,' ERROR: cannot set tag data ', trim(tagname)
+                   call shr_sys_abort(subname//'cannot set tag data ')
+                endif
+             endif
+           endif
 
        else
           write(logunit,*)subname, ' warning: field ',trim(field), ' name1:', trim(name1),  ' is not on restart file'
@@ -1653,16 +1651,16 @@ contains
             do ix = 1,ns
                matrix(ix, index_list)  = data_reorder(ix) !
             enddo
-         else
-            tagname = trim(field)//C_NULL_CHAR
-            if ( ns > 0 ) then
-               ierr = iMOAB_SetDoubleTagStorage (mbxid, tagname, ns , ent_type, data_reorder)
-               if (ierr .ne. 0) then
-                  write(logunit,*) subname,' ERROR: cannot set tag data ', trim(tagname)
-                  call shr_sys_abort(subname//'cannot set tag data ')
-               endif
-            endif
-         endif
+          else
+             tagname = trim(field)
+             if ( ns > 0 ) then
+                ierr = iMOAB_SetDoubleTagStorage (mbxid, trim(tagname)//C_NULL_CHAR, ns , ent_type, data_reorder)
+                if (ierr .ne. 0) then
+                   write(logunit,*) subname,' ERROR: cannot set tag data ', trim(tagname)
+                   call shr_sys_abort(subname//'cannot set tag data ')
+                endif
+             endif
+          endif
 
        end if
        call pio_seterrorhandling(pioid,PIO_INTERNAL_ERROR)

--- a/driver-moab/main/seq_map_mod.F90
+++ b/driver-moab/main/seq_map_mod.F90
@@ -180,6 +180,7 @@ contains
                    description_string, esmf_map, fallback_map_identifier )
 
     use iMOAB, only: iMOAB_LoadMapFile
+    use iso_c_binding, only: C_NULL_CHAR
     implicit none
     !-----------------------------------------------------
     !
@@ -212,6 +213,7 @@ contains
     character(len=128)          :: nl_label
     logical                     :: nl_found
     integer                     :: ierr
+    integer                     :: null_pos
 
     character(len=*),parameter  :: subname = "(moab_map_init_rcfile) "
     !-----------------------------------------------------
@@ -239,7 +241,7 @@ contains
 
     mapfile_term = trim(mapfile)//CHAR(0)
     if (seq_comm_iamroot(CPLID)) then
-        write(logunit,*) subname,' reading map file with iMOAB: ', trim(mapfile_term)
+        write(logunit,*) subname,' reading map file with iMOAB: ', trim(mapfile)
     endif
 
     ierr = iMOAB_LoadMapFile( mapper%src_mbid, mapper%tgt_mbid, mapper%intx_mbid, discretization_type, &
@@ -258,11 +260,19 @@ contains
 
     if (nl_found) then
          mapper%nl_available = .true.
-         nlmap_id = 'ho_'//map_identifier
+         ! Strip any embedded C_NULL_CHAR from map_identifier before concatenating
+         ! so that diagnostic writes remain clean (null-free). The terminator is
+         ! re-added at each iMOAB C API call site below.
+         null_pos = index(map_identifier, C_NULL_CHAR)
+         if (null_pos > 1) then
+            nlmap_id = 'ho_'//map_identifier(1:null_pos-1)
+         else
+            nlmap_id = 'ho_'//trim(map_identifier)
+         end if
          mapper%howeight_identifier = nlmap_id
          mapfile_term = trim(nl_mapfile)//CHAR(0)
          ierr = iMOAB_LoadMapFile( mapper%src_mbid, mapper%tgt_mbid, mapper%intx_mbid, discretization_type, &
-                                 discretization_type, 0, nlmap_id, mapfile_term)
+                                 discretization_type, 0, trim(nlmap_id)//C_NULL_CHAR, mapfile_term)
          if (ierr .ne. 0) then
            write(logunit,*) subname,' error in loading nlmap file - ' // nl_mapfile
            call shr_sys_abort(subname//' ERROR in loading nlmap file - ' // nl_mapfile)
@@ -562,9 +572,9 @@ contains
              !*** After mapping, dividing by the mapped norm8wt gives proper normalization.
              allocate(wghts(lsize_src))
              wghts = 1.0_r8
-             tagname = "norm8wt"//C_NULL_CHAR
+             tagname = "norm8wt"
              !*** MOAB: iMOAB_SetDoubleTagStorage - Set tag values on mesh elements
-             ierr = iMOAB_SetDoubleTagStorage (mapper%src_mbid, tagname, lsize_src , mapper%tag_entity_type, wghts)
+             ierr = iMOAB_SetDoubleTagStorage (mapper%src_mbid, trim(tagname)//C_NULL_CHAR, lsize_src , mapper%tag_entity_type, wghts)
               if (ierr .ne. 0) then
                  write(logunit,*) subname,' error setting init value for mapping norm factor ',ierr,trim(tagname)
                 call shr_sys_abort(subname//' ERROR setting norm init value') ! serious enough
@@ -581,8 +591,8 @@ contains
              !*** This is used for flux-weighted mapping (e.g., area-weighted averages).
              if(mbpresent) then
                 !*** MOAB: iMOAB_GetDoubleTagStorage - Get weight field values
-                tagname = avwtsfld_s//C_NULL_CHAR
-                ierr = iMOAB_GetDoubleTagStorage (mapper%src_mbid, tagname, lsize_src , mapper%tag_entity_type, wghts)
+                tagname = trim(avwtsfld_s)
+                ierr = iMOAB_GetDoubleTagStorage (mapper%src_mbid, trim(tagname)//C_NULL_CHAR, lsize_src , mapper%tag_entity_type, wghts)
                 if (ierr .ne. 0) then
                    write(logunit,*) subname,' error getting value for mapping norm factor ', trim(tagname)
                    call shr_sys_abort(subname//' ERROR getting norm factor') ! serious enough
@@ -724,7 +734,7 @@ contains
              if (ncaas_fields > 0) then
                 filter_type = 2 ! CAAS_LOCAL
                 ierr = iMOAB_ApplyScalarProjectionWeights ( mapper%intx_mbid, filter_type, &
-                       mapper%howeight_identifier, fldlist_caas, fldlist_caas )
+                       trim(mapper%howeight_identifier)//C_NULL_CHAR, fldlist_caas, fldlist_caas )
                 if (ierr .ne. 0) then
                    write(logunit,*) subname,' error in applying weights (data fields, dual-map CAAS)'
                    call shr_sys_abort(subname//' ERROR in applying weights (data fields, dual-map CAAS)')
@@ -757,13 +767,13 @@ contains
              endif
 
              lsize_tgt = nvise(1) ! number of active cells
-             tagname = "norm8wt"//C_NULL_CHAR
+             tagname = "norm8wt"
              allocate(wghts(lsize_tgt))
              wghts = 0.0_r8   ! defensive zero-init: iMOAB_GetDoubleTagStorage may leave some entries untouched
                               ! if the tag was never set on those cells; this avoids reading uninitialised memory below.
 
              !*** MOAB: Get mapped normalization weights on target grid
-             ierr = iMOAB_GetDoubleTagStorage (mapper%tgt_mbid, tagname, lsize_tgt , mapper%tag_entity_type, wghts)
+             ierr = iMOAB_GetDoubleTagStorage (mapper%tgt_mbid, trim(tagname)//C_NULL_CHAR, lsize_tgt , mapper%tag_entity_type, wghts)
               if (ierr .ne. 0) then
                  write(logunit,*) subname,' error getting value for mapping norm factor post-map ', ierr, trim(tagname)
                 call shr_sys_abort(subname//' ERROR getting norm factor') ! serious enough

--- a/driver-moab/main/seq_map_mod.F90
+++ b/driver-moab/main/seq_map_mod.F90
@@ -466,7 +466,7 @@ contains
 #ifdef MOABDEBUG
        if (seq_comm_iamroot(CPLID)) then
           write(logunit,*) subname, 'iMOAB mapper ',trim(mapper%mbname), ' iMOAB_mapper  nfields', &
-                nfields,  ' fldlist_moab=', trim(fldlist_moab), ' moab step ', num_moab_exports
+                nfields,  ' fldlist_moab=', fldlist_moab(1:index(fldlist_moab,C_NULL_CHAR)-1), ' moab step ', num_moab_exports
           call shr_sys_flush(logunit)
        endif
 #endif
@@ -489,7 +489,7 @@ contains
        if ( valid_moab_context ) then
 #ifdef MOABDEBUG
           if (seq_comm_iamroot(CPLID)) then
-             write(logunit, *) subname,' iMOAB mapper rearrange or copy ', mapper%mbname, ' send/recv tags ', trim(fldlist_moab), &
+             write(logunit, *) subname,' iMOAB mapper rearrange or copy ', mapper%mbname, ' send/recv tags ', fldlist_moab(1:index(fldlist_moab,C_NULL_CHAR)-1), &
                ' mbpresent=', mbpresent, ' mbnorm=', mbnorm, ' moab step:', num_moab_exports
              call shr_sys_flush(logunit)
           endif
@@ -502,7 +502,7 @@ contains
           !***   intx_context: Context ID for the intersection/target app
           ierr = iMOAB_SendElementTag( mapper%src_mbid, fldlist_moab, mapper%mpicom, mapper%intx_context );
           if (ierr .ne. 0) then
-             write(logunit, *) subname,' iMOAB mapper ', mapper%mbname, ' error in sending tags ', trim(fldlist_moab), ierr
+             write(logunit, *) subname,' iMOAB mapper ', mapper%mbname, ' error in sending tags ', fldlist_moab(1:index(fldlist_moab,C_NULL_CHAR)-1), ierr
              call shr_sys_flush(logunit)
              call shr_sys_abort(subname//' ERROR in sending tags')
           endif
@@ -514,7 +514,7 @@ contains
           !***   src_context: Context ID for the source app
           ierr = iMOAB_ReceiveElementTag( mapper%tgt_mbid, fldlist_moab, mapper%mpicom, mapper%src_context );
           if (ierr .ne. 0) then
-             write(logunit,*) subname,' error in receiving tags iMOAB mapper ', mapper%mbname,  trim(fldlist_moab)
+             write(logunit,*) subname,' error in receiving tags iMOAB mapper ', mapper%mbname,  fldlist_moab(1:index(fldlist_moab,C_NULL_CHAR)-1)
              call shr_sys_flush(logunit)
              call shr_sys_abort(subname//' ERROR in receiving tags')
           endif
@@ -522,7 +522,7 @@ contains
           !*** Must be called after receive completes to free memory.
           ierr = iMOAB_FreeSenderBuffers( mapper%src_mbid, mapper%intx_context )
           if (ierr .ne. 0) then
-             write(logunit,*) subname,' error in freeing buffers ', trim(fldlist_moab)
+             write(logunit,*) subname,' error in freeing buffers ', fldlist_moab(1:index(fldlist_moab,C_NULL_CHAR)-1)
              call shr_sys_abort(subname//' ERROR in freeing buffers') ! serious enough
           endif
        endif ! if (valid_moab_context)
@@ -567,8 +567,8 @@ contains
              tagname = "norm8wt"//C_NULL_CHAR
              !*** MOAB: iMOAB_SetDoubleTagStorage - Set tag values on mesh elements
              ierr = iMOAB_SetDoubleTagStorage (mapper%src_mbid, tagname, lsize_src , mapper%tag_entity_type, wghts)
-             if (ierr .ne. 0) then
-                write(logunit,*) subname,' error setting init value for mapping norm factor ',ierr,trim(tagname)
+              if (ierr .ne. 0) then
+                 write(logunit,*) subname,' error setting init value for mapping norm factor ',ierr,trim(tagname)
                 call shr_sys_abort(subname//' ERROR setting norm init value') ! serious enough
              endif
 #ifdef MOABDEBUG
@@ -599,7 +599,7 @@ contains
                 !*** MOAB: iMOAB_GetDoubleTagStorage - Get current field values
                 ierr = iMOAB_GetDoubleTagStorage (mapper%src_mbid, fldlist_moab, arrsize_src , mapper%tag_entity_type, targtags)
                 if (ierr .ne. 0) then
-                   write(logunit,*) subname,' error getting source tag values ', mapper%mbname, mapper%src_mbid, trim(fldlist_moab), arrsize_src, mapper%tag_entity_type
+                   write(logunit,*) subname,' error getting source tag values ', mapper%mbname, mapper%src_mbid, fldlist_moab(1:index(fldlist_moab,C_NULL_CHAR)-1), arrsize_src, mapper%tag_entity_type
                    call shr_sys_abort(subname//' ERROR getting source tag values') ! serious enough
                 endif
 
@@ -637,7 +637,7 @@ contains
           !*** where projection weights will be applied.
           ierr = iMOAB_SendElementTag( mapper%src_mbid, fldlist_moab, mapper%mpicom, mapper%intx_context )
           if (ierr .ne. 0) then
-             write(logunit, *) subname,' iMOAB mapper error in sending tags ', mapper%mbname,  trim(fldlist_moab)
+             write(logunit, *) subname,' iMOAB mapper error in sending tags ', mapper%mbname,  fldlist_moab(1:index(fldlist_moab,C_NULL_CHAR)-1)
              call shr_sys_flush(logunit)
              call shr_sys_abort(subname//' ERROR in sending tags')
           endif
@@ -651,12 +651,12 @@ contains
 #ifdef MOABDEBUG
           if (seq_comm_iamroot(CPLID)) then
              write(logunit, *) subname,' iMOAB mapper receiving tags with intx and intx_mbid: ', &
-                mapper%mbname, trim(fldlist_moab), ' moab step:', num_moab_exports
+                mapper%mbname, fldlist_moab(1:index(fldlist_moab,C_NULL_CHAR)-1), ' moab step:', num_moab_exports
           endif
 #endif
           ierr = iMOAB_ReceiveElementTag( mapper%intx_mbid, fldlist_moab, mapper%mpicom, mapper%src_context )
           if (ierr .ne. 0) then
-             write(logunit,*) subname,' error in receiving tags ', mapper%mbname, 'recv:',  mapper%intx_mbid, trim(fldlist_moab)
+             write(logunit,*) subname,' error in receiving tags ', mapper%mbname, 'recv:',  mapper%intx_mbid, fldlist_moab(1:index(fldlist_moab,C_NULL_CHAR)-1)
              call shr_sys_flush(logunit)
              call shr_sys_abort(subname//' ERROR in receiving tags')
              !valid_moab_context = .false. ! do not attempt to project
@@ -664,7 +664,7 @@ contains
           !*** MOAB: iMOAB_FreeSenderBuffers - Release MPI send buffers
           ierr = iMOAB_FreeSenderBuffers( mapper%src_mbid, mapper%intx_context )
           if (ierr .ne. 0) then
-             write(logunit,*) subname,' error in freeing buffers ', trim(fldlist_moab)
+             write(logunit,*) subname,' error in freeing buffers ', fldlist_moab(1:index(fldlist_moab,C_NULL_CHAR)-1)
              call shr_sys_abort(subname//' ERROR in freeing buffers') ! serious enough
           endif
        endif
@@ -676,7 +676,7 @@ contains
 
 #ifdef MOABDEBUG
           if (seq_comm_iamroot(CPLID)) then
-             write(logunit, *) subname,' iMOAB projection mapper: ',trim(mapper%mbname), ' between ', mapper%src_mbid, ' and ',  mapper%tgt_mbid, trim(fldlist_moab), &
+             write(logunit, *) subname,' iMOAB projection mapper: ',trim(mapper%mbname), ' between ', mapper%src_mbid, ' and ',  mapper%tgt_mbid, fldlist_moab(1:index(fldlist_moab,C_NULL_CHAR)-1), &
                 ' moab step:', num_moab_exports
              call shr_sys_flush(logunit)
           endif
@@ -766,8 +766,8 @@ contains
 
              !*** MOAB: Get mapped normalization weights on target grid
              ierr = iMOAB_GetDoubleTagStorage (mapper%tgt_mbid, tagname, lsize_tgt , mapper%tag_entity_type, wghts)
-             if (ierr .ne. 0) then
-                write(logunit,*) subname,' error getting value for mapping norm factor post-map ', ierr, trim(tagname)
+              if (ierr .ne. 0) then
+                 write(logunit,*) subname,' error getting value for mapping norm factor post-map ', ierr, trim(tagname)
                 call shr_sys_abort(subname//' ERROR getting norm factor') ! serious enough
              endif
 

--- a/driver-moab/main/seq_map_mod.F90
+++ b/driver-moab/main/seq_map_mod.F90
@@ -245,7 +245,7 @@ contains
     endif
 
     ierr = iMOAB_LoadMapFile( mapper%src_mbid, mapper%tgt_mbid, mapper%intx_mbid, discretization_type, &
-                                 discretization_type, arearead, map_identifier, mapfile_term)
+                                 discretization_type, arearead, trim(map_identifier)//C_NULL_CHAR, mapfile_term)
     if (ierr .ne. 0) then
        write(logunit,*) subname,' error in loading map file - ' // mapfile
        call shr_sys_abort(subname//' ERROR in loading map file - ' // mapfile)
@@ -697,7 +697,7 @@ contains
           !***   fldlist_moab: Input and output field names (can be different)
           if(.not.use_nonlinear_map) then
              filter_type = 0 ! CAAS_NONE: plain low-order projection
-             ierr = iMOAB_ApplyScalarProjectionWeights ( mapper%intx_mbid, filter_type, mapper%weight_identifier, &
+             ierr = iMOAB_ApplyScalarProjectionWeights ( mapper%intx_mbid, filter_type, trim(mapper%weight_identifier)//C_NULL_CHAR, &
                trim(fldlist_moab)//C_NULL_CHAR, trim(fldlist_moab)//C_NULL_CHAR)
              if (ierr .ne. 0) then
                 write(logunit,*) subname,' error in applying weights '
@@ -746,7 +746,7 @@ contains
                 ! iMOAB takes the plain ApplyWeights branch (no dual-map CAAS)
                 filter_type = 0
                 ierr = iMOAB_ApplyScalarProjectionWeights ( mapper%intx_mbid, filter_type, &
-                       mapper%weight_identifier, fldlist_lo_only, fldlist_lo_only )
+                       trim(mapper%weight_identifier)//C_NULL_CHAR, fldlist_lo_only, fldlist_lo_only )
                 if (ierr .ne. 0) then
                    write(logunit,*) subname,' error in applying weights (excluded fields + norm8wt, low-order)'
                    call shr_sys_abort(subname//' ERROR in applying weights (excluded fields + norm8wt, low-order)')

--- a/driver-moab/main/seq_map_mod.F90
+++ b/driver-moab/main/seq_map_mod.F90
@@ -453,20 +453,18 @@ contains
        ! CAAS list mishandles it: the high-order map of constant 1.0 is not
        ! row-sum-1, so the CAAS-clipped result no longer matches MCT's
        ! mct_sMat_avMult-mapped target norm8wt that the post-divide expects.
-       fldlist_data = trim(fldlist_moab)//C_NULL_CHAR
+        fldlist_data = trim(fldlist_moab)
 
-       if (mbnorm) then
-          fldlist_moab = trim(fldlist_moab)//":norm8wt"//C_NULL_CHAR
-          nfields=nfields + 1
-       else
-          fldlist_moab = trim(fldlist_moab)//C_NULL_CHAR
-       endif
+        if (mbnorm) then
+           fldlist_moab = trim(fldlist_moab)//":norm8wt"
+           nfields=nfields + 1
+        endif
 
 
 #ifdef MOABDEBUG
        if (seq_comm_iamroot(CPLID)) then
           write(logunit,*) subname, 'iMOAB mapper ',trim(mapper%mbname), ' iMOAB_mapper  nfields', &
-                nfields,  ' fldlist_moab=', fldlist_moab(1:index(fldlist_moab,C_NULL_CHAR)-1), ' moab step ', num_moab_exports
+                nfields,  ' fldlist_moab=', trim(fldlist_moab), ' moab step ', num_moab_exports
           call shr_sys_flush(logunit)
        endif
 #endif
@@ -489,7 +487,7 @@ contains
        if ( valid_moab_context ) then
 #ifdef MOABDEBUG
           if (seq_comm_iamroot(CPLID)) then
-             write(logunit, *) subname,' iMOAB mapper rearrange or copy ', mapper%mbname, ' send/recv tags ', fldlist_moab(1:index(fldlist_moab,C_NULL_CHAR)-1), &
+             write(logunit, *) subname,' iMOAB mapper rearrange or copy ', mapper%mbname, ' send/recv tags ', trim(fldlist_moab), &
                ' mbpresent=', mbpresent, ' mbnorm=', mbnorm, ' moab step:', num_moab_exports
              call shr_sys_flush(logunit)
           endif
@@ -500,9 +498,9 @@ contains
           !***   fldlist_moab: Colon-delimited list of tag names to send
           !***   mpicom: MPI communicator
           !***   intx_context: Context ID for the intersection/target app
-          ierr = iMOAB_SendElementTag( mapper%src_mbid, fldlist_moab, mapper%mpicom, mapper%intx_context );
+          ierr = iMOAB_SendElementTag( mapper%src_mbid, trim(fldlist_moab)//C_NULL_CHAR, mapper%mpicom, mapper%intx_context );
           if (ierr .ne. 0) then
-             write(logunit, *) subname,' iMOAB mapper ', mapper%mbname, ' error in sending tags ', fldlist_moab(1:index(fldlist_moab,C_NULL_CHAR)-1), ierr
+             write(logunit, *) subname,' iMOAB mapper ', mapper%mbname, ' error in sending tags ', trim(fldlist_moab), ierr
              call shr_sys_flush(logunit)
              call shr_sys_abort(subname//' ERROR in sending tags')
           endif
@@ -512,9 +510,9 @@ contains
           !***   fldlist_moab: Colon-delimited list of tag names to receive
           !***   mpicom: MPI communicator
           !***   src_context: Context ID for the source app
-          ierr = iMOAB_ReceiveElementTag( mapper%tgt_mbid, fldlist_moab, mapper%mpicom, mapper%src_context );
+          ierr = iMOAB_ReceiveElementTag( mapper%tgt_mbid, trim(fldlist_moab)//C_NULL_CHAR, mapper%mpicom, mapper%src_context );
           if (ierr .ne. 0) then
-             write(logunit,*) subname,' error in receiving tags iMOAB mapper ', mapper%mbname,  fldlist_moab(1:index(fldlist_moab,C_NULL_CHAR)-1)
+             write(logunit,*) subname,' error in receiving tags iMOAB mapper ', mapper%mbname,  trim(fldlist_moab)
              call shr_sys_flush(logunit)
              call shr_sys_abort(subname//' ERROR in receiving tags')
           endif
@@ -522,7 +520,7 @@ contains
           !*** Must be called after receive completes to free memory.
           ierr = iMOAB_FreeSenderBuffers( mapper%src_mbid, mapper%intx_context )
           if (ierr .ne. 0) then
-             write(logunit,*) subname,' error in freeing buffers ', fldlist_moab(1:index(fldlist_moab,C_NULL_CHAR)-1)
+             write(logunit,*) subname,' error in freeing buffers ', trim(fldlist_moab)
              call shr_sys_abort(subname//' ERROR in freeing buffers') ! serious enough
           endif
        endif ! if (valid_moab_context)
@@ -597,9 +595,9 @@ contains
                 arrsize_src=lsize_src*(nfields)
 
                 !*** MOAB: iMOAB_GetDoubleTagStorage - Get current field values
-                ierr = iMOAB_GetDoubleTagStorage (mapper%src_mbid, fldlist_moab, arrsize_src , mapper%tag_entity_type, targtags)
+                ierr = iMOAB_GetDoubleTagStorage (mapper%src_mbid, trim(fldlist_moab)//C_NULL_CHAR, arrsize_src , mapper%tag_entity_type, targtags)
                 if (ierr .ne. 0) then
-                   write(logunit,*) subname,' error getting source tag values ', mapper%mbname, mapper%src_mbid, fldlist_moab(1:index(fldlist_moab,C_NULL_CHAR)-1), arrsize_src, mapper%tag_entity_type
+                   write(logunit,*) subname,' error getting source tag values ', mapper%mbname, mapper%src_mbid, trim(fldlist_moab), arrsize_src, mapper%tag_entity_type
                    call shr_sys_abort(subname//' ERROR getting source tag values') ! serious enough
                 endif
 
@@ -622,7 +620,7 @@ contains
 #endif
                 !*** MOAB: iMOAB_SetDoubleTagStorage - Store weighted values back to source
                 !*** These weighted values will be sent and mapped to the target grid.
-                ierr = iMOAB_SetDoubleTagStorage (mapper%src_mbid, fldlist_moab, arrsize_src , mapper%tag_entity_type, targtags)
+                ierr = iMOAB_SetDoubleTagStorage (mapper%src_mbid, trim(fldlist_moab)//C_NULL_CHAR, arrsize_src , mapper%tag_entity_type, targtags)
                 if (ierr .ne. 0) then
                    write(logunit,*) subname,' error setting normed source tag values ', mapper%mbname
                    call shr_sys_abort(subname//' ERROR setting normed source tag values') ! serious enough
@@ -635,9 +633,9 @@ contains
           !*** MOAB: Send source data to intersection/coverage mesh
           !*** For full mapping, data goes to the intersection app (intx_context)
           !*** where projection weights will be applied.
-          ierr = iMOAB_SendElementTag( mapper%src_mbid, fldlist_moab, mapper%mpicom, mapper%intx_context )
+          ierr = iMOAB_SendElementTag( mapper%src_mbid, trim(fldlist_moab)//C_NULL_CHAR, mapper%mpicom, mapper%intx_context )
           if (ierr .ne. 0) then
-             write(logunit, *) subname,' iMOAB mapper error in sending tags ', mapper%mbname,  fldlist_moab(1:index(fldlist_moab,C_NULL_CHAR)-1)
+             write(logunit, *) subname,' iMOAB mapper error in sending tags ', mapper%mbname,  trim(fldlist_moab)
              call shr_sys_flush(logunit)
              call shr_sys_abort(subname//' ERROR in sending tags')
           endif
@@ -651,12 +649,12 @@ contains
 #ifdef MOABDEBUG
           if (seq_comm_iamroot(CPLID)) then
              write(logunit, *) subname,' iMOAB mapper receiving tags with intx and intx_mbid: ', &
-                mapper%mbname, fldlist_moab(1:index(fldlist_moab,C_NULL_CHAR)-1), ' moab step:', num_moab_exports
+                mapper%mbname, trim(fldlist_moab), ' moab step:', num_moab_exports
           endif
 #endif
-          ierr = iMOAB_ReceiveElementTag( mapper%intx_mbid, fldlist_moab, mapper%mpicom, mapper%src_context )
+          ierr = iMOAB_ReceiveElementTag( mapper%intx_mbid, trim(fldlist_moab)//C_NULL_CHAR, mapper%mpicom, mapper%src_context )
           if (ierr .ne. 0) then
-             write(logunit,*) subname,' error in receiving tags ', mapper%mbname, 'recv:',  mapper%intx_mbid, fldlist_moab(1:index(fldlist_moab,C_NULL_CHAR)-1)
+             write(logunit,*) subname,' error in receiving tags ', mapper%mbname, 'recv:',  mapper%intx_mbid, trim(fldlist_moab)
              call shr_sys_flush(logunit)
              call shr_sys_abort(subname//' ERROR in receiving tags')
              !valid_moab_context = .false. ! do not attempt to project
@@ -664,7 +662,7 @@ contains
           !*** MOAB: iMOAB_FreeSenderBuffers - Release MPI send buffers
           ierr = iMOAB_FreeSenderBuffers( mapper%src_mbid, mapper%intx_context )
           if (ierr .ne. 0) then
-             write(logunit,*) subname,' error in freeing buffers ', fldlist_moab(1:index(fldlist_moab,C_NULL_CHAR)-1)
+             write(logunit,*) subname,' error in freeing buffers ', trim(fldlist_moab)
              call shr_sys_abort(subname//' ERROR in freeing buffers') ! serious enough
           endif
        endif
@@ -676,7 +674,7 @@ contains
 
 #ifdef MOABDEBUG
           if (seq_comm_iamroot(CPLID)) then
-             write(logunit, *) subname,' iMOAB projection mapper: ',trim(mapper%mbname), ' between ', mapper%src_mbid, ' and ',  mapper%tgt_mbid, fldlist_moab(1:index(fldlist_moab,C_NULL_CHAR)-1), &
+             write(logunit, *) subname,' iMOAB projection mapper: ',trim(mapper%mbname), ' between ', mapper%src_mbid, ' and ',  mapper%tgt_mbid, trim(fldlist_moab), &
                 ' moab step:', num_moab_exports
              call shr_sys_flush(logunit)
           endif
@@ -690,7 +688,7 @@ contains
           if(.not.use_nonlinear_map) then
              filter_type = 0 ! CAAS_NONE: plain low-order projection
              ierr = iMOAB_ApplyScalarProjectionWeights ( mapper%intx_mbid, filter_type, mapper%weight_identifier, &
-               fldlist_moab, fldlist_moab)
+               trim(fldlist_moab)//C_NULL_CHAR, trim(fldlist_moab)//C_NULL_CHAR)
              if (ierr .ne. 0) then
                 write(logunit,*) subname,' error in applying weights '
                 call shr_sys_abort(subname//' ERROR in applying weights')
@@ -775,7 +773,7 @@ contains
              allocate(targtags(lsize_tgt,nfields))
              targtags = 0.0_r8   ! defensive zero-init: see above for wghts
              arrsize_tgt=lsize_tgt*(nfields)
-             ierr = iMOAB_GetDoubleTagStorage (mapper%tgt_mbid, fldlist_moab, arrsize_tgt , mapper%tag_entity_type, targtags)
+             ierr = iMOAB_GetDoubleTagStorage (mapper%tgt_mbid, trim(fldlist_moab)//C_NULL_CHAR, arrsize_tgt , mapper%tag_entity_type, targtags)
              if (ierr .ne. 0) then
                 write(logunit,*) subname,' error getting destination tag values ', mapper%mbname
                 call shr_sys_abort(subname//' ERROR getting source tag values') ! serious enough
@@ -794,7 +792,7 @@ contains
              enddo
 
              !*** MOAB: Store normalized field values back to target mesh
-             ierr = iMOAB_SetDoubleTagStorage (mapper%tgt_mbid, fldlist_moab, arrsize_tgt , mapper%tag_entity_type, targtags)
+             ierr = iMOAB_SetDoubleTagStorage (mapper%tgt_mbid, trim(fldlist_moab)//C_NULL_CHAR, arrsize_tgt , mapper%tag_entity_type, targtags)
              if (ierr .ne. 0) then
                 write(logunit,*) subname,' error getting destination tag values ', mapper%mbname
                 call shr_sys_abort(subname//' ERROR getting source tag values') ! serious enough
@@ -812,7 +810,7 @@ contains
                 endif
 #endif
                 !*** MOAB: Restore original values to source mesh
-                ierr = iMOAB_SetDoubleTagStorage (mapper%src_mbid, fldlist_moab, arrsize_src , mapper%tag_entity_type, targtags_ini)
+                ierr = iMOAB_SetDoubleTagStorage (mapper%src_mbid, trim(fldlist_moab)//C_NULL_CHAR, arrsize_src , mapper%tag_entity_type, targtags_ini)
                 if (ierr .ne. 0) then
                    write(logunit,*) subname,' error setting source tag values ', mapper%mbname
                    call shr_sys_abort(subname//' ERROR setting source tag values') ! serious enough


### PR DESCRIPTION
Fix null characters leaking into log files from the MOAB coupler driver and component MCT drivers.
Keep Fortran strings clean and append C_NULL_CHAR only at each iMOAB_* call site.
Append MOAB C string terminators only at iMOAB call sites

Fixes #8461

[BFB]

---

addresses reviewer feedback from #8462.

## Summary

- Keep `appname`, `infile`, `ropts`, `outfile`, `tagName`, and similar strings as clean Fortran
  strings throughout; append `C_NULL_CHAR` inline at each `iMOAB_*` call site.
- Push `C_NULL_CHAR` into `moab_load_mesh` helper (`cplcomp_moab_helpers_mod.F90`) at the
  `iMOAB_LoadMesh` call so all callers pass clean strings.
- Remove `//C_NULL_CHAR` from variable assignments in `cplcomp_exchange_mod.F90`; append inline
  at `iMOAB_SendElementTag`, `iMOAB_ReceiveElementTag`, and `iMOAB_WriteMesh` calls.
- Keep `appname` clean in all component MCT drivers (`ice_comp_mct.F90`, `atm_comp_mct.F90`,
  `dyn_comp.F90` (3 locations), `lnd_comp_mct.F90`, `MOABGridType.F90`, `rof_comp_mct.F90`);
  append `C_NULL_CHAR` only at `iMOAB_RegisterApplication`.
- In `seq_map_mod.F90`, `fldlist_moab` must remain null-terminated (passed directly to MOAB APIs);
  log statements use inline null-strip `fldlist_moab(1:index(fldlist_moab,C_NULL_CHAR)-1)`.
- Remove dead commented-out code from `seq_io_mod.F90`.

## Problem

Fortran strings were null-terminated before being passed to C/C++ MOAB APIs, which is correct
for C interoperability. The bug was that the same null-terminated variables were also passed to
Fortran `write(logunit,...)` statements. Fortran's `trim()` strips trailing spaces (ASCII 32) but
not null characters (ASCII 0), so the null byte leaked into log output. This caused `file cpl.log`
to report binary data and `grep` to fail without the `-a` flag.

## Fix

The approach in this revision directly addresses reviewer feedback from #8462 (rljacob suggested
keeping strings clean and appending `//C_NULL_CHAR` inline at the call; vijaysm agreed). Instead
of storing the null terminator in the variable and then stripping it for logging, the variable
stays clean and each C API call appends `//C_NULL_CHAR` at the call site. Log statements require
no special handling.

| File | Approach |
|------|----------|
| `driver-moab/main/cplcomp_moab_helpers_mod.F90` | Append `C_NULL_CHAR` inside `moab_load_mesh` at the `iMOAB_LoadMesh` call; callers pass clean strings |
| `driver-moab/main/cplcomp_exchange_mod.F90` | Remove `//C_NULL_CHAR` from variable assignments; append inline at each iMOAB call |
| `driver-moab/main/seq_map_mod.F90` | `fldlist_moab` stays null-terminated (direct API pass); log statements use inline null-strip |
| `driver-moab/main/seq_io_mod.F90` | Remove dead commented-out code |
| `components/cice/src/drivers/cpl/ice_comp_mct.F90` | Clean `appname`; `C_NULL_CHAR` inline at `iMOAB_RegisterApplication` |
| `components/eam/src/cpl/atm_comp_mct.F90` | Clean `appname`; `C_NULL_CHAR` inline at `iMOAB_RegisterApplication` |
| `components/eam/src/dynamics/se/dyn_comp.F90` | Clean `appname` in 3 locations; `C_NULL_CHAR` inline at each `iMOAB_RegisterApplication` |
| `components/elm/src/cpl/lnd_comp_mct.F90` | Clean `appname`; `C_NULL_CHAR` inline at `iMOAB_RegisterApplication` |
| `components/elm/src/data_types/MOABGridType.F90` | Clean `appname`; `C_NULL_CHAR` inline at `iMOAB_RegisterApplication` |
| `components/mosart/src/cpl/rof_comp_mct.F90` | Clean `appname`; `C_NULL_CHAR` inline at `iMOAB_RegisterApplication` |


