### PR TITLE
Catch UNSET required file params in EAMxx buildnml at build time

### DIFF
--- a/components/eamxx/cime_config/eamxx_buildnml.py
+++ b/components/eamxx/cime_config/eamxx_buildnml.py
@@ -44,7 +44,8 @@ CIME_VAR_RE = re.compile(r'[$][{](\w+)[}]')
 #    Examples:
 #      - constraints="ge 0; lt 4" means the value V must satisfy V>=0 && V<4.
 #      - constraints="mod 2 eq 0" means the value V must be a multiple of 2.
-METADATA_ATTRIBS = ("type", "valid_values", "locked", "constraints", "inherit", "doc", "append")
+#  - optional: if set to true, marks a "file" param where UNSET is a valid/intentional value
+METADATA_ATTRIBS = ("type", "valid_values", "locked", "constraints", "inherit", "doc", "append", "optional")
 
 ###############################################################################
 def do_cime_vars(entry, case, refine=False, extra=None):
@@ -218,6 +219,53 @@ def perform_consistency_checks(case, xml):
                     "rrtmgp::rad_frequency incompatible with restart frequency.\n"
                     " Please, ensure restart happens on a step when rad is ON\n"
                     " For daily (or less frequent) restart, rad_frequency must divide ATM_NCPL")
+
+    # Check for UNSET required file parameters. After selector evaluation, any
+    # type="file" or type="array(file)" element still holding the sentinel value
+    # "UNSET" and lacking any selector attributes means no entry in
+    # namelist_defaults_eamxx.xml matched the current configuration (e.g. grid+nlev
+    # combination). Catching this here gives a clear, actionable error at buildnml
+    # time instead of an obscure "No such file or directory" from PIO at run time.
+    #
+    # Note: elements where a selector *did* match (e.g. topography_filename set to
+    # UNSET for aquaplanet compsets) retain their selector attributes after
+    # evaluation. We skip those - a deliberate UNSET is not an error.
+    #
+    # Note: elements marked optional="true" are also skipped - UNSET is a valid
+    # value for them (e.g. iop_file, which is only needed for DP/IOP runs).
+    parent_map = {child: parent for parent in xml.iter() for child in parent}
+    unset_params = []
+    file_type_elems = xml.findall('.//*[@type="file"]') + xml.findall('.//*[@type="array(file)"]')
+    for item in file_type_elems:
+        if item.text and item.text.strip() == "UNSET":
+            # Skip params explicitly marked optional: UNSET is valid for them.
+            if item.attrib.get("optional") == "true":
+                continue
+            # If any non-metadata attribute is present, a selector matched and
+            # intentionally set this value to UNSET, so skip it.
+            selector_attribs = [k for k in item.attrib if k not in METADATA_ATTRIBS]
+            if selector_attribs:
+                continue
+            parent = parent_map.get(item)
+            path = "{} -> {}".format(parent.tag, item.tag) if parent is not None else item.tag
+            unset_params.append(path)
+
+    if unset_params:
+        scream_cmake_opts = case.get_value("SCREAM_CMAKE_OPTIONS") or ""
+        nlev_match = re.search(r"SCREAM_NUM_VERTICAL_LEV\s+(\d+)", scream_cmake_opts)
+        nlev = nlev_match.group(1) if nlev_match else "unknown"
+        atm_grid = case.get_value("ATM_GRID") or "unknown"
+        params_str = "\n  ".join(unset_params)
+        expect (False,
+                "The following required file parameter(s) are UNSET for the current "
+                f"configuration (ATM_GRID='{atm_grid}', nlev={nlev}):\n"
+                f"  {params_str}\n"
+                "This typically means no entry exists in namelist_defaults_eamxx.xml "
+                "for this grid + vertical-level combination.\n"
+                f"To fix, add an entry for ATM_GRID='{atm_grid}' with nlev={nlev} "
+                "to namelist_defaults_eamxx.xml, or switch to a supported "
+                "configuration.\n"
+                "See existing entries in namelist_defaults_eamxx.xml for examples.")
 
 ###############################################################################
 def ordered_dump(data, item, Dumper=yaml.SafeDumper, **kwds):

--- a/components/eamxx/cime_config/eamxx_buildnml.py
+++ b/components/eamxx/cime_config/eamxx_buildnml.py
@@ -237,7 +237,7 @@ def perform_consistency_checks(case, xml):
     unset_params = []
     file_type_elems = xml.findall('.//*[@type="file"]') + xml.findall('.//*[@type="array(file)"]')
     for item in file_type_elems:
-        if item.text and item.text.strip() == "UNSET":
+        if item.text is None or not item.text.strip() or item.text.strip() == "UNSET":
             # Skip params explicitly marked optional: UNSET is valid for them.
             if item.attrib.get("optional") == "true":
                 continue
@@ -249,6 +249,16 @@ def perform_consistency_checks(case, xml):
             parent = parent_map.get(item)
             path = "{} -> {}".format(parent.tag, item.tag) if parent is not None else item.tag
             unset_params.append(path)
+
+    enable_iop = find_node(xml, "enable_iop")
+    iop_file = find_node(xml, "iop_file")
+    iop_enabled = (enable_iop is not None and enable_iop.text is not None
+                   and enable_iop.text.strip().lower() == "true")
+    iop_file_unset = (iop_file is None or iop_file.text is None
+                      or not iop_file.text.strip()
+                      or iop_file.text.strip() == "UNSET")
+    expect(not iop_enabled or not iop_file_unset,
+           "The iop_file parameter must be set when enable_iop is true.")
 
     if unset_params:
         scream_cmake_opts = case.get_value("SCREAM_CMAKE_OPTIONS") or ""

--- a/components/eamxx/cime_config/eamxx_buildnml.py
+++ b/components/eamxx/cime_config/eamxx_buildnml.py
@@ -231,13 +231,19 @@ def perform_consistency_checks(case, xml):
     # UNSET for aquaplanet compsets) retain their selector attributes after
     # evaluation. We skip those - a deliberate UNSET is not an error.
     #
-    # Note: elements marked optional="true" are also skipped - UNSET is a valid
-    # value for them (e.g. iop_file, which is only needed for DP/IOP runs).
+    enable_iop = find_node(xml, "enable_iop")
+    iop_file = find_node(xml, "iop_file")
+    iop_enabled = (enable_iop is not None and enable_iop.text is not None
+                   and enable_iop.text.strip().lower() == "true")
+
     parent_map = {child: parent for parent in xml.iter() for child in parent}
     unset_params = []
     file_type_elems = xml.findall('.//*[@type="file"]') + xml.findall('.//*[@type="array(file)"]')
     for item in file_type_elems:
         if item.text is None or not item.text.strip() or item.text.strip() == "UNSET":
+            # iop_file is required only when IOP is enabled.
+            if item is iop_file and not iop_enabled:
+                continue
             # Skip params explicitly marked optional: UNSET is valid for them.
             if item.attrib.get("optional") == "true":
                 continue
@@ -250,10 +256,6 @@ def perform_consistency_checks(case, xml):
             path = "{} -> {}".format(parent.tag, item.tag) if parent is not None else item.tag
             unset_params.append(path)
 
-    enable_iop = find_node(xml, "enable_iop")
-    iop_file = find_node(xml, "iop_file")
-    iop_enabled = (enable_iop is not None and enable_iop.text is not None
-                   and enable_iop.text.strip().lower() == "true")
     iop_file_unset = (iop_file is None or iop_file.text is None
                       or not iop_file.text.strip()
                       or iop_file.text.strip() == "UNSET")

--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -856,7 +856,7 @@ be lost if SCREAM_HACK_XML is not enabled.
   <!-- Default settings for DP-EAMxx -->
   <iop_options>
     <doubly_periodic_mode type="logical" doc="Type of intensive observation period. Currently only DP is supported.">true</doubly_periodic_mode>
-    <iop_file type="file" doc="File containing DP level data">UNSET</iop_file>
+    <iop_file type="file" optional="true" doc="File containing DP level data">UNSET</iop_file>
     <target_latitude type="real" doc="Latitude to initialize IC columns.">-999</target_latitude>
     <target_longitude type="real" doc="Longitude to initialize IC columns.">-999</target_longitude>
     <iop_dosubsidence type="logical" doc="Whether or not to compute Eulerian LS vertical advection.">false</iop_dosubsidence>

--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -896,7 +896,7 @@ be lost if SCREAM_HACK_XML is not enabled.
   <!-- Default settings for DP-EAMxx -->
   <iop_options>
     <doubly_periodic_mode type="logical" doc="Type of intensive observation period. Currently only DP is supported.">true</doubly_periodic_mode>
-    <iop_file type="file" doc="File containing DP level data">UNSET</iop_file>
+    <iop_file type="file" optional="true" doc="File containing DP level data">UNSET</iop_file>
     <target_latitude type="real" doc="Latitude to initialize IC columns.">-999</target_latitude>
     <target_longitude type="real" doc="Longitude to initialize IC columns.">-999</target_longitude>
     <iop_dosubsidence type="logical" doc="Whether or not to compute Eulerian LS vertical advection.">false</iop_dosubsidence>

--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -896,7 +896,7 @@ be lost if SCREAM_HACK_XML is not enabled.
   <!-- Default settings for DP-EAMxx -->
   <iop_options>
     <doubly_periodic_mode type="logical" doc="Type of intensive observation period. Currently only DP is supported.">true</doubly_periodic_mode>
-    <iop_file type="file" optional="true" doc="File containing DP level data">UNSET</iop_file>
+    <iop_file type="file" doc="File containing DP level data">UNSET</iop_file>
     <target_latitude type="real" doc="Latitude to initialize IC columns.">-999</target_latitude>
     <target_longitude type="real" doc="Longitude to initialize IC columns.">-999</target_longitude>
     <iop_dosubsidence type="logical" doc="Whether or not to compute Eulerian LS vertical advection.">false</iop_dosubsidence>

--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -856,7 +856,7 @@ be lost if SCREAM_HACK_XML is not enabled.
   <!-- Default settings for DP-EAMxx -->
   <iop_options>
     <doubly_periodic_mode type="logical" doc="Type of intensive observation period. Currently only DP is supported.">true</doubly_periodic_mode>
-    <iop_file type="file" optional="true" doc="File containing DP level data">UNSET</iop_file>
+    <iop_file type="file" doc="File containing DP level data">UNSET</iop_file>
     <target_latitude type="real" doc="Latitude to initialize IC columns.">-999</target_latitude>
     <target_longitude type="real" doc="Longitude to initialize IC columns.">-999</target_longitude>
     <iop_dosubsidence type="logical" doc="Whether or not to compute Eulerian LS vertical advection.">false</iop_dosubsidence>


### PR DESCRIPTION
Add a build-time check in EAMxx buildnml that detects required file-type namelist parameters left unset after selector evaluation. This prevents missing grid/vertical-level defaults from surfacing later as confusing PIO errors at run time.

## Changes

- Treat missing, empty, whitespace-only, and `UNSET` file values as unset.
- Report unset required file parameters during `case.build`, including the parameter path, `ATM_GRID`, and `nlev`.
- Preserve support for genuinely optional file parameters.
- Require `iop_file` when `enable_iop=true`, while allowing it to remain unset when IOP is disabled.

## Motivation

Some grid and vertical-level combinations lack matching entries in `namelist_defaults_eamxx.xml`. Failing during build provides a clear, actionable error instead of a later runtime failure.

Fixes #7873

[bfb]
