### PR TITLE
Add actions folder to dependabot search paths

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,9 @@ version: 2
 updates:
 
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/*"
     schedule:
       interval: "weekly"
     assignees:


### PR DESCRIPTION
Dependabot only scans `/.github/workflows` and `/action.yml`/`/action.yaml` by default. This PR ensures we also scan our hand-rolled actions.

[BFB]

---

Note: we've been getting this kind of warning in our ghci jobs:

```
Warning: Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/github-script@v7. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```

The only place where `github-script` is used is `.github/actions/show-action-trigger/action.yml`, which is currently not parsed by dependabot. After this is merged, we should see a dependabot update PR for that action the next time it runs (within a week).