### PR TITLE
Machines: set OMPI io to default to romio on mappy

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1804,6 +1804,7 @@
       <env name="OMP_PLACES">threads</env>
       <env name="BLA_VENDOR">OpenBLAS</env>
       <env name="GATOR_INITIAL_MB">4000MB</env>
+      <env name="OMPI_MCA_io">romio321</env>
     </environment_variables>
     <environment_variables mpilib="!mpi-serial">
       <env name="PNETCDF_PATH">$ENV{PARALLEL_NETCDF_ROOT}</env>


### PR DESCRIPTION
Fixes insanely long run times on mappy after the MOAB PR.

[BFB]

---

For reference, with this mod:
```
(bartgol) lbertag@mappy:[SMS_Ln5.ne4pg2_oQU480.F2010.mappy_gnu.eam-thetahy_sl_pg2.20260615_140637_hg2hu7]$ cat timing/e3sm_timing_stats.* | awk '$1 == "\"CPL:INIT\"" || $1 == "\"CPL:RUN_LOOP\"" {print $1, $7}' | sort -rnk3 | column -t
"CPL:INIT"      12.291
"CPL:RUN_LOOP"  2.664
```
with current master:
```
(bartgol) lbertag@mappy:[SMS_Ln5.ne4pg2_oQU480.F2010.mappy_gnu.eam-thetahy_sl_pg2.20260615_144059_f9xxog]$ cat timing/e3sm_timing_stats.* | awk '$1 == "\"CPL:INIT\"" || $1 == "\"CPL:RUN_LOOP\"" {print $1, $7}' | sort -rnk3 | column -t
"CPL:RUN_LOOP"  3.067
"CPL:INIT"      773.271
```