### PR TITLE
EAMxx: Code incorporating changes to mam4xx to support tunable aerosol properties.

### DIFF
--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_functions.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_functions.hpp
@@ -155,7 +155,7 @@ void compute_nucleate_ice_tendencies(
         // grab views from the buffer to store tendencies, not used as all
         // values are store in diags above.
         const mam4::Tendencies tends(nlev);  // not used
-        const mam4::AeroConfig aero_config;
+        const mam4::AeroConfig aero_config(nucleate_ice.aero_species);
         const Real t = 0;  // not used
         nucleate_ice.compute_tendencies(aero_config, team, t, dt, atm,
                                         surf, progs, diags, tends);
@@ -526,9 +526,8 @@ void call_hetfrz_compute_tendencies(
         // grab views from the buffer to store tendencies, not used as all
         // values are store in diags above.
         const mam4::Tendencies tends(nlev);
-        const mam4::AeroConfig aero_config;
         const Real t = 0;  // not used
-        hetfrz.compute_tendencies(aero_config, team, t, dt, atm, surf,
+        hetfrz.compute_tendencies(hetfrz.aero_config, team, t, dt, atm, surf,
                                   progs, diags, tends);
       });
 }

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -28,6 +28,7 @@ MAMMicrophysics::MAMMicrophysics(const ekat::Comm &comm, const ekat::ParameterLi
   config_.amicphys.do_rename = m_params.get<bool>("mam4_do_rename");
   config_.amicphys.do_newnuc = m_params.get<bool>("mam4_do_newnuc");
   config_.amicphys.do_coag   = m_params.get<bool>("mam4_do_coag");
+  config_.amicphys.aero_species = aero_config_.aero_species;
   check_fields_intervals_    = m_params.get<bool>("create_fields_interval_checks", false);
 
   // these parameters guide the coupling between parameterizations

--- a/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.cpp
@@ -323,7 +323,7 @@ void MAMWetscav::initialize_impl(const RunType run_type) {
                                   mam4::aero_model::nimptblgrow_total,
                                   mam4::AeroConfig::num_modes());
 
-  mam4::wetdep::init_scavimptbl(scavimptblvol_host, scavimptblnum_host);
+  mam4::wetdep::init_scavimptbl(aero_config_, scavimptblvol_host, scavimptblnum_host);
 
   scavimptblnum_ = view_2d("scavimptblnum", mam4::aero_model::nimptblgrow_total,
                            mam4::AeroConfig::num_modes());

--- a/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_wetscav_process_interface.hpp
@@ -69,8 +69,8 @@ private:
   // Local variables
   // ------------------------------------------------
 
-  // Number of aerosol modes
-  static constexpr int ntot_amode_ = mam4::AeroConfig::num_modes();
+  // aerosol metadata
+  mam4::AeroConfig aero_config_;
 
   // Work arrays
   view_2d work_;


### PR DESCRIPTION
In order to allow aerosol species properties to be modified for tuning, we've had
to make some changes to mam4xx. This PR updates the mam4xx submodule and
updates the MAM atmosphere processes to accommodate these changes.

[BFB]