### PR TITLE
Update CIME submodule

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1745,6 +1745,7 @@
     <BASELINE_ROOT>/sems-data-store/ACME/baselines/mappy/$COMPILER</BASELINE_ROOT>
     <CCSM_CPRNC>/sems-data-store/ACME/mappy/cprnc/cprnc</CCSM_CPRNC>
     <GMAKE_J>64</GMAKE_J>
+    <BATCHED_BUILD>TRUE</BATCHED_BUILD>
     <TESTS>e3sm_developer</TESTS>
     <BATCH_SYSTEM>slurm_single_node</BATCH_SYSTEM>
     <SUPPORTED_BY>jgfouca at sandia dot gov</SUPPORTED_BY>

--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1745,7 +1745,7 @@
     <BASELINE_ROOT>/sems-data-store/ACME/baselines/mappy/$COMPILER</BASELINE_ROOT>
     <CCSM_CPRNC>/sems-data-store/ACME/mappy/cprnc/cprnc</CCSM_CPRNC>
     <GMAKE_J>64</GMAKE_J>
-    <BATCHED_BUILD>TRUE</BATCHED_BUILD>
+    <BATCHED_BUILD>FALSE</BATCHED_BUILD>
     <TESTS>e3sm_developer</TESTS>
     <BATCH_SYSTEM>slurm_single_node</BATCH_SYSTEM>
     <SUPPORTED_BY>jgfouca at sandia dot gov</SUPPORTED_BY>

--- a/cime_config/machines/config_workflow.xml
+++ b/cime_config/machines/config_workflow.xml
@@ -29,6 +29,17 @@
   -->
   <workflow_jobs id="default">
     <!-- order matters, with no-batch jobs will be run in the order listed here -->
+    <job name="case.build">
+      <template>template.case.build</template>
+      <!-- Not part of the default submit workflow; submitted explicitly by case.build
+           when BATCHED_BUILD is TRUE on the machine. -->
+      <prereq>False</prereq>
+      <runtime_parameters>
+        <task_count>1</task_count>
+        <tasks_per_node>1</tasks_per_node>
+        <walltime>02:00:00</walltime>
+      </runtime_parameters>
+    </job>
     <job name="case.run">
       <template>template.case.run</template>
       <prereq>$BUILD_COMPLETE and not $TEST</prereq>

--- a/cime_config/machines/template.case.build
+++ b/cime_config/machines/template.case.build
@@ -60,10 +60,6 @@ def _main_func(description):
     else:
         caseroot = os.getcwd()
 
-    # Signal to build.py that we are already inside the batch job so it does
-    # not attempt to re-submit.
-    os.environ["CIME_BATCHED_BUILD_ACTIVE"] = "TRUE"
-
     with Case(caseroot, read_only=False, record=True) as case:
         success = build.case_build(
             caseroot,
@@ -74,6 +70,7 @@ def _main_func(description):
             save_build_provenance=not args.skip_provenance_check,
             separate_builds=args.separate_builds,
             ninja=args.ninja,
+            batched_build_active=True,
         )
 
     sys.exit(0 if success else 1)

--- a/cime_config/machines/template.case.build
+++ b/cime_config/machines/template.case.build
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+{{ batchdirectives }}
+
+"""
+Batch script template for building the case when BATCHED_BUILD is TRUE.
+This script is submitted as a batch job by case.build and should not be
+run directly.
+
+DO NOT RUN THIS SCRIPT MANUALLY
+Use ./case.build from the case directory instead.
+"""
+
+import os, sys
+os.chdir( '{{ caseroot }}')
+
+_LIBDIR = os.path.join("{{ cimeroot }}", "CIME", "Tools")
+sys.path.append(_LIBDIR)
+
+from standard_script_setup import *
+
+import CIME.build as build
+from CIME.case import Case
+
+logger = logging.getLogger(__name__)
+
+###############################################################################
+def _main_func(description):
+###############################################################################
+    # Expand any additional args injected via ARGS_FOR_SCRIPT by the submitter.
+    sys.argv.extend(
+        [] if "ARGS_FOR_SCRIPT" not in os.environ
+        else os.environ["ARGS_FOR_SCRIPT"].split()
+    )
+
+    import argparse
+    parser = argparse.ArgumentParser(description=description)
+    CIME.utils.setup_standard_logging_options(parser)
+
+    parser.add_argument("--caseroot", default=os.getcwd(),
+                        help="Case directory to build")
+    parser.add_argument("--sharedlib-only", action="store_true",
+                        help="Only build shared libraries")
+    parser.add_argument("--model-only", "-m", action="store_true",
+                        help="Assume shared libraries are already built")
+    parser.add_argument("--separate-builds", action="store_true",
+                        help="Build each component separately")
+    parser.add_argument("--ninja", action="store_true",
+                        help="Use ninja backend for CMake")
+    parser.add_argument("--skip-provenance-check", action="store_true",
+                        help="Do not check and save build provenance")
+    parser.add_argument("--build", nargs="+", dest="buildlist",
+                        help="Specific libraries/components to build")
+
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args=sys.argv,
+                                                                       parser=parser)
+
+    if args.caseroot is not None:
+        os.chdir(args.caseroot)
+        caseroot = args.caseroot
+    else:
+        caseroot = os.getcwd()
+
+    # Signal to build.py that we are already inside the batch job so it does
+    # not attempt to re-submit.
+    os.environ["CIME_BATCHED_BUILD_ACTIVE"] = "TRUE"
+
+    with Case(caseroot, read_only=False, record=True) as case:
+        success = build.case_build(
+            caseroot,
+            case=case,
+            sharedlib_only=args.sharedlib_only,
+            model_only=args.model_only,
+            buildlist=args.buildlist,
+            save_build_provenance=not args.skip_provenance_check,
+            separate_builds=args.separate_builds,
+            ninja=args.ninja,
+        )
+
+    sys.exit(0 if success else 1)
+
+
+if __name__ == "__main__":
+    _main_func(__doc__)

--- a/cime_config/machines/template.case.build
+++ b/cime_config/machines/template.case.build
@@ -33,11 +33,13 @@ def _main_func(description):
     )
 
     import argparse
-    parser = argparse.ArgumentParser(description=description)
+    parser = argparse.ArgumentParser(description=description, prog=".case.build")
     CIME.utils.setup_standard_logging_options(parser)
 
     parser.add_argument("--caseroot", default=os.getcwd(),
                         help="Case directory to build")
+    parser.add_argument("--no-batch-build", action="store_true",
+                        help="Ignore, this is always True")
     parser.add_argument("--sharedlib-only", action="store_true",
                         help="Only build shared libraries")
     parser.add_argument("--model-only", "-m", action="store_true",
@@ -51,8 +53,7 @@ def _main_func(description):
     parser.add_argument("--build", nargs="+", dest="buildlist",
                         help="Specific libraries/components to build")
 
-    args = CIME.utils.parse_args_and_handle_standard_logging_options(args=sys.argv,
-                                                                       parser=parser)
+    args = CIME.utils.parse_args_and_handle_standard_logging_options(args=sys.argv, parser=parser)
 
     if args.caseroot is not None:
         os.chdir(args.caseroot)
@@ -70,7 +71,7 @@ def _main_func(description):
             save_build_provenance=not args.skip_provenance_check,
             separate_builds=args.separate_builds,
             ninja=args.ninja,
-            batched_build_active=True,
+            batched_build_active=True, # This is a batch script
         )
 
     sys.exit(0 if success else 1)

--- a/cime_config/machines/template.case.run
+++ b/cime_config/machines/template.case.run
@@ -35,11 +35,11 @@ OR
     \033[1;32m# case.run SMS\033[0m
     > {0}
 """.format(os.path.basename(args[0])),
-        description=description,
+        description=description, prog=".case.run",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
 
-    CIME.utils.setup_standard_logging_options(parser, prog=".case.run")
+    CIME.utils.setup_standard_logging_options(parser)
 
     parser.add_argument("--caseroot",
                         help="Case directory to build")

--- a/cime_config/machines/template.case.run
+++ b/cime_config/machines/template.case.run
@@ -39,7 +39,7 @@ OR
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
 
-    CIME.utils.setup_standard_logging_options(parser)
+    CIME.utils.setup_standard_logging_options(parser, prog=".case.run")
 
     parser.add_argument("--caseroot",
                         help="Case directory to build")

--- a/cime_config/machines/template.case.test
+++ b/cime_config/machines/template.case.test
@@ -31,13 +31,11 @@ OR
     \033[1;32m# case.test SMS\033[0m
     > {0}
 """.format(os.path.basename(args[0])),
+        description=description, prog=".case.test",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
 
-description=description,
-
-formatter_class=argparse.ArgumentDefaultsHelpFormatter
-)
-
-    CIME.utils.setup_standard_logging_options(parser, prog=".case.test")
+    CIME.utils.setup_standard_logging_options(parser)
 
     parser.add_argument("testname", nargs="?",default=None,
                         help="Name of the test to run, default is set in TESTCASE in env_test.xml")

--- a/cime_config/machines/template.case.test
+++ b/cime_config/machines/template.case.test
@@ -37,7 +37,7 @@ description=description,
 formatter_class=argparse.ArgumentDefaultsHelpFormatter
 )
 
-    CIME.utils.setup_standard_logging_options(parser)
+    CIME.utils.setup_standard_logging_options(parser, prog=".case.test")
 
     parser.add_argument("testname", nargs="?",default=None,
                         help="Name of the test to run, default is set in TESTCASE in env_test.xml")

--- a/cime_config/machines/template.post_run_io
+++ b/cime_config/machines/template.post_run_io
@@ -38,11 +38,11 @@ OR
     \033[1;32m# case.post_run_io SMS\033[0m
     > {0}
 """.format(os.path.basename(args[0])),
-        description=description,
+        description=description, prog=".case.post_run_io",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
 
-    CIME.utils.setup_standard_logging_options(parser, prog=".case.post_run_io")
+    CIME.utils.setup_standard_logging_options(parser)
 
     parser.add_argument("--caseroot",
                         help="Case directory to build")

--- a/cime_config/machines/template.post_run_io
+++ b/cime_config/machines/template.post_run_io
@@ -42,7 +42,7 @@ OR
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
 
-    CIME.utils.setup_standard_logging_options(parser)
+    CIME.utils.setup_standard_logging_options(parser, prog=".case.post_run_io")
 
     parser.add_argument("--caseroot",
                         help="Case directory to build")

--- a/cime_config/machines/template.st_archive
+++ b/cime_config/machines/template.st_archive
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 def parse_command_line(args, description):
 ###############################################################################
 
-    parser = argparse.ArgumentParser(description=description,
+    parser = argparse.ArgumentParser(description=description, prog=".st_archive",
                                      formatter_class=argparse.RawTextHelpFormatter)
 
     CIME.utils.setup_standard_logging_options(parser)

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -4,7 +4,7 @@
 # suite_name : {
 #     "inherit" : (suite1, suite2, ...), # Optional. Suites to inherit tests from. Default is None. Tuple, list, or str.
 #     "time"    : "HH:MM:SS",            # Optional. Recommended upper-limit on test time.
-#     "share"   : True|False,            # Optional. If True, all tests in this suite share a build. Default is False.
+#     "share"   : True|False|"testname", # Optional. If True, all tests share a build (first in suite order leads). If a test name string, that test's build is shared. Default is False.
 #     "tests"   : (test1, test2, ...)    # Optional. The list of tests for this suite. See above for format. Tuple, list, or str.
 # }
 

--- a/driver-mct/cime_config/config_component.xml
+++ b/driver-mct/cime_config/config_component.xml
@@ -798,6 +798,18 @@
     <desc>Number of processors for gmake</desc>
   </entry>
 
+  <entry id="BATCHED_BUILD">
+    <type>logical</type>
+    <valid_values>TRUE,FALSE</valid_values>
+    <default_value>FALSE</default_value>
+    <group>build_def</group>
+    <file>env_build.xml</file>
+    <desc>If TRUE, case.build submits the build as a batch job instead of
+    building interactively on the login node. The machine must define a
+    supported batch system (BATCH_SYSTEM != none). When BATCH_SYSTEM is
+    none, CIME falls back to an interactive build with a warning.</desc>
+  </entry>
+
   <entry id="BUILD_COMPLETE">
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>

--- a/driver-moab/cime_config/config_component.xml
+++ b/driver-moab/cime_config/config_component.xml
@@ -784,6 +784,18 @@
     <desc>Number of processors for gmake</desc>
   </entry>
 
+  <entry id="BATCHED_BUILD">
+    <type>logical</type>
+    <valid_values>TRUE,FALSE</valid_values>
+    <default_value>FALSE</default_value>
+    <group>build_def</group>
+    <file>env_build.xml</file>
+    <desc>If TRUE, case.build submits the build as a batch job instead of
+    building interactively on the login node. The machine must define a
+    supported batch system (BATCH_SYSTEM != none). When BATCH_SYSTEM is
+    none, CIME falls back to an interactive build with a warning.</desc>
+  </entry>
+
   <entry id="BUILD_COMPLETE">
     <type>logical</type>
     <valid_values>TRUE,FALSE</valid_values>


### PR DESCRIPTION
Update CIME submodule
    
from 189fe3b7c3019b5f0e2564cd69b410e92426102f
to   240989d6ae3d236894cda07993e0f64a20af1623
    
Fixes
1) Remove cdash build description upload, it's wrong for all but latest build
2) Fix a bug in cime_bisect using a non-string in expect arg
3) Fix get_ts_synopsis catch-all triggered by bless trailer after PASS
4) Do NOT skip prereq check for first job

Changes
1) Remove Perl XML dependency (replacing with Lite)
2) Add ability to do builds on compute nodes!
3) For share-exe test suites, allow specification of which case to use
4) Add fused shared/model builds when batched builds is on
5) For batched builds, use the whole node
6) Better support for ninja
    
[BFB]