### PR TITLE
Fix ZM Tests

### DIFF
--- a/components/eam/src/physics/cam/zm/zm_conv_types.F90
+++ b/components/eam/src/physics/cam/zm/zm_conv_types.F90
@@ -208,7 +208,7 @@ subroutine zm_param_set_for_testing(zm_param)
    zm_param%no_deep_pbl     = .false.
    ! ZM micro parameters
    zm_param%zm_microp       = .false.
-   zm_param%old_snow        = .false.
+   zm_param%old_snow        = .true.
    zm_param%auto_fac        = 7.0D0
    zm_param%accr_fac        = 1.5D0
    zm_param%micro_dcs       = 150.E-6

--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -272,7 +272,7 @@ be lost if SCREAM_HACK_XML is not enabled.
     <!-- ZM deep convection -->
     <zm inherit="atm_proc_base">
       <apply_detr_tend    type="logical" doc="ZM flag for cld liq/ice detrainment tend"     >true</apply_detr_tend>
-      <use_fortran_bridge type="logical" doc="ZM flag to call fortran ZM"                   >true</use_fortran_bridge>
+      <use_fortran_bridge type="logical" doc="ZM flag to call fortran ZM"                   >false</use_fortran_bridge>
       <trig_dcape         type="logical" doc="ZM flag to enable DCAPE trigger"              >true</trig_dcape>
       <trig_ull           type="logical" doc="ZM flag to enable ULL mode"                   >true</trig_ull>
       <clos_dyn_adj       type="logical" doc="ZM flag to enable dynamic closure adjustment" >false</clos_dyn_adj>

--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -272,7 +272,7 @@ be lost if SCREAM_HACK_XML is not enabled.
     <!-- ZM deep convection -->
     <zm inherit="atm_proc_base">
       <apply_detr_tend    type="logical" doc="ZM flag for cld liq/ice detrainment tend"     >true</apply_detr_tend>
-      <use_fortran_bridge type="logical" doc="ZM flag to call fortran ZM"                   >false</use_fortran_bridge>
+      <use_fortran_bridge type="logical" doc="ZM flag to call fortran ZM"                   >true</use_fortran_bridge>
       <trig_dcape         type="logical" doc="ZM flag to enable DCAPE trigger"              >true</trig_dcape>
       <trig_ull           type="logical" doc="ZM flag to enable ULL mode"                   >true</trig_ull>
       <clos_dyn_adj       type="logical" doc="ZM flag to enable dynamic closure adjustment" >false</clos_dyn_adj>

--- a/components/eamxx/src/physics/zm/impl/zm_opts_impl.hpp
+++ b/components/eamxx/src/physics/zm/impl/zm_opts_impl.hpp
@@ -57,15 +57,12 @@ void Functions<S,D>::zm_opts_init()
     estbl(i) = svp_trans(ZMC::tmin + i);
   });
 
-  // Intel compiler workaround: the constexpr SharedAllocationTracker default
-  // constructor is not called for inline static template members, leaving
-  // m_record_bits=0 instead of DO_NOT_DEREF_FLAG (0x01), which causes
-  // assign_direct to call decrement(nullptr) -> SIGSEGV. Placement new
-  // forces m_record_bits=0x01 before the assignment; safe because
-  // use_count()==0 means there is no live allocation to leak.
+  // FIXME: Intel compiler bug workaround. We need to reallocate view metadata for this static inline member. 
+  // We can remove this line once we update C++20 (and classic intel compiler is no longer supported). 
   EKAT_ASSERT_MSG(s_zm_opts.estbl.use_count() == 0,
-                  "zm_opts_init: estbl has a live allocation at entry; "
-                  "zm_finalize_cxx must be called before zm_opts_init");
+                  "Internal error: estbl still has a live allocation. "
+                  "Ensure zm_finalize_cxx() is called at the end of each C++ ZM unit test "
+                  "to release estbl allocation before the next unit test is called.");
   new (&s_zm_opts.estbl) view_1d<Real>();
 
   s_zm_opts.estbl = estbl;

--- a/components/eamxx/src/physics/zm/impl/zm_opts_impl.hpp
+++ b/components/eamxx/src/physics/zm/impl/zm_opts_impl.hpp
@@ -56,6 +56,18 @@ void Functions<S,D>::zm_opts_init()
   Kokkos::parallel_for("zm_calculate_estbl", Kokkos::RangePolicy<typename KT::ExeSpace>(0, plenest), KOKKOS_LAMBDA(const int i) {
     estbl(i) = svp_trans(ZMC::tmin + i);
   });
+
+  // Intel compiler workaround: the constexpr SharedAllocationTracker default
+  // constructor is not called for inline static template members, leaving
+  // m_record_bits=0 instead of DO_NOT_DEREF_FLAG (0x01), which causes
+  // assign_direct to call decrement(nullptr) -> SIGSEGV. Placement new
+  // forces m_record_bits=0x01 before the assignment; safe because
+  // use_count()==0 means there is no live allocation to leak.
+  EKAT_ASSERT_MSG(s_zm_opts.estbl.use_count() == 0,
+                  "zm_opts_init: estbl has a live allocation at entry; "
+                  "zm_finalize_cxx must be called before zm_opts_init");
+  new (&s_zm_opts.estbl) view_1d<Real>();
+
   s_zm_opts.estbl = estbl;
 }
 


### PR DESCRIPTION
Various fixes for testing issues originating from PR #8421 which was a major ZM update.

- The default value of `use_fortran_bridge` was not properly updated, so CIME tests with F2010xx-ZM were running the fortran bridge rather than the new C++ version of ZM. This does not explain any failure, but it was an oversight and is incorrect.
- CIME tests with F2010xx-ZM fail on chrysalis due to a intel specific problem with the allocation of the "estbl" variable. The fix is certainly "hacky", but several alternatives were tested that did not fix the problem. The fix does not appear to negatively affect GPU builds.
- ZM unit tests are failing due to a baseline generation problem, but an additional issue was discovered where the "old_snow" value for the fortran bridge was incorrectly set. The default value of this parameter changed n the previous PR, so a diff was expected, but it was expected to be fixed by a bless, which is not what happened. The current `old_snow` update, plus another bless, should resolve the issue.

[non-BFB] for ZM tests and F2010xx-ZM