### PR TITLE
EAMxx: use FieldReader/read_fields in share folders

### DIFF
--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -577,6 +577,8 @@ void MAMMicrophysics::set_exo_coldens_reader()
 // set DataInterpolation object for elevated emissions reader.
 void MAMMicrophysics::set_elevated_emissions_reader()
 {
+  using namespace ShortFieldTagsNames;
+
   const auto z_iface = get_field_out("z_mam4_int");
   const std::string extfrc_map_file =
         m_params.get<std::string>("aero_microphys_remap_file", "");
@@ -591,8 +593,8 @@ void MAMMicrophysics::set_elevated_emissions_reader()
       vertical_fields.push_back(get_field_out(field_name+"_"+var_name).alias(field_name));
     }
     std::shared_ptr<DataInterpolation> di_vertical = std::make_shared<DataInterpolation>(grid_,vertical_fields);
-    di_vertical->set_input_files_dimname(ShortFieldTagsNames::LEV,"altitude");
-    di_vertical->set_input_files_dimname(ShortFieldTagsNames::ILEV,"altitude_int");
+    di_vertical->set_input_files_dimname(e2str(LEV),"altitude");
+    di_vertical->set_input_files_dimname(e2str(ILEV),"altitude_int");
     di_vertical->setup_time_database ({file_name},util::TimeLine::YearlyPeriodic, DataInterpolation::Linear, ref_ts_vertical);
     di_vertical->create_horiz_remappers (extfrc_map_file=="none" ? "" : extfrc_map_file);
     di_vertical->set_logger(m_atm_logger);

--- a/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
+++ b/components/eamxx/src/physics/nudging/eamxx_nudging_process_interface.cpp
@@ -1,7 +1,8 @@
 #include "eamxx_nudging_process_interface.hpp"
 
-#include "share/util/eamxx_universal_constants.hpp"
+#include "share/io/scorpio_input.hpp"
 #include "share/remap/horizontal_remapper.hpp"
+#include "share/util/eamxx_universal_constants.hpp"
 #include "share/util/eamxx_utils.hpp"
 #include "share/scorpio_interface/eamxx_scorpio_interface.hpp"
 

--- a/components/eamxx/src/share/algorithm/eamxx_data_interpolation.cpp
+++ b/components/eamxx/src/share/algorithm/eamxx_data_interpolation.cpp
@@ -6,8 +6,8 @@
 #include "share/remap/iop_remapper.hpp"
 #include "share/grid/point_grid.hpp"
 #include "share/scorpio_interface/eamxx_scorpio_interface.hpp"
-#include "share/io/scorpio_input.hpp"
 #include "share/io/eamxx_io_utils.hpp"
+#include "share/field/field_reader.hpp"
 #include "share/util/eamxx_universal_constants.hpp"
 #include "share/util/eamxx_utils.hpp"
 #include "share/physics/physics_constants.hpp"
@@ -41,12 +41,17 @@ DataInterpolation (const std::shared_ptr<const AbstractGrid>& model_grid,
     m_fields_have_lev_dim |= fl.has_tag(ILEV);
   }
 
-  m_input_files_dimnames[COL] = "ncol";
-  m_input_files_dimnames[LEV] = "lev";
-  m_input_files_dimnames[ILEV] = "ilev";
+  for (auto t : {COL,LEV,ILEV})
+    m_input_files_dimnames[e2str(t)] = e2str(t);
 
   // Initialize logger with a console logger for warnings (logs on all ranks)
   m_logger = console_logger(ekat::logger::LogLevel::warn);
+}
+
+void DataInterpolation::
+set_input_files_dimname (const std::string& name, const std::string& nc_name)
+{
+  m_input_files_dimnames[name] = nc_name;
 }
 
 void DataInterpolation::
@@ -168,26 +173,37 @@ update_end_fields ()
   for (int i=0; i<m_nfields; ++i) {
     fields.push_back(m_horiz_remapper_end->get_src_field(i));
   }
-
   if (m_vr_type==Dynamic3D or m_vr_type==Dynamic3DRef) {
     // We also need to read the src pressure profile
     fields.push_back(m_horiz_remapper_end->get_src_field(m_nfields));
   }
-  m_reader->set_fields(fields);
 
   // If we're also changing the file, must (re)init the scorpio structures
   const auto& slice_beg = m_time_database.slices[m_curr_interval_idx.first];
   const auto& slice_end = m_time_database.slices[m_curr_interval_idx.second];
-  if (m_reader->get_filename()!=slice_end.filename) {
-    m_reader->reset_filename(slice_end.filename);
+
+  if (not m_reader) {
+    // NOTE: Sometimes the original data does not use the same field tags as eamxx.
+    // For these cases, we need to perform a shallow clone of
+    // io_grid because the tags are constant in this object.
+    using namespace ShortFieldTagsNames;
+    auto grid = m_horiz_remapper_beg->get_src_grid()->clone(m_horiz_remapper_beg->get_src_grid()->name(), true);
+
+    auto gids = grid->get_partitioned_dim_gids();
+    auto comm = grid->get_comm();
+    m_reader = std::make_shared<FieldReader>();
+    m_reader->set_dim_decomp(gids,comm);
   }
+  // This triggers opening of a new file at read time ONLY if the filename/fields have changed
+  m_reader->set_file_specs(slice_end.filename,m_input_files_dimnames);
+  m_reader->set_fields(fields);
 
   // Read and interpolate fields
   m_logger->info("[DataInterpolation] Reading end of interval fields.");
   m_logger->info(" - interval: [" + slice_beg.time.to_string() + ", " + slice_end.time.to_string() + "]");
   m_logger->info(" - filename: " + slice_end.filename);
   m_logger->info(" - file time idx: " + std::to_string(slice_end.time_idx));
-  m_reader->read_variables(slice_end.time_idx);
+  m_reader->read(slice_end.time_idx);
   m_horiz_remapper_end->remap_fwd();
 }
 
@@ -198,24 +214,6 @@ init_data_interval (const util::TimeStamp& t0)
       "[DataInterpolation] Error! Cannot call 'init_data_interval' until after remappers creation.\n");
 
   register_fields_in_remappers ();
-
-  // Create a bare reader. Fields and filename are set inside the update_end_fields call
-  strvec_t fnames;
-  for (auto f : m_fields) {
-    fnames.push_back(f.name());
-  }
-
-  // NOTE: Sometimes the original data does not use the same field tags as eamxx.
-  // For these cases, we need to perform a shallow clone of
-  // io_grid because the tags are constant in this object.
-  using namespace ShortFieldTagsNames;
-  auto horiz_interp_src_grid =
-        m_horiz_remapper_beg->get_src_grid()->clone(m_horiz_remapper_beg->get_src_grid()->name(), true);
-  horiz_interp_src_grid->reset_field_tag_name(COL, m_input_files_dimnames[COL]);
-  horiz_interp_src_grid->reset_field_tag_name(LEV, m_input_files_dimnames[LEV]);
-  horiz_interp_src_grid->reset_field_tag_name(ILEV, m_input_files_dimnames[ILEV]);
-
-  m_reader = std::make_shared<AtmosphereInput>(fnames,horiz_interp_src_grid);
 
   // Loop over all stored time slices to find an interval that contains t0
   auto t0_interval = m_time_database.find_interval(t0);
@@ -434,12 +432,12 @@ create_horiz_remappers (const std::string& map_file)
 
   // Create hremap tgt grid
   int nlevs_data = nlevs_model;
-  int ncols_data = m_fields_have_col_dim ? get_input_files_dimlen (m_input_files_dimnames[COL]) : ncols_model;
+  int ncols_data = m_fields_have_col_dim ? get_input_files_dimlen (m_input_files_dimnames[e2str(COL)]) : ncols_model;
 
   if (m_fields_have_lev_dim) {
-    nlevs_data = get_input_files_dimlen (m_input_files_dimnames[LEV]);
+    nlevs_data = get_input_files_dimlen (m_input_files_dimnames[e2str(LEV)]);
   } else if (m_fields_have_ilev_dim) {
-    nlevs_data = get_input_files_dimlen(m_input_files_dimnames[ILEV]);
+    nlevs_data = get_input_files_dimlen(m_input_files_dimnames[e2str(ILEV)]);
   }
 
   m_data_grid = create_point_grid(m_name+"_data",ncols_data,nlevs_data,m_model_grid->get_comm(),1);
@@ -481,17 +479,16 @@ create_horiz_remappers (const Real iop_lat, const Real iop_lon)
   int nlevs_model = m_model_grid->get_num_vertical_levels();
 
   // Create hremap tgt grid
-  int nlevs_data = m_fields_have_lev_dim ? get_input_files_dimlen (m_input_files_dimnames[LEV]) : nlevs_model;
-  int ncols_data = m_fields_have_col_dim ? get_input_files_dimlen (m_input_files_dimnames[COL]) : ncols_model;
+  int nlevs_data = m_fields_have_lev_dim ? get_input_files_dimlen (m_input_files_dimnames[e2str(LEV)]) : nlevs_model;
+  int ncols_data = m_fields_have_col_dim ? get_input_files_dimlen (m_input_files_dimnames[e2str(COL)]) : ncols_model;
 
   // Create grid for IO and load lat/lon field in IO grid from any data file
   m_data_grid = create_point_grid(m_name+"_data",ncols_data,nlevs_data,m_model_grid->get_comm());
-  std::vector<Field> latlon = {
-    m_data_grid->create_geometry_data("lat",m_data_grid->get_2d_scalar_layout()),
-    m_data_grid->create_geometry_data("lon",m_data_grid->get_2d_scalar_layout())
-  };
-  AtmosphereInput latlon_reader (m_time_database.files.front(),m_data_grid,latlon);
-  latlon_reader.read_variables();
+  auto lat  = m_data_grid->create_geometry_data("lat",m_data_grid->get_2d_scalar_layout());
+  auto lon  = m_data_grid->create_geometry_data("lon",m_data_grid->get_2d_scalar_layout());
+  auto gids = m_data_grid->get_partitioned_dim_gids();
+  auto comm = m_data_grid->get_comm();
+  read_fields(m_time_database.files.front(),{lat,lon},gids,comm);
 
   // Create iop remap tgt grid
   m_grid_after_hremap = m_model_grid->clone(m_name+"_post_hremap",true);
@@ -627,17 +624,14 @@ create_vert_remapper (const VertRemapData& data)
       // We read and store hyam/hybm in the vremap src grid
       auto layout = m_grid_after_hremap->get_vertical_layout(LEVP);
       DataType real_t = DataType::RealType;
-      std::vector<Field> fields = {
-        m_grid_after_hremap->create_geometry_data("hyam",layout,ekat::units::none,real_t,SCREAM_PACK_SIZE),
-        m_grid_after_hremap->create_geometry_data("hybm",layout,ekat::units::none,real_t,SCREAM_PACK_SIZE)
-      };
-      AtmosphereInput hvcoord_reader (m_time_database.files.front(),m_grid_after_hremap,fields,true);
-      hvcoord_reader.read_variables();
+      auto hyam = m_grid_after_hremap->create_geometry_data("hyam",layout,ekat::units::none,real_t,SCREAM_PACK_SIZE);
+      auto hybm = m_grid_after_hremap->create_geometry_data("hybm",layout,ekat::units::none,real_t,SCREAM_PACK_SIZE);
+      read_fields (m_time_database.files.front(),{hyam,hybm});
     } else if (m_vr_type==Static1D) {
       // Can load p now, since it's static
       std::vector<Field> fields = {p_data.alias(data.pname)};
-      AtmosphereInput p_data_reader (m_time_database.files.front(),m_grid_after_hremap,fields,true);
-      p_data_reader.read_variables();
+      auto gids = m_grid_after_hremap->get_partitioned_dim_gids();
+      read_fields(m_time_database.files.front(),fields);
     }
     vremap->set_source_pressure (m_helper_pressure_fields["p_data"]);
 

--- a/components/eamxx/src/share/algorithm/eamxx_data_interpolation.hpp
+++ b/components/eamxx/src/share/algorithm/eamxx_data_interpolation.hpp
@@ -5,13 +5,12 @@
 #include "share/remap/abstract_remapper.hpp"
 #include "share/util/eamxx_time_stamp.hpp"
 #include "share/field/field.hpp"
+#include "share/field/field_reader.hpp"
 
 #include <ekat_logger.hpp>
 
 namespace scream
 {
-
-class AtmosphereInput;
 
 class DataInterpolation
 {
@@ -59,8 +58,8 @@ public:
                             const TimeInterpType interp_type = Linear,
                             const util::TimeStamp& ref_ts = util::TimeStamp());
 
-  // In case the input files store col/lev dims with exhotic names, the user can provide them here
-  void set_input_files_dimname (const FieldTag t, const std::string& name) { m_input_files_dimnames[t] = name; }
+  // In case the input files store dims with exhotic names, the user can provide them here
+  void set_input_files_dimname (const std::string& name, const std::string& nc_name);
 
   void create_horiz_remappers (const std::string& map_file = "");
   void create_horiz_remappers (const Real iop_lat, const Real iop_lon);
@@ -106,7 +105,7 @@ protected:
 
   // --------------- Internal data ------------- //
 
-  std::shared_ptr<AtmosphereInput> m_reader;
+  std::shared_ptr<FieldReader> m_reader;
 
   std::shared_ptr<const AbstractGrid> m_model_grid;
 
@@ -123,7 +122,7 @@ protected:
 
   // These are inited as the usual "ncol" and "lev" at construction, but the user
   // can reset them in case the input files store funky dimensions
-  std::map<FieldTag,std::string>    m_input_files_dimnames;
+  std::map<std::string,std::string>    m_input_files_dimnames;
 
   // If vertical remap happens, at runtime we may need to access some
   // versions of certain perssure fields. Store them here for convenient access

--- a/components/eamxx/src/share/algorithm/eamxx_time_interpolation.cpp
+++ b/components/eamxx/src/share/algorithm/eamxx_time_interpolation.cpp
@@ -28,7 +28,7 @@ TimeInterpolation::TimeInterpolation(
 void TimeInterpolation::finalize()
 {
   if (m_is_data_from_file) {
-    m_file_data_atm_input = nullptr;
+    m_field_reader = nullptr;
     m_is_data_from_file = false;
   }
 }
@@ -109,13 +109,12 @@ void TimeInterpolation::add_field(const Field& field_in, const bool store_shallo
  */
 void TimeInterpolation::shift_data()
 {
+  std::swap(m_fm_time0,m_fm_time1);
+  std::vector<Field> fields;
   for (auto name : m_field_names)
-  {
-    auto& field0 = m_fm_time0->get_field(name);
-    auto& field1 = m_fm_time1->get_field(name);
-    std::swap(field0,field1);
-  }
-  m_file_data_atm_input->set_field_manager(m_fm_time1);
+    fields.push_back(m_fm_time1->get_field(name));
+
+  m_field_reader->set_fields(fields);
 }
 /*-----------------------------------------------------------------------------------------------*/
 /* Function which will initialize the TimeStamps.
@@ -158,12 +157,16 @@ void TimeInterpolation::initialize_data_from_field(const Field& field_in)
 void TimeInterpolation::initialize_data_from_files()
 {
   auto triplet_curr = m_file_data_triplets[m_triplet_idx];
-  // Initialize the AtmosphereInput object that will be used to gather data
-  ekat::ParameterList input_params;
-  input_params.set("field_names",m_field_names);
-  input_params.set("filename",triplet_curr.filename);
-  m_file_data_atm_input = std::make_shared<AtmosphereInput>(input_params,m_fm_time1);
-  m_file_data_atm_input->set_logger(m_logger);
+
+  auto gids = m_fm_time1->get_grid()->get_partitioned_dim_gids();
+  auto comm = m_fm_time1->get_grid()->get_comm();
+  std::vector<Field> fields;
+  for (auto n : m_field_names)
+    fields.push_back(m_fm_time1->get_field(n));
+  m_field_reader = std::make_shared<FieldReader>();
+  m_field_reader->set_file_specs(triplet_curr.filename);
+  m_field_reader->set_dim_decomp(gids,comm);
+  m_field_reader->set_fields(fields);
 
   // Read first snap of data and shift to time0
   read_data();
@@ -292,18 +295,13 @@ void TimeInterpolation::set_file_data_triplets(const vos_type& list_of_files) {
 void TimeInterpolation::read_data()
 {
   const auto triplet_curr = m_file_data_triplets[m_triplet_idx];
-  if (not m_file_data_atm_input or triplet_curr.filename != m_file_data_atm_input->get_filename()) {
-    // Then we need to close this input stream and open a new one
-    ekat::ParameterList input_params;
-    input_params.set("field_names",m_field_names);
-    input_params.set("filename",triplet_curr.filename);
-    m_file_data_atm_input = std::make_shared<AtmosphereInput>(input_params,m_fm_time1);
-    m_file_data_atm_input->set_logger(m_logger);
-  }
+
+  // If the filename has not changed, this is a no-op.
+  m_field_reader->set_file_specs(triplet_curr.filename);
 
   m_logger->info(m_header);
   m_logger->info("[EAMxx:time_interpolation] Reading data at time " + triplet_curr.timestamp.to_string());
-  m_file_data_atm_input->read_variables(triplet_curr.time_idx);
+  m_field_reader->read(triplet_curr.time_idx);
   m_time1 = triplet_curr.timestamp;
 }
 /*-----------------------------------------------------------------------------------------------*/

--- a/components/eamxx/src/share/algorithm/eamxx_time_interpolation.hpp
+++ b/components/eamxx/src/share/algorithm/eamxx_time_interpolation.hpp
@@ -3,13 +3,12 @@
 
 #include "share/grid/abstract_grid.hpp"
 
+#include "share/field/field_reader.hpp"
 #include "share/util/eamxx_time_stamp.hpp"
 #include "share/util/eamxx_utils.hpp"
 
 #include "share/field/field.hpp"
 #include "share/data_managers/field_manager.hpp"
-
-#include "share/io/scorpio_input.hpp"
 
 namespace scream{
 namespace util {
@@ -87,7 +86,7 @@ protected:
   // Variables related to the case where we use data from file
   std::vector<DataFromFileTriplet>           m_file_data_triplets;
   int                                        m_triplet_idx;
-  std::shared_ptr<AtmosphereInput>           m_file_data_atm_input;
+  std::shared_ptr<FieldReader>               m_field_reader;
   bool                                       m_is_data_from_file=false;
 
   std::shared_ptr<ekat::logger::LoggerBase>  m_logger = console_logger(ekat::logger::LogLevel::warn);

--- a/components/eamxx/src/share/data_managers/IOPDataManager.cpp
+++ b/components/eamxx/src/share/data_managers/IOPDataManager.cpp
@@ -2,6 +2,7 @@
 #include "share/remap/iop_remapper.hpp"
 #include "share/scorpio_interface/eamxx_scorpio_interface.hpp"
 #include "share/data_managers/IOPDataManager.hpp"
+#include "share/field/field_reader.hpp"
 
 #include <ekat_assert.hpp>
 #include <ekat_pack.hpp>
@@ -11,59 +12,6 @@
 #include <numeric>
 
 namespace scream {
-
-namespace {
-
-void read_fields (const std::string& filename,
-                  const std::shared_ptr<const AbstractGrid>& grid,
-                  std::vector<Field>& fields)
-{
-  using gid_type = AbstractGrid::gid_type;
-
-  scorpio::register_file(filename,scorpio::Read);
-
-  // Some input files have the "time" dimension as non-unlimited. This messes up our
-  // scorpio interface, which stores a pointer to a "time" dim to be used to read/write
-  // slices. This ptr is automatically inited to the unlimited dim in the file. If there is
-  // no unlim dim, this ptr remains uninited.
-  if (not scorpio::has_time_dim(filename) and scorpio::has_dim(filename,"time")) {
-    scorpio::mark_dim_as_time(filename,"time");
-  }
-
-  auto min_gid = grid->get_global_min_partitioned_dim_gid();
-  auto gids_h = grid->get_dofs_gids().get_view<const gid_type*,Host>();
-  std::vector<scorpio::offset_t> offsets(gids_h.size());
-  for (size_t i=0; i<gids_h.size(); ++i) {
-    offsets[i] = gids_h[i]-min_gid;
-  }
-  const auto decomp_tag  = grid->get_partitioned_dim_tag();
-  std::string decomp_dim = grid->has_special_tag_name(decomp_tag)
-                         ? grid->get_special_tag_name(decomp_tag)
-                         : e2str(decomp_tag);
-
-  scorpio::set_dim_decomp(filename,decomp_dim,offsets);
-  for (auto& f : fields) {
-    EKAT_REQUIRE_MSG (f.get_header().get_parent()==nullptr,
-        "Error! Fields to be read from file in IOPDataManager should not be subfields.\n"
-        " - field name: " + f.name() + "\n"
-        " - parent field name: " + f.get_header().get_parent()->get_identifier().name() + "\n");
-
-    if (f.get_header().get_alloc_properties().get_padding()==0 and
-        f.get_header().get_alloc_properties().contiguous()) {
-      scorpio::read_var(filename,f.name(),f.get_internal_view_data<Real,Host>());
-      f.sync_to_dev();
-    } else {
-      // Create non-padded, contiguous clone
-      auto f_no_padding = f.clone();
-      scorpio::read_var(filename,f.name(),f_no_padding.get_internal_view_data<Real,Host>());
-      f_no_padding.sync_to_dev();
-      f.deep_copy(f_no_padding);
-    }
-  }
-  scorpio::release_file(filename);
-}
-
-} // anonymous namespace
 
 IOPDataManager::
 IOPDataManager(const ekat::Comm& comm,
@@ -370,7 +318,7 @@ setup_io_info(const std::string& file_name,
       grid->create_geometry_data("lat",grid->get_2d_scalar_layout()),
       grid->create_geometry_data("lon",grid->get_2d_scalar_layout())
     };
-    read_fields(file_name,grid,latlon);
+    read_fields(file_name,latlon,grid->get_partitioned_dim_gids(),grid->get_comm());
 
     m_io_grids[grid_name] = grid;
   }
@@ -389,11 +337,13 @@ read_fields_from_file_for_iop (const std::string& file_name,
       "Error! Attempting to read IOP initial conditions on" +
       grid->name() + " grid, but m_io_grid entry has not been created.\n");
 
+  std::map<std::string,std::string> tag_rename;
   if (grid->name()=="physics_gll" and scorpio::has_dim(file_name,"ncol_d")) {
     // If we are on GLL grid, and nc file contains "ncol_d" dimension, we need to reset COL dim tag
     auto grid = io_grid->clone(io_grid->name(),true);
     grid->reset_field_tag_name(FieldTag::Column,"ncol_d");
     io_grid = grid;
+    tag_rename["ncol"] = "ncol_d";
   }
 
   // Create IOP remapper
@@ -411,7 +361,11 @@ read_fields_from_file_for_iop (const std::string& file_name,
   for (int i=0; i<remapper->get_num_fields(); ++i) {
     io_fields.push_back(remapper->get_src_field(i));
   }
-  read_fields(file_name,io_grid,io_fields);
+  FieldReader reader;
+  reader.set_file_specs(file_name,tag_rename);
+  reader.set_fields(io_fields);
+  reader.set_dim_decomp(io_grid->get_partitioned_dim_gids(),io_grid->get_comm());
+  reader.read();
 
   // Remap
   remapper->remap_fwd();

--- a/components/eamxx/src/share/data_managers/mesh_free_grids_manager.cpp
+++ b/components/eamxx/src/share/data_managers/mesh_free_grids_manager.cpp
@@ -1,8 +1,10 @@
 #include "share/data_managers/mesh_free_grids_manager.hpp"
+
 #include "share/grid/point_grid.hpp"
 #include "share/grid/se_grid.hpp"
 #include "share/property_checks/field_nan_check.hpp"
 #include "share/property_checks/field_within_interval_check.hpp"
+#include "share/field/field_reader.hpp"
 #include "share/scorpio_interface/eamxx_scorpio_interface.hpp"
 
 #include "share/physics/physics_constants.hpp"
@@ -208,36 +210,13 @@ add_geo_data (const nonconstgrid_ptr_type& grid) const
 void MeshFreeGridsManager::
 load_lat_lon (const nonconstgrid_ptr_type& grid, const std::string& filename) const
 {
-  using gid_type = AbstractGrid::gid_type;
-
   auto degN = ekat::units::none.rename("degrees_north");
   auto degE = ekat::units::none.rename("degrees_east");
 
   auto lat = grid->create_geometry_data("lat" , grid->get_2d_scalar_layout(), degN);
   auto lon = grid->create_geometry_data("lon" , grid->get_2d_scalar_layout(), degE);
 
-  auto lat_v = lat.get_view<Real*,Host>();
-  auto lon_v = lon.get_view<Real*,Host>();
-
-  auto min_gid = grid->get_global_min_partitioned_dim_gid();
-  auto gids_h = grid->get_dofs_gids().get_view<const gid_type*,Host>();
-  std::vector<scorpio::offset_t> offsets(gids_h.size());
-  for (size_t i=0; i<gids_h.size(); ++i) {
-    offsets[i] = gids_h[i]-min_gid;
-  }
-  const auto decomp_tag  = grid->get_partitioned_dim_tag();
-  std::string decomp_dim = grid->has_special_tag_name(decomp_tag)
-                         ? grid->get_special_tag_name(decomp_tag)
-                         : e2str(decomp_tag);
-
-  scorpio::register_file(filename,scorpio::Read);
-  scorpio::set_dim_decomp(filename,decomp_dim,offsets);
-  scorpio::read_var(filename,"lat",lat_v.data());
-  scorpio::read_var(filename,"lon",lon_v.data());
-  scorpio::release_file(filename);
-
-  lat.sync_to_dev();
-  lon.sync_to_dev();
+  read_fields(filename,{lat,lon},grid->get_partitioned_dim_gids(),grid->get_comm());
 
 #ifndef NDEBUG
   auto lat_check = std::make_shared<FieldNaNCheck>(lat,grid)->check();
@@ -266,21 +245,7 @@ load_vertical_coordinates (const nonconstgrid_ptr_type& grid, const std::string&
   auto lev  = grid->create_geometry_data("lev",  layout_mid, mbar);
   auto ilev = grid->create_geometry_data("ilev", layout_int, mbar);
 
-  auto hyam_v  = hyam.get_view<Real*,Host>();
-  auto hybm_v  = hybm.get_view<Real*,Host>();
-  auto hyai_v  = hyai.get_view<Real*,Host>();
-  auto hybi_v  = hybi.get_view<Real*,Host>();
-  auto lev_v   = lev.get_view<Real*,Host>();
-  auto ilev_v  = ilev.get_view<Real*,Host>();
-
-  scorpio::register_file(filename,scorpio::Read);
-  scorpio::read_var(filename,"hyam",hyam_v.data());
-  scorpio::read_var(filename,"hybm",hybm_v.data());
-  scorpio::read_var(filename,"hyai",hyai_v.data());
-  scorpio::read_var(filename,"hybi",hybi_v.data());
-  scorpio::read_var(filename,"lev", lev_v.data());
-  scorpio::read_var(filename,"ilev",ilev_v.data());
-  scorpio::release_file(filename);
+  read_fields(filename,{hyam,hybm,hyai,hybi});
 
   using stratts_t = std::map<std::string,std::string>;
   auto& lev_io_atts  = lev.get_header().get_extra_data<stratts_t>("io: string attributes");
@@ -294,21 +259,12 @@ load_vertical_coordinates (const nonconstgrid_ptr_type& grid, const std::string&
   using PC       = scream::physics::Constants<Real>;
   const Real ps0 = PC::P0.value;
 
-  auto num_lev = grid->get_num_vertical_levels();
-  for (int ii=0;ii<num_lev;ii++) {
-    lev_v(ii)  = 0.01*ps0*(hyam_v(ii)+hybm_v(ii));
-    ilev_v(ii) = 0.01*ps0*(hyai_v(ii)+hybi_v(ii));
-  }
-  // Note, ilev is just 1 more level than the number of midpoint levs
-  ilev_v(num_lev) = 0.01*ps0*(hyai_v(num_lev)+hybi_v(num_lev));
-
-  // Sync to dev
-  hyam.sync_to_dev();
-  hybm.sync_to_dev();
-  hyai.sync_to_dev();
-  hybi.sync_to_dev();
-  lev.sync_to_dev();
-  ilev.sync_to_dev();
+  ilev.deep_copy(hyai);
+  ilev.update(hybi,1,1);
+  ilev.scale(0.01*ps0);
+  lev.deep_copy(hyam);
+  lev.update(hybm,1,1);
+  lev.scale(0.01*ps0);
 
 #ifndef NDEBUG
   for (auto f : {hyam, hybm, hyai, hybi}) {

--- a/components/eamxx/src/share/field/field_reader.cpp
+++ b/components/eamxx/src/share/field/field_reader.cpp
@@ -173,6 +173,13 @@ void FieldReader::setup_internals ()
 
       auto f_dims = fl.names();
       auto f_extents = fl.dims();
+      for (int i=0; i<fl.rank(); ++i) {
+        if (f_dims[i]=="dim")
+          f_dims[i] += std::to_string(f_extents[i]);
+        if (m_tag_rename.count(f_dims[i]))
+          f_dims[i] = m_tag_rename.at(f_dims[i]);
+      }
+
       auto var_dims = var.dim_names();
 
       if (fl.has_tag(COL) and latlon_in_file) {

--- a/components/eamxx/src/share/field/field_reader.cpp
+++ b/components/eamxx/src/share/field/field_reader.cpp
@@ -160,6 +160,8 @@ void FieldReader::setup_internals ()
 
   // 2. Check fields are in the file, with correct dim names
   bool latlon_decomp = false;
+  auto dim_decomp_ncname = m_tag_rename.count(m_dim_decomp_name)>0 ?
+                           m_tag_rename.at(m_dim_decomp_name) : m_dim_decomp_name;
   if (m_reader_state & (NEW_FIELDS | NEW_FILE)) {
     for (const auto & f : m_fields) {
       // Check that the variable is in the file.
@@ -200,7 +202,7 @@ void FieldReader::setup_internals ()
           " - file var dim names: " + ekat::join(var.dim_names(),",") + "\n");
 
       for (auto [f_dim,var_dim,f_ext] : ekat::zip(f_dims,var_dims,f_extents)) {
-        if (f_dim!=m_dim_decomp_name) {
+        if (f_dim!=dim_decomp_ncname) {
           const int file_len  = scorpio::get_dimlen(m_filename,f_dim);
           EKAT_REQUIRE_MSG (f_ext==file_len,
               "Error! Dimension mismatch for input file variable.\n"
@@ -221,7 +223,7 @@ void FieldReader::setup_internals ()
       if (latlon_decomp) {
         scorpio::set_dims_decomp(m_filename,{name_lat,name_lon},m_dim_decomp_offsets);
       } else {
-        scorpio::set_dim_decomp(m_filename, m_dim_decomp_name, m_dim_decomp_offsets);
+        scorpio::set_dim_decomp(m_filename, dim_decomp_ncname, m_dim_decomp_offsets);
       }
     } else {
       std::vector<scorpio::offset_t> offsets(m_dim_decomp_offsets.begin(),
@@ -229,7 +231,7 @@ void FieldReader::setup_internals ()
       if (latlon_decomp) {
         scorpio::set_dims_decomp(m_filename,{name_lat,name_lon},offsets);
       } else {
-        scorpio::set_dim_decomp(m_filename, m_dim_decomp_name, offsets);
+        scorpio::set_dim_decomp(m_filename, dim_decomp_ncname, offsets);
       }
     }
   }

--- a/components/eamxx/src/share/grid/CMakeLists.txt
+++ b/components/eamxx/src/share/grid/CMakeLists.txt
@@ -9,7 +9,7 @@ target_link_libraries (eamxx_grid PUBLIC
   eamxx_core
   eamxx_utils
   eamxx_field
-  eamxx_scorpio_interface)
+)
 
 if (NOT SCREAM_LIB_ONLY)
   add_subdirectory(tests)

--- a/components/eamxx/src/share/grid/abstract_grid.cpp
+++ b/components/eamxx/src/share/grid/abstract_grid.cpp
@@ -1,7 +1,6 @@
 #include "share/grid/abstract_grid.hpp"
 
 #include "share/field/field_utils.hpp"
-#include "share/scorpio_interface/eamxx_scorpio_interface.hpp"
 
 #include <ekat_assert.hpp>
 
@@ -419,76 +418,6 @@ AbstractGrid::delete_geometry_data (const std::string& name)
       "  - geo data name: " + name + "\n");
 
   m_geo_fields.erase(name);
-}
-
-void AbstractGrid::
-read_geometry_data(const std::string& filename,
-                   const std::vector<std::string>& names,
-                   const std::map<std::string,std::string>& dim_to_ncdim)
-{
-  read_geometry_data(filename,names,names,dim_to_ncdim);
-}
-
-void AbstractGrid::
-read_geometry_data(const std::string& filename,
-                   const std::vector<std::string>& names,
-                   const std::vector<std::string>& nc_names,
-                   const std::map<std::string,std::string>& dim_to_ncdim)
-{
-  EKAT_REQUIRE_MSG (names.size()==nc_names.size(),
-      "[AbstractGrid] Error! Input names and nc_names sizes differ.\n"
-      "  - grid name: " + this->name() + "\n"
-      "  - geo data names: " + ekat::join(names,",") + "\n"
-      "  - nc vars names: " + ekat::join(nc_names,",") + "\n");
-  scorpio::register_file(filename,scorpio::Read);
-
-  for (size_t i=0; i<names.size(); ++i) {
-    EKAT_REQUIRE_MSG (has_geometry_data(names[i]),
-        "Error! Cannot read geometry data from file, since it is does not exist.\n"
-        "  - grid name: " + this->name() + "\n"
-        "  - geo data name: " + names[i] + "\n");
-
-    auto f = m_geo_fields.at(names[i]);
-    const auto& fl = f.get_header().get_identifier().get_layout();
-
-    // If one of the field tags corresponds to the partitioned dim, init the decomp
-    if (fl.has_tag(get_partitioned_dim_tag())) {
-      auto t = get_partitioned_dim_tag();
-      std::string dimname = has_special_tag_name(t)
-                          ? get_special_tag_name(t)
-                          : e2str(t);
-      auto gids_h = get_partitioned_dim_gids().get_view<const gid_type*,Host>();
-      auto min_gid = get_global_min_partitioned_dim_gid();
-      std::vector<scorpio::offset_t> offsets(m_num_local_dofs);
-      for (int idof=0; idof<m_num_local_dofs; ++idof) {
-        offsets[idof] = gids_h[idof] - min_gid;
-      }
-      std::string nc_dimname = dim_to_ncdim.count(dimname)==1 ? dim_to_ncdim.at(dimname) : dimname;
-      scorpio::set_dim_decomp(filename,nc_dimname,offsets);
-    }
-
-    switch (f.data_type()) {
-      case DataType::DoubleType:
-        scorpio::read_var(filename,nc_names[i],f.get_internal_view_data<double,Host>());
-        break;
-      case DataType::FloatType:
-        scorpio::read_var(filename,nc_names[i],f.get_internal_view_data<float,Host>());
-        break;
-      case DataType::IntType:
-        scorpio::read_var(filename,nc_names[i],f.get_internal_view_data<int,Host>());
-        break;
-      default:
-        EKAT_ERROR_MSG (
-            "Error! Unsupported/unrecognized data type while reading field from file.\n"
-            " - file name : " + filename + "\n"
-            " - field name: " + names[i] + "\n");
-    }
-
-    // Ensure data is up to date on device, since we read on host
-    f.sync_to_dev();
-  }
-
-  scorpio::release_file(filename);
 }
 
 void

--- a/components/eamxx/src/share/grid/abstract_grid.hpp
+++ b/components/eamxx/src/share/grid/abstract_grid.hpp
@@ -186,15 +186,6 @@ public:
   void set_geometry_data(const Field &f) const;
   void delete_geometry_data(const std::string &name);
 
-  // Reads some geometry data from file
-  void read_geometry_data(const std::string& filename,
-                          const std::vector<std::string>& names,
-                          const std::map<std::string,std::string>& dim_to_ncdim = {});
-  void read_geometry_data(const std::string& filename,
-                          const std::vector<std::string>& names,
-                          const std::vector<std::string>& nc_names,
-                          const std::map<std::string,std::string>& dim_to_ncdim = {});
-
   bool
   has_geometry_data(const std::string &name) const
   {

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -1,8 +1,8 @@
 #include "share/io/scorpio_output.hpp"
 
 #include "share/field/field_utils.hpp"
+#include "share/field/field_reader.hpp"
 #include "share/io/eamxx_io_utils.hpp"
-#include "share/io/scorpio_input.hpp"
 #include "share/remap/horizontal_remapper.hpp"
 #include "share/remap/vertical_remapper.hpp"
 #include "share/util/eamxx_timing.hpp"
@@ -324,8 +324,7 @@ void AtmosphereOutput::restart (const std::string& filename)
     fields.push_back(f.alias(f.name(),fm->get_grid()->name()));
   }
 
-  AtmosphereInput hist_restart (filename, fm->get_grid(), fields);
-  hist_restart.read_variables();
+  read_fields(filename, fields, fm->get_grid()->get_partitioned_dim_gids(), m_comm );
 }
 
 void AtmosphereOutput::init()

--- a/components/eamxx/src/share/io/scorpio_scm_input.cpp
+++ b/components/eamxx/src/share/io/scorpio_scm_input.cpp
@@ -1,5 +1,5 @@
 #include "share/io/scorpio_scm_input.hpp"
-#include "share/io/scorpio_input.hpp"
+#include "share/field/field_reader.hpp"
 
 #include "share/scorpio_interface/eamxx_scorpio_interface.hpp"
 #include "share/grid/point_grid.hpp"
@@ -107,12 +107,8 @@ void SCMInput::create_closest_col_info (double target_lat, double target_lon)
   auto lat = m_io_grid->create_geometry_data("lat",m_io_grid->get_2d_scalar_layout(),ekat::units::none);
   auto lon = m_io_grid->create_geometry_data("lon",m_io_grid->get_2d_scalar_layout(),ekat::units::none);
 
-  std::vector<Field> latlon = {lat,lon};
-
   // Read from file
-  AtmosphereInput file_reader(m_filename, m_io_grid, latlon);
-  file_reader.read_variables();
-  file_reader.finalize();
+  read_fields(m_filename, {lat,lon}, m_io_grid->get_partitioned_dim_gids(),m_io_grid->get_comm());
 
   // Find column index of closest lat/lon to target_lat/lon params
   auto lat_d = lat.get_view<Real*>();

--- a/components/eamxx/src/share/io/tests/io_alias.cpp
+++ b/components/eamxx/src/share/io/tests/io_alias.cpp
@@ -5,8 +5,8 @@
 #include "share/io/eamxx_io_utils.hpp"
 #include "share/io/eamxx_output_manager.hpp"
 #include "share/scorpio_interface/eamxx_scorpio_interface.hpp"
-#include "share/io/scorpio_input.hpp"
 #include "share/diagnostics/register_diagnostics.hpp"
+#include "share/field/field_reader.hpp"
 #include "share/field/field.hpp"
 #include "share/field/field_utils.hpp"
 #include "share/util/eamxx_time_stamp.hpp"
@@ -101,7 +101,6 @@ create_test_field_manager(const std::shared_ptr<const AbstractGrid> &grid,
 TEST_CASE("io_with_aliases") {
   using namespace ShortFieldTagsNames;
   using namespace ekat::units;
-  using strvec_t = std::vector<std::string>;
   
   // This test uses diagnostics, so make sure they are registered
   register_diagnostics();
@@ -185,9 +184,6 @@ TEST_CASE("io_with_aliases") {
   file_check.close();
 
   // Now verify the file was created and contains the correct aliased field names
-  // Create a new field manager with fields using aliased names for reading
-  auto read_fm = std::make_shared<FieldManager>(grid);
-
   // Create fields with aliased names for reading back
   FieldIdentifier qv_read_id("qv", {{COL, LEV}, {ncols, nlevs}}, kg / kg, grid->name());
   FieldIdentifier temp_read_id("TEMP", {{COL, LEV}, {ncols, nlevs}}, K, grid->name());
@@ -209,52 +205,29 @@ TEST_CASE("io_with_aliases") {
   psurf_read.get_header().get_tracking().update_time_stamp(t0);
   surf_temp_read.get_header().get_tracking().update_time_stamp(t0);
 
-  read_fm->add_field(qv_read);
-  read_fm->add_field(temp_read);
-  read_fm->add_field(psurf_read);
-  read_fm->add_field(surf_temp_read);
-
-  // Set up reader parameter list
-  ekat::ParameterList reader_pl;
-  reader_pl.set("filename", expected_filename);
-
-  // Use the aliased names in the field list for reading
-  reader_pl.set<strvec_t>("field_names", {"qv", "TEMP", "PSURF", "surf_temp"});
-
   // Try to read the file - this will fail if the aliases weren't written correctly
-  AtmosphereInput reader(reader_pl, read_fm);
+  FieldReader reader;
+  reader.set_file_specs(expected_filename);
+  reader.set_dim_decomp(grid->get_partitioned_dim_gids(),comm);
+  reader.set_fields({qv_read,temp_read,psurf_read,surf_temp_read});
 
-  reader.set_logger(console_logger(ekat::logger::LogLevel::trace));
-  auto qv_field_read        = read_fm->get_field("qv");
-  auto temp_field_read      = read_fm->get_field("TEMP");
-  auto psurf_field_read     = read_fm->get_field("PSURF");
-  auto surf_temp_field_read = read_fm->get_field("surf_temp");
-
-  auto qv_tgt    = qv_field_read.clone();
-  auto T_mid_tgt = temp_field_read.clone();
-  auto ps_tgt    = psurf_field_read.clone();
+  auto qv_tgt    = qv_read.clone();
+  auto T_mid_tgt = temp_read.clone();
+  auto ps_tgt    = psurf_read.clone();
   auto T_mid_bot_tgt = T_mid_tgt.subfield(LEV,nlevs-1);
   for (int n=0; n<=nsteps; ++n) {
-    reader.read_variables(n); // Read n-th timestamp
+    reader.read(n); // Read n-th timestamp
 
     calc_fields (qv_tgt, T_mid_tgt, ps_tgt, col, n);
 
-    if (not views_are_equal(qv_tgt,qv_field_read)) {
-      print_field_hyperslab(qv_tgt.alias("qv_tgt"));
-      print_field_hyperslab(qv_field_read.alias("qv_field_read"));
-    }
-    REQUIRE (views_are_equal(qv_tgt,qv_field_read));
-    REQUIRE (views_are_equal(T_mid_tgt,temp_field_read));
-    REQUIRE (views_are_equal(ps_tgt,psurf_field_read));
-    if (not views_are_equal(T_mid_bot_tgt,surf_temp_field_read)) {
-      print_field_hyperslab(T_mid_bot_tgt.alias("T_mid_bot_tgt"));
-      print_field_hyperslab(surf_temp_read.alias("surf_temp_read"));
-    }
-    REQUIRE (views_are_equal(T_mid_bot_tgt,surf_temp_field_read));
+    REQUIRE (views_are_equal(qv_tgt,qv_read));
+    REQUIRE (views_are_equal(T_mid_tgt,temp_read));
+    REQUIRE (views_are_equal(ps_tgt,psurf_read));
+    REQUIRE (views_are_equal(T_mid_bot_tgt,surf_temp_read));
   }
-  reader.finalize();
 
   // Clean up PIO subsystem
+  reader.clean_up();
   scorpio::finalize_subsystem();
 }
 

--- a/components/eamxx/src/share/io/tests/io_basic.cpp
+++ b/components/eamxx/src/share/io/tests/io_basic.cpp
@@ -1,10 +1,10 @@
 #include <catch2/catch.hpp>
 
 #include "share/io/eamxx_output_manager.hpp"
-#include "share/io/scorpio_input.hpp"
 
 #include "share/data_managers/mesh_free_grids_manager.hpp"
 
+#include "share/field/field_reader.hpp"
 #include "share/field/field_utils.hpp"
 #include "share/field/field.hpp"
 #include "share/data_managers/field_manager.hpp"
@@ -37,7 +37,7 @@ void add (const Field& f, const double v) {
 }
 
 int get_dt (const std::string& freq_units) {
-  int dt;
+  int dt = -1;
   if (freq_units=="nsteps") {
     dt = 1;
   } else if (freq_units=="nsecs") {
@@ -208,15 +208,13 @@ void read (const std::string& avg_type, const std::string& freq_units,
 
   // Get initial fields. Use wrong seed for fm, so fields are not
   // inited with right data (avoid getting right answer without reading).
-  auto fm0 = get_fm(grid,t0,seed);
-  auto fm  = get_fm(grid,t0,-seed-1);
-  std::vector<std::string> fnames;
+  auto fm = get_fm(grid,t0,seed);
+  std::vector<Field> fields_in;
   for (auto it : fm->get_repo()) {
-    fnames.push_back(it.second->name());
+    fields_in.push_back(it.second->clone());
   }
 
   // Create reader pl
-  ekat::ParameterList reader_pl;
   std::string casename = "io_basic";
   auto filename = casename
     + "." + avg_type
@@ -225,9 +223,11 @@ void read (const std::string& avg_type, const std::string& freq_units,
     + ".np" + std::to_string(comm.size())
     + "." + t0.to_string()
     + ".nc";
-  reader_pl.set("filename",filename);
-  reader_pl.set("field_names",fnames);
-  AtmosphereInput reader(reader_pl,fm);
+
+  FieldReader reader;
+  reader.set_file_specs(filename);
+  reader.set_dim_decomp(grid->get_partitioned_dim_gids(),comm);
+  reader.set_fields(fields_in);
 
   // We added 1.0 to the input fields for each timestep
   // Hence, at output step N, we should get
@@ -242,10 +242,9 @@ void read (const std::string& avg_type, const std::string& freq_units,
   double delta = (freq+1)/2.0;
 
   for (int n=0; n<num_writes; ++n) {
-    reader.read_variables(n);
-    for (const auto& fn : fnames) {
-      auto f0 = fm0->get_field(fn).clone(CloneFlags::CopyData);
-      auto f  = fm->get_field(fn);
+    reader.read(n);
+    for (const auto& f : fields_in) {
+      auto f0 = fm->get_field(f.name()).clone(CloneFlags::CopyData);
       if (avg_type=="MIN") {
         // The 1st snap in the avg window (the smallest)
         // is one past window_start=n*freq
@@ -265,12 +264,12 @@ void read (const std::string& avg_type, const std::string& freq_units,
   }
 
   // Check that the expected metadata was appropriately set for each variable
-  for (const auto& fn: fnames) {
-    auto att_fill = scorpio::get_attribute<float>(filename,fn,"_FillValue");
+  for (const auto& f: fields_in) {
+    auto att_fill = scorpio::get_attribute<float>(filename,f.name(),"_FillValue");
     REQUIRE(att_fill==constants::fill_value<Real>);
 
-    auto att_str = scorpio::get_attribute<std::string>(filename,fn,"test");
-    REQUIRE (att_str==fn);
+    auto att_str = scorpio::get_attribute<std::string>(filename,f.name(),"test");
+    REQUIRE (att_str==f.name());
   }
 
   // Check constants

--- a/components/eamxx/src/share/io/tests/io_diags.cpp
+++ b/components/eamxx/src/share/io/tests/io_diags.cpp
@@ -3,10 +3,10 @@
 #include "share/diagnostics/abstract_diagnostic.hpp"
 
 #include "share/io/eamxx_output_manager.hpp"
-#include "share/io/scorpio_input.hpp"
 
 #include "share/data_managers/mesh_free_grids_manager.hpp"
 
+#include "share/field/field_reader.hpp"
 #include "share/field/field_utils.hpp"
 #include "share/field/field.hpp"
 #include "share/data_managers/field_manager.hpp"
@@ -206,43 +206,33 @@ void read (const int seed, const ekat::Comm& comm)
   // Get gm
   auto gm = get_gm (comm);
   auto grid = gm->get_grid("point_grid");
+  auto gids = grid->get_partitioned_dim_gids();
 
   // Get initial fields
   auto fm0 = get_fm(grid,t0,seed);
   auto fm  = get_fm(grid,t0,seed,true);
 
-  std::vector<std::string> fnames;
-  std::string f_name;
-  for (auto it : fm->get_repo()) {
-    const auto& fn = it.second->name();
-    fnames.push_back(fn);
-    if (fn!="MyDiag") {
-      f_name = fn;
-    }
-  }
-
-  auto f0 = fm0->get_field(f_name).clone(CloneFlags::CopyData);
-  auto f  = fm->get_field(f_name);
-
-  // Sanity check
-  REQUIRE (f_name!="");
+  auto f  = fm->get_field("my_f");
+  auto f0 = f.clone(CloneFlags::CopyData);
 
   // Create reader pl
-  ekat::ParameterList reader_pl;
   std::string casename = "io_diags";
   auto filename = casename
     + ".INSTANT.nsteps_x1"
     + ".np" + std::to_string(comm.size())
     + "." + t0.to_string()
     + ".nc";
-  reader_pl.set("filename",filename);
-  reader_pl.set("field_names",fnames);
-  AtmosphereInput reader(reader_pl,fm);
+
+  auto d = fm->get_field("MyDiag");
+  FieldReader reader;
+  reader.set_file_specs(filename);
+  reader.set_dim_decomp(gids,comm);
+  reader.set_fields({f,d});
 
   Field one = f0.clone("one");
   one.deep_copy(1.0);
   for (int i=0; i<2; ++i) {
-    reader.read_variables(i);
+    reader.read(i);
 
     // Check regular field is correct
     REQUIRE (views_are_equal(f,f0));
@@ -250,7 +240,6 @@ void read (const int seed, const ekat::Comm& comm)
     // Check diag field is correct
     const auto t = t0+i*get_dt();
     const double dt = t-t0;
-    auto d = fm->get_field("MyDiag");
     auto d0 = f0.clone(CloneFlags::CopyData);
     d0.update(one,dt,2.0);
     REQUIRE (views_are_equal(d,d0));

--- a/components/eamxx/src/share/io/tests/io_filled.cpp
+++ b/components/eamxx/src/share/io/tests/io_filled.cpp
@@ -1,11 +1,11 @@
 #include <catch2/catch.hpp>
 
 #include "share/io/eamxx_output_manager.hpp"
-#include "share/io/scorpio_input.hpp"
 #include "share/io/eamxx_io_utils.hpp"
 
 #include "share/data_managers/mesh_free_grids_manager.hpp"
 
+#include "share/field/field_reader.hpp"
 #include "share/field/field_utils.hpp"
 #include "share/field/field.hpp"
 #include "share/data_managers/field_manager.hpp"
@@ -39,7 +39,7 @@ void set (const Field& f, const double v) {
 }
 
 int get_dt (const std::string& freq_units) {
-  int dt;
+  int dt = -1;
   if (freq_units=="nsteps") {
     dt = 1;
   } else if (freq_units=="nsecs") {
@@ -180,18 +180,17 @@ void read (const std::string& avg_type, const std::string& freq_units,
   // Get gm
   auto gm = get_gm (comm);
   auto grid = gm->get_grid("point_grid");
+  auto gids = grid->get_partitioned_dim_gids();
 
   // Get initial fields. Use wrong seed for fm, so fields are not
   // inited with right data (avoid getting right answer without reading).
   auto fm0 = get_fm(grid,t0,seed);
-  auto fm  = get_fm(grid,t0,-seed-1);
-  std::vector<std::string> fnames;
-  for (auto it : fm->get_repo()) {
-    fnames.push_back(it.second->name());
+  std::vector<Field> fields;
+  for (auto it : fm0->get_repo()) {
+    fields.push_back(it.second->clone());
   }
 
   // Create reader pl
-  ekat::ParameterList reader_pl;
   std::string casename = "io_filled";
   auto filename = casename
     + "." + avg_type
@@ -200,9 +199,10 @@ void read (const std::string& avg_type, const std::string& freq_units,
     + ".np" + std::to_string(comm.size())
     + "." + t0.to_string()
     + ".nc";
-  reader_pl.set("filename",filename);
-  reader_pl.set("field_names",fnames);
-  AtmosphereInput reader(reader_pl,fm);
+  FieldReader reader;
+  reader.set_file_specs(filename);
+  reader.set_dim_decomp(gids,comm);
+  reader.set_fields(fields);
 
   // We set the value n to each input field for each odd valued timestep and fill_value for each even valued timestep
   // Hence, at output step N = snap*freq, we should get
@@ -217,10 +217,9 @@ void read (const std::string& avg_type, const std::string& freq_units,
   //         where M = freq/2 + ( N%2=0 ? 0 : 1 ),
   //               a = floor(N/freq)*freq + ( N%2=0 ? 0 : -1)
   for (int n=0; n<num_writes; ++n) {
-    reader.read_variables(n);
-    for (const auto& fn : fnames) {
-      auto f0 = fm0->get_field(fn).clone(CloneFlags::CopyData);
-      auto f  = fm->get_field(fn);
+    reader.read(n);
+    for (const auto& f : fields) {
+      auto f0 = fm0->get_field(f.name()).clone(CloneFlags::CopyData);
       if (avg_type=="MIN") {
         Real test_val = ((n+1)*freq%2==0) ? n*freq+1 : n*freq+2;
         set(f0,test_val);
@@ -249,9 +248,9 @@ void read (const std::string& avg_type, const std::string& freq_units,
   }
 
   // Check that the fill value gets appropriately set for each variable
-  for (const auto& fn: fnames) {
+  for (const auto& f: fields) {
     // NOTE: use float, since default fp_precision for I/O is 'single'
-    auto att_fill = scorpio::get_attribute<float>(filename,fn,"_FillValue");
+    auto att_fill = scorpio::get_attribute<float>(filename,f.name(),"_FillValue");
     REQUIRE(att_fill==constants::fill_value<Real>);
   }
 }

--- a/components/eamxx/src/share/io/tests/io_horiz_sampling.cpp
+++ b/components/eamxx/src/share/io/tests/io_horiz_sampling.cpp
@@ -4,8 +4,8 @@
 #include "share/diagnostics/register_diagnostics.hpp"
 
 #include "share/io/eamxx_output_manager.hpp"
-#include "share/io/scorpio_input.hpp"
 #include "share/scorpio_interface/eamxx_scorpio_interface.hpp"
+#include "share/field/field_reader.hpp"
 #include "share/field/field_utils.hpp"
 #include "share/core/eamxx_setup_random_test.hpp"
 
@@ -142,9 +142,7 @@ TEST_CASE("io_remap_test","io_remap_test")
 
   std::vector<Field> fields = {s2d_tgt,s3d_tgt};
 
-  AtmosphereInput reader(filename,tgt_grid,fields);
-  reader.read_variables();
-  reader.finalize(); // manually finalize, or scorpio cleanup will complain about a file still open
+  read_fields(filename,fields,tgt_grid->get_partitioned_dim_gids(),comm);
 
   // Check values
   auto s2d_src_h = s2d_src.get_view<const Real* ,Host>();

--- a/components/eamxx/src/share/io/tests/io_latlon.cpp
+++ b/components/eamxx/src/share/io/tests/io_latlon.cpp
@@ -1,9 +1,9 @@
 #include <catch2/catch.hpp>
 #include <memory>
 
-#include "share/io/scorpio_input.hpp"
 #include "share/io/eamxx_output_manager.hpp"
 #include "share/grid/point_grid.hpp"
+#include "share/field/field_reader.hpp"
 
 #include <ekat_test_utils.hpp>
 
@@ -14,18 +14,25 @@ namespace scream {
 inline std::shared_ptr<AbstractGrid>
 create_grid(const ekat::Comm& comm, const std::string& map_file, const std::string& name, bool src)
 {
+  auto COL = FieldTag::Column;
+
   // Note: map files are 1-based, so create pt grid with 1-based gids
   auto deg = ekat::units::none.rename("degrees");
   std::string suffix = src ? "_a" : "_b";
   int ncols = scorpio::get_dimlen(map_file,"n"+suffix);
   auto grid = create_point_grid(name,ncols,1,comm,1);
-
   auto lat = grid->create_geometry_data("lat",grid->get_2d_scalar_layout(),deg);
   auto lon = grid->create_geometry_data("lon",grid->get_2d_scalar_layout(),deg);
-  auto io_grid = grid->clone(grid->name(),true);
-  io_grid->reset_field_tag_name(FieldTag::Column,"n"+suffix);
-  AtmosphereInput reader(map_file,io_grid,std::vector<Field>{lat.alias("yc"+suffix),lon.alias("xc"+suffix)});
-  reader.read_variables();
+
+  // Use temp fields for IO, so we can rename ncol to n_SUFFIX, and lat/lon to yc/xc_SUFFIX
+  std::map<FieldTag,std::string> io_dims = {
+    {COL,"n"+suffix}
+  };
+  auto io_gids = grid->get_partitioned_dim_gids().alias("gids",io_dims);
+  auto io_lat  = lat.alias("yc"+suffix,io_dims);
+  auto io_lon  = lon.alias("xc"+suffix,io_dims);
+  read_fields(map_file,{io_lat,io_lon},io_gids,comm);
+
   return grid;
 }
 

--- a/components/eamxx/src/share/io/tests/io_monthly.cpp
+++ b/components/eamxx/src/share/io/tests/io_monthly.cpp
@@ -1,10 +1,10 @@
 #include <catch2/catch.hpp>
 
 #include "share/io/eamxx_output_manager.hpp"
-#include "share/io/scorpio_input.hpp"
 
 #include "share/data_managers/mesh_free_grids_manager.hpp"
 
+#include "share/field/field_reader.hpp"
 #include "share/field/field_utils.hpp"
 #include "share/field/field.hpp"
 #include "share/data_managers/field_manager.hpp"
@@ -156,14 +156,14 @@ void read (const int seed, const ekat::Comm& comm)
   // Get gm
   auto gm = get_gm (comm);
   auto grid = gm->get_grid("point_grid");
+  auto gids = grid->get_partitioned_dim_gids();
 
   // Get initial fields. Use wrong seed for fm, so fields are not
   // inited with right data (avoid getting right answer without reading).
   auto fm0 = get_fm(grid,t0,seed);
-  auto fm  = get_fm(grid,t0,-seed-1);
-  std::vector<std::string> fnames;
-  for (auto it : fm->get_repo()) {
-    fnames.push_back(it.second->name());
+  std::vector<Field> fields;
+  for (auto it : fm0->get_repo()) {
+    fields.push_back(it.second->clone());
   }
 
   // Get filename from timestamp
@@ -178,10 +178,6 @@ void read (const int seed, const ekat::Comm& comm)
     return fname;
   };
 
-  // Create reader pl
-  ekat::ParameterList reader_pl;
-  reader_pl.set("field_names",fnames);
-
   for (int n=0; n<12; ++n) {
     auto t = t0 + n*dt;
     auto filename = get_filename(t);
@@ -189,13 +185,10 @@ void read (const int seed, const ekat::Comm& comm)
     // There should be just one time snapshot per file
     REQUIRE(scorpio::get_dimlen(filename,"time")==1);
 
-    reader_pl.set("filename",filename);
-    AtmosphereInput reader(reader_pl,fm);
-    reader.read_variables();
+    read_fields (filename,fields,gids,comm);
 
-    for (const auto& fn : fnames) {
-      auto f0 = fm0->get_field(fn).clone(CloneFlags::CopyData);
-      auto f  = fm->get_field(fn);
+    for (const auto& f : fields) {
+      auto f0 = fm0->get_field(f.name()).clone(CloneFlags::CopyData);
       add(f0,n);
       REQUIRE (views_are_equal(f,f0));
     }

--- a/components/eamxx/src/share/io/tests/io_packed.cpp
+++ b/components/eamxx/src/share/io/tests/io_packed.cpp
@@ -1,10 +1,10 @@
 #include <catch2/catch.hpp>
 
 #include "share/io/eamxx_output_manager.hpp"
-#include "share/io/scorpio_input.hpp"
 
 #include "share/data_managers/mesh_free_grids_manager.hpp"
 
+#include "share/field/field_reader.hpp"
 #include "share/field/field_utils.hpp"
 #include "share/field/field.hpp"
 #include "share/data_managers/field_manager.hpp"
@@ -132,18 +132,17 @@ void read (const int freq, const int seed, const int ps_write, const int ps_read
   // Get gm
   auto gm = get_gm (comm);
   auto grid = gm->get_grid("point_grid");
+  auto gids = grid->get_partitioned_dim_gids();
 
   // Get initial fields. Use wrong seed for fm, so fields are not
   // inited with right data (avoid getting right answer without reading).
   auto fm0 = get_fm(grid,t0,seed,ps_read);
-  auto fm  = get_fm(grid,t0,-seed-1,ps_read);
-  std::vector<std::string> fnames;
-  for (auto it : fm->get_repo()) {
-    fnames.push_back(it.second->name());
+  std::vector<Field> fields;
+  for (auto it : fm0->get_repo()) {
+    fields.push_back(it.second->clone());
   }
 
   // Create reader pl
-  ekat::ParameterList reader_pl;
   std::string casename = "io_packed_ps"+std::to_string(ps_write);
   auto filename = casename
     + ".INSTANT.nsteps"
@@ -151,14 +150,9 @@ void read (const int freq, const int seed, const int ps_write, const int ps_read
     + ".np" + std::to_string(comm.size())
     + "." + t0.to_string()
     + ".nc";
-  reader_pl.set("filename",filename);
-  reader_pl.set("field_names",fnames);
-  AtmosphereInput reader(reader_pl,fm);
-
-  reader.read_variables();
-  for (const auto& fn : fnames) {
-    auto f0 = fm0->get_field(fn);
-    auto f  = fm->get_field(fn);
+  read_fields(filename,fields,gids,comm);
+  for (const auto& f : fields) {
+    auto f0 = fm0->get_field(f.name());
     if (not views_are_equal(f,f0)) {
       print_field_hyperslab(f,{},{},std::cout);
       print_field_hyperslab(f0,{},{},std::cout);

--- a/components/eamxx/src/share/io/tests/io_remap_test.cpp
+++ b/components/eamxx/src/share/io/tests/io_remap_test.cpp
@@ -4,10 +4,9 @@
 #include "share/diagnostics/register_diagnostics.hpp"
 
 #include "share/io/eamxx_output_manager.hpp"
-#include "share/io/scorpio_input.hpp"
-#include "share/scorpio_interface/eamxx_scorpio_interface.hpp"
-
 #include "share/data_managers/mesh_free_grids_manager.hpp"
+#include "share/scorpio_interface/eamxx_scorpio_interface.hpp"
+#include "share/field/field_reader.hpp"
 
 #include <ekat_pack.hpp>
 
@@ -28,10 +27,13 @@ get_test_gm(const ekat::Comm& io_comm, const Int num_gcols, const Int num_levs);
 std::shared_ptr<FieldManager>
 get_test_fm(std::shared_ptr<const AbstractGrid> grid, const bool midonly, const int p_ref=-1);
 
+std::vector<Field>
+get_test_fields(std::shared_ptr<FieldManager> fm, const int p_ref=-1);
+
 Real calculate_output(const Real pressure, const int col, const int cmp);
 
 ekat::ParameterList set_output_params(const std::string& name, const std::string& remap_filename, const int p_ref, const bool vert_remap, const bool horiz_remap);
-ekat::ParameterList set_input_params(const std::string& name, ekat::Comm& comm, const std::string& tstamp, const int p_ref);
+std::string get_filename(const std::string& name, ekat::Comm& comm, const std::string& tstamp);
 
 bool approx(const Real a, const Real b) {
   const Real tol = std::numeric_limits<Real>::epsilon()*100000;
@@ -288,16 +290,16 @@ TEST_CASE("io_remap_test","io_remap_test")
     print ("    -> vertical remap ... \n",io_comm);
     auto gm_vert   = get_test_gm(io_comm,ncols_src,nlevs_tgt);
     auto grid_vert = gm_vert->get_grid("point_grid");
+    auto gids      = grid_vert->get_partitioned_dim_gids();
     auto fm_vert   = get_test_fm(grid_vert,true,p_ref);
-    auto vert_in   = set_input_params("remap_vertical",io_comm,t0.to_string(),p_ref);
-    AtmosphereInput test_input(vert_in,fm_vert);
-    test_input.read_variables();
+    auto fields    = get_test_fields(fm_vert,p_ref);
+    auto filename  = get_filename("remap_vertical",io_comm,t0.to_string());
+    read_fields(filename,fields,gids,io_comm);
 
     // Check the "test" metadata, which should match the field name
     // Note: the FieldAtPressureLevel diag should get the attribute from its input field,
     //       so the valuf for "Y_int"_at_XPa should be "Y_int"
     std::string att_val;
-    const auto& filename = vert_in.get<std::string>("filename");
     for (auto& fname : fnames) {
       att_val = scorpio::get_attribute<std::string>(filename,fname,"test");
       REQUIRE (att_val==fname);
@@ -305,8 +307,6 @@ TEST_CASE("io_remap_test","io_remap_test")
     std::string f_at_lev_name = "Y_int_at_" + std::to_string(p_ref) + "Pa";
     att_val = scorpio::get_attribute<std::string>(filename,f_at_lev_name,"test");
     REQUIRE (att_val=="Y_int");
-
-    test_input.finalize();
 
     // Test vertically remapped output.
     // The single flat variable, "Y_flat" should match the source value exactly.  No vertical interpolation.
@@ -356,16 +356,16 @@ TEST_CASE("io_remap_test","io_remap_test")
     print ("    -> horizontal remap ... \n",io_comm);
     auto gm_horiz   = get_test_gm(io_comm,ncols_tgt,nlevs_src);
     auto grid_horiz = gm_horiz->get_grid("point_grid");
+    auto gids       = grid_horiz->get_partitioned_dim_gids();
     auto fm_horiz   = get_test_fm(grid_horiz,false,p_ref);
-    auto horiz_in   = set_input_params("remap_horizontal",io_comm,t0.to_string(),p_ref);
-    AtmosphereInput test_input(horiz_in,fm_horiz);
-    test_input.read_variables();
+    auto fields     = get_test_fields(fm_horiz,p_ref);
+    auto filename   = get_filename("remap_horizontal",io_comm,t0.to_string());
+    read_fields(filename,fields,gids,io_comm);
 
     // Check the "test" metadata, which should match the field name
     // Note: the FieldAtPressureLevel diag should get the attribute from its input field,
     //       so the valuf for "Y_int"_at_XPa should be "Y_int"
     std::string att_val;
-    const auto& filename = horiz_in.get<std::string>("filename");
     for (auto& fname : fnames) {
       att_val = scorpio::get_attribute<std::string>(filename,fname,"test");
       REQUIRE (att_val==fname);
@@ -373,7 +373,6 @@ TEST_CASE("io_remap_test","io_remap_test")
     std::string f_at_lev_name = "Y_int_at_" + std::to_string(p_ref) + "Pa";
     att_val = scorpio::get_attribute<std::string>(filename,f_at_lev_name,"test");
     REQUIRE (att_val=="Y_int");
-    test_input.finalize();
 
     // Test horizontally remapped output.
     // The remap we are testing is rather simple, each pair of subsequent columns are remapped to a single
@@ -438,18 +437,18 @@ TEST_CASE("io_remap_test","io_remap_test")
   //                                ---  Vertical + Horizontal Remapping ---
   {
     print ("    -> vertical + horizontal remap ... \n",io_comm);
-    auto gm_vh   = get_test_gm(io_comm,ncols_tgt,nlevs_tgt);
-    auto grid_vh = gm_vh->get_grid("point_grid");
-    auto fm_vh   = get_test_fm(grid_vh,true,p_ref);
-    auto vh_in   = set_input_params("remap_vertical_horizontal",io_comm,t0.to_string(),p_ref);
-    AtmosphereInput test_input(vh_in,fm_vh);
-    test_input.read_variables();
+    auto gm_vh    = get_test_gm(io_comm,ncols_tgt,nlevs_tgt);
+    auto grid_vh  = gm_vh->get_grid("point_grid");
+    auto gids     = grid_vh->get_partitioned_dim_gids();
+    auto fm_vh    = get_test_fm(grid_vh,true,p_ref);
+    auto fields   = get_test_fields(fm_vh,p_ref);
+    auto filename = get_filename("remap_vertical_horizontal",io_comm,t0.to_string());
+    read_fields(filename,fields,gids,io_comm);
 
     // Check the "test" metadata, which should match the field name
     // Note: the FieldAtPressureLevel diag should get the attribute from its input field,
     //       so the valuf for "Y_int"_at_XPa should be "Y_int"
     std::string att_val;
-    const auto& filename = vh_in.get<std::string>("filename");
     for (auto& fname : fnames) {
       att_val = scorpio::get_attribute<std::string>(filename,fname,"test");
       REQUIRE (att_val==fname);
@@ -457,7 +456,6 @@ TEST_CASE("io_remap_test","io_remap_test")
     std::string f_at_lev_name = "Y_int_at_" + std::to_string(p_ref) + "Pa";
     att_val = scorpio::get_attribute<std::string>(filename,f_at_lev_name,"test");
     REQUIRE (att_val=="Y_int");
-    test_input.finalize();
 
     // Test vertically + horizontally remapped output.
     // This test is a combination of the vertical test and horizontal test above.
@@ -667,6 +665,19 @@ std::shared_ptr<FieldManager> get_test_fm(std::shared_ptr<const AbstractGrid> gr
 
   return fm;
 }
+
+std::vector<Field>
+get_test_fields(std::shared_ptr<FieldManager> fm, const int p_ref)
+{
+  std::vector<Field> fields;
+  for (std::string n : {"Y_flat", "Y_mid", "Y_int", "V_mid", "V_int"}) {
+    fields.push_back(fm->get_field(n));
+  }
+  if (p_ref>=0) {
+    fields.push_back(fm->get_field("Y_int_at_"+std::to_string(p_ref)+"Pa"));
+  }
+  return fields;
+}
 /*==========================================================================================================*/
 ekat::ParameterList set_output_params(const std::string& name, const std::string& remap_filename, const int p_ref, const bool vert_remap, const bool horiz_remap)
 {
@@ -701,21 +712,10 @@ ekat::ParameterList set_output_params(const std::string& name, const std::string
   return params;
 }
 /*==========================================================================================================*/
-ekat::ParameterList set_input_params(const std::string& name, ekat::Comm& comm, const std::string& tstamp, const int p_ref)
+std::string get_filename(const std::string& name, ekat::Comm& comm, const std::string& tstamp)
 {
-  using vos_type = std::vector<std::string>;
-  ekat::ParameterList in_params("Input Parameters");
-  std::string filename = name + ".INSTANT.nsteps_x1.np" + std::to_string(comm.size()) + "." + tstamp + ".nc";
-  in_params.set<std::string>("filename",filename);
-  vos_type fields_in =  {"Y_flat", "Y_mid", "Y_int", "V_mid", "V_int"};
-  if (p_ref>=0) {
-    fields_in.push_back("Y_int_at_"+std::to_string(p_ref)+"Pa");
-  }
+  return name + ".INSTANT.nsteps_x1.np" + std::to_string(comm.size()) + "." + tstamp + ".nc";
 
-  in_params.set<vos_type>("field_names", fields_in);
-  in_params.set<std::string>("floating_point_precision","real");
-  return in_params;
 }
-/*==========================================================================================================*/
 
 } //namespace

--- a/components/eamxx/src/share/io/tests/io_se_grid.cpp
+++ b/components/eamxx/src/share/io/tests/io_se_grid.cpp
@@ -1,14 +1,13 @@
 #include <catch2/catch.hpp>
 
 #include "share/io/eamxx_output_manager.hpp"
-#include "share/io/scorpio_input.hpp"
 #include "share/scorpio_interface/eamxx_scorpio_interface.hpp"
 
 #include "share/data_managers/mesh_free_grids_manager.hpp"
 
-#include "share/field/field_identifier.hpp"
-#include "share/field/field.hpp"
 #include "share/data_managers/field_manager.hpp"
+#include "share/field/field_reader.hpp"
+#include "share/field/field.hpp"
 #include "share/field/field_utils.hpp"
 
 #include "share/core/eamxx_setup_random_test.hpp"
@@ -53,6 +52,7 @@ TEST_CASE("se_grid_io")
   // First set up a field manager and grids manager to interact with the output functions
   auto gm = get_test_gm(io_comm,num_my_elems,np,num_levs);
   auto grid = gm->get_grid("SE Grid");
+  auto gids = grid->get_partitioned_dim_gids();
 
   // Construct a timestamp
   util::TimeStamp t0 ({2000,1,1},{0,0,0});
@@ -78,22 +78,25 @@ TEST_CASE("se_grid_io")
   // Get a fresh new field manager, and set fields to NaN
   auto fm1 = get_test_fm(grid,t0,false);
   const auto fnames = {"field_1", "field_2", "field_3", "field_packed"};
+  std::vector<Field> fields;
   for (const auto& fname : fnames) {
-    auto f = fm1->get_field(fname);
+    auto& f = fields.emplace_back(fm1->get_field(fname));
     f.deep_copy(ekat::invalid<Real>());
   }
 
   // Check fields were written correctly
   auto in_params = get_in_params(io_comm,t0);
-  AtmosphereInput ins_input(in_params,fm1);
-  ins_input.read_variables();
+  std::string filename = "io_se_grid.INSTANT.nsteps_x1.np"
+                       + std::to_string(io_comm.size())
+                       + "." + t0.to_string() + ".nc";
+
+  read_fields(filename,fields,gids,io_comm);
 
   for (const auto& fname : fnames) {
     auto f0 = fm0->get_field(fname);
     auto f1 = fm1->get_field(fname);
     REQUIRE (views_are_equal(f0,f1));
   }
-  ins_input.finalize();
 
   // All Done
   scorpio::finalize_subsystem();

--- a/components/eamxx/src/share/io/tests/io_transpose.cpp
+++ b/components/eamxx/src/share/io/tests/io_transpose.cpp
@@ -1,13 +1,12 @@
 #include <catch2/catch.hpp>
 
 #include "share/io/eamxx_output_manager.hpp"
-#include "share/io/scorpio_input.hpp"
 
 #include "share/data_managers/mesh_free_grids_manager.hpp"
 
+#include "share/data_managers/field_manager.hpp"
 #include "share/field/field_utils.hpp"
 #include "share/field/field.hpp"
-#include "share/data_managers/field_manager.hpp"
 
 #include "share/util/eamxx_universal_constants.hpp"
 #include "share/core/eamxx_setup_random_test.hpp"
@@ -36,7 +35,7 @@ void add (const Field& f, const double v) {
 }
 
 int get_dt (const std::string& freq_units) {
-  int dt;
+  int dt = -1;
   if (freq_units=="nsteps") {
     dt = 1;
   } else if (freq_units=="nsecs") {

--- a/components/eamxx/src/share/io/tests/output_restart.cpp
+++ b/components/eamxx/src/share/io/tests/output_restart.cpp
@@ -2,17 +2,14 @@
 
 #include "share/io/eamxx_output_manager.hpp"
 #include "share/io/scorpio_output.hpp"
-#include "share/io/scorpio_input.hpp"
 #include "share/scorpio_interface/eamxx_scorpio_interface.hpp"
 
 #include "share/data_managers/mesh_free_grids_manager.hpp"
 #include "share/grid/point_grid.hpp"
 
-#include "share/field/field_identifier.hpp"
-#include "share/field/field_header.hpp"
-#include "share/field/field.hpp"
 #include "share/data_managers/field_manager.hpp"
 #include "share/field/field_utils.hpp"
+#include "share/field/field.hpp"
 #include "share/core/eamxx_setup_random_test.hpp"
 
 #include "share/core/eamxx_types.hpp"

--- a/components/eamxx/src/share/remap/horiz_interp_remapper_data.cpp
+++ b/components/eamxx/src/share/remap/horiz_interp_remapper_data.cpp
@@ -1,5 +1,6 @@
 #include "horiz_interp_remapper_data.hpp"
 
+#include "share/field/field_reader.hpp"
 #include "share/grid/point_grid.hpp"
 #include "share/grid/grid_import_export.hpp"
 #include "share/scorpio_interface/eamxx_scorpio_interface.hpp"
@@ -154,8 +155,12 @@ build (const std::shared_ptr<const AbstractGrid>& grid,
        const std::string& map_file)
 {
   std::filesystem::path p(map_file);
+
   // The "1" stands for "build from 1 grid"
   start_timer ("HRemap1 " + p.filename().string() + " bld");
+
+  using namespace ShortFieldTagsNames;
+  using namespace ekat::units;
 
   EKAT_REQUIRE_MSG (grid,
       "[HorizRemapperDataRepo::build_data_from_src] Error! Invalid src grid pointer.\n");
@@ -190,15 +195,15 @@ build (const std::shared_ptr<const AbstractGrid>& grid,
 
   // Only read the lat/lon/area vars if they are present. If one is present, we assume they all are
   if (scorpio::has_var(map_file,"yc"+suffix)) {
-    auto deg = ekat::units::none.rename("deg");
+    std::map<FieldTag,std::string> tag_rename = { {COL,"n"+suffix} };
+    auto deg = none.rename("deg");
 
-    gen_grid->create_geometry_data("lat", gen_grid->get_2d_scalar_layout(),deg);
-    gen_grid->create_geometry_data("lon", gen_grid->get_2d_scalar_layout(),deg);
-    gen_grid->create_geometry_data("area",gen_grid->get_2d_scalar_layout(),ekat::units::sr);
-    gen_grid->read_geometry_data(map_file,
-                                 {"lat","lon","area"},
-                                 {"yc"+suffix,"xc"+suffix,"area"+suffix},
-                                 {{"ncol","n"+suffix}});
+    const auto& layout2d = gen_grid->get_2d_scalar_layout();
+    auto lat  = gen_grid->create_geometry_data("lat", layout2d,deg).alias("yc"+suffix,tag_rename);
+    auto lon  = gen_grid->create_geometry_data("lon", layout2d,deg).alias("xc"+suffix,tag_rename);
+    auto area = gen_grid->create_geometry_data("area",layout2d,sr ).alias("area"+suffix,tag_rename);
+    auto gids = gen_grid->get_partitioned_dim_gids().alias("gids",tag_rename);
+    read_fields(map_file,{lat,lon,area},gids,comm);
 
     // If this is a remap TO a lat-lon grid, setup some geo data that our output classes
     // will use to write to file using (lat,lon) layout rather than (ncol)
@@ -224,21 +229,27 @@ read_mat_triplets (const std::string& map_file)
 {
   using gid_type = AbstractGrid::gid_type;
   using namespace ShortFieldTagsNames;
+  using namespace ekat::units;
 
   const auto& comm = m_src_grid->get_comm();
 
   // Split the triplets evenly across ranks, and read them
   int n_s = scorpio::get_dimlen(map_file,"n_s");
   auto io_grid = create_point_grid("remap_data_io_grid",n_s,0,comm);
-  io_grid->reset_field_tag_name(COL,"n_s");
 
-  auto row_h = io_grid->create_geometry_data<gid_type>("row",io_grid->get_2d_scalar_layout()).get_view<const gid_type*,Host>();
-  auto col_h = io_grid->create_geometry_data<gid_type>("col",io_grid->get_2d_scalar_layout()).get_view<const gid_type*,Host>();
-  auto S_h   = io_grid->create_geometry_data<Real>("S",  io_grid->get_2d_scalar_layout()).get_view<const Real*,Host>();
-  io_grid->read_geometry_data(map_file,{"row","col","S"});
+  auto fl = io_grid->get_2d_scalar_layout().rename_dim(0,"n_s");
+  auto gids = io_grid->get_partitioned_dim_gids().alias("gids",{{COL,"n_s"}});
+
+  Field row(FieldIdentifier("row",fl,none,"",DataType::IntType),true);
+  Field col(FieldIdentifier("col",fl,none,"",DataType::IntType),true);
+  Field S  (FieldIdentifier("S",fl,none,""),true);
+  read_fields(map_file,{row,col,S},gids,comm);
 
   int nlweights = io_grid->get_num_local_dofs();
 
+  auto row_h = row.get_view<const gid_type*,Host>();
+  auto col_h = col.get_view<const gid_type*,Host>();
+  auto S_h   = S.get_view<const Real*,Host>();
   std::vector<Triplet> triplets;
   for (int i=0; i<nlweights; ++i) {
     triplets.emplace_back(row_h[i],col_h[i],S_h[i]);
@@ -388,10 +399,11 @@ setup_latlon_data(const std::shared_ptr<AbstractGrid>& grid,
                   const std::string& map_file)
 {
   using namespace ShortFieldTagsNames;
+  using namespace ekat::units;
 
   // Add lat/lon to the temp grid, and read from map file
-  auto nondim = ekat::units::none;
-  ekat::units::Units deg(nondim,"degrees");
+  auto degN = none.rename("degrees_north");
+  auto degE = none.rename("degrees_east");
 
   // Declare lat/lon and read them from the map file.
   // WARNING: the vars/dims names are different from what eamxx uses
@@ -417,8 +429,8 @@ setup_latlon_data(const std::shared_ptr<AbstractGrid>& grid,
   // Re-create lat/lon geometry data with only lat (or lon) dim
   grid->delete_geometry_data("lat");
   grid->delete_geometry_data("lon");
-  auto lat = grid->create_geometry_data("lat",FieldLayout({CMP},{nlat},{"lat"}),deg);
-  auto lon = grid->create_geometry_data("lon",FieldLayout({CMP},{nlon},{"lon"}),deg);
+  auto lat = grid->create_geometry_data("lat",FieldLayout({CMP},{nlat},{"lat"}),degN);
+  auto lon = grid->create_geometry_data("lon",FieldLayout({CMP},{nlon},{"lon"}),degE);
   
   auto lat_h = lat.get_view<Real*,Host>();
   auto lon_h = lon.get_view<Real*,Host>();
@@ -428,8 +440,8 @@ setup_latlon_data(const std::shared_ptr<AbstractGrid>& grid,
   lon.sync_to_dev();
 
   auto scalar2d = grid->get_2d_scalar_layout();
-  auto lat_idx = grid->create_geometry_data("lat_idx",scalar2d,nondim,DataType::IntType);
-  auto lon_idx = grid->create_geometry_data("lon_idx",scalar2d,nondim,DataType::IntType);
+  auto lat_idx = grid->create_geometry_data("lat_idx",scalar2d,none,DataType::IntType);
+  auto lon_idx = grid->create_geometry_data("lon_idx",scalar2d,none,DataType::IntType);
   lat_idx.get_header().set_extra_data("save_as_geo_data",false);
   lon_idx.get_header().set_extra_data("save_as_geo_data",false);
 

--- a/components/eamxx/src/share/remap/vertical_remapper.cpp
+++ b/components/eamxx/src/share/remap/vertical_remapper.cpp
@@ -4,6 +4,7 @@
 #include "share/io/scorpio_input.hpp"
 #include "share/field/field_tag.hpp"
 #include "share/field/field_identifier.hpp"
+#include "share/field/field_reader.hpp"
 #include "share/util/eamxx_timing.hpp"
 #include "share/util/eamxx_universal_constants.hpp"
 #include "share/scorpio_interface/eamxx_scorpio_interface.hpp"
@@ -25,7 +26,6 @@ create_tgt_grid (const grid_ptr_type& src_grid,
                  const std::string& map_file)
 {
   // Create tgt_grid as a clone of src_grid with different nlevs
-  scorpio::register_file(map_file,scorpio::FileMode::Read);
   auto nlevs_tgt = scorpio::get_dimlen(map_file,"lev");
 
   auto tgt_grid = src_grid->clone(src_grid->name()+"_vremap_tgt",true);
@@ -34,12 +34,10 @@ create_tgt_grid (const grid_ptr_type& src_grid,
   // Gather the pressure level data for vertical remapping
   using namespace ShortFieldTagsNames;
   auto layout = tgt_grid->get_vertical_layout(LEVP);
+
   // Add tgt pressure levels to the tgt grid
   auto p_tgt = tgt_grid->create_geometry_data<Real>("p_levs",layout,ekat::units::Pa,SCREAM_PACK_SIZE);
-  scorpio::read_var(map_file,"p_levs",p_tgt.get_view<Real*,Host>().data());
-  p_tgt.sync_to_dev();
-
-  scorpio::release_file(map_file);
+  read_fields(map_file,{p_tgt});
 
   return tgt_grid;
 }


### PR DESCRIPTION
Replace AtmosphereInput with either `FieldReader` obj instances or calls to `read_fields`.

[BFB]

---

