### PR TITLE
PEM/ERP fixes for conusx4v1pg2_r05_oECv3

### DIFF
--- a/driver-moab/main/cplcomp_exchange_mod.F90
+++ b/driver-moab/main/cplcomp_exchange_mod.F90
@@ -413,7 +413,6 @@ subroutine  copy_aream_from_area(mbappid)
 
       use iMOAB, only: iMOAB_WriteMesh, iMOAB_GetMeshInfo
       use seq_infodata_mod, only: seq_infodata_type, seq_infodata_GetData
-      use shr_moab_mod, only: mbGetnCells, mbGetCellTagVals, mbSetCellTagVals
 
       type(seq_infodata_type), intent(in) :: infodata
       type(component_type),    intent(inout) :: comp
@@ -428,10 +427,7 @@ subroutine  copy_aream_from_area(mbappid)
       integer :: ierr
       character*200 :: appname, outfile, wopts, ropts, infile
       character(CL) :: ocn_domain
-      character(CXX) :: tagname
       integer :: nvert(3), nvise(3), nbl(3), nsurf(3), nvisBC(3)
-      real(r8), allocatable :: tagValues(:)
-      integer :: arrsize, nloc
 
       call seq_comm_getinfo(cplid ,mpigrp=mpigrp_cplid)  ! receiver group
       call seq_comm_getinfo(id_old,mpigrp=mpigrp_old)   !  component group pes

--- a/driver-moab/main/cplcomp_exchange_mod.F90
+++ b/driver-moab/main/cplcomp_exchange_mod.F90
@@ -76,7 +76,6 @@ module cplcomp_exchange_mod
   character(*),parameter :: subName = '(seq_mctext_mct)'
   real(r8),parameter :: c1 = 1.0_r8
    integer, parameter :: ATM_PHYS_ID_OFFSET = 200
-   integer, parameter :: OCN_SECOND_COPY_ID_OFFSET = 1000
 
   !=======================================================================
 contains
@@ -527,62 +526,22 @@ subroutine  copy_aream_from_area(mbappid)
          call moab_exchange_domain_tags(comp, mpoid, mboxid, 'lat:lon:area:frac:mask', 'domo')
       endif
 
-!!!!!!!!! OCEAN 2nd COPY
-      ! start copy
-      ! Do another ocean copy on the coupler so So_fswpen does not collide between
-      ! xao states and o2x states. Preserve the explicit second-copy context offset.
-      id_join = id_join + OCN_SECOND_COPY_ID_OFFSET
-
-!!!!!!  OCEAN COMPONENT
-      if (MPI_COMM_NULL /= mpicom_old ) then ! it means we are on the component pes (ocean)
- !!!! FULL OCEAN
-         if ( trim(ocn_domain) == 'none' ) then
-            !  send mesh to coupler, the second time! a copy would be cheaper
-            call moab_send_mesh(mpoid, mpicom_join, mpigrp_cplid, id_join, partMethod, subname)
-         endif
-      endif
-
-!!!!!!  ON 2nd OCN ON CPL
+!!!!!!!!! OCEAN 2nd COPY (mbofxid) -- ALIAS of mboxid (robust fix)
+      ! mbofxid shares mboxid's MOAB app / mesh / local ordering instead of being an
+      ! independent second load. Two independent LoadMesh (data ocn) or send/receive
+      ! (full ocn) calls do NOT guarantee identical local (handle) ordering: each rank
+      ! owns the same ocean cells but in a different order, which scattered every by-index
+      ! mboxid<->mbofxid transfer (atm-ocn flux xao, ofrac, domain copy, albedo, budget
+      ! diagnostics) whenever the PE layout changed (PEM/ERP). Sharing one mesh makes all
+      ! by-index access correct by construction, for both data and active ocean.
+      !
+      ! The single field that lived on BOTH o2x and xao states, So_fswpen, is renamed to
+      ! So_fswpen_ao on the xao side (seq_flds_mod) so the two do not collide on the shared
+      ! mesh. The xao->atm second-hop map reuses mboxid's o2x->atm comm graph (prep_atm_mod);
+      ! no separate app id / context offset is needed for mbofxid any more.
       if (MPI_COMM_NULL /= mpicom_new ) then !  we are on the coupler pes
-         appname = "COUPLE_MPASOF"
-         ! migrated mesh gets another app id, moab ocean to coupler (mbox)
-         call moab_register_app(appname, mpicom_new, id_join, mbofxid, subname)
- !!!!! FULL OCN
-         if ( trim(ocn_domain) == 'none' ) then
-            call moab_receive_mesh(mbofxid, mpicom_join, mpigrp_old, id_old, subname)
- !!!!! DATA OCN
-         else
-             ! we need to read the ocean mesh on coupler, from domain file
-            infile = trim(ocn_domain)
-            ropts = 'PARALLEL=READ_PART;PARTITION_METHOD=SQIJ;VARIABLE=;NO_CULLING;REPARTITION'
-            if (seq_comm_iamroot(CPLID)) then
-               write(logunit,'(A)') subname//' load ocn domain mesh from file for second ocn instance '//trim(ocn_domain) &
-               , ' with options '//trim(ropts)
-            endif
-            call moab_load_mesh(mbofxid, infile, ropts, 0, subname)
-            call moab_define_global_id_tag(mbofxid, subname)
-         endif
-
-  !! ON 2nd OCEAN ON COUPLER
-         call moab_define_double_tag(mbofxid, trim(seq_flds_dom_fields)//":norm8wt", subname)
-
-         ! copy domain data to mbofxid
-         nloc = mbGetnCells(mbofxid)
-         arrsize=nloc*5
-         allocate(tagValues(arrsize))
-         call mbGetCellTagVals(mboxid,'lat:lon:area:frac:mask'//C_NULL_CHAR,tagValues,arrsize)
-         call mbSetCellTagVals(mbofxid,'lat:lon:area:frac:mask'//C_NULL_CHAR,tagValues,arrsize)
-         deallocate(tagValues)
-
+         mbofxid = mboxid
       endif
-
-!!!!!!  ON OCN COMPONENT
-      if (mpoid .ge. 0) then  ! we are on component ocn pes again, release buffers
-          if ( trim(ocn_domain) == 'none' ) then
-            call moab_free_sender_buffers(mpoid, id_join, subname)
-          endif
-      endif
-      ! end copy
 #ifdef MOABDEBUG
    if (mbofxid >= 0) then
       outfile = 'recMeshOcnF.h5m'//C_NULL_CHAR

--- a/driver-moab/main/prep_atm_mod.F90
+++ b/driver-moab/main/prep_atm_mod.F90
@@ -492,14 +492,16 @@ contains
             ! OCN for the intersection of OCN-ATM context (coverage)
             call seq_comm_getinfo(CPLID ,mpigrp=mpigrp_CPLID)
 
-            ! we identified the app mbofxid with !id_join = id_join + 1000! kind of random
-            ! line 1267 in cplcomp_exchange_mod.F90
-            context_id = ocn(1)%cplcompid + 1000
-            mapper_Sof2a%src_mbid = mbofxid
+            ! mbofxid is now an ALIAS of mboxid (same MOAB app / mesh; see cplcomp_moab_init_ocn).
+            ! The xao->atm second hop therefore REUSES mboxid's o2x->atm comm graph exactly like
+            ! mapper_Fo2a does (same src_mbid, src_context and intx_context as mapper_So2a). No
+            ! separate app id, context offset (formerly ocn%cplcompid+1000), or ComputeCommGraph
+            ! is needed -- the (mboxid -> mbintxoa) graph under (ocn%cplcompid, idintx) already exists.
+            mapper_Sof2a%src_mbid = mboxid
             mapper_Sof2a%tgt_mbid = mbaxid
             mapper_Sof2a%intx_mbid = mbintxoa
-            mapper_Sof2a%src_context = context_id
-            mapper_Sof2a%intx_context = mapper_So2a%intx_context ! basically will use the same intx as ocean on coupler
+            mapper_Sof2a%src_context = mapper_So2a%src_context ! ocn(1)%cplcompid
+            mapper_Sof2a%intx_context = mapper_So2a%intx_context ! same intx as ocean on coupler
             mapper_Sof2a%weight_identifier = wgtIdSo2a
             mapper_Sof2a%mbname = 'mapper_Sof2a'
 
@@ -508,45 +510,14 @@ contains
               write(logunit,F00) 'Initializing MOAB mapper_Fof2a with copy of mapper_Sof2a'
             endif
             ! now take care of the mapper
-            mapper_Fof2a%src_mbid = mbofxid
+            mapper_Fof2a%src_mbid = mboxid
             mapper_Fof2a%tgt_mbid = mbaxid
             mapper_Fof2a%intx_mbid = mbintxoa
-            mapper_Fof2a%src_context = mapper_Sof2a%src_context ! we use the same source 1000 + ?
-            mapper_Fof2a%intx_context = mapper_Sof2a%intx_context ! depends on samegrid_ao
+            mapper_Fof2a%src_context = mapper_So2a%src_context ! ocn(1)%cplcompid
+            mapper_Fof2a%intx_context = mapper_So2a%intx_context
             mapper_Fof2a%weight_identifier = wgtIdFo2a
             mapper_Fof2a%mbname = 'mapper_Fof2a'
-
-            type1 = 3; !  fv for ocean and atm;
-            if (.not. samegrid_ao) then
-               ! Coverage/intersection mesh always has FV cells with GLOBAL_IDs,
-               ! so type2 must be 3 (element-based matching), regardless of
-               ! atm_pg_active. Using type2=2 (vertex matching) here would cause
-               ! MOAB to match against vertex GLOBAL_IDs of mbintxoa instead of
-               ! element GLOBAL_IDs, leading to an incorrect comm graph and
-               ! heap corruption in iMOAB_ReceiveElementTag.
-               ierr = iMOAB_ComputeCommGraph( mbofxid, mbintxoa, mpicom_CPLID, mpigrp_CPLID, mpigrp_CPLID, type1, 3, &
-                                          context_id, idintx)
-               if (ierr .ne. 0) then
-                  write(logunit,*) subname,' error in computing comm graph for Sof2a, mbofxid-mbintxoa'
-                  call shr_sys_abort(subname//' ERROR in computing comm graph for Sof2a, mbofxid-mbintxoa')
-               endif
-            else
-               ! samegrid: comm graph to ATM mesh directly
-               ! type2 depends on ATM discretization (PC for spectral, FV for PG2)
-               if (atm_pg_active .or. dead_comps) then
-                  type2 = 3
-               else
-                  type2 = 2 ! PC cloud
-               endif
-               ! this is a case appearing in the data ocean case --res ne4pg2_ne4pg2 --compset FAQP
-               ! also in spectral case, monogrid --res ne4_ne4 --compset F2010-SCREAMv1 ( type2 is 2, point cloud )
-               ierr = iMOAB_ComputeCommGraph( mbofxid, mbaxid, mpicom_CPLID, mpigrp_CPLID, mpigrp_CPLID, type1, type2, &
-                                      context_id, atm(1)%cplcompid )
-               if (ierr .ne. 0) then
-                  write(logunit,*) subname,' error in computing communication graph for second hop, ATM-OCN'
-                  call shr_sys_abort(subname//' ERROR in computing communication graph for second hop, ATM-OCN')
-               endif
-            endif
+            ! comm graph reused from mapper_So2a/Fo2a (aliased mbofxid == mboxid); nothing to compute
          endif
 
       endif ! endif (ocn_present) then

--- a/driver-moab/main/seq_flux_mct.F90
+++ b/driver-moab/main/seq_flux_mct.F90
@@ -1607,7 +1607,7 @@ contains
        index_xao_Faox_lwup = mct_aVect_indexRA(xao,'Faox_lwup')
        index_xao_Faox_swdn = mct_aVect_indexRA(xao,'Faox_swdn')
        index_xao_Faox_swup = mct_aVect_indexRA(xao,'Faox_swup')
-       index_xao_So_fswpen            = mct_aVect_indexRA(xao,'So_fswpen')
+       index_xao_So_fswpen            = mct_aVect_indexRA(xao,'So_fswpen_ao')
        index_xao_So_warm_diurn        = mct_aVect_indexRA(xao,'So_warm_diurn')
        index_xao_So_salt_diurn        = mct_aVect_indexRA(xao,'So_salt_diurn')
        index_xao_So_speed_diurn       = mct_aVect_indexRA(xao,'So_speed_diurn')
@@ -1935,7 +1935,9 @@ contains
     call mbSetCellTagVals(mbfid, 'So_u10', u10res, nloc)
     u10gust = sqrt(duu10n)
     call mbSetCellTagVals(mbfid, 'So_u10withgusts', u10gust, nloc)
-    call mbSetCellTagVals(mbfid, 'So_fswpen', fswpen, nloc)
+    ! xao copy of fswpen: renamed So_fswpen_ao so it does not collide with the o2x So_fswpen
+    ! tag on the shared (aliased) ocn coupler mesh. See seq_flds_mod / cplcomp_moab_init_ocn.
+    call mbSetCellTagVals(mbfid, 'So_fswpen_ao', fswpen, nloc)
 
 #ifdef MOABDEBUG
         ! debug out file

--- a/driver-moab/main/seq_rest_mod.F90
+++ b/driver-moab/main/seq_rest_mod.F90
@@ -476,6 +476,7 @@ subroutine seq_rest_mb_read(rest_file, infodata, samegrid_al, samegrid_lr)
 
     integer (in), pointer   :: l2racc_lm_cnt
     integer (in)   :: nx_lnd ! will be used if land and atm are on same grid
+    integer (in)   :: lnd_nx, lnd_ny ! global land grid dims (from infodata), for non-samegrid land restart I/O
     integer (in)   :: ngv, nge ! global num vertices / elements from iMOAB_GetGlobalInfo
     integer (in)   ::  ierr
 
@@ -523,6 +524,7 @@ subroutine seq_rest_mb_read(rest_file, infodata, samegrid_al, samegrid_lr)
          iac_prognostic=iac_prognostic,      &
          ocn_c2_glcshelf=ocn_c2_glcshelf,    &
          do_bgc_budgets=do_bgc_budgets,      &
+         lnd_nx=lnd_nx, lnd_ny=lnd_ny,       &
          case_name=case_name,                &
          model_doi_url=model_doi_url)
 
@@ -667,9 +669,14 @@ subroutine seq_rest_mb_read(rest_file, infodata, samegrid_al, samegrid_lr)
                 'afrac:lfrac:lfrin', & !  seq_frac_mod: character(*),parameter :: fraclist_l = 'afrac:lfrac:lfrin'
                  whead=whead, wdata=wdata, nx=nx_lnd)
              else
+                ! land on its own (masked) grid, distinct from atm and rof: size the
+                ! PIO global dim from the land grid dims in infodata, exactly as the
+                ! cpl.hi history write does (seq_hist_mod). mblxid's num_global_elems
+                ! is the packed active-cell count and is smaller than the max land
+                ! GLOBAL_ID, which would scramble lfrac/lfrin on restart.
                 call seq_io_write(rest_file, mblxid, 'fractions_lx', &
                  'afrac:lfrac:lfrin', & !  seq_frac_mod: character(*),parameter :: fraclist_l = 'afrac:lfrac:lfrin'
-                  whead=whead, wdata=wdata)
+                  whead=whead, wdata=wdata, nx=lnd_nx, ny=lnd_ny)
              endif
           endif
           if (lnd_present .and. rof_prognostic) then
@@ -698,9 +705,10 @@ subroutine seq_rest_mb_read(rest_file, infodata, samegrid_al, samegrid_lr)
                 trim(tagname), &
                 whead=whead, wdata=wdata, matrix = p_l2racc_lm, nx=nx_lnd)
              else
+                ! land on its own (masked) grid: size PIO global dim from infodata land dims
                 call seq_io_write(rest_file, mblxid, 'l2racc_lx', &
                  trim(tagname), &
-                 whead=whead, wdata=wdata, matrix = p_l2racc_lm )
+                 whead=whead, wdata=wdata, matrix = p_l2racc_lm, nx=lnd_nx, ny=lnd_ny )
              endif
              call seq_io_write(rest_file, l2racc_lm_cnt, 'l2racc_lx_cnt', &
                  whead=whead, wdata=wdata)

--- a/driver-moab/shr/seq_flds_mod.F90
+++ b/driver-moab/shr/seq_flds_mod.F90
@@ -1838,12 +1838,20 @@ contains
     attname  = 'So_bldepth'
     call metadata_set(attname, longname, stdname, units)
 
-    call seq_flds_add(xao_states,"So_fswpen")
+    ! NOTE: So_fswpen is the one field carried by BOTH o2x and xao states. In the MOAB
+    ! coupler the atm-ocn "flux" mesh (mbofxid) is an alias of the ocn coupler mesh (mboxid),
+    ! so o2x and xao tags live on the SAME MOAB mesh. To avoid a tag collision, the xao copy
+    ! is named So_fswpen_ao while o2x keeps So_fswpen. (So_fswpen is consumed only by the
+    ! atm-ocn flux as an o2x input; the xao copy is not merged to x2a/x2o, so this rename is
+    ! transparent.) See cplcomp_moab_init_ocn (alias) and seq_flux_atmocn_moab (write).
+    call seq_flds_add(xao_states,"So_fswpen_ao")
     call seq_flds_add(o2x_states,"So_fswpen")
     longname = 'Fraction of sw penetrating surface layer for diurnal cycle'
     stdname  = 'Fraction of sw penetrating surface layer for diurnal cycle'
     units    = '1'
     attname  = 'So_fswpen'
+    call metadata_set(attname, longname, stdname, units)
+    attname  = 'So_fswpen_ao'
     call metadata_set(attname, longname, stdname, units)
 
     !------------------------------


### PR DESCRIPTION
Change MOAB-coupler ATM-OCN flux handling by removing the extra copy of the ocean mesh in the coupler 
and associated comms.  This fixes the ERP/PEM fails seen with regionally refined atm meshes. It also addresses a 
restart I/O sizing issue when land is on its own masked grid and the river model is a stub.

[BFB] but changes field list.

Fixes #8543 

---

## Details

This pull request makes significant improvements to the handling of the ocean "second copy" mesh and the associated flux fields in the MOAB-based coupler. The main change is to treat the second ocean mesh (`mbofxid`) as an alias of the primary ocean mesh (`mboxid`), eliminating the need for a separate mesh load and context offset. This resolves issues with inconsistent mesh ordering and tag collisions, especially for the `So_fswpen` field, which is now uniquely named on the flux mesh. We also expect a bump up in performance since redundant copies of the ocean mesh, its I/O or migration from component PEs, construction and use of separate communication graphs etc are all now eliminated.

Additionally, the pull request improves the handling of land grid dimensions for restart I/O when land is on a separate grid. We now size the land-fraction restart write by the land grid dimensions when land is on its own masked grid, a case the same grid branches do not cover. PEM is now bit-for-bit and ERP passes for both conus and ne30pg2 data-ocean F-cases.


**Ocean mesh and field aliasing improvements:**

* The second ocean mesh (`mbofxid`) is now an alias of the primary mesh (`mboxid`), removing the need for a separate load, app id, or context offset. This ensures consistent mesh ordering and correct by-index transfers for all ocean/atm fluxes. [[1]](diffhunk://#diff-37a6c0050e47d422dd451a91e18725a66eaffde7e5789eadbf5a795cb408cbc4L79) [[2]](diffhunk://#diff-37a6c0050e47d422dd451a91e18725a66eaffde7e5789eadbf5a795cb408cbc4L530-L585) [[3]](diffhunk://#diff-444a740d7ee30a29ae77d667f7c6d6e3bc8f61fb21445ae8b8a2e106fe86d9b9L495-R504) [[4]](diffhunk://#diff-444a740d7ee30a29ae77d667f7c6d6e3bc8f61fb21445ae8b8a2e106fe86d9b9L511-R520)
* The field `So_fswpen` is renamed to `So_fswpen_ao` on the xao state to avoid tag collisions on the shared mesh. All relevant code is updated to use the new name, and metadata is set accordingly. [[1]](diffhunk://#diff-a36b0a736d86b054c8bab715804f46a7f9ed2ec9747d683688a675441f289ac4L1610-R1610) [[2]](diffhunk://#diff-a36b0a736d86b054c8bab715804f46a7f9ed2ec9747d683688a675441f289ac4L1938-R1940) [[3]](diffhunk://#diff-e2ce8aa5680be21b112b0af9da60854258e8efb4edf1ef570f459de9f789d8adL1841-R1855)

**Code cleanup and removal of obsolete logic:**

* Removes the `OCN_SECOND_COPY_ID_OFFSET` constant and all logic related to explicit second-copy context offsets, as they're no longer needed with the mesh aliasing approach. [[1]](diffhunk://#diff-37a6c0050e47d422dd451a91e18725a66eaffde7e5789eadbf5a795cb408cbc4L79) [[2]](diffhunk://#diff-37a6c0050e47d422dd451a91e18725a66eaffde7e5789eadbf5a795cb408cbc4L530-L585)
* Cleans up unused variables and removes unnecessary calls to mesh copy, tag copy, and comm graph construction for the second ocean mesh. [[1]](diffhunk://#diff-37a6c0050e47d422dd451a91e18725a66eaffde7e5789eadbf5a795cb408cbc4L417) [[2]](diffhunk://#diff-37a6c0050e47d422dd451a91e18725a66eaffde7e5789eadbf5a795cb408cbc4L432-L435) [[3]](diffhunk://#diff-444a740d7ee30a29ae77d667f7c6d6e3bc8f61fb21445ae8b8a2e106fe86d9b9L511-R520)

**Land grid restart I/O improvements:**

* When land is on a separate grid, restart output now uses the correct global land grid dimensions (`lnd_nx`, `lnd_ny`) from `infodata` for writing fractions and accumulators, ensuring compatibility with history output and preventing scrambled restarts. [[1]](diffhunk://#diff-9276034654a2bf2a5411e71bc9330e19424bece5ca1f0b25881fed36fb78f001R479) [[2]](diffhunk://#diff-9276034654a2bf2a5411e71bc9330e19424bece5ca1f0b25881fed36fb78f001R527) [[3]](diffhunk://#diff-9276034654a2bf2a5411e71bc9330e19424bece5ca1f0b25881fed36fb78f001R672-R679) [[4]](diffhunk://#diff-9276034654a2bf2a5411e71bc9330e19424bece5ca1f0b25881fed36fb78f001R708-R711)
*  Land-fraction restart scramble (ERP / restart).** When land is on its own masked grid, distinct from both atm and rof (these F-cases use a stub river, `ROF_GRID=null`, so `samegrid_al` and `samegrid_lr` are both false), the `fractions_lx`/`l2racc_lx` restart write used no global `nx`. PIO then sized the global dimension from `mblxid`'s packed active-cell count, which is smaller than the maximum land `GLOBAL_ID`, scrambling `lfrac`/`lfrin` on restart. This is the `else` branch that PR #8541's samegrid fixes do not reach.

These changes simplify the codebase, improve robustness for different PE layouts and grid configurations, and resolve prior issues with field collisions and restart compatibility.

## Validation
- `PEM_Ln22.conusx4v1pg2_r05_oECv3.F2010-SCREAMv1-noAero`: `COMPARE_base_modpes` **bit-for-bit**  (cprnc 413 fields, 0 diffs; previously 159 differing fields).
- `ERP_Ln22.conusx4v1pg2_r05_oECv3.F2010-SCREAMv1-noAero`: `COMPARE_base_rest` **PASS**.
- `ERP_Ln22.ne30pg2_r05_oECv3.F2010-SCREAMv1-noAero`: `COMPARE_base_rest` **PASS**.
