### PR TITLE
Change old_snow parameter to true for ZM fortran testing

### DIFF
--- a/components/eam/src/physics/cam/zm/zm_conv_types.F90
+++ b/components/eam/src/physics/cam/zm/zm_conv_types.F90
@@ -208,7 +208,7 @@ subroutine zm_param_set_for_testing(zm_param)
    zm_param%no_deep_pbl     = .false.
    ! ZM micro parameters
    zm_param%zm_microp       = .false.
-   zm_param%old_snow        = .false.
+   zm_param%old_snow        = .true.
    zm_param%auto_fac        = 7.0D0
    zm_param%accr_fac        = 1.5D0
    zm_param%micro_dcs       = 150.E-6


### PR DESCRIPTION
I forgot to make this change in the recent ZM PR, but the evap tests were expected to diff anyway, which led me to miss that I needed to make this additional change.