### PR TITLE
A few guardrails for EAM

### DIFF
--- a/components/eam/src/physics/cam/tropopause.F90
+++ b/components/eam/src/physics/cam/tropopause.F90
@@ -94,6 +94,12 @@ module tropopause
   real(r8) :: cnst_faktor  ! = -gravit/rair
   real(r8) :: cnst_ka1     ! = cnst_kap - 1._r8
 
+  ! If pressure values in all model layers are higher than the threshold specified below,
+  ! do not attempt to locate the tropopause. The value used here is somewhat
+  ! arbitrary and is taken from subroutine tropopause_twmo.
+
+  real(r8),parameter :: ptop_thresh = 45000._r8  ! unit: Pa
+
 !================================================================================================
 contains
 !================================================================================================
@@ -1557,6 +1563,11 @@ contains
     lchnk = pstate%lchnk
     ncol  = pstate%ncol
 
+    ! Skip the rest of the subroutine if pressure values in all model layers are
+    ! higher than ptop_thresh. This is unlikely in typical global simulations but
+    ! can happen in idealized tests.
+    if (minval(pstate%pmid(:ncol,:)).gt.ptop_thresh) return
+
     ! Find the tropopause using the default algorithm backed by the climatology.
     call tropopause_find(pstate, tropLev, tropP=tropP, tropT=tropT, tropZ=tropZ)
     
@@ -1664,6 +1675,11 @@ contains
     e90_ndx = get_spc_ndx('E90')
 
     if (e90_ndx < 0) return
+
+    ! Skip the rest of the subroutine if pressure values in all model layers are
+    ! higher than ptop_thresh. This is unlikely in typical global simulations but
+    ! can happen in idealized tests.
+    if (minval(pstate%pmid(:ncol,:)).gt.ptop_thresh) return
 
     ! Find the tropopause
     call tropopause_e90_3d(pstate, tropLevB, tropLevU, tropFlag, tropFlagInt, tropP=tropP, tropT=tropT, tropZ=tropZ)

--- a/components/eam/src/physics/rrtmg/radiation.F90
+++ b/components/eam/src/physics/rrtmg/radiation.F90
@@ -19,7 +19,7 @@ use spmd_utils,      only: masterproc, iam, npes
 use ppgrid,          only: pcols, pver, pverp, begchunk, endchunk
 use physics_types,   only: physics_state, physics_ptend
 use physconst,       only: cappa
-use time_manager,    only: get_nstep, is_first_restart_step
+use time_manager,    only: get_nstep, is_first_restart_step, is_first_step
 use cam_abortutils,      only: endrun
 use error_messages,  only: handle_err
 use cam_control_mod, only: lambm0, obliqr, mvelpp, eccen
@@ -1144,6 +1144,28 @@ end function radiation_nextsw_cday
 
     dosw     = radiation_do('sw')      ! do shortwave heating calc this timestep?
     dolw     = radiation_do('lw')      ! do longwave heating calc this timestep?
+
+    ! In sensitivity experiments with iradsw = 0, dosw is always .false.;
+    ! consequently, the "if (dosw) then" blocks later in this subroutine are skipped.
+    ! With a debug build, arrays like qrs, fsnt, and fsns may be left
+    ! in an uninitialized state and subsequently cause floating-point exception.
+    ! Here, we initialize these arrays with zero at the first timestep to avoid trouble.
+
+    if ( (.not.dosw) .and. is_first_step() ) then
+       qrs(1:ncol,1:pver) = 0._r8
+       fsnt(1:ncol) = 0._r8
+       fsns(1:ncol) = 0._r8
+    end if
+
+    ! Similarly, initialize qrl, flnt, and flns with 0 for experiments that have iradlw = 0.
+
+    if ( (.not.dolw) .and. is_first_step() ) then
+       qrl(1:ncol,1:pver) = 0._r8
+       flnt(1:ncol) = 0._r8
+       flns(1:ncol) = 0._r8
+    end if
+
+    !-----------
 
     if (dosw .or. dolw) then
 

--- a/components/eam/src/utils/hycoef.F90
+++ b/components/eam/src/utils/hycoef.F90
@@ -301,6 +301,9 @@ subroutine hycoef_read(File)
    ierr = pio_get_var(File, hyam_desc, hyam)
    ierr = pio_get_var(File, hybm_desc, hybm)
 
+   ! Make sure hybi(1) is zero, in order to be consistent with pressure calculations in the SE dycore.
+   if (hybi(1) .ne. 0._r8) call endrun(routine//':ERROR: hybi(1) is non-zero.')
+
 #if ( defined OFFLINE_DYN )
    ! make sure top interface is non zero for fv dycore
    if (hyai(1) .eq. 0._r8) then

--- a/components/homme/src/share/hybvcoord_mod.F90
+++ b/components/homme/src/share/hybvcoord_mod.F90
@@ -148,6 +148,12 @@ contains
        end if
     endif
 
+    ! Mark error if the B coefficient at model top is non-zero.
+    if (hvcoord%hybi(1) .ne. 0._r8) then
+       write(iulog,*) 'error: hvcoord%hybi(1) is non-zero'
+       ierr = 99
+    end if
+
 #if (defined HORIZ_OPENMP)
 !$OMP END CRITICAL
 #endif


### PR DESCRIPTION
Make three modifications that help prevent sensitivity experiments from violating model assumptions or getting into crashes.

- Abort a simulation if `hybi(1)/=0`.
- Initialize a few key variables with zero for radiation.
- Skip tropopause search when a simulation has a low model top (i.e., all `pmid` values are > 450 hPa).

These only affect certain non-standard EAM simulations (both global and single-column runs).

[BFB]
Fixes #7921