### PR TITLE
Deallocate memory when getting string from MCT to avoid memory leaks

### DIFF
--- a/components/data_comps/datm/src/datm_comp_mod.F90
+++ b/components/data_comps/datm/src/datm_comp_mod.F90
@@ -1351,8 +1351,8 @@ CONTAINS
       mct_field = mct_string_toChar(mctOStr)
       tagname= trim(mct_field)//C_NULL_CHAR
       call moab_set_tag_from_av(tagname, a2x, index_list, mphaid, datam, lsize) ! loop over all a2x fields, not just a few
+      call mct_string_clean(mctOStr) ! mct_list_get allocates a new string each iteration; free it here to avoid a per-timestep leak
     enddo
-    call mct_string_clean(mctOStr)
     call mct_list_clean(temp_list)
     deallocate(datam) ! maybe we should keep it around, deallocate at the final only?
 

--- a/components/data_comps/dice/src/dice_comp_mod.F90
+++ b/components/data_comps/dice/src/dice_comp_mod.F90
@@ -916,6 +916,7 @@ CONTAINS
       mct_field = mct_string_toChar(mctOStr)
       tagname= trim(mct_field)//C_NULL_CHAR
       call moab_set_tag_from_av(tagname, i2x, index_list, MPSIID, datam, lsize) ! loop over all a2x fields, not just a few
+      call mct_string_clean(mctOStr) ! mct_list_get allocates a new string each iteration; free it here to avoid a per-timestep leak
     enddo
     call mct_list_clean(temp_list)
     deallocate(datam) ! maybe we should keep it around, deallocate at the final only?

--- a/components/data_comps/dlnd/src/dlnd_comp_mod.F90
+++ b/components/data_comps/dlnd/src/dlnd_comp_mod.F90
@@ -646,6 +646,7 @@ CONTAINS
       mct_field = mct_string_toChar(mctOStr)
       tagname= trim(mct_field)//C_NULL_CHAR
       call moab_set_tag_from_av(tagname, l2x, index_list, mlnid, datam, lsize) ! loop over all a2x fields, not just a few
+      call mct_string_clean(mctOStr) ! mct_list_get allocates a new string each iteration; free it here to avoid a per-timestep leak
     enddo
     call mct_list_clean(temp_list)
     deallocate(datam) ! maybe we should keep it around, deallocate at the final only?

--- a/components/data_comps/docn/src/docn_comp_mod.F90
+++ b/components/data_comps/docn/src/docn_comp_mod.F90
@@ -988,6 +988,7 @@ CONTAINS
       mct_field = mct_string_toChar(mctOStr)
       tagname = trim(mct_field)//C_NULL_CHAR
       call moab_set_tag_from_av(tagname, o2x, index_list, mpoid, data, lsize)
+      call mct_string_clean(mctOStr) ! mct_list_get allocates a new string each iteration; free it here to avoid a per-timestep leak
     enddo
     call mct_list_clean(temp_list)
     deallocate(data)

--- a/components/data_comps/drof/src/drof_comp_mod.F90
+++ b/components/data_comps/drof/src/drof_comp_mod.F90
@@ -588,6 +588,7 @@ CONTAINS
       mct_field = mct_string_toChar(mctOStr)
       tagname= trim(mct_field)//C_NULL_CHAR
       call moab_set_tag_from_av(tagname, r2x, index_list, mrofid, datam, lsize) ! loop over all a2x fields, not just a few
+      call mct_string_clean(mctOStr) ! mct_list_get allocates a new string each iteration; free it here to avoid a per-timestep leak
     enddo
     call mct_list_clean(temp_list)
     deallocate(datam) ! maybe we should keep it around, deallocate at the final only?


### PR DESCRIPTION
Fixes memory leaks when accessing the string from MCT for data models

[BFB]