### PR TITLE
EAMxx: fix order of driver ops in IOP unit test

### DIFF
--- a/components/eamxx/tests/multi-process/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_pg2_dp/homme_shoc_cld_spa_p3_rrtmgp_pg2_dp.cpp
+++ b/components/eamxx/tests/multi-process/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_pg2_dp/homme_shoc_cld_spa_p3_rrtmgp_pg2_dp.cpp
@@ -84,8 +84,9 @@ TEST_CASE("scream_homme_physics", "scream_homme_physics") {
                                          4, 4, ncols, import_data.data(), import_names[0], import_cpl_indices.data(),
                                          import_vec_comps.data(), import_constant_multiple.data(), do_import_during_init.data());
   ad.initialize_fields ();
-  ad.initialize_output_managers ();
   ad.initialize_atm_procs ();
+  ad.reset_accumulated_fields();
+  ad.initialize_output_managers ();
 
   if (atm_comm.am_i_root()) {
     printf("Start time stepping loop...       [  0%%]\n");


### PR DESCRIPTION
The order of operations need to reflect the typical timestep.

[non-BFB only for one eamxx unit test]

---

I'm still adding the BFB label, as this only changes one internal unit test, and should have zero impact on any other run/test.