### PR TITLE
Add v3.HR 1950 CMIP7 forcings to maint-3.2

### DIFF
--- a/components/eam/bld/namelist_files/use_cases/1950_eam_CMIP7-HR_chemUCI-Linoz-mam5-vbs.xml
+++ b/components/eam/bld/namelist_files/use_cases/1950_eam_CMIP7-HR_chemUCI-Linoz-mam5-vbs.xml
@@ -10,7 +10,7 @@
 <solar_data_type>FIXED</solar_data_type>
 
 <!-- 1950 GHG values from CMIP7 input4MIPS -->
-<!-- <co2vmr>313.079e-6</co2vmr> The CMIP7 concentration set by CCSM_CO2_PPMV in drivers-mct/cime_config/config_component_e3sm.xml -->
+<!-- <co2vmr>313.079e-6</co2vmr> The CMIP7 concentration set by CCSM_CO2_PPMV in the coupler's cime_config/config_component_e3sm.xml -->
 <ch4vmr>1165.016e-9</ch4vmr>
 <n2ovmr>290.567e-9</n2ovmr>
 <f11vmr>45.454e-12</f11vmr>
@@ -49,7 +49,7 @@
 <isop_vbs_emis_file   >atm/cam/chem/trop_mozart_aero/emis/CMIP7_0.5deg/F1950/cmip7_ISOP_surf_1950_clim_0.5x0.63_c20260407.nc </isop_vbs_emis_file>
 <c10h16_emis_file     >atm/cam/chem/trop_mozart_aero/emis/CMIP7_0.5deg/F1950/cmip7_MTERP_surf_1950_clim_0.5x0.63_c20260407.nc </c10h16_emis_file>
 <nox_emis_file        >atm/cam/chem/trop_mozart_aero/emis/CMIP7_0.5deg/F1950/cmip7_NO_surf_1950_clim_0.5x0.63_c20260407.nc </nox_emis_file>
-<dms_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DMSflux.2010.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20190220.nc</dms_emis_file>
+<dms_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DMSflux.1950.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20171210.nc </dms_emis_file>
 <soag0_emis_file      >atm/cam/chem/trop_mozart_aero/emis/CMIP7_0.5deg/F1950/cmip7_SOAG0_surf_1950_clim_0.5x0.63_c20260407.nc </soag0_emis_file>
 <so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/CMIP7_0.5deg/F1950/cmip7_so2_surf_1950_clim_0.5x0.63_c20260407.nc </so2_emis_file>
 <bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/CMIP7_0.5deg/F1950/cmip7_mam5_bc_a4_surf_1950_clim_0.5x0.63_c20260407.nc </bc_a4_emis_file>
@@ -110,7 +110,6 @@
 <linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
 <linoz_data_type            >CYCLICAL</linoz_data_type>
 
-<!-- Turn off ozone dry deposition, as Linoz O3v2 and ozone are not separated for now. Need to turn on ozone dry deposition when interactive tropospheric chemistry is implemented -->
 <drydep_method       >'xactive_lnd'</drydep_method>
 <drydep_list         >'O3','H2O2','CH2O','CH3OOH','NO','NO2','HNO3','HO2NO2','PAN','CO','CH3COCH3','C2H5OOH','CH3CHO','H2SO4','SO2','NO3','N2O5','SOAG0','SOAG15','SOAG24','SOAG35','SOAG34','SOAG33','SOAG32','SOAG31'</drydep_list>
 <gas_wetdep_method   >'NEU'</gas_wetdep_method>

--- a/components/eam/bld/namelist_files/use_cases/1950_eam_CMIP7-HR_chemUCI-Linoz-mam5-vbs.xml
+++ b/components/eam/bld/namelist_files/use_cases/1950_eam_CMIP7-HR_chemUCI-Linoz-mam5-vbs.xml
@@ -124,9 +124,6 @@
 <dp_cut_accum_rename>  1.0D-6   </dp_cut_accum_rename>
 <dp_xferall_thresh_accum_rename>  1.0D-6  </dp_xferall_thresh_accum_rename>
 
-<!-- sim_year used for CLM datasets -->
-<sim_year>2015</sim_year>
-
 <!-- land datasets -->
 <!-- Set in components/elm/bld/namelist_files/use_cases/1950_CMIP7_control.xml -->
 

--- a/components/eam/bld/namelist_files/use_cases/1950_eam_CMIP7-HR_chemUCI-Linoz-mam5-vbs.xml
+++ b/components/eam/bld/namelist_files/use_cases/1950_eam_CMIP7-HR_chemUCI-Linoz-mam5-vbs.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0"?>
+<namelist_defaults>
+
+<!-- Set default output options for CMIP7 simulations -->
+<cosp_lite>.true.</cosp_lite>
+
+<!-- Solar constant from CMIP6 input4MIPS -->
+<solar_data_file>atm/cam/solar/multiple_input4MIPs_solar_CMIP_SOLARIS-HEPPA-CMIP-4-6_gn_1950ctl.nc</solar_data_file>
+<solar_data_ymd>19500101</solar_data_ymd>
+<solar_data_type>FIXED</solar_data_type>
+
+<!-- 1950 GHG values from CMIP7 input4MIPS -->
+<!-- <co2vmr>313.079e-6</co2vmr> The CMIP7 concentration set by CCSM_CO2_PPMV in drivers-mct/cime_config/config_component_e3sm.xml -->
+<ch4vmr>1165.016e-9</ch4vmr>
+<n2ovmr>290.567e-9</n2ovmr>
+<f11vmr>45.454e-12</f11vmr>
+<f12vmr>6.076e-12</f12vmr>
+
+<!-- For comprehensive history -->
+<history_amwg       >.true.</history_amwg>
+<history_aerosol    >.true.</history_aerosol>
+<history_aero_optics>.true.</history_aero_optics>
+
+<!-- External forcing for BAM or MAM.  CMIP7 input4mips data -->
+<ext_frc_type         >CYCLICAL</ext_frc_type>
+<ext_frc_cycle_yr     >1950</ext_frc_cycle_yr>
+<no2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/CMIP7_0.5deg/F1950/cmip7_NO2_elev_1950_clim_0.5x0.63_c20260407.nc </no2_ext_file>
+<so2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/CMIP7_0.5deg/F1950/cmip7_so2_volc_elev_1950_clim_0.5x0.63_c20260419.nc </so2_ext_file>
+<soag0_ext_file       >atm/cam/chem/trop_mozart_aero/emis/CMIP7_0.5deg/F1950/cmip7_SOAG0_elev_1950_clim_0.5x0.63_c20260407.nc </soag0_ext_file>
+<bc_a4_ext_file       >atm/cam/chem/trop_mozart_aero/emis/CMIP7_0.5deg/F1950/cmip7_mam5_bc_a4_elev_1950_clim_0.5x0.63_c20260407.nc </bc_a4_ext_file>
+<mam7_num_a1_ext_file >atm/cam/chem/trop_mozart_aero/emis/CMIP7_0.5deg/F1950/cmip7_mam5_num_a1_elev_1950_clim_0.5x0.63_c20260407.nc </mam7_num_a1_ext_file>
+<num_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/CMIP7_0.5deg/F1950/cmip7_mam5_num_a2_elev_1950_clim_0.5x0.63_c20260407.nc </num_a2_ext_file>
+<mam7_num_a3_ext_file >atm/cam/chem/trop_mozart_aero/emis/CMIP7_0.5deg/F1950/cmip7_mam5_num_a4_elev_1950_clim_0.5x0.63_c20260407.nc </mam7_num_a3_ext_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_ext_file      >atm/cam/chem/trop_mozart_aero/emis/CMIP7_0.5deg/F1950/cmip7_mam5_pom_a4_elev_1950_clim_0.5x0.63_c20260407.nc </pom_a4_ext_file>
+<so4_a1_ext_file      >atm/cam/chem/trop_mozart_aero/emis/CMIP7_0.5deg/F1950/cmip7_mam5_so4_a1_elev_1950_clim_0.5x0.63_c20260407.nc </so4_a1_ext_file>
+<so4_a2_ext_file      >atm/cam/chem/trop_mozart_aero/emis/CMIP7_0.5deg/F1950/cmip7_mam5_so4_a2_elev_1950_clim_0.5x0.63_c20260407.nc </so4_a2_ext_file>
+
+<!-- Surface emissions for chemUCI-Linoz, MAM5, VBS SOA.  CMIP7 input4mips data -->
+<srf_emis_type        >CYCLICAL</srf_emis_type>
+<srf_emis_cycle_yr    >1950</srf_emis_cycle_yr>
+<c2h4_emis_file       >atm/cam/chem/trop_mozart_aero/emis/CMIP7_0.5deg/F1950/cmip7_C2H4_surf_1950_clim_0.5x0.63_c20260407.nc </c2h4_emis_file>
+<c2h6_emis_file       >atm/cam/chem/trop_mozart_aero/emis/CMIP7_0.5deg/F1950/cmip7_C2H6_surf_1950_clim_0.5x0.63_c20260407.nc </c2h6_emis_file>
+<c3h8_emis_file       >atm/cam/chem/trop_mozart_aero/emis/CMIP7_0.5deg/F1950/cmip7_C3H8_surf_1950_clim_0.5x0.63_c20260407.nc </c3h8_emis_file>
+<ch2o_emis_file       >atm/cam/chem/trop_mozart_aero/emis/CMIP7_0.5deg/F1950/cmip7_CH2O_surf_1950_clim_0.5x0.63_c20260407.nc </ch2o_emis_file>
+<ch3cho_emis_file     >atm/cam/chem/trop_mozart_aero/emis/CMIP7_0.5deg/F1950/cmip7_CH3CHO_surf_1950_clim_0.5x0.63_c20260407.nc </ch3cho_emis_file>
+<ch3coch3_emis_file   >atm/cam/chem/trop_mozart_aero/emis/CMIP7_0.5deg/F1950/cmip7_CH3COCH3_surf_1950_clim_0.5x0.63_c20260407.nc </ch3coch3_emis_file>
+<co_emis_file         >atm/cam/chem/trop_mozart_aero/emis/CMIP7_0.5deg/F1950/cmip7_CO_surf_1950_clim_0.5x0.63_c20260407.nc </co_emis_file>
+<isop_emis_file       >atm/cam/chem/trop_mozart_aero/emis/CMIP7_0.5deg/F1950/cmip7_ISOP_surf_1950_clim_0.5x0.63_c20260407.nc </isop_emis_file>
+<isop_vbs_emis_file   >atm/cam/chem/trop_mozart_aero/emis/CMIP7_0.5deg/F1950/cmip7_ISOP_surf_1950_clim_0.5x0.63_c20260407.nc </isop_vbs_emis_file>
+<c10h16_emis_file     >atm/cam/chem/trop_mozart_aero/emis/CMIP7_0.5deg/F1950/cmip7_MTERP_surf_1950_clim_0.5x0.63_c20260407.nc </c10h16_emis_file>
+<nox_emis_file        >atm/cam/chem/trop_mozart_aero/emis/CMIP7_0.5deg/F1950/cmip7_NO_surf_1950_clim_0.5x0.63_c20260407.nc </nox_emis_file>
+<dms_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/DMSflux.2010.1deg_latlon_conserv.POPmonthlyClimFromACES4BGC_c20190220.nc</dms_emis_file>
+<soag0_emis_file      >atm/cam/chem/trop_mozart_aero/emis/CMIP7_0.5deg/F1950/cmip7_SOAG0_surf_1950_clim_0.5x0.63_c20260407.nc </soag0_emis_file>
+<so2_emis_file	      >atm/cam/chem/trop_mozart_aero/emis/CMIP7_0.5deg/F1950/cmip7_so2_surf_1950_clim_0.5x0.63_c20260407.nc </so2_emis_file>
+<bc_a4_emis_file      >atm/cam/chem/trop_mozart_aero/emis/CMIP7_0.5deg/F1950/cmip7_mam5_bc_a4_surf_1950_clim_0.5x0.63_c20260407.nc </bc_a4_emis_file>
+<mam7_num_a1_emis_file>atm/cam/chem/trop_mozart_aero/emis/CMIP7_0.5deg/F1950/cmip7_mam5_num_a1_surf_1950_clim_0.5x0.63_c20260407.nc </mam7_num_a1_emis_file> 
+<num_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/CMIP7_0.5deg/F1950/cmip7_mam5_num_a2_surf_1950_clim_0.5x0.63_c20260407.nc </num_a2_emis_file>
+<mam7_num_a3_emis_file>atm/cam/chem/trop_mozart_aero/emis/CMIP7_0.5deg/F1950/cmip7_mam5_num_a4_surf_1950_clim_0.5x0.63_c20260407.nc </mam7_num_a3_emis_file> <!-- This is to set num_a4 emissions -->
+<pom_a4_emis_file     >atm/cam/chem/trop_mozart_aero/emis/CMIP7_0.5deg/F1950/cmip7_mam5_pom_a4_surf_1950_clim_0.5x0.63_c20260407.nc </pom_a4_emis_file>
+<so4_a1_emis_file     >atm/cam/chem/trop_mozart_aero/emis/CMIP7_0.5deg/F1950/cmip7_mam5_so4_a1_surf_1950_clim_0.5x0.63_c20260407.nc </so4_a1_emis_file>
+<so4_a2_emis_file     >atm/cam/chem/trop_mozart_aero/emis/CMIP7_0.5deg/F1950/cmip7_mam5_so4_a2_surf_1950_clim_0.5x0.63_c20260407.nc </so4_a2_emis_file>
+<e90_emis_file        >atm/cam/chem/trop_mozart/ub/emissions_E90_surface_1750-2101_1.9x2.5_c20231222.nc </e90_emis_file>
+
+<airpl_emis_file></airpl_emis_file>   <!-- need to be empty, but if specifying empty here, the value would be root of input_data_path -->
+
+<!-- <tracer_cnst_filelist>this_field_is_not_used</tracer_cnst_filelist> -->
+<tracer_cnst_type    >CYCLICAL</tracer_cnst_type>
+<tracer_cnst_cycle_yr>1955</tracer_cnst_cycle_yr>
+<tracer_cnst_file    >oxid_1.9x2.5_L26_1850-2025_c20251005.nc</tracer_cnst_file>
+<tracer_cnst_filelist>''</tracer_cnst_filelist>
+<tracer_cnst_datapath>atm/cam/chem/trop_mozart_aero/oxid</tracer_cnst_datapath>
+<tracer_cnst_specifier>'prsd_O3:O3','prsd_NO3:NO3','prsd_OH:OH'</tracer_cnst_specifier>
+
+<!-- prescribed methane  -->
+<prescribed_ghg_file      >ch4_oxid_1.9x2.5_L26_1990-1999clim.c090804.nc</prescribed_ghg_file>
+<prescribed_ghg_datapath  >atm/cam/chem/methane</prescribed_ghg_datapath>
+<prescribed_ghg_type      >CYCLICAL</prescribed_ghg_type>
+<prescribed_ghg_cycle_yr  >1995</prescribed_ghg_cycle_yr>
+<prescribed_ghg_filelist  >''</prescribed_ghg_filelist>
+<prescribed_ghg_specifier>'prsd_ch4:CH4'</prescribed_ghg_specifier>
+
+<!-- rad_climate -->
+<rad_climate>
+  'A:H2OLNZ:H2O', 'N:O2:O2', 'N:CO2:CO2',
+  'A:O3:O3', 'A:N2OLNZ:N2O', 'A:CH4LNZ:CH4',
+  'N:CFC11:CFC11', 'N:CFC12:CFC12',
+  'M:mam5_mode1:$INPUTDATA_ROOT/atm/cam/physprops/mam5_mode1_rrtmg_dgnh1.2_c20250927.nc',
+  'M:mam5_mode2:$INPUTDATA_ROOT/atm/cam/physprops/mam4_mode2_rrtmg_c130628.nc',
+  'M:mam5_mode3:$INPUTDATA_ROOT/atm/cam/physprops/mam4_mode3_rrtmg_aeronetdust_c141106.nc',
+  'M:mam5_mode4:$INPUTDATA_ROOT/atm/cam/physprops/mam4_mode4_rrtmg_c130628.nc',
+  'M:mam5_mode5:$INPUTDATA_ROOT/atm/cam/physprops/mam5_mode5_rrtmg_sig1.2_dgnl1.0_c20250927.nc'
+</rad_climate>
+
+<!-- Marine organic aerosol namelist settings -->
+<mam_mom_mixing_state>3</mam_mom_mixing_state>
+<mam_mom_cycle_yr  >1                                                                                    </mam_mom_cycle_yr  >
+<mam_mom_datapath  >'atm/cam/chem/trop_mam/marine_BGC/'                                                  </mam_mom_datapath  >
+<mam_mom_datatype  >'CYCLICAL'										 </mam_mom_datatype  >
+<mam_mom_filename  >'monthly_macromolecules_0.1deg_bilinear_latlon_year01_merge_date.nc'                 </mam_mom_filename  > <!-- Using the 2000 file, for now -->
+<mam_mom_fixed_tod >0											 </mam_mom_fixed_tod >
+<mam_mom_fixed_ymd >0											 </mam_mom_fixed_ymd >
+<mam_mom_specifier >'chla:CHL1','mpoly:TRUEPOLYC','mprot:TRUEPROTC','mlip:TRUELIPC'			 </mam_mom_specifier >
+
+<!-- Stratospheric ozone (Linoz) updated using CMIP6 input4MIPS GHG concentrations -->
+<chlorine_loading_file      >atm/cam/chem/trop_mozart/ub/Linoz_Chlorine_Loading_CMIP6_Hist_SSP245_0003-2503_c20200808.nc</chlorine_loading_file>
+<chlorine_loading_fixed_ymd >19500101</chlorine_loading_fixed_ymd>
+<chlorine_loading_type      >FIXED</chlorine_loading_type>
+<linoz_data_cycle_yr        >1950</linoz_data_cycle_yr>
+<linoz_data_file            >linv3_1849-2101_CMIP6_Hist_SSP245_10deg_58km_c20231207.nc</linoz_data_file>
+<linoz_data_path            >atm/cam/chem/trop_mozart/ub</linoz_data_path>
+<linoz_data_type            >CYCLICAL</linoz_data_type>
+
+<!-- Turn off ozone dry deposition, as Linoz O3v2 and ozone are not separated for now. Need to turn on ozone dry deposition when interactive tropospheric chemistry is implemented -->
+<drydep_method       >'xactive_lnd'</drydep_method>
+<drydep_list         >'O3','H2O2','CH2O','CH3OOH','NO','NO2','HNO3','HO2NO2','PAN','CO','CH3COCH3','C2H5OOH','CH3CHO','H2SO4','SO2','NO3','N2O5','SOAG0','SOAG15','SOAG24','SOAG35','SOAG34','SOAG33','SOAG32','SOAG31'</drydep_list>
+<gas_wetdep_method   >'NEU'</gas_wetdep_method>
+<gas_wetdep_list     >'C2H5OOH','CH2O','CH3CHO','CH3OOH','H2O2','H2SO4','HNO3','HO2NO2','SO2','SOAG0','SOAG15','SOAG24','SOAG35','SOAG34','SOAG33','SOAG32','SOAG31'</gas_wetdep_list>
+<fstrat_efold_list>'CH2O', 'CH3O2', 'CH3OOH', 'PAN', 'CO', 'C2H6', 'C3H8', 'C2H4', 'ROHO2', 'CH3COCH3', 'C2H5O2', 'C2H5OOH', 'CH3CHO', 'CH3CO3', 'ISOP', 'ISOPO2', 'MVKMACR', 'MVKO2'</fstrat_efold_list>
+
+<fstrat_list         >''</fstrat_list>
+
+<!-- Tuning parameters for low-res config using CMIP7 forcing to work with mode1 and mode5 physprop specified here -->
+<!-- This is to distinguish from the values specified in namelist_defaults.xml for LR with CMIP6 or HR with CMIP7 -->
+
+<dp_cut_accum_rename>  1.0D-6   </dp_cut_accum_rename>
+<dp_xferall_thresh_accum_rename>  1.0D-6  </dp_xferall_thresh_accum_rename>
+
+<!-- sim_year used for CLM datasets -->
+<sim_year>2015</sim_year>
+
+<!-- land datasets -->
+<!-- Set in components/elm/bld/namelist_files/use_cases/1950_CMIP7_control.xml -->
+
+
+</namelist_defaults>

--- a/components/eam/cime_config/config_component.xml
+++ b/components/eam/cime_config/config_component.xml
@@ -120,6 +120,7 @@
       <value compset="1850(?:SOI)?_EAM.*CHEMUCI.*LINOZ.*MAM5"  >1850_eam_chemUCI-Linoz-mam5</value>
       <value compset="1950(?:SOI)?_EAM.*CMIP6"          >1950_eam_CMIP6_chemUCI-Linoz-mam5-vbs</value>
       <value compset="1950(?:SOI)?.*CMIP7_EAM"          >1950_eam_CMIP7_chemUCI-Linoz-mam5-vbs</value>
+      <value compset="1950(?:SOI)?.*CMIP7_EAM" grid="a%ne120np4.pg2">1950_eam_CMIP7-HR_chemUCI-Linoz-mam5-vbs</value>
       <value compset="1850(?:SOI)?_EAM.*CMIP6.*_BGC%*"  >1850_eam_CMIP6_chemUCI-Linoz-mam5-vbs</value>
       <value compset="2010(?:SOI)?_EAM.*CMIP6"          >2010_eam_CMIP6_chemUCI-Linoz-mam5-vbs</value>
       <value compset="2010(?:SOI)?.*CMIP7_EAM"          >2010_eam_CMIP7_chemUCI-Linoz-mam5-vbs</value>

--- a/components/elm/bld/namelist_files/use_cases/1950_CMIP7_control.xml
+++ b/components/elm/bld/namelist_files/use_cases/1950_CMIP7_control.xml
@@ -23,4 +23,5 @@
 <!-- CMIP7 DECK compsets -->
       
 <fsurdat hgrid="r025" >lnd/clm2/surfdata_map/surfdata_r025_simyr1950_cmip7_c260404.nc </fsurdat>
+<finidat hgrid="r025" >lnd/clm2/initdata_map/elmi.CNPRDCTCBCTOP.r025_RRSwISC6to18E3r5.1950-01-01-00000.c20260412.nc </finidat>
 </namelist_defaults>

--- a/components/elm/bld/namelist_files/use_cases/1950_CMIP7_control.xml
+++ b/components/elm/bld/namelist_files/use_cases/1950_CMIP7_control.xml
@@ -10,6 +10,7 @@
 
 <stream_year_first_ndep phys="elm" use_cn=".true." ndepsrc="stream" >1950</stream_year_first_ndep>
 <stream_year_last_ndep  phys="elm" use_cn=".true." ndepsrc="stream" >1950</stream_year_last_ndep>
+<stream_fldfilename_ndep phys="elm" use_cn=".true." >lnd/clm2/ndepdata/ndep_from_CMIP7_simyr1950_v2.0_1.9x2.5_aave_c260525.nc</stream_fldfilename_ndep>
 
 <stream_year_first_pdep phys="elm" use_cn=".true." ndepsrc="stream" >2000</stream_year_first_pdep>
 <stream_year_last_pdep  phys="elm" use_cn=".true." ndepsrc="stream" >2000</stream_year_last_pdep>
@@ -17,7 +18,7 @@
 <stream_year_first_popdens phys="elm" use_cn=".true." ndepsrc="stream" >1950</stream_year_first_popdens>
 <stream_year_last_popdens  phys="elm" use_cn=".true." ndepsrc="stream" >1950</stream_year_last_popdens>
 
-<stream_fldfilename_popdens phys="elm" use_cn=".true." >lnd/clm2/firedata/elmforc.popden_cmip7_gr_0.5x0.5_simyr1950_c260510.nc</stream_fldfilename_popdens>
+<stream_fldfilename_popdens phys="elm" use_cn=".true." >lnd/clm2/firedata/elmforc.popden_cmip7_gr_0.5x0.5_simyr1950_c260525.nc</stream_fldfilename_popdens>
 
 <!-- CMIP7 DECK compsets -->
       

--- a/components/elm/bld/namelist_files/use_cases/1950_CMIP7_control.xml
+++ b/components/elm/bld/namelist_files/use_cases/1950_CMIP7_control.xml
@@ -17,6 +17,9 @@
 <stream_year_first_popdens phys="elm" use_cn=".true." ndepsrc="stream" >1950</stream_year_first_popdens>
 <stream_year_last_popdens  phys="elm" use_cn=".true." ndepsrc="stream" >1950</stream_year_last_popdens>
 
-<stream_fldfilename_popdens phys="elm" use_cn=".true." >lnd/clm2/firedata/elmforc.popden_cmip7_gr_0.5x0.5_simyr1850-2025_c251024.nc</stream_fldfilename_popdens>
+<stream_fldfilename_popdens phys="elm" use_cn=".true." >lnd/clm2/firedata/elmforc.popden_cmip7_gr_0.5x0.5_simyr1950_c260510.nc</stream_fldfilename_popdens>
 
+<!-- CMIP7 DECK compsets -->
+      
+<fsurdat hgrid="r025" >lnd/clm2/surfdata_map/surfdata_r025_simyr1950_cmip7_c260404.nc </fsurdat>
 </namelist_defaults>

--- a/driver-mct/cime_config/config_component_e3sm.xml
+++ b/driver-mct/cime_config/config_component_e3sm.xml
@@ -789,8 +789,8 @@
       <value compset="^20TR.+CMIP6-LULC"                        >284.317</value>
       <value compset="^20TR.+CMIP6-VOLC"                        >284.317</value>
       <value compset="^SSP.+CMIP6"                              >0.000001</value>
-      <value compset="^SSP245.+CMIP6"			                    	>0.000001</value>
-      <value compset="^SSP370.+CMIP6"				                    >0.000001</value>
+      <value compset="^SSP245.+CMIP6"                           >0.000001</value>
+      <value compset="^SSP370.+CMIP6"                           >0.000001</value>
       <value compset="^20TR.*BGC%BCRC"                          >284.317</value>
       <value compset="^20TR.*BGC%BCRD"                          >284.317</value>
       <value compset="^20TR.*BGC%BDRC"                          >284.317</value>
@@ -798,6 +798,7 @@
       <value compset="^SSP585.*BGC%B"                           >284.317</value>  
       <value compset="^1850.*CMIP7"                             >284.297</value>
       <value compset="^1850.*CMIP7.+4xCO2"                      >1137.188</value>
+      <value compset="^1950.*CMIP7"                             >313.079</value>
       <value compset="^2010.+CMIP7"                             >388.901</value>
       <!-- Override values based on EAM (WACCM) chemistry -->
       <value compset="EAM%W"				>0.000001</value>

--- a/driver-moab/cime_config/config_component_e3sm.xml
+++ b/driver-moab/cime_config/config_component_e3sm.xml
@@ -802,8 +802,8 @@
       <value compset="^20TR.+CMIP6-LULC"                        >284.317</value>
       <value compset="^20TR.+CMIP6-VOLC"                        >284.317</value>
       <value compset="^SSP.+CMIP6"                              >0.000001</value>
-      <value compset="^SSP245.+CMIP6"			                    	>0.000001</value>
-      <value compset="^SSP370.+CMIP6"				                    >0.000001</value>
+      <value compset="^SSP245.+CMIP6"                           >0.000001</value>
+      <value compset="^SSP370.+CMIP6"                           >0.000001</value>
       <value compset="^20TR.*BGC%BCRC"                          >284.317</value>
       <value compset="^20TR.*BGC%BCRD"                          >284.317</value>
       <value compset="^20TR.*BGC%BDRC"                          >284.317</value>
@@ -811,6 +811,7 @@
       <value compset="^SSP585.*BGC%B"                           >284.317</value>  
       <value compset="^1850.*CMIP7"                             >284.297</value>
       <value compset="^1850.*CMIP7.+4xCO2"                      >1137.188</value>
+      <value compset="^1950.*CMIP7"                             >313.079</value>
       <value compset="^2010.+CMIP7"                             >388.901</value>
       <!-- Override values based on EAM (WACCM) chemistry -->
       <value compset="EAM%W"				>0.000001</value>


### PR DESCRIPTION
Set EAM and ELM CMIP7 forcings for v3.HR 1950 configuration.

[BFB] for non-1950-CMIP7 cases.
------------------------------------------
Identical branch is used to create this PR for maint-3.2. 