### PR TITLE
EAMxx: MAM4xx + DPxx

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -290,7 +290,7 @@ be lost if SCREAM_HACK_XML is not enabled.
 
     <!-- MAM4xx-Dry Deposition -->
     <mam4_drydep inherit="mam4_atm_proc_base">
-    <fractional_land_use_file type="file" doc="File containing Fractional land use data for drydep">${DIN_LOC_ROOT}/atm/scream/mam4xx/drydep/ne30pg2/atmsrf_ne30pg2_c20241017.nc</fractional_land_use_file>
+    <fractional_land_use_file type="file" doc="File containing Fractional land use data for drydep">${DIN_LOC_ROOT}/atm/scream/mam4xx/drydep/ne30pg2/atmsrf_ne30pg2_c20260624.nc</fractional_land_use_file>
     <fractional_land_use_file hgrid="ne4np4.pg2" type="file" doc="File containing Fractional land use data for drydep">${DIN_LOC_ROOT}/atm/scream/mam4xx/drydep/ne4pg2/atmsrf_ne4pg2_c20241017.nc</fractional_land_use_file>
 
     <!-- Mapping Files for finer resolutions -->

--- a/components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/mam4xx/dpxx_arm97/shell_commands
+++ b/components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/mam4xx/dpxx_arm97/shell_commands
@@ -1,0 +1,26 @@
+# Sets up a DPxx/IOP case to test MAM4xx processes
+# using the ARM97 (continental deep convection over land) IOP
+# with prescribed surface fluxes and nudged winds
+
+./xmlchange RUN_STARTDATE="1997-06-23"
+./xmlchange PTS_LAT=36.605
+./xmlchange PTS_LON=262.515
+
+# Scripts location
+ATMCHANGE=$CIMEROOT/../components/eamxx/scripts/atmchange
+
+#------------------------------------------------------
+# Add MAM4xx processes
+#------------------------------------------------------
+$ATMCHANGE physics::atm_procs_list="iop_forcing,mam4_constituent_fluxes,mac_aero_mic,rrtmgp,mam4_aero_microphys,mam4_srf_online_emiss,mam4_drydep" -b
+
+$ATMCHANGE mam4_drydep::fractional_land_use_file='${DIN_LOC_ROOT}'/atm/scream/mam4xx/drydep/ne30pg2/atmsrf_ne30pg2_c20260624.nc
+
+#------------------------------------------------------
+# Set IOP parameters (ARM97)
+#------------------------------------------------------
+$ATMCHANGE iop_file='${DIN_LOC_ROOT}'/atm/cam/scam/iop/ARM97_iopfile_4scam.nc -b
+$ATMCHANGE target_latitude=36.605 -b
+$ATMCHANGE target_longitude=262.515 -b
+$ATMCHANGE iop_nudge_uv=true -b
+$ATMCHANGE iop_srf_prop=true -b

--- a/components/eamxx/src/physics/mam/eamxx_mam_dry_deposition_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_dry_deposition_process_interface.cpp
@@ -163,9 +163,20 @@ void MAMDryDep::create_requests() {
   const std::string dim_name2 = "class";
 
   // initialize the file read
-  FracLandUseFunc::init_frac_landuse_file_read(
-      ncol_, field_name, dim_name1, dim_name2, grid_, frac_landuse_data_file,
-      mapping_file, horizInterp_, dataReader_);  // output
+  if (m_iop_data_manager != nullptr) {
+    EKAT_REQUIRE_MSG(mapping_file == "" or mapping_file == "none",
+      "Error! Cannot define drydep_remap_file for cases with an Intensive Observation Period defined. "
+      "The IOP class defines its own remap from file data -> model data.\n");
+    Real iop_lat = m_iop_data_manager->get_params().get<Real>("target_latitude");
+    Real iop_lon = m_iop_data_manager->get_params().get<Real>("target_longitude");
+    FracLandUseFunc::init_frac_landuse_file_read(
+        ncol_, field_name, dim_name1, dim_name2, grid_, frac_landuse_data_file,
+        iop_lat, iop_lon, horizInterp_, dataReader_);  // output
+  } else {
+    FracLandUseFunc::init_frac_landuse_file_read(
+        ncol_, field_name, dim_name1, dim_name2, grid_, frac_landuse_data_file,
+        mapping_file, horizInterp_, dataReader_);  // output
+  }
 
 }  // set_grids
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -472,7 +472,16 @@ void MAMMicrophysics::set_oxid_reader()
   util::TimeStamp ref_ts_oxid (1,1,1,0,0,0);
   data_interp_oxid_ = std::make_shared<DataInterpolation>(grid_,oxid_fields);
   data_interp_oxid_->setup_time_database ({oxid_file_name},util::TimeLine::YearlyPeriodic, DataInterpolation::Linear, ref_ts_oxid);
-  data_interp_oxid_->create_horiz_remappers (oxid_map_file=="none" ? "" : oxid_map_file);
+  if (m_iop_data_manager != nullptr) {
+    EKAT_REQUIRE_MSG(oxid_map_file == "" or oxid_map_file == "none",
+      "Error! Cannot define aero_microphys_remap_file for cases with an Intensive Observation Period defined. "
+      "The IOP class defines its own remap from file data -> model data.\n");
+    Real iop_lat = m_iop_data_manager->get_params().get<Real>("target_latitude");
+    Real iop_lon = m_iop_data_manager->get_params().get<Real>("target_longitude");
+    data_interp_oxid_->create_horiz_remappers (iop_lat, iop_lon);
+  } else {
+    data_interp_oxid_->create_horiz_remappers (oxid_map_file=="none" ? "" : oxid_map_file);
+  }
   data_interp_oxid_->set_logger(m_atm_logger);
   DataInterpolation::VertRemapData remap_data_oxid;
   remap_data_oxid.vr_type = DataInterpolation::Dynamic3DRef;
@@ -508,7 +517,16 @@ void MAMMicrophysics::set_linoz_reader(){
 
   data_interp_linoz_ = std::make_shared<DataInterpolation>(grid_,linoz_fields);
   data_interp_linoz_->setup_time_database ({m_linoz_file_name},util::TimeLine::YearlyPeriodic, DataInterpolation::Linear, ref_ts_linoz);
-  data_interp_linoz_->create_horiz_remappers (linoz_map_file=="none" ? "" : linoz_map_file);
+  if (m_iop_data_manager != nullptr) {
+    EKAT_REQUIRE_MSG(linoz_map_file == "" or linoz_map_file == "none",
+      "Error! Cannot define aero_microphys_remap_file for cases with an Intensive Observation Period defined. "
+      "The IOP class defines its own remap from file data -> model data.\n");
+    Real iop_lat = m_iop_data_manager->get_params().get<Real>("target_latitude");
+    Real iop_lon = m_iop_data_manager->get_params().get<Real>("target_longitude");
+    data_interp_linoz_->create_horiz_remappers (iop_lat, iop_lon);
+  } else {
+    data_interp_linoz_->create_horiz_remappers (linoz_map_file=="none" ? "" : linoz_map_file);
+  }
   data_interp_linoz_->set_logger(m_atm_logger);
 
   DataInterpolation::VertRemapData remap_data_linoz;
@@ -558,7 +576,16 @@ void MAMMicrophysics::set_exo_coldens_reader()
   util::TimeStamp ref_ts_exo_coldens (1,1,1,0,0,0);
   data_interp_exo_coldens_ = std::make_shared<DataInterpolation>(grid_exo_coldens,exo_coldens_fields_);
   data_interp_exo_coldens_->setup_time_database ({exo_coldens_file_name},util::TimeLine::YearlyPeriodic,DataInterpolation::Linear, ref_ts_exo_coldens);
-  data_interp_exo_coldens_->create_horiz_remappers (exo_coldens_map_file=="none" ? "" : exo_coldens_map_file);
+  if (m_iop_data_manager != nullptr) {
+    EKAT_REQUIRE_MSG(exo_coldens_map_file == "" or exo_coldens_map_file == "none",
+      "Error! Cannot define aero_microphys_remap_file for cases with an Intensive Observation Period defined. "
+      "The IOP class defines its own remap from file data -> model data.\n");
+    Real iop_lat = m_iop_data_manager->get_params().get<Real>("target_latitude");
+    Real iop_lon = m_iop_data_manager->get_params().get<Real>("target_longitude");
+    data_interp_exo_coldens_->create_horiz_remappers (iop_lat, iop_lon);
+  } else {
+    data_interp_exo_coldens_->create_horiz_remappers (exo_coldens_map_file=="none" ? "" : exo_coldens_map_file);
+  }
   data_interp_exo_coldens_->set_logger(m_atm_logger);
   DataInterpolation::VertRemapData remap_exo_coldens;
   remap_exo_coldens.vr_type = DataInterpolation::Custom;
@@ -582,6 +609,14 @@ void MAMMicrophysics::set_elevated_emissions_reader()
   const auto z_iface = get_field_out("z_mam4_int");
   const std::string extfrc_map_file =
         m_params.get<std::string>("aero_microphys_remap_file", "");
+  Real iop_lat = 0, iop_lon = 0;
+  if (m_iop_data_manager != nullptr) {
+    EKAT_REQUIRE_MSG(extfrc_map_file == "" or extfrc_map_file == "none",
+      "Error! Cannot define aero_microphys_remap_file for cases with an Intensive Observation Period defined. "
+      "The IOP class defines its own remap from file data -> model data.\n");
+    iop_lat = m_iop_data_manager->get_params().get<Real>("target_latitude");
+    iop_lon = m_iop_data_manager->get_params().get<Real>("target_longitude");
+  }
   for(const auto &pair : elevated_emis_var_names_) {
     const auto& var_name=pair.first;
     std::string item_name = "mam4_" + var_name + "_elevated_emiss_file_name";
@@ -596,7 +631,11 @@ void MAMMicrophysics::set_elevated_emissions_reader()
     di_vertical->set_input_files_dimname(e2str(LEV),"altitude");
     di_vertical->set_input_files_dimname(e2str(ILEV),"altitude_int");
     di_vertical->setup_time_database ({file_name},util::TimeLine::YearlyPeriodic, DataInterpolation::Linear, ref_ts_vertical);
-    di_vertical->create_horiz_remappers (extfrc_map_file=="none" ? "" : extfrc_map_file);
+    if (m_iop_data_manager != nullptr) {
+      di_vertical->create_horiz_remappers (iop_lat, iop_lon);
+    } else {
+      di_vertical->create_horiz_remappers (extfrc_map_file=="none" ? "" : extfrc_map_file);
+    }
     di_vertical->set_logger(m_atm_logger);
     DataInterpolation::VertRemapData remap_data_vertical;
     remap_data_vertical.vr_type = DataInterpolation::Custom;

--- a/components/eamxx/src/physics/mam/eamxx_mam_srf_and_online_emissions_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_srf_and_online_emissions_process_interface.cpp
@@ -205,12 +205,27 @@ void MAMSrfOnlineEmiss::create_requests() {
   //--------------------------------------------------------------------
   // Init data structures to read and interpolate
   //--------------------------------------------------------------------
-  for(srf_emiss_ &ispec_srf : srf_emiss_species_) {
-    srfEmissFunc::init_srf_emiss_objects(
-        ncol_, grid_, ispec_srf.data_file, ispec_srf.sectors, srf_map_file,
-        // output
-        ispec_srf.horizInterp_, ispec_srf.data_start_, ispec_srf.data_end_,
-        ispec_srf.data_out_, ispec_srf.dataReader_);
+  if (m_iop_data_manager != nullptr) {
+    EKAT_REQUIRE_MSG(srf_map_file == "" or srf_map_file == "none",
+      "Error! Cannot define srf_remap_file for cases with an Intensive Observation Period defined. "
+      "The IOP class defines its own remap from file data -> model data.\n");
+    Real iop_lat = m_iop_data_manager->get_params().get<Real>("target_latitude");
+    Real iop_lon = m_iop_data_manager->get_params().get<Real>("target_longitude");
+    for(srf_emiss_ &ispec_srf : srf_emiss_species_) {
+      srfEmissFunc::init_srf_emiss_objects(
+          ncol_, grid_, ispec_srf.data_file, ispec_srf.sectors, iop_lat, iop_lon,
+          // output
+          ispec_srf.horizInterp_, ispec_srf.data_start_, ispec_srf.data_end_,
+          ispec_srf.data_out_, ispec_srf.dataReader_);
+    }
+  } else {
+    for(srf_emiss_ &ispec_srf : srf_emiss_species_) {
+      srfEmissFunc::init_srf_emiss_objects(
+          ncol_, grid_, ispec_srf.data_file, ispec_srf.sectors, srf_map_file,
+          // output
+          ispec_srf.horizInterp_, ispec_srf.data_start_, ispec_srf.data_end_,
+          ispec_srf.data_out_, ispec_srf.dataReader_);
+    }
   }  // srf emissions file read init
 
   // -------------------------------------------------------------

--- a/components/eamxx/src/physics/mam/eamxx_mam_srf_and_online_emissions_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_srf_and_online_emissions_process_interface.cpp
@@ -205,21 +205,22 @@ void MAMSrfOnlineEmiss::create_requests() {
   //--------------------------------------------------------------------
   // Init data structures to read and interpolate
   //--------------------------------------------------------------------
+  Real iop_lat = 0, iop_lon = 0;
   if (m_iop_data_manager != nullptr) {
     EKAT_REQUIRE_MSG(srf_map_file == "" or srf_map_file == "none",
       "Error! Cannot define srf_remap_file for cases with an Intensive Observation Period defined. "
       "The IOP class defines its own remap from file data -> model data.\n");
-    Real iop_lat = m_iop_data_manager->get_params().get<Real>("target_latitude");
-    Real iop_lon = m_iop_data_manager->get_params().get<Real>("target_longitude");
-    for(srf_emiss_ &ispec_srf : srf_emiss_species_) {
+    iop_lat = m_iop_data_manager->get_params().get<Real>("target_latitude");
+    iop_lon = m_iop_data_manager->get_params().get<Real>("target_longitude");
+  }
+  for(srf_emiss_ &ispec_srf : srf_emiss_species_) {
+    if (m_iop_data_manager != nullptr) {
       srfEmissFunc::init_srf_emiss_objects(
           ncol_, grid_, ispec_srf.data_file, ispec_srf.sectors, iop_lat, iop_lon,
           // output
           ispec_srf.horizInterp_, ispec_srf.data_start_, ispec_srf.data_end_,
           ispec_srf.data_out_, ispec_srf.dataReader_);
-    }
-  } else {
-    for(srf_emiss_ &ispec_srf : srf_emiss_species_) {
+    } else {
       srfEmissFunc::init_srf_emiss_objects(
           ncol_, grid_, ispec_srf.data_file, ispec_srf.sectors, srf_map_file,
           // output
@@ -242,10 +243,17 @@ void MAMSrfOnlineEmiss::create_requests() {
   const std::string soil_erod_dname = "ncol";
 
   // initialize the file read
-  soilErodibilityFunc::init_soil_erodibility_file_read(
-      ncol_, soil_erod_fld_name, soil_erod_dname, grid_,
-      soil_erodibility_data_file, srf_map_file, serod_horizInterp_,
-      serod_dataReader_);  // output
+  if (m_iop_data_manager != nullptr) {
+    soilErodibilityFunc::init_soil_erodibility_file_read(
+        ncol_, soil_erod_fld_name, soil_erod_dname, grid_,
+        soil_erodibility_data_file, iop_lat, iop_lon,
+        serod_horizInterp_, serod_dataReader_);  // output
+  } else {
+    soilErodibilityFunc::init_soil_erodibility_file_read(
+        ncol_, soil_erod_fld_name, soil_erod_dname, grid_,
+        soil_erodibility_data_file, srf_map_file,
+        serod_horizInterp_, serod_dataReader_);  // output
+  }
 
   // -------------------------------------------------------------
   // Setup to enable reading marine organics file
@@ -262,12 +270,21 @@ void MAMSrfOnlineEmiss::create_requests() {
   const std::string marine_org_dname = "ncol";
 
   // initialize the file read
-  marineOrganicsFunc::init_marine_organics_file_read(
-      ncol_, marine_org_fld_name, marine_org_dname, grid_,
-      marine_organics_data_file, srf_map_file,
-      // output
-      morg_horizInterp_, morg_data_start_, morg_data_end_, morg_data_out_,
-      morg_dataReader_);
+  if (m_iop_data_manager != nullptr) {
+    marineOrganicsFunc::init_marine_organics_file_read(
+        ncol_, marine_org_fld_name, marine_org_dname, grid_,
+        marine_organics_data_file, iop_lat, iop_lon,
+        // output
+        morg_horizInterp_, morg_data_start_, morg_data_end_, morg_data_out_,
+        morg_dataReader_);
+  } else {
+    marineOrganicsFunc::init_marine_organics_file_read(
+        ncol_, marine_org_fld_name, marine_org_dname, grid_,
+        marine_organics_data_file, srf_map_file,
+        // output
+        morg_horizInterp_, morg_data_start_, morg_data_end_, morg_data_out_,
+        morg_dataReader_);
+  }
 
 }  // set_grid ends
 

--- a/components/eamxx/src/physics/mam/readfiles/fractional_land_use.hpp
+++ b/components/eamxx/src/physics/mam/readfiles/fractional_land_use.hpp
@@ -24,6 +24,13 @@ struct fracLandUseFunctions {
       const std::string &field_name, const std::string &dim_name1,
       const std::string &dim_name2);
 
+  static std::shared_ptr<AbstractRemapper> create_horiz_remapper(
+      const std::shared_ptr<const AbstractGrid> &model_grid,
+      const std::string &fracLandUse_data_file,
+      const Real iop_lat, const Real iop_lon,
+      const std::string &field_name, const std::string &dim_name1,
+      const std::string &dim_name2);
+
   // -------------------------------------------------------------------------------------------
   // -------------------------------------------------------------------------------------------
 
@@ -46,6 +53,16 @@ struct fracLandUseFunctions {
       const std::string dim_name2,
       const std::shared_ptr<const AbstractGrid> &grid,
       const std::string &data_file, const std::string &mapping_file,
+      // output
+      std::shared_ptr<AbstractRemapper> &FracLandUseHorizInterp,
+      std::shared_ptr<AtmosphereInput> &FracLandUseDataReader);
+
+  static void init_frac_landuse_file_read(
+      const int ncol, const std::string field_name, const std::string dim_name1,
+      const std::string dim_name2,
+      const std::shared_ptr<const AbstractGrid> &grid,
+      const std::string &data_file,
+      const Real iop_lat, const Real iop_lon,
       // output
       std::shared_ptr<AbstractRemapper> &FracLandUseHorizInterp,
       std::shared_ptr<AtmosphereInput> &FracLandUseDataReader);

--- a/components/eamxx/src/physics/mam/readfiles/fractional_land_use_impl.hpp
+++ b/components/eamxx/src/physics/mam/readfiles/fractional_land_use_impl.hpp
@@ -3,6 +3,9 @@
 
 #include "share/remap/identity_remapper.hpp"
 #include "share/remap/horizontal_remapper.hpp"
+#include "share/remap/iop_remapper.hpp"
+#include "share/grid/point_grid.hpp"
+#include "share/io/scorpio_input.hpp"
 #include "share/scorpio_interface/eamxx_scorpio_interface.hpp"
 #include "share/util/eamxx_timing.hpp"
 
@@ -66,6 +69,54 @@ fracLandUseFunctions<S, D>::create_horiz_remapper(
 
   return remapper;
 }  // create_horiz_remapper
+
+// -------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------
+
+template <typename S, typename D>
+std::shared_ptr<AbstractRemapper>
+fracLandUseFunctions<S, D>::create_horiz_remapper(
+    const std::shared_ptr<const AbstractGrid> &model_grid,
+    const std::string &data_file, const Real iop_lat, const Real iop_lon,
+    const std::string &field_name, const std::string &dim_name1,
+    const std::string &dim_name2) {
+  using namespace ShortFieldTagsNames;
+
+  scorpio::register_file(data_file, scorpio::Read);
+  const int ncols_data  = scorpio::get_dimlen(data_file, dim_name1);
+  const int nclass_data = scorpio::get_dimlen(data_file, dim_name2);
+  scorpio::release_file(data_file);
+
+  // Create a point grid matching the data file's column count
+  auto data_grid = create_point_grid("frac_land_use_iop_data", ncols_data, 1,
+                                     model_grid->get_comm());
+
+  // Read lat/lon geometry so IOPRemapper can locate the closest column
+  std::vector<Field> latlon = {
+    data_grid->create_geometry_data("lat", data_grid->get_2d_scalar_layout()),
+    data_grid->create_geometry_data("lon", data_grid->get_2d_scalar_layout())
+  };
+  AtmosphereInput latlon_reader(data_file, data_grid, latlon);
+  latlon_reader.read_variables();
+
+  auto horiz_interp_tgt_grid =
+      model_grid->clone("frac_land_use_horiz_interp_tgt_grid", true);
+
+  auto remapper = std::make_shared<IOPRemapper>(data_grid, horiz_interp_tgt_grid,
+                                                iop_lat, iop_lon);
+
+  const auto tgt_grid  = remapper->get_tgt_grid();
+  const auto layout_2d = tgt_grid->get_2d_vector_layout(nclass_data, "class");
+
+  Field fractional_land_use(
+      FieldIdentifier(field_name, layout_2d, ekat::units::none, tgt_grid->name()));
+  fractional_land_use.allocate_view();
+
+  remapper->register_field_from_tgt(fractional_land_use);
+  remapper->registration_ends();
+
+  return remapper;
+}  // create_horiz_remapper (IOP)
 
 // -------------------------------------------------------------------------------------------
 // -------------------------------------------------------------------------------------------
@@ -138,6 +189,27 @@ void fracLandUseFunctions<S, D>::init_frac_landuse_file_read(
   // Create reader (an AtmosphereInput object)
   FracLandUseDataReader = create_data_reader(FracLandUseHorizInterp, data_file);
 }  // init_frac_landuse_file_read
+
+// -------------------------------------------------------------------------------------------
+// -------------------------------------------------------------------------------------------
+
+template <typename S, typename D>
+void fracLandUseFunctions<S, D>::init_frac_landuse_file_read(
+    const int ncol, const std::string field_name, const std::string dim_name1,
+    const std::string dim_name2,
+    const std::shared_ptr<const AbstractGrid> &grid,
+    const std::string &data_file,
+    const Real iop_lat, const Real iop_lon,
+    // output
+    std::shared_ptr<AbstractRemapper> &FracLandUseHorizInterp,
+    std::shared_ptr<AtmosphereInput> &FracLandUseDataReader) {
+  // Init horizontal remap using IOP target lat/lon
+  FracLandUseHorizInterp = create_horiz_remapper(
+      grid, data_file, iop_lat, iop_lon, field_name, dim_name1, dim_name2);
+
+  // Create reader (an AtmosphereInput object)
+  FracLandUseDataReader = create_data_reader(FracLandUseHorizInterp, data_file);
+}  // init_frac_landuse_file_read (IOP)
 
 }  // namespace frac_landuse
 }  // namespace scream

--- a/components/eamxx/src/physics/mam/readfiles/marine_organics.hpp
+++ b/components/eamxx/src/physics/mam/readfiles/marine_organics.hpp
@@ -73,6 +73,12 @@ struct marineOrganicsFunctions {
       const std::string &marineOrganics_data_file, const std::string &map_file,
       const std::vector<std::string> &field_name, const std::string &dim_name1);
 
+  static std::shared_ptr<AbstractRemapper> create_horiz_remapper(
+      const std::shared_ptr<const AbstractGrid> &model_grid,
+      const std::string &marineOrganics_data_file,
+      const Real iop_lat, const Real iop_lon,
+      const std::vector<std::string> &field_name, const std::string &dim_name1);
+
   // -------------------------------------------------------------------------------------------
   static std::shared_ptr<AtmosphereInput> create_data_reader(
       const std::shared_ptr<AbstractRemapper> &horiz_remapper,
@@ -118,6 +124,18 @@ struct marineOrganicsFunctions {
       const std::string &dim_name1,
       const std::shared_ptr<const AbstractGrid> &grid,
       const std::string &data_file, const std::string &mapping_file,
+      // output
+      std::shared_ptr<AbstractRemapper> &marineOrganicsHorizInterp,
+      marineOrganicsInput &morg_data_start_,
+      marineOrganicsInput &morg_data_end_, marineOrganicsData &morg_data_out_,
+      std::shared_ptr<AtmosphereInput> &marineOrganicsDataReader);
+
+  static void init_marine_organics_file_read(
+      const int &ncol, const std::vector<std::string> &field_name,
+      const std::string &dim_name1,
+      const std::shared_ptr<const AbstractGrid> &grid,
+      const std::string &data_file,
+      const Real iop_lat, const Real iop_lon,
       // output
       std::shared_ptr<AbstractRemapper> &marineOrganicsHorizInterp,
       marineOrganicsInput &morg_data_start_,

--- a/components/eamxx/src/physics/mam/readfiles/marine_organics_impl.hpp
+++ b/components/eamxx/src/physics/mam/readfiles/marine_organics_impl.hpp
@@ -3,6 +3,9 @@
 
 #include "share/remap/identity_remapper.hpp"
 #include "share/remap/horizontal_remapper.hpp"
+#include "share/remap/iop_remapper.hpp"
+#include "share/grid/point_grid.hpp"
+#include "share/io/scorpio_input.hpp"
 #include "share/scorpio_interface/eamxx_scorpio_interface.hpp"
 #include "share/util/eamxx_timing.hpp"
 
@@ -75,6 +78,55 @@ marineOrganicsFunctions<S, D>::create_horiz_remapper(
   return remapper;
 
 }  // create_horiz_remapper
+
+// -------------------------------------------------------------------------------------------
+template <typename S, typename D>
+std::shared_ptr<AbstractRemapper>
+marineOrganicsFunctions<S, D>::create_horiz_remapper(
+    const std::shared_ptr<const AbstractGrid> &model_grid,
+    const std::string &data_file, const Real iop_lat, const Real iop_lon,
+    const std::vector<std::string> &field_name, const std::string &dim_name1) {
+  using namespace ShortFieldTagsNames;
+  using namespace ekat::units;
+  using namespace ekat::prefixes;
+
+  scorpio::register_file(data_file, scorpio::Read);
+  const int ncols_data = scorpio::get_dimlen(data_file, dim_name1);
+  scorpio::release_file(data_file);
+
+  // Create a point grid matching the data file's column count
+  auto data_grid = create_point_grid("marine_organics_iop_data", ncols_data, 1,
+                                     model_grid->get_comm());
+
+  // Read lat/lon geometry so IOPRemapper can locate the closest column
+  std::vector<Field> latlon = {
+    data_grid->create_geometry_data("lat", data_grid->get_2d_scalar_layout()),
+    data_grid->create_geometry_data("lon", data_grid->get_2d_scalar_layout())
+  };
+  AtmosphereInput latlon_reader(data_file, data_grid, latlon);
+  latlon_reader.read_variables();
+
+  auto horiz_interp_tgt_grid =
+      model_grid->clone("marine_organics_horiz_interp_tgt_grid", true);
+
+  auto remapper = std::make_shared<IOPRemapper>(data_grid, horiz_interp_tgt_grid,
+                                                iop_lat, iop_lon);
+
+  const auto tgt_grid  = remapper->get_tgt_grid();
+  const auto layout_2d = tgt_grid->get_2d_scalar_layout();
+  Units umolC(micro * mol, "umol C");
+
+  const int field_size = field_name.size();
+  for(int icomp = 0; icomp < field_size; ++icomp) {
+    Field f(FieldIdentifier(field_name[icomp], layout_2d, umolC, tgt_grid->name()));
+    f.allocate_view();
+    remapper->register_field_from_tgt(f);
+  }
+
+  remapper->registration_ends();
+
+  return remapper;
+}  // create_horiz_remapper (IOP)
 
 // -------------------------------------------------------------------------------------------
 template <typename S, typename D>
@@ -286,6 +338,33 @@ void marineOrganicsFunctions<S, D>::init_marine_organics_file_read(
       create_data_reader(marineOrganicsHorizInterp, data_file);
 
 }  // init_marine_organics_file_read
+
+// -------------------------------------------------------------------------------------------
+template <typename S, typename D>
+void marineOrganicsFunctions<S, D>::init_marine_organics_file_read(
+    const int &ncol, const std::vector<std::string> &field_name,
+    const std::string &dim_name1,
+    const std::shared_ptr<const AbstractGrid> &grid,
+    const std::string &data_file,
+    const Real iop_lat, const Real iop_lon,
+    // output
+    std::shared_ptr<AbstractRemapper> &marineOrganicsHorizInterp,
+    marineOrganicsInput &data_start_, marineOrganicsInput &data_end_,
+    marineOrganicsData &data_out_,
+    std::shared_ptr<AtmosphereInput> &marineOrganicsDataReader) {
+  // Init horizontal remap using IOP target lat/lon
+  marineOrganicsHorizInterp = create_horiz_remapper(
+      grid, data_file, iop_lat, iop_lon, field_name, dim_name1);
+
+  // Initialize the size of start/end/out data structures
+  data_start_ = marineOrganicsInput(ncol, field_name.size());
+  data_end_   = marineOrganicsInput(ncol, field_name.size());
+  data_out_.init(ncol, field_name.size(), true);
+
+  // Create reader (an AtmosphereInput object)
+  marineOrganicsDataReader =
+      create_data_reader(marineOrganicsHorizInterp, data_file);
+}  // init_marine_organics_file_read (IOP)
 }  // namespace marine_organics
 }  // namespace scream
 

--- a/components/eamxx/src/physics/mam/readfiles/soil_erodibility.hpp
+++ b/components/eamxx/src/physics/mam/readfiles/soil_erodibility.hpp
@@ -19,6 +19,12 @@ struct soilErodibilityFunctions {
       const std::string &soilErodibility_data_file, const std::string &map_file,
       const std::string &field_name, const std::string &dim_name1);
 
+  static std::shared_ptr<AbstractRemapper> create_horiz_remapper(
+      const std::shared_ptr<const AbstractGrid> &model_grid,
+      const std::string &soilErodibility_data_file,
+      const Real iop_lat, const Real iop_lon,
+      const std::string &field_name, const std::string &dim_name1);
+
   static std::shared_ptr<AtmosphereInput> create_data_reader(
       const std::shared_ptr<AbstractRemapper> &horiz_remapper,
       const std::string &data_file);
@@ -31,6 +37,15 @@ struct soilErodibilityFunctions {
       const int ncol, const std::string field_name, const std::string dim_name1,
       const std::shared_ptr<const AbstractGrid> &grid,
       const std::string &data_file, const std::string &mapping_file,
+      // output
+      std::shared_ptr<AbstractRemapper> &SoilErodibilityHorizInterp,
+      std::shared_ptr<AtmosphereInput> &SoilErodibilityDataReader);
+
+  static void init_soil_erodibility_file_read(
+      const int ncol, const std::string field_name, const std::string dim_name1,
+      const std::shared_ptr<const AbstractGrid> &grid,
+      const std::string &data_file,
+      const Real iop_lat, const Real iop_lon,
       // output
       std::shared_ptr<AbstractRemapper> &SoilErodibilityHorizInterp,
       std::shared_ptr<AtmosphereInput> &SoilErodibilityDataReader);

--- a/components/eamxx/src/physics/mam/readfiles/soil_erodibility_impl.hpp
+++ b/components/eamxx/src/physics/mam/readfiles/soil_erodibility_impl.hpp
@@ -3,6 +3,9 @@
 
 #include "share/remap/identity_remapper.hpp"
 #include "share/remap/horizontal_remapper.hpp"
+#include "share/remap/iop_remapper.hpp"
+#include "share/grid/point_grid.hpp"
+#include "share/io/scorpio_input.hpp"
 #include "share/scorpio_interface/eamxx_scorpio_interface.hpp"
 #include "share/util/eamxx_timing.hpp"
 
@@ -65,6 +68,50 @@ soilErodibilityFunctions<S, D>::create_horiz_remapper(
   return remapper;
 
 }  // create_horiz_remapper
+
+// -------------------------------------------------------------------------------------------
+template <typename S, typename D>
+std::shared_ptr<AbstractRemapper>
+soilErodibilityFunctions<S, D>::create_horiz_remapper(
+    const std::shared_ptr<const AbstractGrid> &model_grid,
+    const std::string &data_file, const Real iop_lat, const Real iop_lon,
+    const std::string &field_name, const std::string &dim_name1) {
+  using namespace ShortFieldTagsNames;
+
+  scorpio::register_file(data_file, scorpio::Read);
+  const int ncols_data = scorpio::get_dimlen(data_file, dim_name1);
+  scorpio::release_file(data_file);
+
+  // Create a point grid matching the data file's column count
+  auto data_grid = create_point_grid("soil_erodibility_iop_data", ncols_data, 1,
+                                     model_grid->get_comm());
+
+  // Read lat/lon geometry so IOPRemapper can locate the closest column
+  std::vector<Field> latlon = {
+    data_grid->create_geometry_data("lat", data_grid->get_2d_scalar_layout()),
+    data_grid->create_geometry_data("lon", data_grid->get_2d_scalar_layout())
+  };
+  AtmosphereInput latlon_reader(data_file, data_grid, latlon);
+  latlon_reader.read_variables();
+
+  auto horiz_interp_tgt_grid =
+      model_grid->clone("soil_erodibility_horiz_interp_tgt_grid", true);
+
+  auto remapper = std::make_shared<IOPRemapper>(data_grid, horiz_interp_tgt_grid,
+                                                iop_lat, iop_lon);
+
+  const auto tgt_grid  = remapper->get_tgt_grid();
+  const auto layout_2d = tgt_grid->get_2d_scalar_layout();
+
+  Field soil_erodibility(
+      FieldIdentifier(field_name, layout_2d, ekat::units::none, tgt_grid->name()));
+  soil_erodibility.allocate_view();
+
+  remapper->register_field_from_tgt(soil_erodibility);
+  remapper->registration_ends();
+
+  return remapper;
+}  // create_horiz_remapper (IOP)
 
 // -------------------------------------------------------------------------------------------
 template <typename S, typename D>
@@ -138,6 +185,25 @@ void soilErodibilityFunctions<S, D>::init_soil_erodibility_file_read(
   soilErodibilityDataReader =
       create_data_reader(soilErodibilityHorizInterp, data_file);
 }  // init_soil_erodibility_file_read
+
+// -------------------------------------------------------------------------------------------
+template <typename S, typename D>
+void soilErodibilityFunctions<S, D>::init_soil_erodibility_file_read(
+    const int ncol, const std::string field_name, const std::string dim_name1,
+    const std::shared_ptr<const AbstractGrid> &grid,
+    const std::string &data_file,
+    const Real iop_lat, const Real iop_lon,
+    // output
+    std::shared_ptr<AbstractRemapper> &soilErodibilityHorizInterp,
+    std::shared_ptr<AtmosphereInput> &soilErodibilityDataReader) {
+  // Init horizontal remap using IOP target lat/lon
+  soilErodibilityHorizInterp = create_horiz_remapper(
+      grid, data_file, iop_lat, iop_lon, field_name, dim_name1);
+
+  // Create reader (an AtmosphereInput object)
+  soilErodibilityDataReader =
+      create_data_reader(soilErodibilityHorizInterp, data_file);
+}  // init_soil_erodibility_file_read (IOP)
 }  // namespace soil_erodibility
 }  // namespace scream
 

--- a/components/eamxx/src/physics/mam/srf_emission.hpp
+++ b/components/eamxx/src/physics/mam/srf_emission.hpp
@@ -75,6 +75,12 @@ struct srfEmissFunctions {
       const std::string &srfEmiss_data_file,
       const std::vector<std::string> &field_names, const std::string &map_file);
 
+  static std::shared_ptr<AbstractRemapper> create_horiz_remapper(
+      const std::shared_ptr<const AbstractGrid> &model_grid,
+      const std::string &srfEmiss_data_file,
+      const std::vector<std::string> &field_names,
+      const Real iop_lat, const Real iop_lon);
+
   static std::shared_ptr<AtmosphereInput> create_srfEmiss_data_reader(
       const std::shared_ptr<AbstractRemapper> &horiz_remapper,
       const std::string &srfEmiss_data_file);
@@ -124,6 +130,16 @@ struct srfEmissFunctions {
       const int ncol, const std::shared_ptr<const AbstractGrid> &grid,
       const std::string &data_file, const std::vector<std::string> &sectors,
       const std::string &srf_map_file,
+      // output
+      std::shared_ptr<AbstractRemapper> &SrfEmissHorizInterp,
+      srfEmissInput &SrfEmissData_start, srfEmissInput &SrfEmissData_end,
+      srfEmissOutput &SrfEmissData_out,
+      std::shared_ptr<AtmosphereInput> &SrfEmissDataReader);
+
+  static void init_srf_emiss_objects(
+      const int ncol, const std::shared_ptr<const AbstractGrid> &grid,
+      const std::string &data_file, const std::vector<std::string> &sectors,
+      const Real iop_lat, const Real iop_lon,
       // output
       std::shared_ptr<AbstractRemapper> &SrfEmissHorizInterp,
       srfEmissInput &SrfEmissData_start, srfEmissInput &SrfEmissData_end,

--- a/components/eamxx/src/physics/mam/srf_emission_impl.hpp
+++ b/components/eamxx/src/physics/mam/srf_emission_impl.hpp
@@ -3,6 +3,9 @@
 
 #include "share/remap/identity_remapper.hpp"
 #include "share/remap/horizontal_remapper.hpp"
+#include "share/remap/iop_remapper.hpp"
+#include "share/grid/point_grid.hpp"
+#include "share/io/scorpio_input.hpp"
 #include "share/scorpio_interface/eamxx_scorpio_interface.hpp"
 
 #include <ekat_team_policy_utils.hpp>
@@ -70,6 +73,53 @@ srfEmissFunctions<S, D>::create_horiz_remapper(
 
   return remapper;
 }  // create_horiz_remapper
+
+template <typename S, typename D>
+std::shared_ptr<AbstractRemapper>
+srfEmissFunctions<S, D>::create_horiz_remapper(
+    const std::shared_ptr<const AbstractGrid> &model_grid,
+    const std::string &data_file, const std::vector<std::string> &sector_names,
+    const Real iop_lat, const Real iop_lon) {
+  using namespace ShortFieldTagsNames;
+
+  scorpio::register_file(data_file, scorpio::Read);
+  const int ncols_data = scorpio::get_dimlen(data_file, "ncol");
+  scorpio::release_file(data_file);
+
+  // Create a point grid matching the data file's column count
+  auto data_grid = create_point_grid("srf_emiss_iop_data", ncols_data, 1,
+                                     model_grid->get_comm());
+
+  // Read lat/lon geometry from the data file so IOPRemapper can find the
+  // closest column to the IOP target point
+  std::vector<Field> latlon = {
+    data_grid->create_geometry_data("lat", data_grid->get_2d_scalar_layout()),
+    data_grid->create_geometry_data("lon", data_grid->get_2d_scalar_layout())
+  };
+  AtmosphereInput latlon_reader(data_file, data_grid, latlon);
+  latlon_reader.read_variables();
+
+  auto horiz_interp_tgt_grid =
+      model_grid->clone("srf_emiss_horiz_interp_tgt_grid", true);
+
+  auto remapper = std::make_shared<IOPRemapper>(data_grid, horiz_interp_tgt_grid,
+                                                iop_lat, iop_lon);
+
+  const auto tgt_grid = remapper->get_tgt_grid();
+  const auto layout_2d = tgt_grid->get_2d_scalar_layout();
+
+  const int sector_size = sector_names.size();
+  for(int icomp = 0; icomp < sector_size; ++icomp) {
+    Field f(FieldIdentifier(sector_names[icomp], layout_2d, ekat::units::none,
+                            tgt_grid->name()));
+    f.allocate_view();
+    remapper->register_field_from_tgt(f);
+  }
+
+  remapper->registration_ends();
+
+  return remapper;
+}  // create_horiz_remapper (IOP)
 
 template <typename S, typename D>
 std::shared_ptr<AtmosphereInput>
@@ -271,6 +321,30 @@ void srfEmissFunctions<S, D>::init_srf_emiss_objects(
   SrfEmissDataReader =
       create_srfEmiss_data_reader(SrfEmissHorizInterp, data_file);
 }  // init_srf_emiss_objects
+
+template <typename S, typename D>
+void srfEmissFunctions<S, D>::init_srf_emiss_objects(
+    const int ncol, const std::shared_ptr<const AbstractGrid> &grid,
+    const std::string &data_file, const std::vector<std::string> &sectors,
+    const Real iop_lat, const Real iop_lon,
+    // output
+    std::shared_ptr<AbstractRemapper> &SrfEmissHorizInterp,
+    srfEmissInput &SrfEmissData_start, srfEmissInput &SrfEmissData_end,
+    srfEmissOutput &SrfEmissData_out,
+    std::shared_ptr<AtmosphereInput> &SrfEmissDataReader) {
+  // Init horizontal remap using IOP target lat/lon
+  SrfEmissHorizInterp =
+      create_horiz_remapper(grid, data_file, sectors, iop_lat, iop_lon);
+
+  // Initialize the size of start/end/out data structures
+  SrfEmissData_start = srfEmissInput(ncol, sectors.size());
+  SrfEmissData_end   = srfEmissInput(ncol, sectors.size());
+  SrfEmissData_out.init(ncol, 1, true);
+
+  // Create reader (an AtmosphereInput object)
+  SrfEmissDataReader =
+      create_srfEmiss_data_reader(SrfEmissHorizInterp, data_file);
+}  // init_srf_emiss_objects (IOP)
 }  // namespace scream::mam_coupling
 
 #endif  // SRF_EMISSION_IMPL_HPP

--- a/components/eamxx/src/share/remap/iop_remapper.cpp
+++ b/components/eamxx/src/share/remap/iop_remapper.cpp
@@ -35,8 +35,9 @@ IOPRemapper (const grid_ptr_type src_grid,
 
   EKAT_REQUIRE_MSG (src_grid->has_geometry_data("lat") and src_grid->has_geometry_data("lon"),
       "Error! IOP remapper requires lat/lon geometry data in the source grid.\n");
-  EKAT_REQUIRE_MSG (src_grid->get_num_vertical_levels()==tgt_grid->get_num_vertical_levels(),
-      "Error! IOP remapper requires src/tgt grid to have the same number of vertical levels.\n");
+  ! Does the IOP mapper also perform vertical interpolation?
+  !EKAT_REQUIRE_MSG (src_grid->get_num_vertical_levels()==tgt_grid->get_num_vertical_levels(),
+  !    "Error! IOP remapper requires src/tgt grid to have the same number of vertical levels.\n");
   EKAT_REQUIRE_MSG (src_grid->type()==GridType::Point and tgt_grid->type()==GridType::Point,
       "Error! IOP remapper requires src/tgt grid to be PointGrid instances.\n");
   

--- a/components/eamxx/src/share/remap/iop_remapper.cpp
+++ b/components/eamxx/src/share/remap/iop_remapper.cpp
@@ -35,9 +35,9 @@ IOPRemapper (const grid_ptr_type src_grid,
 
   EKAT_REQUIRE_MSG (src_grid->has_geometry_data("lat") and src_grid->has_geometry_data("lon"),
       "Error! IOP remapper requires lat/lon geometry data in the source grid.\n");
-  ! Does the IOP mapper also perform vertical interpolation?
-  !EKAT_REQUIRE_MSG (src_grid->get_num_vertical_levels()==tgt_grid->get_num_vertical_levels(),
-  !    "Error! IOP remapper requires src/tgt grid to have the same number of vertical levels.\n");
+  // Does the IOP mapper also perform vertical interpolation?
+  //EKAT_REQUIRE_MSG (src_grid->get_num_vertical_levels()==tgt_grid->get_num_vertical_levels(),
+  //    "Error! IOP remapper requires src/tgt grid to have the same number of vertical levels.\n");
   EKAT_REQUIRE_MSG (src_grid->type()==GridType::Point and tgt_grid->type()==GridType::Point,
       "Error! IOP remapper requires src/tgt grid to be PointGrid instances.\n");
   

--- a/components/eamxx/src/share/remap/tests/iop_remapper_tests.cpp
+++ b/components/eamxx/src/share/remap/tests/iop_remapper_tests.cpp
@@ -103,12 +103,12 @@ TEST_CASE("iop_remap")
   REQUIRE_THROWS (std::make_shared<IOPRemapper>(src_grid,se_grid,0,0)); // tgt!=PointGrid
   REQUIRE_THROWS (std::make_shared<IOPRemapper>(se_grid,tgt_grid,0,0)); // src!=PointGrid
 
-  auto bad_tgt = tgt_grid->clone("bad_tgt",true);
-  bad_tgt->reset_vertical_configuration(12, AbstractGrid::VKind::Model);
-  REQUIRE_THROWS (std::make_shared<IOPRemapper>(src_grid,bad_tgt,0,0)); // nlevs doesn't match
+  //auto bad_tgt = tgt_grid->clone("bad_tgt",true);
+  //bad_tgt->reset_vertical_configuration(12, AbstractGrid::VKind::Model);
+  //REQUIRE_THROWS (std::make_shared<IOPRemapper>(src_grid,bad_tgt,0,0)); // nlevs doesn't match
 
-  REQUIRE_THROWS (std::make_shared<IOPRemapper>(src_grid,bad_tgt,91,0)); // lat OOB
-  REQUIRE_THROWS (std::make_shared<IOPRemapper>(src_grid,bad_tgt,0,-1)); // lat OOB
+  //REQUIRE_THROWS (std::make_shared<IOPRemapper>(src_grid,bad_tgt,91,0)); // lat OOB
+  //REQUIRE_THROWS (std::make_shared<IOPRemapper>(src_grid,bad_tgt,0,-1)); // lat OOB
 
   // Finally a working remapper
   int closest_rank = IPDF(0,comm.size()-1)(engine);


### PR DESCRIPTION
This PR adds the IOP remapper to the mam4xx process, enabling mam4xx to be used by DPxx. It also includes a test mod and updates the fractional_land_use_file nc file to contain the required lat and lon variables for the IOP remapper.
Additionally, the PR removes the restriction that the number of vertical levels in the source and target grids must be equal, as a vertical remapper is now applied within the mam4xx process.

@susburrows @meng630 
