### PR TITLE
Workflows: miscellanea fixes related to ghci-snl machine

### DIFF
--- a/.github/workflows/eamxx-sa-coverage.yml
+++ b/.github/workflows/eamxx-sa-coverage.yml
@@ -26,9 +26,9 @@ defaults:
     shell: bash --login {0}
 
 jobs:
-  gcc-openmp:
-    runs-on:  [self-hosted, ghci-snl-cpu, gcc]
-    name: gcc-openmp / cov
+  gnu-openmp:
+    runs-on:  [self-hosted, ghci-snl, gnu]
+    name: gnu-openmp / cov
     steps:
       - name: Check out the repository
         uses: actions/checkout@v6
@@ -42,13 +42,13 @@ jobs:
         uses: ./.github/actions/test-all-eamxx
         with:
           build_type: cov
-          machine: ghci-snl-cpu
+          machine: ghci-snl-gnu
           generate: false
           submit: ${{ env.submit }}
           cmake-configs: Kokkos_ENABLE_OPENMP=ON
-  gcc-cuda:
-    runs-on:  [self-hosted, ghci-snl-cuda, cuda, gcc]
-    name: gcc-cuda / cov
+  gnu-cuda:
+    runs-on:  [self-hosted, ghci-snl, cuda, gnu]
+    name: gnu-cuda / cov
     steps:
       - name: Check out the repository
         uses: actions/checkout@v6

--- a/.github/workflows/eamxx-sa-sanitizer.yml
+++ b/.github/workflows/eamxx-sa-sanitizer.yml
@@ -26,9 +26,9 @@ defaults:
     shell: bash --login {0}
 
 jobs:
-  gcc-openmp:
-    runs-on:  [self-hosted, ghci-snl-cpu, gcc]
-    name: gcc-openmp / valg
+  gnu-openmp:
+    runs-on:  [self-hosted, ghci-snl, gnu]
+    name: gnu-openmp / valg
     steps:
       - name: Check out the repository
         uses: actions/checkout@v6
@@ -42,17 +42,17 @@ jobs:
         uses: ./.github/actions/test-all-eamxx
         with:
           build_type: valg
-          machine: ghci-snl-cpu
+          machine: ghci-snl-gnu
           generate: false
           submit: ${{ env.submit }}
           cmake-configs: Kokkos_ENABLE_OPENMP=ON
-  gcc-cuda:
-    runs-on:  [self-hosted, ghci-snl-cuda, cuda, gcc]
+  gnu-cuda:
+    runs-on:  [self-hosted, ghci-snl, cuda, gnu]
     strategy:
       fail-fast: false
       matrix:
         build_type: [csm, csr, csi, css]
-    name: gcc-cuda / ${{ matrix.build_type }}
+    name: gnu-cuda / ${{ matrix.build_type }}
     steps:
       - name: Check out the repository
         uses: actions/checkout@v6

--- a/.github/workflows/eamxx-sa-testing.yml
+++ b/.github/workflows/eamxx-sa-testing.yml
@@ -31,8 +31,8 @@ on:
         required: true
         type: choice
         options:
-          - gcc-openmp
-          - gcc-cuda
+          - gnu-openmp
+          - gnu-cuda
           - oneapi-openmp
           - all
       bless:
@@ -74,21 +74,21 @@ defaults:
     shell: bash --login {0}
 
 jobs:
-  gcc-openmp:
+  gnu-openmp:
     if: |
       ${{
         github.event_name != 'workflow_dispatch' ||
         (
-          github.event.inputs.job_to_run == 'gcc-openmp' ||
+          github.event.inputs.job_to_run == 'gnu-openmp' ||
           github.event.inputs.job_to_run == 'all'
         )
       }}
-    runs-on:  [self-hosted, ghci-snl-cpu, gcc]
+    runs-on:  [self-hosted, ghci-snl, gnu]
     strategy:
       fail-fast: false
       matrix:
         build_type: [sp, dbg, fpe, opt]
-    name: gcc-openmp / ${{ matrix.build_type }}
+    name: gnu-openmp / ${{ matrix.build_type }}
     steps:
       - name: Check out the repository
         uses: actions/checkout@v6
@@ -117,7 +117,7 @@ jobs:
           github.event.inputs.job_to_run == 'all'
         )
       }}
-    runs-on:  [self-hosted, ghci-snl-oneapi, oneapi]
+    runs-on:  [self-hosted, ghci-snl, oneapi]
     strategy:
       fail-fast: false
       matrix:
@@ -142,16 +142,16 @@ jobs:
           cmake-configs: Kokkos_ENABLE_OPENMP=ON
           ekat: ${{ env.ekat }}
           kokkos_develop: ${{ env.kokkos_dev_test }}
-  gcc-cuda:
+  gnu-cuda:
     if: |
       ${{
         github.event_name != 'workflow_dispatch' ||
         (
-          github.event.inputs.job_to_run == 'gcc-cuda' ||
+          github.event.inputs.job_to_run == 'gnu-cuda' ||
           github.event.inputs.job_to_run == 'all'
         )
       }}
-    runs-on:  [self-hosted, ghci-snl-cuda, cuda, gcc]
+    runs-on:  [self-hosted, ghci-snl, cuda, gnu]
     strategy:
       fail-fast: false
       matrix:
@@ -162,7 +162,7 @@ jobs:
             SK: ON
           - build_type: opt
             SK: OFF
-    name: gcc-cuda / ${{ matrix.test.build_type }}
+    name: gnu-cuda / ${{ matrix.test.build_type }}
     steps:
       - name: Check out the repository
         uses: actions/checkout@v6

--- a/.github/workflows/eamxx-scripts-tests.yml
+++ b/.github/workflows/eamxx-scripts-tests.yml
@@ -40,8 +40,8 @@ defaults:
     shell: bash --login {0}
 
 jobs:
-  cpu-gcc:
-    runs-on:  [self-hosted, gcc, ghci-snl-cpu]
+  gnu:
+    runs-on:  [self-hosted, gnu, ghci-snl]
     steps:
       - name: Check out the repository
         uses: actions/checkout@v6
@@ -55,8 +55,8 @@ jobs:
         run: |
           cd components/eamxx
           if [ "${{ env.submit }}" == "true" ]; then
-            ./scripts/scripts-ctest-driver -s -m ghci-snl-cpu
+            ./scripts/scripts-ctest-driver -s -m ghci-snl-gnu
           else
-            ./scripts/scripts-tests -f -m ghci-snl-cpu
+            ./scripts/scripts-tests -f -m ghci-snl-gnu
             ./scripts/cime-nml-tests
           fi

--- a/.github/workflows/eamxx-v1-testing.yml
+++ b/.github/workflows/eamxx-v1-testing.yml
@@ -29,7 +29,7 @@ on:
         required: true
         type: choice
         options:
-          - cpu-gcc
+          - gnu
           - all
       bless:
         description: 'Generate baselines'
@@ -60,31 +60,31 @@ env:
   flags: ${{ github.event_name == 'workflow_dispatch' && inputs.bless && '-o -g -b master' || '-c -b master' }}
 
 jobs:
-  cpu-gcc:
+  gnu:
     if: |
       ${{
         github.event_name != 'workflow_dispatch' ||
         (
-          github.event.inputs.job_to_run == 'cpu-gcc' || 
+          github.event.inputs.job_to_run == 'gnu' ||
           github.event.inputs.job_to_run == 'all'
         )
       }}
-    runs-on:  [self-hosted, gcc, ghci-snl-cpu]
+    runs-on:  [self-hosted, gnu, ghci-snl]
     strategy:
       matrix:
         test:
-          - full_name: ERS_Ln9.ne4_ne4.F2000-SCREAMv1-AQP1.ghci-snl-cpu_gnu.eamxx-output-preset-2--eamxx-L72
+          - full_name: ERS_Ln9.ne4_ne4.F2000-SCREAMv1-AQP1.ghci-snl_gnu.eamxx-output-preset-2--eamxx-L72
             short_name: ERS_Ln9.ne4_ne4.F2000-SCREAMv1-AQP1.eamxx-output-preset-2
-          - full_name: ERS_P16_Ln22.ne30pg2_ne30pg2.FIOP-SCREAMv1-DP.ghci-snl-cpu_gnu.eamxx-dpxx-arm97
+          - full_name: ERS_P16_Ln22.ne30pg2_ne30pg2.FIOP-SCREAMv1-DP.ghci-snl_gnu.eamxx-dpxx-arm97
             short_name: ERS_P16_Ln22.ne30pg2_ne30pg2.FIOP-SCREAMv1-DP.eamxx-dpxx-arm97
-          - full_name: ERS_Ln22.ne4pg2_ne4pg2.F2010-SCREAMv1.ghci-snl-cpu_gnu.eamxx-small_kernels--eamxx-output-preset-5
+          - full_name: ERS_Ln22.ne4pg2_ne4pg2.F2010-SCREAMv1.ghci-snl_gnu.eamxx-small_kernels--eamxx-output-preset-5
             short_name: ERS_Ln22.ne4pg2_ne4pg2.F2010-SCREAMv1.eamxx-small_kernels--eamxx-output-preset-5
-          - full_name: REP_D_Ln5.ne4pg2_oQU480.F2010-EAMxx-MAM4xx.ghci-snl-cpu_gnu.eamxx-L72
+          - full_name: REP_D_Ln5.ne4pg2_oQU480.F2010-EAMxx-MAM4xx.ghci-snl_gnu.eamxx-L72
             short_name: REP_D_Ln5.ne4pg2_oQU480.F2010-EAMxx-MAM4xx.eamxx-L72
-          - full_name: ERS.ne4pg2_ne4pg2.F2010-SCREAMv1.ghci-snl-cpu_gnu.eamxx-prod
+          - full_name: ERS.ne4pg2_ne4pg2.F2010-SCREAMv1.ghci-snl_gnu.eamxx-prod
             short_name: ERS.ne4pg2_ne4pg2.F2010-SCREAMv1.eamxx-prod
       fail-fast: false
-    name: cpu-gcc / ${{ matrix.test.short_name }}
+    name: gnu / ${{ matrix.test.short_name }}
     steps:
       - name: Check out the repository
         uses: actions/checkout@v6

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1817,7 +1817,7 @@
     </resource_limits>
   </machine>
 
-  <machine MACH="ghci-snl-cpu">
+  <machine MACH="ghci-snl">
     <DESC>Huge Linux workstation for Sandia climate scientists</DESC>
     <NODENAME_REGEX>^[a-fA-F0-9]{12}$</NODENAME_REGEX>
     <OS>LINUX</OS>
@@ -1828,7 +1828,7 @@
     <DIN_LOC_ROOT>/projects/e3sm/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>/projects/e3sm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
-    <BASELINE_ROOT>/projects/e3sm/baselines/ghci-snl-cpu/$COMPILER</BASELINE_ROOT>
+    <BASELINE_ROOT>/projects/e3sm/baselines/ghci-snl/$COMPILER</BASELINE_ROOT>
     <CCSM_CPRNC>/projects/e3sm/cprnc/cprnc</CCSM_CPRNC>
     <GMAKE_J>32</GMAKE_J>
     <TESTS>e3sm_developer</TESTS>

--- a/components/eamxx/cacts.yaml
+++ b/components/eamxx/cacts.yaml
@@ -131,8 +131,8 @@ machines:
       - "eval $(${project.root_dir}/../../cime/CIME/Tools/get_case_env -c SMS.ne4pg2_ne4pg2.F2010-SCREAMv1.compy_intel)"
     batch: "srun --time 02:00:00 --nodes=1 -p short --exclusive --account e3sm"
 
-  ghci-snl-cpu:
-    baselines_dir: "/projects/e3sm/baselines/scream/ghci-snl-cpu"
+  ghci-snl-gnu:
+    baselines_dir: "/projects/e3sm/baselines/scream/ghci-snl-gnu"
     env_setup: ["export GATOR_INITIAL_MB=4000MB"]
 
   ghci-snl-cuda:

--- a/components/eamxx/cmake/machine-files/ghci-snl.cmake
+++ b/components/eamxx/cmake/machine-files/ghci-snl.cmake
@@ -11,5 +11,5 @@ option (EKAT_TEST_LAUNCHER_MANAGE_RESOURCES "" ON)
 set (EKAT_MPIRUN_EXE "mpirun" CACHE STRING "")
 set (EKAT_MPI_NP_FLAG "-n" CACHE STRING "")
 
-set(EKAT_VALGRIND_SUPPRESSION_FILE "/projects/e3sm/baselines/scream/ghci-snl-cpu/eamxx-valgrind.supp" CACHE FILEPATH "Use this valgrind suppression file if valgrind is enabled.")
+set(EKAT_VALGRIND_SUPPRESSION_FILE "/projects/e3sm/baselines/scream/ghci-snl-gnu/eamxx-valgrind.supp" CACHE FILEPATH "Use this valgrind suppression file if valgrind is enabled.")
 set (Python_EXECUTABLE "/projects/e3sm/eamxx-venv/bin/python3" CACHE STRING "")


### PR DESCRIPTION
Fix the names across eamxx scripts, cime configs, and workflows

[BFB]

---

More in detail:

- change "gcc" to "gnu" in workflow names, as the compiler suite is GNU. Also, change the runner labels to be `[self-hosted, ghci-snl, <COMPILERS>]`.
- remove "-cpu" from the CIME machine name in config_machines, and renamed cmake macro file accordingly. This allows adding oneapi/cuda support down the road as if it was just another compiler on ghci-snl (yes, we have separate images for each compiler, but that's an impl detail. Plus, lots (most) of settings would be exactly the same).

@jgfouca I thoguht about removing all our `scripts/jenkins` stuff in eamxx, since it is no longer used. but I thought it's best to do it in a separate PR.