### PR TITLE
fix ZM behavior on first step

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -751,6 +751,8 @@ be lost if SCREAM_HACK_XML is not enabled.
     <nc_nuceat_tend    >0.0</nc_nuceat_tend>
     <!-- SHOC internally inits TKE; just set to 0 here to signal it's not in the IC file -->
     <tke               >0.0</tke>
+    <!-- ZM normally runs before SHOC, but produces odd results when pbl_height is not initialized -->
+    <pbl_height        >2000.0</pbl_height>
     <!-- Note: these should be provided by surface models, but we init here to keep AD from reading from file -->
     <sfc_alb_dir_vis   >0.0</sfc_alb_dir_vis>
     <sfc_alb_dir_nir   >0.0</sfc_alb_dir_nir>

--- a/components/eamxx/src/physics/zm/impl/zm_find_mse_max_impl.hpp
+++ b/components/eamxx/src/physics/zm/impl/zm_find_mse_max_impl.hpp
@@ -36,7 +36,7 @@ void Functions<S,D>::find_mse_max(
   //----------------------------------------------------------------------------
   // initialize values
   mse_max_val = 0;
-  msemax_klev = 0;
+  msemax_klev = pver - 1;
   const Int bot_layer = pver - 1 - runtime_opt.mx_bot_lyr_adj; // set lower limit to search for launch level with max MSE
 
   //----------------------------------------------------------------------------


### PR DESCRIPTION
These two changes correct a subtle issue in the C++ port of ZM that was only discovered when using trig_ull=false. The additional initialization of pbl_height to 2km makes the first time step results from ZM more reasonable.

[non-BFB] - only for F2010xx-ZM