### PR TITLE
Generalize the team size calc for SYCL/CUDA/HIP in Homme

### DIFF
--- a/components/homme/src/share/compose/compose_slmm_siqk.cpp
+++ b/components/homme/src/share/compose/compose_slmm_siqk.cpp
@@ -60,10 +60,8 @@ public:
     // tol is on dx, not (a,b), so adjust slightly.
     if ( ! info.success || err > 1e4*tol_) {
       jinfo.nfails++;
-#ifndef KOKKOS_ENABLE_SYCL
-      printf("calc_sphere_to_ref ei %d i %d j %d: nits %d re %1.1e\n",
-             ei, i, j, info.n_iterations, err);
-#endif
+      Kokkos::printf("calc_sphere_to_ref ei %d i %d j %d: nits %d re %1.1e\n",
+                     ei, i, j, info.n_iterations, err);
     }
     jinfo.sum_nits += info.n_iterations;
     jinfo.max_nits = max(jinfo.max_nits, info.n_iterations);

--- a/components/homme/src/share/cxx/ExecSpaceDefs.cpp
+++ b/components/homme/src/share/cxx/ExecSpaceDefs.cpp
@@ -71,7 +71,6 @@ team_num_threads_vectors_for_gpu (
   assert(num_warps_total >= max_num_warps);
   assert(tp.max_threads_usable >= 1 && tp.max_vectors_usable >= 1);
 
-#ifndef KOKKOS_ENABLE_SYCL
   int num_warps;
   if (tp.prefer_larger_team) {
     const int num_warps_usable =
@@ -116,9 +115,6 @@ team_num_threads_vectors_for_gpu (
     return std::make_pair( num_device_threads / num_vectors,
                            num_vectors );
   }
-#else
-  return std::make_pair(16,8);
-#endif
 }
 
 } // namespace Parallel
@@ -139,17 +135,15 @@ team_num_threads_vectors (const int num_parallel_iterations,
   max_num_warps = std::min(max_num_warps, 8);
 #endif
 
-#ifdef KOKKOS_ENABLE_CUDA
-  // No such thing sometime after Kokkos version 4.2:
-  //    Kokkos::Impl::cuda_internal_maximum_concurrent_block_count();
-  // This number is not super important as long as it's large. 3456 is the A100
-  // spec, so we'll use that.
-  const int num_warps_device = 3456;
-  const int num_threads_warp = Kokkos::Impl::CudaTraits::WarpSize;
-#elif defined(KOKKOS_ENABLE_HIP)
-  // Use 64 wavefronts per CU and 120 CUs.
-  const int num_warps_device = 120*64; // no such thing Kokkos::Impl::hip_internal_maximum_warp_count();
-  const int num_threads_warp = Kokkos::Impl::HIPTraits::WarpSize;
+#if defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP) || defined(KOKKOS_ENABLE_SYCL)
+  // vector_length_max() is a static method — no instance needed.
+  // It returns the hardware warp/wavefront/subgroup size for this backend
+  const int num_threads_warp = Kokkos::TeamPolicy<HommexxGPU>::vector_length_max();
+
+  // concurrency() returns total hardware threads across all SMs/CUs.
+  // Dividing by warp size gives effective total warp count - portable
+  // across CUDA, HIP and SYCL without any magic numbers.
+  const int num_warps_device = HommexxGPU().concurrency() / num_threads_warp;
 #else
   // I want thread-distribution rules to be unit-testable even when GPU spaces
   // are off. Thus, make up a GPU-like machine:


### PR DESCRIPTION
Previously `num_warps_device` was hard-coded, and `num_threads_warp` was obtained using `Kokko::Impl` variables which a) could go away and should not be relied on and b) did not have a SYCL equiv.

SYCL was also using hard coding num thread/vector lane which were too small and lead to large loss of performance at small work/node runs (e.g., 2K and 4K nodes for ne1024).

This solutions was found and tested at the ALCF 2026 hackathon with @abagusetty. 

[BFB]