### PR TITLE
EAMxx: put CTest error exceptions in CTestCustom.cmake file in bin dir

### DIFF
--- a/components/eamxx/cmake/ctest_script.cmake
+++ b/components/eamxx/cmake/ctest_script.cmake
@@ -20,10 +20,12 @@ ctest_start(${dashboard_model} TRACK ${dashboard_track})
 # Add some exception rules for ctest automatic error detection
 # These are strings in the build output that ctest mistakenly
 # interprets as errors
-list(APPEND CTEST_CUSTOM_ERROR_EXCEPTION
-  ".*error_handler.*"
-  ".*spdlog/fmt/bundled/format.h.*"
-)
+file(WRITE "${CTEST_BINARY_DIRECTORY}/CTestCustom.cmake" "
+  list(APPEND CTEST_CUSTOM_ERROR_EXCEPTION
+    \".*error_handler.*\"
+    \".*spdlog/fmt/bundled/format.h.*\"
+  )
+")
 
 if (USE_NINJA)
   set (CTEST_CMAKE_GENERATOR Ninja)


### PR DESCRIPTION
Should fix intermittent errors with oneapi CI tests.

[BFB]

---

Gemini seems to support this approach (which was also done, for the same reason, in [CACTS](https://github.com/E3SM-Project/cacts/pull/37) , which is used to test EKAT, and seems to have worked there).