### PR TITLE
EAM SCM bug fixes

### DIFF
--- a/components/eam/src/control/getinterpnetcdfdata.F90
+++ b/components/eam/src/control/getinterpnetcdfdata.F90
@@ -344,11 +344,22 @@ subroutine interplevs( inputdata,   dplevs,   nlev, &
 !     fill in the missing end values 
 !           (usually  done if this is global model dataset)
 !
+!        Note of change from 2025-12-03:
+!        do end-fill only on model levels that are strictly outside the IOP data domain.
+!        The earlier code used "do i=1, mstart_lev" and "do i= mend_lev, plev",
+!        meaning that the model's boundary levels just inside the IOP data domain, i.e.,
+!        mstart_lev and mend_lev, were also overwritten with the IOP data's end values,
+!        i.e., inputdata(1) and inputdata(nlev).
+!          - This was probably fine when the model domain exceeded the IOP data domain;
+!          - When the model domain was smaller than (i.e., nested inside) the IOP data domain,
+!            the model's inside boundaries got overwritten by the IOP end-values
+!            which might come from far away and therefore cause big jumps at model top and/or bottom.
+
    if ( fill_ends ) then 
-      do i=1, mstart_lev
+      do i=1, mstart_lev-1
          outdata(i) = inputdata(1)
       end do
-      do i= mend_lev, plev
+      do i= mend_lev+1, plev
          outdata(i) = inputdata(nlev)
       end do
    end if

--- a/components/eam/src/dynamics/se/stepon.F90
+++ b/components/eam/src/dynamics/se/stepon.F90
@@ -574,7 +574,7 @@ subroutine stepon_run3(dtime, cam_out, phys_state, dyn_in, dyn_out)
 #endif     
      iop_update_phase1 = .false. 
      if (doiopupdate) then
-       call iop_setinitial(elem)
+      !  call iop_setinitial(elem)
        if (masterproc) call readiopdata(iop_update_phase1,hyam,hybm)
        call iop_broadcast()
        if (.not. dp_crm) call iop_setfield(elem,iop_update_phase1)

--- a/components/eam/src/physics/cam/tropopause.F90
+++ b/components/eam/src/physics/cam/tropopause.F90
@@ -94,6 +94,12 @@ module tropopause
   real(r8) :: cnst_faktor  ! = -gravit/rair
   real(r8) :: cnst_ka1     ! = cnst_kap - 1._r8
 
+  ! If pressure values in all model layers are higher than the threshold specified below,
+  ! do not attempt to locate the tropopause. The value used here is somewhat
+  ! arbitrary and is taken from subroutine tropopause_twmo.
+
+  real(r8),parameter :: ptop_thresh = 45000._r8  ! unit: Pa
+
 !================================================================================================
 contains
 !================================================================================================
@@ -1557,6 +1563,11 @@ contains
     lchnk = pstate%lchnk
     ncol  = pstate%ncol
 
+    ! Skip the rest of the subroutine if pressure values in all model layers are
+    ! higher than ptop_thresh. This is unlikely in typical global simulations but
+    ! can happen in idealized tests.
+    if (minval(pstate%pmid(:ncol,:)).gt.ptop_thresh) return
+
     ! Find the tropopause using the default algorithm backed by the climatology.
     call tropopause_find(pstate, tropLev, tropP=tropP, tropT=tropT, tropZ=tropZ)
     
@@ -1664,6 +1675,11 @@ contains
     e90_ndx = get_spc_ndx('E90')
 
     if (e90_ndx < 0) return
+
+    ! Skip the rest of the subroutine if pressure values in all model layers are
+    ! higher than ptop_thresh. This is unlikely in typical global simulations but
+    ! can happen in idealized tests.
+    if (minval(pstate%pmid(:ncol,:)).gt.ptop_thresh) return
 
     ! Find the tropopause
     call tropopause_e90_3d(pstate, tropLevB, tropLevU, tropFlag, tropFlagInt, tropP=tropP, tropT=tropT, tropZ=tropZ)

--- a/components/eam/src/physics/rrtmg/radiation.F90
+++ b/components/eam/src/physics/rrtmg/radiation.F90
@@ -19,7 +19,7 @@ use spmd_utils,      only: masterproc, iam, npes
 use ppgrid,          only: pcols, pver, pverp, begchunk, endchunk
 use physics_types,   only: physics_state, physics_ptend
 use physconst,       only: cappa
-use time_manager,    only: get_nstep, is_first_restart_step
+use time_manager,    only: get_nstep, is_first_restart_step, is_first_step
 use cam_abortutils,      only: endrun
 use error_messages,  only: handle_err
 use cam_control_mod, only: lambm0, obliqr, mvelpp, eccen
@@ -1144,6 +1144,28 @@ end function radiation_nextsw_cday
 
     dosw     = radiation_do('sw')      ! do shortwave heating calc this timestep?
     dolw     = radiation_do('lw')      ! do longwave heating calc this timestep?
+
+    ! In sensitivity experiments with iradsw = 0, dosw is always .false.;
+    ! consequently, the "if (dosw) then" blocks later in this subroutine are skipped.
+    ! With a debug build, arrays like qrs, fsnt, and fsns may be left
+    ! in an uninitialized state and subsequently cause floating-point exception.
+    ! Here, we initialize these arrays with zero at the first timestep to avoid trouble.
+
+    if ( (.not.dosw) .and. is_first_step() ) then
+       qrs(1:ncol,1:pver) = 0._r8
+       fsnt(1:ncol) = 0._r8
+       fsns(1:ncol) = 0._r8
+    end if
+
+    ! Similarly, initialize qrl, flnt, and flns with 0 for experiments that have iradlw = 0.
+
+    if ( (.not.dolw) .and. is_first_step() ) then
+       qrl(1:ncol,1:pver) = 0._r8
+       flnt(1:ncol) = 0._r8
+       flns(1:ncol) = 0._r8
+    end if
+
+    !-----------
 
     if (dosw .or. dolw) then
 

--- a/components/eam/src/utils/hycoef.F90
+++ b/components/eam/src/utils/hycoef.F90
@@ -301,6 +301,9 @@ subroutine hycoef_read(File)
    ierr = pio_get_var(File, hyam_desc, hyam)
    ierr = pio_get_var(File, hybm_desc, hybm)
 
+   ! Make sure hybi(1) is zero, in order to be consistent with pressure calculations in the SE dycore.
+   if (hybi(1) .ne. 0._r8) call endrun(routine//':ERROR: hybi(1) is non-zero.')
+
 #if ( defined OFFLINE_DYN )
    ! make sure top interface is non zero for fv dycore
    if (hyai(1) .eq. 0._r8) then

--- a/components/homme/src/share/hybvcoord_mod.F90
+++ b/components/homme/src/share/hybvcoord_mod.F90
@@ -148,6 +148,12 @@ contains
        end if
     endif
 
+    ! Mark error if the B coefficient at model top is non-zero.
+    if (hvcoord%hybi(1) .ne. 0._r8) then
+       write(iulog,*) 'error: hvcoord%hybi(1) is non-zero'
+       ierr = 99
+    end if
+
 #if (defined HORIZ_OPENMP)
 !$OMP END CRITICAL
 #endif

--- a/components/homme/src/share/prim_driver_base.F90
+++ b/components/homme/src/share/prim_driver_base.F90
@@ -1966,6 +1966,13 @@ contains
           elem(1)%state%dp3d(:,:,k,np1)
       enddo
     enddo
+
+    ! Copy horizontal wind components, assuming no horizontal advection
+    ! of momentum.
+
+    do k=1,nlev
+      elem(1)%state%v(:,:,:,k,np1) = elem(1)%state%v(:,:,:,k,n0)
+    enddo
     
   end subroutine set_prescribed_scm
     


### PR DESCRIPTION
This PR builds on top of #8537. It Includes 3 bug fixes for the EAM (Fortran) Single Column Model (SCM):

**Fix 1:**  Revise the behavior of the "fill_end" option when using IOP files to initialize model so that the end values from an IOP file are applied only to model levels outside the IOP domain, not to the upper/lower boundary levels that are just inside the IOP domain. This change is needed for SCM simulations with low model top.

The sample figure below shows two DYCOMS RF01 simulations using a ~10 m vertical resolution and a ~3 km model top. Only after the fix do we see the expected temperature inversion near 900 hPa and the expected stratocumulus cloud layer. These simulations were performed with v3 ("master"), using CLUBB as the turbulence parameterization.

<img width="490" height="400" alt="T_and_CLDLIQ__fill_end" src="https://github.com/user-attachments/assets/41c470f3-5520-47be-a6d0-1ac2efef4aad" />

-------

**Fix 2:**  In the "dycore" part of the SCM configuration, advance in time the u and v fields (in addition to T, q, etc.). In typical SCM setups, this is not necessary, as u and v are overwritten with values from an IOP file. On the other hand, if the IOP file does not include u, v, or if the user choose to comment out that overwrite, then not advancing u, v in time in the dycore part will lead to erroneous results for winds.

-------

 **Fix 3:** It seems to us (the PAESCAL team) that during an SCM simulation, the subroutine call `call iop_setinitial(elem)` is done twice. The impact should be negligible and rather harmless in most cases, expect that in one of our attempts to compare a further simplified SCM simulation with a turbulence "offline" test, this extra initialization caused confusion. If @bogensch could confirm that the call of `iop_setinitial` identified in 
[4c07d90](https://github.com/E3SM-Project/E3SM/pull/8542/commits/4c07d90b57fe10bd6b31457d94285831ad6dae50) is indeed not necessary, we would suggest removing it. 

Below is a sample figure, again from the DYCOMS RF01 case, showing the slight impact on CLDLIQ of that second initialization. 

<img width="750" height="350" alt="CLDLIQ_2vs1_init" src="https://github.com/user-attachments/assets/f6c49ee2-8255-41f6-8c6d-18808cf03cc7" />

-------

My run script, plotting script, and the IC file can be found via [NERSC's web portal](https://portal.nersc.gov/project/m4359/amr/RF01_dz_sensitivity/e3sm/202607_PRs/) or in NERSC's CFS under 

```
/global/cfs/projectdirs/m4359/www/amr/RF01_dz_sensitivity/e3sm/202607_PRs/
```
