### PR TITLE
For pm-cpu/pm-gpu, explicitly remove cray-libsci module for Intel builds (as Intel uses MKL)

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -226,7 +226,7 @@
       <modules compiler="intel">
         <command name="load">PrgEnv-intel/8.6.0</command>
         <command name="load">intel/2025.3</command>
-        <command name="load">cray-libsci/25.09.0</command>
+        <command name="unload">cray-libsci</command>
       </modules>
 
       <modules compiler="nvidia">
@@ -486,6 +486,10 @@
         <command name="load">cray-mpich/9.0.1</command>
         <command name="load">cmake/3.30.2</command>
       </modules>
+
+      <modules compiler="intel.*">
+        <command name="unload">cray-libsci</command>
+      </modules>
       <modules DEBUG="TRUE"> <!-- https://github.com/E3SM-Project/E3SM/issues/8062 -->
         <command name="load">cray-hdf5-parallel/1.12.2.9</command>
         <command name="load">cray-netcdf-hdf5parallel/4.9.0.9</command>
@@ -652,6 +656,7 @@
       <modules compiler="intel">
         <command name="load">PrgEnv-intel/8.6.0</command>
         <command name="load">intel/2025.3</command>
+        <command name="unload">cray-libsci</command>
       </modules>
 
       <modules compiler="nvidia">
@@ -908,6 +913,10 @@
         <command name="load">cray-mpich/9.0.1</command>
         <command name="load">cmake/3.30.2</command>
       </modules>
+
+      <modules compiler="intel.*">
+        <command name="unload">cray-libsci</command>
+      </modules>
       <modules DEBUG="TRUE"> <!-- https://github.com/E3SM-Project/E3SM/issues/8062 -->
         <command name="load">cray-hdf5-parallel/1.12.2.9</command>
         <command name="load">cray-netcdf-hdf5parallel/4.9.0.9</command>
@@ -1071,6 +1080,7 @@
       <modules compiler="intel">
         <command name="load">PrgEnv-intel/8.6.0</command>
         <command name="load">intel/2025.3</command>
+        <command name="unload">cray-libsci</command>
       </modules>
 
       <modules compiler="nvidia">
@@ -1326,6 +1336,10 @@
         <command name="load">craype/2.7.35</command>
         <command name="load">cray-mpich/9.0.1</command>
         <command name="load">cmake/3.30.2</command>
+      </modules>
+
+      <modules compiler="intel.*">
+        <command name="unload">cray-libsci</command>
       </modules>
       <modules DEBUG="TRUE"> <!-- https://github.com/E3SM-Project/E3SM/issues/8062 -->
         <command name="load">cray-hdf5-parallel/1.12.2.9</command>


### PR DESCRIPTION
On all NERSC machines, explicitly remove cray-libsci module for Intel builds.
For Intel, we wants to use Intel's MKL (for BLAS/LAPACK for example).
Cases will currently still pick MKL, but it's better to explicitly remove cray-libsci.
Note that PR  #8326 actually *added* module load of cray-libsci to pm-cpu, which was bad form.
Also of note, the next CPE coming to NERSC machine from HPE may automatically load cray-libsci,
making explicit unload even more important.


[bfb]
