### PR TITLE
Add netcdf4 engine to NetCDF file output

### DIFF
--- a/tools/generate_domain_files/generate_domain_files_E3SM.py
+++ b/tools/generate_domain_files/generate_domain_files_E3SM.py
@@ -259,7 +259,7 @@ def main():
     ds_out['frac'] = xr.DataArray( ofrac       .values.reshape([nj,ni]),   dims=['nj','ni'])
     ds_out['mask'] = xr.DataArray( omask       .values.reshape([nj,ni]),   dims=['nj','ni'])
 
-  ds_out.to_netcdf(path=domain_file_ocn_on_ocn, mode='w', format=output_netcdf_type)
+  ds_out.to_netcdf(path=domain_file_ocn_on_ocn, mode='w', format=output_netcdf_type, engine='netcdf4')
 
   print(f'successfully created domain file: {clr.MAGENTA}{domain_file_ocn_on_ocn}{clr.END}')
 
@@ -334,7 +334,7 @@ def main():
 
   add_metadata(ds_out)
 
-  ds_out.to_netcdf(path=domain_file_lnd_on_atm, mode='w', format=output_netcdf_type)
+  ds_out.to_netcdf(path=domain_file_lnd_on_atm, mode='w', format=output_netcdf_type, engine='netcdf4')
 
   print(f'successfully created domain file: {clr.MAGENTA}{domain_file_lnd_on_atm}{clr.END}')
 

--- a/tools/generate_domain_files/generate_domain_files_E3SM.py
+++ b/tools/generate_domain_files/generate_domain_files_E3SM.py
@@ -365,7 +365,7 @@ def main():
 
   add_metadata(ds_out)
 
-  ds_out.to_netcdf(path=domain_file_ocn_on_atm, mode='w', format=output_netcdf_type)
+  ds_out.to_netcdf(path=domain_file_ocn_on_atm, mode='w', format=output_netcdf_type, engine='netcdf4')
 
   print(f'successfully created domain file: {clr.MAGENTA}{domain_file_ocn_on_atm}{clr.END}')
   print()


### PR DESCRIPTION
specify engine='netcdf4' for generate_domain_files_E3SM.py to fix problem with latest version of E3SM unified env