### PR TITLE
eamxx: set fillval thresholds to match science/diags

### DIFF
--- a/components/eamxx/docs/user/model_configuration.md
+++ b/components/eamxx/docs/user/model_configuration.md
@@ -505,6 +505,15 @@ the grid where the fields are defined and a coarser grid.
       the size of the output file.
           - **Note:** with this feature, the user can only specify fields
           from a single grid.
+- `horiz_remap_fill_threshold`: fraction (in `[0,1)`) of a target column that must
+come from valid (i.e., not fill-valued) source columns for the remapped value to be
+written out.
+      - When remapping fields that may contain fill values, EAMxx computes, for each
+      target column, the fraction of its interpolation weight that comes from valid
+      source columns.
+      - Target columns whose fraction is above this threshold store the average over
+      the valid source columns only, while the others are set to the fill value.
+      - If not set, it defaults to `0.5`, i.e., majority rules.
 - `vertical_remap_file`: similar to the previous option, this map file is used to
 refine/coarsen fields in the vertical direction.
 - `IOGrid`: this parameter can be specified inside one of the grids sections,
@@ -552,6 +561,14 @@ There are, however, particular use cases that require some less common options,
 which we list here (in parentheses, the location in the YAML file and the type
 of the parameter value).
 
+- `fill_threshold` (top-level list, `real`):
+      - This parameter is only used for `average` output of fields that may contain
+      fill values (e.g., vertically remapped fields, or `X_at_YhPa` diagnostics).
+      - It specifies the fraction (in `[0,1)`) of the output window that must be
+      unfilled for the time average to be written out; if the fraction of unfilled
+      snapshots does not exceed this threshold, the fill value is written instead.
+      - By default, it is `0.0`, meaning that the output stores the average over the
+      unfilled snapshots only, regardless of how many there are.
 - `flush_frequency` (top-level list, `integer`)
       - This parameter can be used to specify how often the IO library
       should sync the in-memory data to file.

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -219,6 +219,11 @@ AtmosphereOutput::AtmosphereOutput(const ekat::Comm &comm, const ekat::Parameter
     }
     if (params.isParameter("fill_threshold")) {
       m_avg_coeff_threshold = params.get<Real>("fill_threshold");
+      EKAT_REQUIRE_MSG (m_avg_coeff_threshold>=0 and m_avg_coeff_threshold<1,
+          "Error! Invalid value for 'fill_threshold'.\n"
+          "  - output stream: " + m_stream_name + "\n"
+          "  - fill_threshold: " + std::to_string(m_avg_coeff_threshold) + "\n"
+          "  - valid range   : [0,1)\n");
     }
   }
 
@@ -261,7 +266,11 @@ AtmosphereOutput::AtmosphereOutput(const ekat::Comm &comm, const ekat::Parameter
     if (use_horiz_remap_from_file) {
       // Construct the coarsening remapper
       auto horiz_remap_file   = params.get<std::string>("horiz_remap_file");
-      m_horiz_remapper = std::make_shared<HorizontalRemapper>(grid_after_vr,horiz_remap_file,true);
+      auto hr = std::make_shared<HorizontalRemapper>(grid_after_vr,horiz_remap_file,true);
+      if (params.isParameter("horiz_remap_fill_threshold")) {
+        hr->set_mask_threshold(params.get<Real>("horiz_remap_fill_threshold"));
+      }
+      m_horiz_remapper = hr;
     } else {
       // Construct a generic remapper (likely, Dyn->PhysicsGLL)
       grid_after_hr = fm_grid->get_aux_grid(output_data_layout);

--- a/components/eamxx/src/share/io/scorpio_output.hpp
+++ b/components/eamxx/src/share/io/scorpio_output.hpp
@@ -221,7 +221,7 @@ protected:
   // How to combine multiple snapshots in the output: instant, Max, Min, Average
   OutputAvgType m_avg_type;
   Real m_avg_coeff_threshold =
-      0.5; // % of unfilled values required to not just assign value as FillValue
+      0.01; // % of unfilled values required to not just assign value as FillValue
 
   // Internal maps to the output fields, how the columns are distributed, the file dimensions and
   // the global ids.

--- a/components/eamxx/src/share/io/scorpio_output.hpp
+++ b/components/eamxx/src/share/io/scorpio_output.hpp
@@ -220,8 +220,10 @@ protected:
 
   // How to combine multiple snapshots in the output: instant, Max, Min, Average
   OutputAvgType m_avg_type;
-  Real m_avg_coeff_threshold =
-      0.01; // % of unfilled values required to not just assign value as FillValue
+  // Fraction (in [0,1)) of the output interval that must be valid for an averaged
+  // value to be written out (rather than assigned the FillValue). The default of 0
+  // means the output stores the average over the unfilled snapshots only.
+  Real m_avg_coeff_threshold = 0;
 
   // Internal maps to the output fields, how the columns are distributed, the file dimensions and
   // the global ids.

--- a/components/eamxx/src/share/io/scorpio_output.hpp
+++ b/components/eamxx/src/share/io/scorpio_output.hpp
@@ -222,7 +222,7 @@ protected:
   OutputAvgType m_avg_type;
   // Fraction (in [0,1)) of the output interval that must be valid for an averaged
   // value to be written out (rather than assigned the FillValue). The default of 0
-  // means the output stores the average over the unfilled snapshots only.
+  // means we take into account >0 valid snaps (i.e., even if only 1 is valid, we take it).
   Real m_avg_coeff_threshold = 0;
 
   // Internal maps to the output fields, how the columns are distributed, the file dimensions and

--- a/components/eamxx/src/share/io/tests/io_remap_test.cpp
+++ b/components/eamxx/src/share/io/tests/io_remap_test.cpp
@@ -16,6 +16,11 @@ using namespace scream;
 
 constexpr int packsize = SCREAM_PACK_SIZE;
 constexpr Real fill_val = constants::fill_value<Real>;
+// Fraction of a tgt column that must come from valid (unfilled) src columns during
+// horiz remap. The 'remap_horizontal' stream sets this explicitly via the output
+// params, while 'remap_vertical_horizontal' leaves it unset, to test the default.
+constexpr Real hr_fill_threshold     = 0.0;
+constexpr Real hr_fill_threshold_def = 0.5;
 using         Pack     = ekat::Pack<Real,packsize>;
 using stratts_t = std::map<std::string,std::string>;
 
@@ -32,7 +37,7 @@ get_test_fields(std::shared_ptr<FieldManager> fm, const int p_ref=-1);
 
 Real calculate_output(const Real pressure, const int col, const int cmp);
 
-ekat::ParameterList set_output_params(const std::string& name, const std::string& remap_filename, const int p_ref, const bool vert_remap, const bool horiz_remap);
+ekat::ParameterList set_output_params(const std::string& name, const std::string& remap_filename, const int p_ref, const bool vert_remap, const bool horiz_remap, const Real hr_thresh=-1);
 std::string get_filename(const std::string& name, ekat::Comm& comm, const std::string& tstamp);
 
 bool approx(const Real a, const Real b) {
@@ -258,7 +263,7 @@ TEST_CASE("io_remap_test","io_remap_test")
   print ("    -> vertical remap ... done\n",io_comm);
 
   print ("    -> horizontal remap ... \n",io_comm);
-  auto horiz_remap_control = set_output_params("remap_horizontal",remap_filename,p_ref,false,true);
+  auto horiz_remap_control = set_output_params("remap_horizontal",remap_filename,p_ref,false,true,hr_fill_threshold);
   om_horiz.initialize(io_comm,horiz_remap_control,t0,false);
   om_horiz.setup(field_manager,gm->get_grid_names());
   io_comm.barrier();
@@ -413,18 +418,15 @@ TEST_CASE("io_remap_test","io_remap_test")
       // For the pressured sliced variable we expect some masking which needs to be checked.
       Real Ys_exp = 0.0;
       Real Ys_wgt = 0.0;
-      bool found  = false;
       if (p_ref<=pi_v(col1,nlevs_src) && p_ref>=pi_v(col1,0)) {
-        found = true;
         Ys_exp += calculate_output(p_ref,col1,0)*wgt;
         Ys_wgt += wgt;
       }
       if (p_ref<=pi_v(col2,nlevs_src) && p_ref>=pi_v(col2,0)) {
-        found = true;
         Ys_exp += calculate_output(p_ref,col2,0)*(1.0-wgt);
         Ys_wgt += (1.0 - wgt);
       }
-      if (found) {
+      if (Ys_wgt>hr_fill_threshold) {
         Ys_exp /= Ys_wgt;
       } else {
         Ys_exp = fill_val;
@@ -489,33 +491,36 @@ TEST_CASE("io_remap_test","io_remap_test")
         const Real mid_mask_2 = (p_jj<=pm_v(col2,nlevs_src-1) && p_jj>=pm_v(col2,0));
         const Real int_mask_1 = (p_jj<=pi_v(col1,nlevs_src)   && p_jj>=pi_v(col1,0));
         const Real int_mask_2 = (p_jj<=pi_v(col2,nlevs_src)   && p_jj>=pi_v(col2,0));
+        // Fraction of the tgt column coming from valid src columns
+        const Real mid_mask_r = mid_mask_1*wgt + mid_mask_2*(1-wgt);
+        const Real int_mask_r = int_mask_1*wgt + int_mask_2*(1-wgt);
         Real test_mid;
         Real test_int;
-        if (mid_mask_1 + mid_mask_2 > 0.0) {
-          test_mid = (mid_mask_1*calculate_output(p_jj,col1,0)*wgt + mid_mask_2*calculate_output(p_jj,col2,0)*(1-wgt))/(mid_mask_1*wgt + mid_mask_2*(1-wgt));
+        if (mid_mask_r > hr_fill_threshold_def) {
+          test_mid = (mid_mask_1*calculate_output(p_jj,col1,0)*wgt + mid_mask_2*calculate_output(p_jj,col2,0)*(1-wgt))/mid_mask_r;
         } else {
-          // This point is completely masked out, assign masked value
+          // Not enough valid src data, assign masked value
           test_mid = fill_val;
         }
-        if (int_mask_1 + int_mask_2 > 0.0) {
-          test_int = (int_mask_1*calculate_output(p_jj,col1,0)*wgt + int_mask_2*calculate_output(p_jj,col2,0)*(1-wgt))/(int_mask_1*wgt + int_mask_2*(1-wgt));
+        if (int_mask_r > hr_fill_threshold_def) {
+          test_int = (int_mask_1*calculate_output(p_jj,col1,0)*wgt + int_mask_2*calculate_output(p_jj,col2,0)*(1-wgt))/int_mask_r;
         } else {
-          // This point is completely masked out, assign masked value
+          // Not enough valid src data, assign masked value
           test_int = fill_val;
         }
         REQUIRE(approx(Ym_v_vh(ii,jj), test_mid));
         REQUIRE(approx(Yi_v_vh(ii,jj), test_int));
         for (int cc=0; cc<2; cc++) {
-          if (mid_mask_1 + mid_mask_2 > 0.0) {
-            test_mid = (mid_mask_1*calculate_output(p_jj,col1,cc+1)*wgt + mid_mask_2*calculate_output(p_jj,col2,cc+1)*(1-wgt))/(mid_mask_1*wgt + mid_mask_2*(1-wgt));
+          if (mid_mask_r > hr_fill_threshold_def) {
+            test_mid = (mid_mask_1*calculate_output(p_jj,col1,cc+1)*wgt + mid_mask_2*calculate_output(p_jj,col2,cc+1)*(1-wgt))/mid_mask_r;
           } else {
-            // This point is completely masked out, assign masked value
+            // Not enough valid src data, assign masked value
             test_mid = fill_val;
           }
-          if (int_mask_1 + int_mask_2 > 0.0) {
-            test_int = (int_mask_1*calculate_output(p_jj,col1,cc+1)*wgt + int_mask_2*calculate_output(p_jj,col2,cc+1)*(1-wgt))/(int_mask_1*wgt + int_mask_2*(1-wgt));
+          if (int_mask_r > hr_fill_threshold_def) {
+            test_int = (int_mask_1*calculate_output(p_jj,col1,cc+1)*wgt + int_mask_2*calculate_output(p_jj,col2,cc+1)*(1-wgt))/int_mask_r;
           } else {
-            // This point is completely masked out, assign masked value
+            // Not enough valid src data, assign masked value
             test_int = fill_val;
           }
           REQUIRE(approx(Vm_v_vh(ii,cc,jj), test_mid));
@@ -525,18 +530,15 @@ TEST_CASE("io_remap_test","io_remap_test")
       // For the pressured sliced variable we expect it to match the solution from horizontal mapping only so we use the same syntax.
       Real Ys_exp = 0.0;
       Real Ys_wgt = 0.0;
-      bool found  = false;
       if (p_ref<=pi_v(col1,nlevs_src) && p_ref>=pi_v(col1,0)) {
-        found = true;
         Ys_exp += calculate_output(p_ref,col1,0)*wgt;
         Ys_wgt += wgt;
       }
       if (p_ref<=pi_v(col2,nlevs_src) && p_ref>=pi_v(col2,0)) {
-        found = true;
         Ys_exp += calculate_output(p_ref,col2,0)*(1.0-wgt);
         Ys_wgt += (1.0 - wgt);
       }
-      if (found) {
+      if (Ys_wgt>hr_fill_threshold_def) {
         Ys_exp /= Ys_wgt;
       } else {
         Ys_exp = fill_val;
@@ -679,7 +681,7 @@ get_test_fields(std::shared_ptr<FieldManager> fm, const int p_ref)
   return fields;
 }
 /*==========================================================================================================*/
-ekat::ParameterList set_output_params(const std::string& name, const std::string& remap_filename, const int p_ref, const bool vert_remap, const bool horiz_remap)
+ekat::ParameterList set_output_params(const std::string& name, const std::string& remap_filename, const int p_ref, const bool vert_remap, const bool horiz_remap, const Real hr_thresh)
 {
   using vos_type = std::vector<std::string>;
   ekat::ParameterList params;
@@ -707,6 +709,10 @@ ekat::ParameterList set_output_params(const std::string& name, const std::string
   }
   if (horiz_remap) {
     params.set<std::string>("horiz_remap_file",remap_filename); // TODO, make this work for general np=?
+    // A negative value means "don't set the param", so that we test the default too
+    if (hr_thresh>=0) {
+      params.set<Real>("horiz_remap_fill_threshold",hr_thresh);
+    }
   }
 
   return params;

--- a/components/eamxx/src/share/remap/horizontal_remapper.cpp
+++ b/components/eamxx/src/share/remap/horizontal_remapper.cpp
@@ -501,7 +501,7 @@ rescale_masked_fields (const Field& x, const Field& real_mask) const
   const auto& layout = x.get_header().get_identifier().get_layout();
   const int rank = layout.rank();
   const int ncols = m_tgt_grid->get_num_local_dofs();
-  const Real mask_threshold = std::numeric_limits<Real>::epsilon();  // TODO: Should we not hardcode the threshold for simply masking out the column.
+  const Real mask_threshold = 0.25;
 
   Pack fv_pack(fill_val);
   auto& mask = x.get_valid_mask();

--- a/components/eamxx/src/share/remap/horizontal_remapper.cpp
+++ b/components/eamxx/src/share/remap/horizontal_remapper.cpp
@@ -107,6 +107,18 @@ HorizontalRemapper::
 }
 
 void HorizontalRemapper::
+set_mask_threshold (const Real thresh)
+{
+  EKAT_REQUIRE_MSG (thresh>=0 and thresh<1,
+      "Error! Invalid mask threshold for HorizontalRemapper.\n"
+      "  - remapper name: " + name() + "\n"
+      "  - threshold    : " + std::to_string(thresh) + "\n"
+      "  - valid range  : [0,1)\n");
+
+  m_mask_threshold = thresh;
+}
+
+void HorizontalRemapper::
 registration_ends_impl ()
 {
   using namespace ShortFieldTagsNames;
@@ -501,7 +513,7 @@ rescale_masked_fields (const Field& x, const Field& real_mask) const
   const auto& layout = x.get_header().get_identifier().get_layout();
   const int rank = layout.rank();
   const int ncols = m_tgt_grid->get_num_local_dofs();
-  const Real mask_threshold = 0.25;
+  const Real mask_threshold = m_mask_threshold;
 
   Pack fv_pack(fill_val);
   auto& mask = x.get_valid_mask();

--- a/components/eamxx/src/share/remap/horizontal_remapper.hpp
+++ b/components/eamxx/src/share/remap/horizontal_remapper.hpp
@@ -62,7 +62,7 @@ public:
   // When tracking masks, each tgt entry gets a real-valued mask in [0,1]: the fraction
   // of its interpolation weight coming from valid (i.e., not filled) src entries.
   // Entries above thresh are rescaled by that fraction (so they store the average over
-  // the valid src entries), while the others are set to the fill value.
+  // the valid src entries), while the others are masked (and set to the fill value later on).
   void set_mask_threshold (const Real thresh);
 
 protected:

--- a/components/eamxx/src/share/remap/horizontal_remapper.hpp
+++ b/components/eamxx/src/share/remap/horizontal_remapper.hpp
@@ -59,6 +59,12 @@ public:
 
   ~HorizontalRemapper ();
 
+  // When tracking masks, each tgt entry gets a real-valued mask in [0,1]: the fraction
+  // of its interpolation weight coming from valid (i.e., not filled) src entries.
+  // Entries above thresh are rescaled by that fraction (so they store the average over
+  // the valid src entries), while the others are set to the fill value.
+  void set_mask_threshold (const Real thresh);
+
 protected:
 
   void registration_ends_impl () override;
@@ -98,6 +104,9 @@ protected:
 
   // Whether we are tracking mask fields
   bool                m_track_mask;
+
+  // See set_mask_threshold
+  Real                m_mask_threshold = 0.5;
 
   // Indermediate version of the fields, on the overlap grid
   std::vector<Field>  m_ov_fields;


### PR DESCRIPTION
This pull request makes targeted adjustments to threshold values in the EAMxx component, specifically affecting how masked and unfilled data are handled in output and remapping routines. These changes aim to improve the robustness and accuracy of data processing by fine-tuning when data is considered valid or should be masked.

**Threshold adjustments for data validity and masking:**

* Reduced the `m_avg_coeff_threshold` in `AtmosphereOutput` from `0.5` to `0.01`, making the output more tolerant of unfilled values before assigning the fill value. (`components/eamxx/src/share/io/scorpio_output.hpp`)
* Changed the `mask_threshold` in `rescale_masked_fields` from `std::numeric_limits<Real>::epsilon()` to `0.5`, setting a more practical threshold for masking out columns during remapping. (`components/eamxx/src/share/remap/horizontal_remapper.cpp`)