### PR TITLE
Machines: fix ghci-snl machine specs

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1938,18 +1938,18 @@
   </machine>
 
   <machine MACH="ghci-snl">
-    <DESC>Huge Linux workstation for Sandia climate scientists</DESC>
+    <DESC>RHEL9 image(s) hosted on SNL machines, used for Git Hub CI</DESC>
     <NODENAME_REGEX>^[a-fA-F0-9]{12}$</NODENAME_REGEX>
     <OS>LINUX</OS>
     <PROXY>proxy.sandia.gov:80</PROXY>
     <COMPILERS>gnu</COMPILERS>
     <MPILIBS>openmpi</MPILIBS>
     <CIME_OUTPUT_ROOT>/tmp</CIME_OUTPUT_ROOT>
-    <DIN_LOC_ROOT>/projects/e3sm/inputdata</DIN_LOC_ROOT>
-    <DIN_LOC_ROOT_CLMFORC>/projects/e3sm/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
+    <DIN_LOC_ROOT>/projects/e3sm/data/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/projects/e3sm/data/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
-    <BASELINE_ROOT>/projects/e3sm/baselines/ghci-snl/$COMPILER</BASELINE_ROOT>
-    <CCSM_CPRNC>/projects/e3sm/cprnc/cprnc</CCSM_CPRNC>
+    <BASELINE_ROOT>/projects/e3sm/data/baselines/ghci-snl/$COMPILER</BASELINE_ROOT>
+    <CCSM_CPRNC>/projects/e3sm/software/cprnc/cprnc</CCSM_CPRNC>
     <GMAKE_J>32</GMAKE_J>
     <TESTS>e3sm_developer</TESTS>
     <BATCH_SYSTEM>none</BATCH_SYSTEM>
@@ -1977,7 +1977,7 @@
       <env name="OMP_PLACES">threads</env>
       <env name="BLA_VENDOR">Generic</env>
       <env name="GATOR_INITIAL_MB">4000MB</env>
-      <env name="MOAB_ROOT">/projects/e3sm/moab</env>
+      <env name="MOAB_ROOT">/projects/e3sm/software/moab</env>
     </environment_variables>
   </machine>
 

--- a/components/eamxx/cmake/machine-files/ghci-snl-gnu.cmake
+++ b/components/eamxx/cmake/machine-files/ghci-snl-gnu.cmake
@@ -11,4 +11,5 @@ set(LAPACK_LIBRARIES "$ENV{BLAS_ROOT}/lib64/liblapack.so" CACHE STRING "Path to 
 # Set SCREAM_MACHINE
 set(SCREAM_MACHINE ghci-snl-gnu CACHE STRING "")
 
+set(EKAT_VALGRIND_SUPPRESSION_FILE "/projects/e3sm/data/baselines/scream/ghci-snl-gnu/eamxx-valgrind.supp" CACHE FILEPATH "Use this valgrind suppression file if valgrind is enabled.")
 option (EAMXX_ENABLE_PYTHON "Whether to enable python interface from eamxx" ON)

--- a/components/eamxx/cmake/machine-files/ghci-snl.cmake
+++ b/components/eamxx/cmake/machine-files/ghci-snl.cmake
@@ -1,5 +1,5 @@
 # Set the path to SCREAM input data
-set(SCREAM_INPUT_ROOT /projects/e3sm/inputdata CACHE PATH "Path to SCREAM input data" FORCE)
+set(SCREAM_INPUT_ROOT /projects/e3sm/data/inputdata CACHE PATH "Path to SCREAM input data" FORCE)
 
 # Let's catch usage of code deprecated in Kokkos 4
 option (Kokkos_ENABLE_DEPRECATED_CODE_4 "" OFF)
@@ -11,5 +11,4 @@ option (EKAT_TEST_LAUNCHER_MANAGE_RESOURCES "" ON)
 set (EKAT_MPIRUN_EXE "mpirun" CACHE STRING "")
 set (EKAT_MPI_NP_FLAG "-n" CACHE STRING "")
 
-set(EKAT_VALGRIND_SUPPRESSION_FILE "/projects/e3sm/baselines/scream/ghci-snl-gnu/eamxx-valgrind.supp" CACHE FILEPATH "Use this valgrind suppression file if valgrind is enabled.")
-set (Python_EXECUTABLE "/projects/e3sm/eamxx-venv/bin/python3" CACHE STRING "")
+set (Python_EXECUTABLE "/projects/e3sm/software/eamxx-venv/bin/python3" CACHE STRING "")

--- a/components/eamxx/scripts/machines_specs.py
+++ b/components/eamxx/scripts/machines_specs.py
@@ -261,7 +261,7 @@ class GHCISNLGNU(Machine):
     @classmethod
     def setup(cls):
         super().setup_base("ghci-snl-gnu")
-        cls.baselines_dir = "/projects/e3sm/baselines/scream/ghci-snl-gnu"
+        cls.baselines_dir = "/projects/e3sm/data/baselines/scream/ghci-snl-gnu"
         cls.env_setup = ["export GATOR_INITIAL_MB=4000MB"]
 
 ###############################################################################
@@ -271,7 +271,7 @@ class GHCISNLOneAPI(Machine):
     @classmethod
     def setup(cls):
         super().setup_base("ghci-snl-oneapi")
-        cls.baselines_dir = "/projects/e3sm/baselines/scream/ghci-snl-oneapi"
+        cls.baselines_dir = "/projects/e3sm/data/baselines/scream/ghci-snl-oneapi"
         cls.env_setup = ["export GATOR_INITIAL_MB=4000MB",
                          "export OMPI_MCA_io=romio321"]
 
@@ -282,7 +282,7 @@ class GHCISNLCuda(Machine):
     @classmethod
     def setup(cls):
         super().setup_base(name="ghci-snl-cuda")
-        cls.baselines_dir = "/projects/e3sm/baselines/scream/ghci-snl-cuda"
+        cls.baselines_dir = "/projects/e3sm/data/baselines/scream/ghci-snl-cuda"
         cls.gpu_arch = "cuda"
         cls.num_run_res = int(run_cmd_no_fail("nvidia-smi --query-gpu=name --format=csv,noheader | wc -l"))
 


### PR DESCRIPTION
The content of /projects/e3sm has been moved to the subdirectories 'software' and 'data'.

[BFB]

---

This PR will be merged quickly when the containers used for gh CI testing get updated. We are trying to fix an issue that appeared ever since I installed MOAB on the container images, where for some reason subfolders in /projects/e3sm are not there when the AT2 framework runs containers in parallel on mappy, but they are there when I manually run the container. According to gemini, this has to do with how fuse-overlay-fs resolves the presence of mounted (baselines, inputdata) and pre-existing (moab) folders in /projects/e3sm in the container when firing it up. We are trying some fixes, but unfortunately we can't test them until the whole framework has been updated.

This tentative fix tries to make the mounted and existing folders not "siblings" in /projects/e3sm, and instead nest the former in /projects/e3sm/data and the latter in /projects/e3sm/software. In theory (or, better, in gemini's theory) this should prevent inode conflicts when fuse-overlay-fs merges the static content (what's in the image) with the dynamic content (the mounted folders).

Edit: obviously, we expect all testing to fail while the old images are in use, b/c this PR changes all paths, and the paths won't work until the new image comes online.