### PR TITLE
Fix driver-moab land restart for cell vs point-cloud

### DIFF
--- a/driver-moab/main/seq_rest_mod.F90
+++ b/driver-moab/main/seq_rest_mod.F90
@@ -164,8 +164,9 @@ contains
 subroutine seq_rest_mb_read(rest_file, infodata, samegrid_al, samegrid_lr)
 
     use seq_comm_mct,     only: mbaxid, mbixid, mboxid, mblxid, mbrxid, mbofxid ! coupler side instances
-    use iMOAB,            only: iMOAB_GetGlobalInfo
     use seq_comm_mct ,    only: num_moab_exports ! it is used only as a counter for moab h5m files
+    use seq_comm_mct,     only: atm_pg_active ! whether the atm/lnd mesh is cells (pg2/FV) or a point cloud (np4)
+    use iMOAB,            only: iMOAB_GetGlobalInfo
 
     implicit none
 
@@ -185,7 +186,8 @@ subroutine seq_rest_mb_read(rest_file, infodata, samegrid_al, samegrid_lr)
 
     integer (in), pointer   :: l2racc_lm_cnt
     integer (in)   :: nx_lnd ! will be used if land and atm are on same grid
-    integer (in)   ::  ierr, ngv
+    integer (in)   :: ngv, nge ! global num vertices / elements from iMOAB_GetGlobalInfo
+    integer (in)   ::  ierr
 
     real(r8), dimension(:,:), pointer  :: p_x2oacc_om
     real(r8), dimension(:,:), pointer  :: p_o2racc_om
@@ -245,13 +247,22 @@ subroutine seq_rest_mb_read(rest_file, infodata, samegrid_al, samegrid_lr)
         endif
         if (lnd_present) then
              if(samegrid_al) then
-                ! nx for land will be from global nb atmosphere
-                ierr = iMOAB_GetGlobalInfo(mbaxid, ngv, nx_lnd) ! max id for land will come from atm
+                ! land is on the atm mesh; max global land id comes from atm.
+                ! Point-cloud atm (np4) stores land on vertices; cell atm
+                ! (pg2/FV) stores it on elements.  Pick the matching count.
+                ierr = iMOAB_GetGlobalInfo(mbaxid, ngv, nge)
+                if (atm_pg_active) then
+                   nx_lnd = nge ! atm mesh is cells
+                else
+                   nx_lnd = ngv ! atm mesh is a point cloud
+                endif
                 call seq_io_read(moab_rest_file, mblxid, 'fractions_lx', &
                    'afrac:lfrac:lfrin', nx=nx_lnd)
              else if(samegrid_lr) then
-               ! nx for land will be from global nb rof
-               ierr = iMOAB_GetGlobalInfo(mbrxid, ngv, nx_lnd) ! max id for land will come from rof
+               ! land is on the rof mesh; max global land id comes from rof.
+               ! The rof mesh is cell-based, so use the global element count.
+               ierr = iMOAB_GetGlobalInfo(mbrxid, ngv, nge)
+               nx_lnd = nge
                call seq_io_read(moab_rest_file, mblxid, 'fractions_lx', &
                   'afrac:lfrac:lfrin', nx=nx_lnd)
              else ! is this ever true  ?
@@ -264,14 +275,23 @@ subroutine seq_rest_mb_read(rest_file, infodata, samegrid_al, samegrid_lr)
              l2racc_lm_cnt => prep_rof_get_l2racc_lm_cnt()
              p_l2racc_lm => prep_rof_get_l2racc_lm()
              if(samegrid_al) then
-                ! nx for land will be from global nb atmosphere
-                ierr = iMOAB_GetGlobalInfo(mbaxid, ngv, nx_lnd) ! max id for land will come from atm
+                ! land is on the atm mesh; max global land id comes from atm.
+                ! Point-cloud atm (np4) stores land on vertices; cell atm
+                ! (pg2/FV) stores it on elements.  Pick the matching count.
+                ierr = iMOAB_GetGlobalInfo(mbaxid, ngv, nge)
+                if (atm_pg_active) then
+                   nx_lnd = nge ! atm mesh is cells
+                else
+                   nx_lnd = ngv ! atm mesh is a point cloud
+                endif
                 call seq_io_read(moab_rest_file, mblxid, 'l2racc_lx', &
                  trim(tagname), &
                  matrix = p_l2racc_lm, nx=nx_lnd)
              else if(samegrid_lr) then
-               ! nx for land will be from global nb rof
-               ierr = iMOAB_GetGlobalInfo(mbrxid, ngv, nx_lnd) ! max id for land will come from rof
+               ! land is on the rof mesh; max global land id comes from rof.
+               ! The rof mesh is cell-based, so use the global element count.
+               ierr = iMOAB_GetGlobalInfo(mbrxid, ngv, nge)
+               nx_lnd = nge
                call seq_io_read(moab_rest_file, mblxid, 'l2racc_lx', &
                 trim(tagname), &
                 matrix = p_l2racc_lm, nx=nx_lnd)
@@ -406,8 +426,9 @@ subroutine seq_rest_mb_read(rest_file, infodata, samegrid_al, samegrid_lr)
                tag, samegrid_al, samegrid_lr, rest_file)
 
     use seq_comm_mct,     only: mbaxid, mbixid, mboxid, mblxid, mbrxid, mbofxid ! coupler side instances
-    use iMOAB,            only: iMOAB_GetGlobalInfo
     use seq_comm_mct ,    only: num_moab_exports ! it is used only as a counter for moab h5m files
+    use seq_comm_mct,     only: atm_pg_active ! whether the atm/lnd mesh is cells (pg2/FV) or a point cloud (np4)
+    use iMOAB,            only: iMOAB_GetGlobalInfo
 
     implicit none
 
@@ -455,7 +476,8 @@ subroutine seq_rest_mb_read(rest_file, infodata, samegrid_al, samegrid_lr)
 
     integer (in), pointer   :: l2racc_lm_cnt
     integer (in)   :: nx_lnd ! will be used if land and atm are on same grid
-    integer (in)   ::  ierr, ngv
+    integer (in)   :: ngv, nge ! global num vertices / elements from iMOAB_GetGlobalInfo
+    integer (in)   ::  ierr
 
     real(r8), dimension(:,:), pointer  :: p_x2oacc_om
     real(r8), dimension(:,:), pointer  :: p_o2racc_om
@@ -624,14 +646,23 @@ subroutine seq_rest_mb_read(rest_file, infodata, samegrid_al, samegrid_lr)
 
           if (lnd_present) then
              if(samegrid_al) then
-                ! nx for land will be from global nb atmosphere
-                ierr = iMOAB_GetGlobalInfo(mbaxid, ngv, nx_lnd) ! max id for land will come from atm
+                ! land is on the atm mesh; max global land id comes from atm.
+                ! Point-cloud atm (np4) stores land on vertices; cell atm
+                ! (pg2/FV) stores it on elements.  Pick the matching count.
+                ierr = iMOAB_GetGlobalInfo(mbaxid, ngv, nge)
+                if (atm_pg_active) then
+                   nx_lnd = nge ! atm mesh is cells
+                else
+                   nx_lnd = ngv ! atm mesh is a point cloud
+                endif
                 call seq_io_write(rest_file, mblxid, 'fractions_lx', &
                  'afrac:lfrac:lfrin', & !  seq_frac_mod: character(*),parameter :: fraclist_l = 'afrac:lfrac:lfrin'
                   whead=whead, wdata=wdata, nx=nx_lnd)
              else if(samegrid_lr) then
-               ! nx for land will be from global nb atmosphere
-               ierr = iMOAB_GetGlobalInfo(mbrxid, ngv, nx_lnd) ! max id for land will come from rof
+               ! land is on the rof mesh; max global land id comes from rof.
+               ! The rof mesh is cell-based, so use the global element count.
+               ierr = iMOAB_GetGlobalInfo(mbrxid, ngv, nge)
+               nx_lnd = nge
                call seq_io_write(rest_file, mblxid, 'fractions_lx', &
                 'afrac:lfrac:lfrin', & !  seq_frac_mod: character(*),parameter :: fraclist_l = 'afrac:lfrac:lfrin'
                  whead=whead, wdata=wdata, nx=nx_lnd)
@@ -646,14 +677,23 @@ subroutine seq_rest_mb_read(rest_file, infodata, samegrid_al, samegrid_lr)
              l2racc_lm_cnt => prep_rof_get_l2racc_lm_cnt()
              p_l2racc_lm => prep_rof_get_l2racc_lm()
              if(samegrid_al) then
-                ! nx for land will be from global nb atmosphere
-                ierr = iMOAB_GetGlobalInfo(mbaxid, ngv, nx_lnd) ! max id for land will come from atm
+                ! land is on the atm mesh; max global land id comes from atm.
+                ! Point-cloud atm (np4) stores land on vertices; cell atm
+                ! (pg2/FV) stores it on elements.  Pick the matching count.
+                ierr = iMOAB_GetGlobalInfo(mbaxid, ngv, nge)
+                if (atm_pg_active) then
+                   nx_lnd = nge ! atm mesh is cells
+                else
+                   nx_lnd = ngv ! atm mesh is a point cloud
+                endif
                 call seq_io_write(rest_file, mblxid, 'l2racc_lx', &
                  trim(tagname), &
                  whead=whead, wdata=wdata, matrix = p_l2racc_lm, nx=nx_lnd)
              else if(samegrid_lr) then
-               ! nx for land will be from global nb atmosphere
-               ierr = iMOAB_GetGlobalInfo(mbrxid, ngv, nx_lnd) ! max id for land will come from rof
+               ! land is on the rof mesh; max global land id comes from rof.
+               ! The rof mesh is cell-based, so use the global element count.
+               ierr = iMOAB_GetGlobalInfo(mbrxid, ngv, nge)
+               nx_lnd = nge
                call seq_io_write(rest_file, mblxid, 'l2racc_lx', &
                 trim(tagname), &
                 whead=whead, wdata=wdata, matrix = p_l2racc_lm, nx=nx_lnd)


### PR DESCRIPTION
Use atm_pg_active to choose between the global element count (pg2/FV cell meshes) and the global vertex count (np4 
point clouds) when determining nx_lnd from iMOAB_GetGlobalInfo for samegrid_al. Previously the code always used the 
elem count, which was incorrect for vertex-based atmosphere grids such as ne4_ne4 and ne30_ne30. The rof mesh path is 
also corrected to use the element count consistently.

[BFB]
Fixes #8540 

---

(explanation from claude)

  The coupler restart read/write of fractions_lx and l2racc_lx sized the
  PIO global dimension (nx_lnd) with iMOAB_GetGlobalInfo(mb*, ngv, nx_lnd),
  which assigns num_global_elems into nx_lnd. On a point-cloud land mesh
  (ne4_ne4 and ne30_ne30) the land points are vertices, so num_global_elems (407) is
  smaller than the actual number of land points (866). Passing this
  undersized value as the global dimension scrambled the on-disk ordering,
  corrupting the static lfrac and lfrin fields across an exact restart and
  failing COMPARE_base_rest. The MCT driver is unaffected because it sizes
  these fields from the land gsmap.

  The correct count depends on how MOAB represents the mesh: point-cloud
  grids (np4) store the land field on vertices, while cell grids (pg2, FV,
  r05) store it on elements. Choose the matching global count the same way
  seq_io_mod picks its entity type: when land is on the atm mesh
  (samegrid_al), use num_global_verts if the atm mesh is a point cloud
  (.not. atm_pg_active) and num_global_elems otherwise; when land is on the
  rof mesh (samegrid_lr), the rof mesh is cell-based so use
  num_global_elems. Apply at all read and write sites for fractions_lx and
  l2racc_lx, and correct two stale "global nb atmosphere" comments in the
  write routine's rof branch.
