### PR TITLE
Add the ice-aware MLE scheme to MPAS-Ocean

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -307,6 +307,7 @@ _TESTS = {
             "SMS_D_Ld1.T62_oQU240.GMPAS-IAF.mpaso-upwind_advection",
             "SMS_D_Ld1.T62_oQU240.GMPAS-IAF.mpaso-freshwater_tracers",
             "SMS_D_Ld1.T62_oQU240.GMPAS-IAF.mpaso-lat_dep_diffusivity",
+            "SMS_D_Ld1.T62_oQU240.GMPAS-IAF.mpaso-ice_aware_mle",
             "ERS_Ld5_D.T62_oQU240.GMPAS-IAF.mpaso-conservation_check",
             "ERS_Ld5_PS.ne30pg2_r05_IcoswISC30E3r5.CRYO1850-DISMF.mpaso-scaled_dib_dismf",
             "SMS_PS.ne30pg2_r05_IcoswISC30E3r5.WCYCL1850.mpaso-frazil_ice_porosity",

--- a/components/mpas-ocean/bld/build-namelist
+++ b/components/mpas-ocean/bld/build-namelist
@@ -597,6 +597,8 @@ add_default($nl, 'config_submesoscale_tau');
 add_default($nl, 'config_submesoscale_Ce');
 add_default($nl, 'config_submesoscale_Lfmin');
 add_default($nl, 'config_submesoscale_ds_max');
+add_default($nl, 'config_submesoscale_ice_aware');
+add_default($nl, 'config_submesoscale_ice_aware_crit');
 
 ############################################
 # Namelist group: GM_eddy_parameterization #

--- a/components/mpas-ocean/bld/build-namelist-section
+++ b/components/mpas-ocean/bld/build-namelist-section
@@ -119,6 +119,8 @@ add_default($nl, 'config_submesoscale_tau');
 add_default($nl, 'config_submesoscale_Ce');
 add_default($nl, 'config_submesoscale_Lfmin');
 add_default($nl, 'config_submesoscale_ds_max');
+add_default($nl, 'config_submesoscale_ice_aware');
+add_default($nl, 'config_submesoscale_ice_aware_crit');
 
 ############################################
 # Namelist group: GM_eddy_parameterization #

--- a/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_defaults_mpaso.xml
@@ -218,6 +218,8 @@
 <config_submesoscale_Ce>0.08</config_submesoscale_Ce>
 <config_submesoscale_Lfmin>1000.0</config_submesoscale_Lfmin>
 <config_submesoscale_ds_max>100000.0</config_submesoscale_ds_max>
+<config_submesoscale_ice_aware>.false.</config_submesoscale_ice_aware>
+<config_submesoscale_ice_aware_crit>0.5</config_submesoscale_ice_aware_crit>
 
 <!-- GM_eddy_parameterization -->
 <config_use_GM>.true.</config_use_GM>

--- a/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
+++ b/components/mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml
@@ -533,6 +533,22 @@ Valid values: around 1 degree
 Default: Defined in namelist_defaults.xml
 </entry>
 
+<entry id="config_submesoscale_ice_aware" type="logical"
+	category="submesoscale_eddy_parameterization" group="submesoscale_eddy_parameterization">
+flag to enable the ice-aware MLE for submesoscale eddies
+
+Valid values: .true. or .false.
+Default: Defined in namelist_defaults.xml
+</entry>
+
+<entry id="config_submesoscale_ice_aware_crit" type="real"
+	category="submesoscale_eddy_parameterization" group="submesoscale_eddy_parameterization">
+Criteria for evaluating the efficiency of the ice-aware MLE in submesoscale eddies
+
+Valid values: between 0 and 1
+Default: Defined in namelist_defaults.xml
+</entry>
+
 
 <!-- GM_eddy_parameterization -->
 

--- a/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/ice_aware_mle/README
+++ b/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/ice_aware_mle/README
@@ -1,0 +1,5 @@
+This testdef is used to test a stealth feature in mpaso introduced by
+PR #8520. It simplies changes one mpaso namelist variable,
+    config_submesoscale_ice_aware
+from its default value of .fase. to .true..
+This option only works when 'iceFraction' exists in the forcing pool.

--- a/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/ice_aware_mle/user_nl_mpaso
+++ b/components/mpas-ocean/cime_config/testdefs/testmods_dirs/mpaso/ice_aware_mle/user_nl_mpaso
@@ -1,0 +1,1 @@
+ config_submesoscale_ice_aware = .true.

--- a/components/mpas-ocean/driver/ocn_comp_mct.F
+++ b/components/mpas-ocean/driver/ocn_comp_mct.F
@@ -125,7 +125,7 @@ module ocn_comp_mct
    integer :: itimestep, &  ! time step number for MPAS
               ocn_cpl_dt    ! length of coupling interval in seconds - set by coupler/ESMF
 
-   real (kind=RKIND) :: precFactor 
+   real (kind=RKIND) :: precFactor
 
 !=======================================================================
 
@@ -241,10 +241,10 @@ contains
     real (kind=RKIND), pointer :: &
        runningMeanRemovedIceRunoff ! the area integrated, running mean of removed ice runoff from the ocean
 
-    ! freshwater balance adjustment 
+    ! freshwater balance adjustment
     logical, pointer :: config_use_precip_scaling
     character (len=StrKIND), pointer :: config_precip_scaling_mode
-    real (kind=RKIND), pointer :: SFWFScalingFactor ! scaling factor on freshwater fluxes 
+    real (kind=RKIND), pointer :: SFWFScalingFactor ! scaling factor on freshwater fluxes
     real(kind=RKIND), pointer :: scalingFactor
 
 #ifdef HAVE_MOAB
@@ -848,9 +848,9 @@ contains
        ! initialize scaled data ice-shelf melt fluxes based on remove ice runoff
        call ocn_init_scaled_dismf(domain)
 
-       ! Initialize the precipitation scaling scheme 
+       ! Initialize the precipitation scaling scheme
        call ocn_scaled_sfwf_init(domain)
-       ! Ensure a valid first guess at the initial time 
+       ! Ensure a valid first guess at the initial time
        call mpas_pool_get_config(domain % configs, 'config_use_precip_scaling', config_use_precip_scaling)
        if (config_use_precip_scaling) then
           call mpas_pool_get_config(domain % configs, 'config_precip_scaling_mode', config_precip_scaling_mode)
@@ -858,10 +858,10 @@ contains
           block_ptr => domain % blocklist
           call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
           call mpas_pool_get_array(forcingPool, "SFWFScalingFactor", SFWFScalingFactor)
-          if (trim(config_precip_scaling_mode) == 'time-dependent') then 
+          if (trim(config_precip_scaling_mode) == 'time-dependent') then
             call mpas_pool_get_config(domain % configs, 'config_precip_scaling_initial_factor', scalingFactor)
           else if (trim(config_precip_scaling_mode) == 'constant') then
-            call mpas_pool_get_config(domain % configs, 'config_precip_scaling_constant_factor', scalingFactor) 
+            call mpas_pool_get_config(domain % configs, 'config_precip_scaling_constant_factor', scalingFactor)
           end if
           ! Broadcast the scalar to the field
           SFWFScalingFactor = scalingFactor
@@ -925,7 +925,7 @@ contains
       ! initialize scaled data ice-shelf melt fluxes based on remove ice runoff
        call ocn_init_scaled_dismf(domain)
 
-      ! initialize scaled data freshwater fluxes based on water balance relationship 
+      ! initialize scaled data freshwater fluxes based on water balance relationship
        call ocn_scaled_sfwf_init(domain)
 
     end if
@@ -964,13 +964,13 @@ contains
 
     !configuration for freshwater conservation
     call mpas_pool_get_config(domain % configs, 'config_use_precip_scaling', config_use_precip_scaling)
-    if (config_use_precip_scaling) then 
+    if (config_use_precip_scaling) then
       ! independent of space so should be no need to loop over blocks
       block_ptr => domain % blocklist
       call mpas_pool_get_subpool(block_ptr % structs, 'forcing', forcingPool)
       call mpas_pool_get_array(forcingPool, "SFWFScalingFactor", SFWFScalingFactor)
       call seq_infodata_PutData(infodata, precip_fact=SFWFScalingFactor)
-    end if 
+    end if
 
 !-----------------------------------------------------------------------
 !
@@ -1084,9 +1084,9 @@ contains
       real (kind=RKIND), pointer :: &
          runningMeanRemovedIceRunoff ! the area integrated, running mean of removed ice runoff from the ocean
 
-      ! freshwater balance adjustment 
+      ! freshwater balance adjustment
       logical, pointer :: config_use_precip_scaling
-      real (kind=RKIND), pointer :: SFWFScalingFactor ! scaling factor on freshwater fluxes 
+      real (kind=RKIND), pointer :: SFWFScalingFactor ! scaling factor on freshwater fluxes
 
 #ifdef HAVE_MOAB
     integer :: ent_type
@@ -1204,7 +1204,7 @@ contains
 
             if (config_submesoscale_enable) then
                 call mpas_timer_start("submesoscale eddy velocity compute", .false.)
-                call ocn_submesoscale_compute_velocity()
+                call ocn_submesoscale_compute_velocity(forcingPool)
                 call mpas_timer_stop("submesoscale eddy velocity compute")
             end if
             ! Compute normalGMBolusVelocity, relativeSlope and RediDiffVertCoef if respective flags are turned on
@@ -1328,7 +1328,7 @@ contains
             call mpas_log_write('   Validating ocean state')
          endif
 
-        ! update scalling factors for freshwater fluxes 
+        ! update scalling factors for freshwater fluxes
         call ocn_update_scaling_factor(domain, timeLevel=1)
 
          call ocn_validate_state(domain, timeLevel=1)
@@ -2204,7 +2204,7 @@ contains
 
    real (kind=RKIND) :: riverFactor
 
-   ! freshwater balance adjustment 
+   ! freshwater balance adjustment
    logical, pointer :: config_use_precip_scaling
 
 !-----------------------------------------------------------------------
@@ -2243,7 +2243,7 @@ contains
    !configuration for freshwater balance constrains
    call mpas_pool_get_config(domain % configs, 'config_use_precip_scaling', config_use_precip_scaling)
    if (config_use_precip_scaling) then
-      !extract scaling factors 
+      !extract scaling factors
       call seq_infodata_GetData(infodata, precip_fact=precFactor)
    end if
 
@@ -2466,14 +2466,14 @@ contains
       do i = 1, nCellsSolve
         n = n + 1
         if ( windStressZonalField % isActive ) then
-           if (config_momentum_use_active_wave) then     
+           if (config_momentum_use_active_wave) then
               windStressZonal(i) = x2o_o(index_x2o_Foxx_taux, n) - (x2o_o(index_x2o_Faww_Tawx, n) - x2o_o(index_x2o_Fwow_Twox, n))
            else
               windStressZonal(i) = x2o_o(index_x2o_Foxx_taux, n)
            endif
         end if
         if ( windStressMeridionalField % isActive ) then
-           if (config_momentum_use_active_wave) then     
+           if (config_momentum_use_active_wave) then
               windStressMeridional(i) = x2o_o(index_x2o_Foxx_tauy, n) - (x2o_o(index_x2o_Faww_Tawy, n) - x2o_o(index_x2o_Fwow_Twoy, n))
            else
               windStressMeridional(i) = x2o_o(index_x2o_Foxx_tauy, n)

--- a/components/mpas-ocean/src/Registry.xml
+++ b/components/mpas-ocean/src/Registry.xml
@@ -382,6 +382,14 @@
 					description="maximum grid scale to scale up buoyancy gradient"
 					possible_values="around 1 degree"
 					/>
+		<nml_option name="config_submesoscale_ice_aware" type="logical" default_value=".false."
+					description="flag to enable the ice-aware MLE for submesoscale eddies"
+					possible_values=".true. or .false."
+					/>
+		<nml_option name="config_submesoscale_ice_aware_crit" type="real" default_value="0.5"
+					description="Criteria for evaluating the efficiency of the ice-aware MLE in submesoscale eddies"
+					possible_values="between 0 and 1"
+					/>
 	</nml_record>
 	<nml_record name="GM_eddy_parameterization" mode="forward">
 		<nml_option name="config_use_GM" type="logical" default_value=".false."
@@ -2174,7 +2182,7 @@
 			<var name="SSHinitial" packages="scaledSFWFPKG"/>
 			<var name="SSHfinal" packages="scaledSFWFPKG"/>
 			<var name="nValidTotalfwFluxHistory" packages="scaledSFWFPKG"/>
-			<var name="SFWFScalingFactor" packages="scaledSFWFPKG"/> 
+			<var name="SFWFScalingFactor" packages="scaledSFWFPKG"/>
 		</stream>
 
 		<stream name="output"

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
@@ -161,7 +161,8 @@ module ocn_forward_mode
          block              ! structure with all data for a given block
 
       type (mpas_pool_type), pointer :: &
-         diagnosticsPool    ! structure containing diagnostics data
+         diagnosticsPool, &  ! structure containing diagnostics data
+         forcingPool         ! structure containing forcing data
 
       type (MPAS_Time_type) :: &
          xtime_timeType,               &! current time
@@ -337,6 +338,7 @@ module ocn_forward_mode
       daysSinceStartOfSim = daysSinceStartOfSim*days_per_second
 
       call mpas_pool_get_subpool(block % structs, 'diagnostics', diagnosticsPool)
+      call mpas_pool_get_subpool(block % structs, 'forcing', forcingPool)
 
       ! add units of "days since <ref_date>" to Time
       write(units, '(a10,a20)') 'days since', &
@@ -475,7 +477,7 @@ module ocn_forward_mode
       ierr = ior(ierr,err_tmp)
       call ocn_gm_init(domain, err_tmp)
       ierr = ior(ierr,err_tmp)
-      call ocn_submesoscale_init(err_tmp)
+      call ocn_submesoscale_init(forcingPool,err_tmp)
       ierr = ior(ierr,err_tmp)
       call ocn_tracer_nonlocalflux_init(err_tmp)
       ierr = ior(ierr,err_tmp)

--- a/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
+++ b/components/mpas-ocean/src/mode_forward/mpas_ocn_forward_mode.F
@@ -669,7 +669,7 @@ module ocn_forward_mode
       call ocn_time_varying_forcing_init(domain)
 
       ! if not using RK4, calculate time varying forcing terms once per
-      ! time-step as opposed at each RK substage as implemented in RK4 
+      ! time-step as opposed at each RK substage as implemented in RK4
       if (timeIntegratorChoice /= timeIntRK4) then
         call ocn_time_varying_forcing_get(domain % streamManager, domain, domain % clock)
       endif
@@ -716,7 +716,7 @@ module ocn_forward_mode
                call mpas_pool_get_subpool(forcingPool, 'ecosysFrazilForcing', ecosysFrazilForcingPool)
                call ocn_frazil_forcing_build_ecosys_arrays(domain, meshPool, forcingPool, statePool, &
                   ecosysFrazilForcingPool, ierr)
-           end if  
+           end if
            call mpas_timer_start("land_ice_build_arrays")
            call ocn_surface_land_ice_fluxes_build_arrays(meshPool, &
                                                          forcingPool, scratchPool, statePool, err)
@@ -735,7 +735,7 @@ module ocn_forward_mode
 
            if (config_submesoscale_enable) then
                call mpas_timer_start("submesoscale eddy velocity compute", .false.)
-               call ocn_submesoscale_compute_velocity()
+               call ocn_submesoscale_compute_velocity(forcingPool)
                call mpas_timer_stop("submesoscale eddy velocity compute")
            end if
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_submesoscale_eddies.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_submesoscale_eddies.F
@@ -43,6 +43,12 @@ module ocn_submesoscale_eddies
    real(kind=RKIND) :: tau, LfMin, Ce, dsMax
    real(kind=RKIND),dimension(:),allocatable :: time_scale
 
+   ! Ice-aware MLE
+   logical :: iceAwareActive
+   real(kind=RKIND) :: iceMLE_s, iceMLE_k, iceMLE_u, iceMLE_c, &
+                       iceMLE_crit, iceFracEdge, iceMLE_eps,   &
+                       iceMLE_eff, erfv, expc
+
   !***********************************************************************
 
   contains
@@ -53,32 +59,45 @@ module ocn_submesoscale_eddies
   !
   !> \brief   Computes velocity from submesoscale eddies
   !> \details
-  !>  This routine implements the Fox-Kemper et al 2011 submesoscale 
+  !>  This routine implements the Fox-Kemper et al 2011 submesoscale
   !>  parameterization (https://doi.org/10.1016/j.ocemod.2010.09.002).
-  !>  The transport velocity from the submesoscales is given by a 
+  !>  The transport velocity from the submesoscales is given by a
   !>  stream function which is given as
   !>
   !>  Psi = C_e*Delta_S/L_f*H^2 int(bGrad_H)/sqrt(f^2+tau^-2)*mu(z)
   !>
-  !>  here C_e is a specified efficiency, Delta_s is taken as 
+  !>  here C_e is a specified efficiency, Delta_s is taken as
   !>  min(dcEdge,dsMax), H is the mixed layer depth, L_f is the subgrid
-  !>  frontal width that is scaled to the coarse grid, f is the 
-  !>  coriolis parameter, and tau is a time scale specified to prevent 
+  !>  frontal width that is scaled to the coarse grid, f is the
+  !>  coriolis parameter, and tau is a time scale specified to prevent
   !>  the singularity near the equator.  the horizontal buoyancy gradient
   !>  is integrated over the mixed layer depth and mu(z) is a non-dimensional
   !>  shape function that is zero below the mixed layer depth
   !>
   !***********************************************************************
 
-  subroutine ocn_submesoscale_compute_velocity()
+  subroutine ocn_submesoscale_compute_velocity(forcingPool)
+
+     !-----------------------------------------------------------------
+     !
+     ! input variables
+     !
+     !-----------------------------------------------------------------
+
+     type (mpas_pool_type), pointer, intent(in) :: &
+        forcingPool   !< Input: forcing information
 
      !-----------------------------------------------------------------
      !
      ! local variables
      !
      !-----------------------------------------------------------------
+     real (kind=RKIND), dimension(:), pointer :: iceFraction, landIceFraction
+
+     integer, dimension(:), pointer :: landIceMask
 
      integer :: k, nEdges, nCells, iCell, iEdge, cell1, cell2, indMLDedge
+     integer :: landIceMaskEdge
 
      real(kind=RKIND),dimension(:),allocatable :: &
         streamFunction, &
@@ -92,12 +111,22 @@ module ocn_submesoscale_eddies
      allocate(streamFunction(nVertLevels+1))
      allocate(zEdge(nVertLevels+1))
 
+     call mpas_pool_get_array(forcingPool, 'iceFraction', iceFraction)
+     call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
+     call mpas_pool_get_array(forcingPool, 'landIceMask',landIceMask)
+
+     if ( associated(iceFraction) .and. associated(landIceFraction) ) then
+        iceAwareActive = .true.
+     else
+        iceAwareActive = .false.
+     end if
+
      !compute the mixed layer average buoyancy gradient and bvf
-     !This is thickness weighted to allow for non uniform grid spacing, 
-     !and centered on layer interfaces. The mixed layer goes from the 
+     !This is thickness weighted to allow for non uniform grid spacing,
+     !and centered on layer interfaces. The mixed layer goes from the
      !ocean top layer to mid-depth of layer(indMLDedge)
-     !NOTE, gradDensityEddy and BFV are defined at the top cell interface 
-     !and not valid for minLevelCell, so properties for the top layer 
+     !NOTE, gradDensityEddy and BFV are defined at the top cell interface
+     !and not valid for minLevelCell, so properties for the top layer
      !rely on the values at (minLevelCell+1).
      !$omp parallel
      !$omp do schedule(runtime) &
@@ -149,10 +178,41 @@ module ocn_submesoscale_eddies
 
         ds = min(dcEdge(iEdge),dsMax)
 
+        ! Ice-aware MLE efficiency computation:
+        !  - Section 8 in Shrestha and Manucharyan, 2022
+        !    (https://journals.ametsoc.org/view/journals/phoc/52/3/JPO-D-21-0024.1.xml)
+        if ( iceAwareActive ) then
+           iceFracEdge = 0.5_RKIND*(    iceFraction(cell1)+    iceFraction(cell2)) &
+                       + 0.5_RKIND*(landIceFraction(cell1)+landIceFraction(cell2))
+
+           if ( iceFracEdge <= iceMLE_crit ) then
+              expc = iceFracEdge**2.0_RKIND * exp(-iceMLE_c * (1.0_RKIND - iceFracEdge))
+              erfv = 0.8_RKIND * erf((iceFracEdge - iceMLE_crit)/0.05_RKIND)
+              iceMLE_eps = iceMLE_k * (1.0_RKIND - erfv) * expc
+           else
+              iceMLE_eps = iceMLE_u
+           end if
+
+           iceMLE_eff = 1.0_RKIND - iceMLE_s * iceMLE_eps
+
+           landIceMaskEdge = max(landIceMask(cell1), landIceMask(cell2))
+
+           ! We add an addtional condition here to prevent grid-scale noise in MLE at
+           ! land-ice mask = 1.
+           if ( landIceMaskEdge == 1 .or. iceFracEdge > 1.000000001_RKIND ) then
+              iceMLE_eff = 0.0_RKIND
+           end if
+
+        else
+
+           iceMLE_eff = 1.0_RKIND
+
+        end if ! iceAwareActive
+
         do k = minLevelEdgeTop(iEdge)+1,maxLevelEdgeTop(iEdge)
            mu = max(0.0_RKIND,(1.0_RKIND - (2.0_RKIND*zEdge(k) / zMLD + 1.0_RKIND)**2.0)* &
                     (1.0_RKIND + 5.0_RKIND/21.0_RKIND*(2.0_RKIND*zEdge(k)/zMLD + 1.0_RKIND)**2.0))
-           streamFunction(k) = Ce*ds/Lf*zMLD**2.0*gradBuoyML/time_scale(iEdge)*mu
+           streamFunction(k) = Ce*ds/Lf*zMLD**2.0*gradBuoyML/time_scale(iEdge)*mu * iceMLE_eff
         end do
 
         ! integrate in vertical to get the velocity
@@ -175,8 +235,8 @@ module ocn_submesoscale_eddies
   !
   !> \brief   Submesoscale parameterization add to transport Vel
   !> \details
-  !>  adds the MLE induced velocity to the transport velocity 
-  !>  
+  !>  adds the MLE induced velocity to the transport velocity
+  !>
   !***********************************************************************
 
   subroutine ocn_MLE_add_to_transport_vel(normalTransportVelocity, nEdges)
@@ -210,8 +270,8 @@ module ocn_submesoscale_eddies
   !
   !> \brief   Submesoscale parameterization init
   !> \details
-  !>  Initializes parameters related to the submesoscale eddy parameterization 
-  !>  
+  !>  Initializes parameters related to the submesoscale eddy parameterization
+  !>
   !***********************************************************************
 
   subroutine ocn_submesoscale_init(err)
@@ -235,6 +295,14 @@ module ocn_submesoscale_eddies
      end do
      !$omp end do
      !$omp end parallel
+
+     ! Ice-aware MLE
+     iceAwareActive = config_submesoscale_ice_aware
+     iceMLE_crit    = config_submesoscale_ice_aware_crit
+     iceMLE_s       = 2.25_RKIND
+     iceMLE_k       = 430.0_RKIND
+     iceMLE_u       = 0.33_RKIND
+     iceMLE_c       = 20.0_RKIND
 
    end subroutine ocn_submesoscale_init
 

--- a/components/mpas-ocean/src/shared/mpas_ocn_submesoscale_eddies.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_submesoscale_eddies.F
@@ -111,16 +111,6 @@ module ocn_submesoscale_eddies
      allocate(streamFunction(nVertLevels+1))
      allocate(zEdge(nVertLevels+1))
 
-     call mpas_pool_get_array(forcingPool, 'iceFraction', iceFraction)
-     call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
-     call mpas_pool_get_array(forcingPool, 'landIceMask',landIceMask)
-
-     if ( associated(iceFraction) .and. associated(landIceFraction) ) then
-        iceAwareActive = .true.
-     else
-        iceAwareActive = .false.
-     end if
-
      !compute the mixed layer average buoyancy gradient and bvf
      !This is thickness weighted to allow for non uniform grid spacing,
      !and centered on layer interfaces. The mixed layer goes from the
@@ -182,6 +172,10 @@ module ocn_submesoscale_eddies
         !  - Section 8 in Shrestha and Manucharyan, 2022
         !    (https://journals.ametsoc.org/view/journals/phoc/52/3/JPO-D-21-0024.1.xml)
         if ( iceAwareActive ) then
+           call mpas_pool_get_array(forcingPool, 'iceFraction', iceFraction)
+           call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
+           call mpas_pool_get_array(forcingPool, 'landIceMask',landIceMask)
+
            iceFracEdge = 0.5_RKIND*(    iceFraction(cell1)+    iceFraction(cell2)) &
                        + 0.5_RKIND*(landIceFraction(cell1)+landIceFraction(cell2))
 
@@ -199,7 +193,7 @@ module ocn_submesoscale_eddies
 
            ! We add an addtional condition here to prevent grid-scale noise in MLE at
            ! land-ice mask = 1.
-           if ( landIceMaskEdge == 1 .or. iceFracEdge > 1.000000001_RKIND ) then
+           if ( landIceMaskEdge == 1 ) then
               iceMLE_eff = 0.0_RKIND
            end if
 
@@ -274,7 +268,12 @@ module ocn_submesoscale_eddies
   !>
   !***********************************************************************
 
-  subroutine ocn_submesoscale_init(err)
+  subroutine ocn_submesoscale_init(forcingPool,err)
+
+     type (mpas_pool_type), pointer, intent(in) :: &
+        forcingPool   !< Input: forcing information
+
+     real (kind=RKIND), dimension(:), pointer :: iceFraction, landIceFraction
 
      integer, intent(out) :: err !< Output: error flag
 
@@ -297,7 +296,19 @@ module ocn_submesoscale_eddies
      !$omp end parallel
 
      ! Ice-aware MLE
-     iceAwareActive = config_submesoscale_ice_aware
+     call mpas_pool_get_array(forcingPool, 'iceFraction', iceFraction)
+     call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
+
+     if ( .not. config_submesoscale_ice_aware ) then
+        iceAwareActive = .false.
+     else
+        if ( associated(iceFraction) .and. associated(landIceFraction) ) then
+           iceAwareActive = .true.
+        else
+           iceAwareActive = .false.
+        end if
+     end if
+
      iceMLE_crit    = config_submesoscale_ice_aware_crit
      iceMLE_s       = 2.25_RKIND
      iceMLE_k       = 430.0_RKIND

--- a/components/mpas-ocean/src/shared/mpas_ocn_submesoscale_eddies.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_submesoscale_eddies.F
@@ -92,7 +92,7 @@ module ocn_submesoscale_eddies
      ! local variables
      !
      !-----------------------------------------------------------------
-     real (kind=RKIND), dimension(:), pointer :: iceFraction, landIceFraction
+     real (kind=RKIND), dimension(:), pointer :: iceFraction
 
      integer, dimension(:), pointer :: landIceMask
 
@@ -173,11 +173,9 @@ module ocn_submesoscale_eddies
         !    (https://journals.ametsoc.org/view/journals/phoc/52/3/JPO-D-21-0024.1.xml)
         if ( iceAwareActive ) then
            call mpas_pool_get_array(forcingPool, 'iceFraction', iceFraction)
-           call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
            call mpas_pool_get_array(forcingPool, 'landIceMask',landIceMask)
 
-           iceFracEdge = 0.5_RKIND*(    iceFraction(cell1)+    iceFraction(cell2)) &
-                       + 0.5_RKIND*(landIceFraction(cell1)+landIceFraction(cell2))
+           iceFracEdge = 0.5_RKIND * (iceFraction(cell1) + iceFraction(cell2))
 
            if ( iceFracEdge <= iceMLE_crit ) then
               expc = iceFracEdge**2.0_RKIND * exp(-iceMLE_c * (1.0_RKIND - iceFracEdge))
@@ -273,7 +271,7 @@ module ocn_submesoscale_eddies
      type (mpas_pool_type), pointer, intent(in) :: &
         forcingPool   !< Input: forcing information
 
-     real (kind=RKIND), dimension(:), pointer :: iceFraction, landIceFraction
+     real (kind=RKIND), dimension(:), pointer :: iceFraction
 
      integer, intent(out) :: err !< Output: error flag
 
@@ -297,12 +295,11 @@ module ocn_submesoscale_eddies
 
      ! Ice-aware MLE
      call mpas_pool_get_array(forcingPool, 'iceFraction', iceFraction)
-     call mpas_pool_get_array(forcingPool, 'landIceFraction', landIceFraction)
 
      if ( .not. config_submesoscale_ice_aware ) then
         iceAwareActive = .false.
      else
-        if ( associated(iceFraction) .and. associated(landIceFraction) ) then
+        if ( associated(iceFraction) ) then
            iceAwareActive = .true.
         else
            iceAwareActive = .false.

--- a/components/mpas-ocean/src/shared/mpas_ocn_submesoscale_eddies.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_submesoscale_eddies.F
@@ -44,7 +44,7 @@ module ocn_submesoscale_eddies
    real(kind=RKIND),dimension(:),allocatable :: time_scale
 
    ! Ice-aware MLE
-   logical :: iceAwareActive
+   logical :: iceAwareActive, landIceMaskExist
    real(kind=RKIND) :: iceMLE_s, iceMLE_k, iceMLE_u, iceMLE_c, &
                        iceMLE_crit, iceFracEdge, iceMLE_eps,   &
                        iceMLE_eff, erfv, expc
@@ -187,12 +187,14 @@ module ocn_submesoscale_eddies
 
            iceMLE_eff = 1.0_RKIND - iceMLE_s * iceMLE_eps
 
-           landIceMaskEdge = max(landIceMask(cell1), landIceMask(cell2))
+           if ( landIceMaskExist ) then
+              landIceMaskEdge = max(landIceMask(cell1), landIceMask(cell2))
 
-           ! We add an addtional condition here to prevent grid-scale noise in MLE at
-           ! land-ice mask = 1.
-           if ( landIceMaskEdge == 1 ) then
-              iceMLE_eff = 0.0_RKIND
+              ! We add an addtional condition here to prevent grid-scale noise in MLE at
+              ! land-ice mask = 1.
+              if ( landIceMaskEdge == 1 ) then
+                 iceMLE_eff = 0.0_RKIND
+              end if
            end if
 
         else
@@ -273,6 +275,8 @@ module ocn_submesoscale_eddies
 
      real (kind=RKIND), dimension(:), pointer :: iceFraction
 
+     integer, dimension(:), pointer :: landIceMask
+
      integer, intent(out) :: err !< Output: error flag
 
      integer :: iEdge
@@ -304,6 +308,14 @@ module ocn_submesoscale_eddies
         else
            iceAwareActive = .false.
         end if
+     end if
+
+     ! Land-ice mask check
+     call mpas_pool_get_array(forcingPool, 'landIceMask',landIceMask)
+     if ( associated(landIceMask) ) then
+        landIceMaskExist = .true.
+     else
+        landIceMaskExist = .false.
      end if
 
      iceMLE_crit    = config_submesoscale_ice_aware_crit


### PR DESCRIPTION
This PR adds the ice-aware option to the mixed-layer eddy (MLE) parametrization in MPAS-Ocean

- The ice-aware MLE suppresses submesoscale eddy activity beneath sea ice.
- The implementation follows [Shrestha and Manucharyan (2022)](https://journals.ametsoc.org/view/journals/phoc/52/3/JPO-D-21-0024.1.xml).

- The relevant namelist options for the ice-aware MLE scheme are listed below. Details for each option are provided in `mpas-ocean/bld/namelist_files/namelist_definition_mpaso.xml`.

  - `config_submesoscale_ice_aware = .true.`
  - `config_submesoscale_ice_aware_crit = 0.5`

- This option is implemented as a stealth feature in MPAS-Ocean.

This work was carried out under the ImPACTS SciDAC project, led by @vanroekel .