### PR TITLE
Fix updating physics state with cflx_tend in tphysbc 

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -340,7 +340,7 @@ _TESTS = {
         },
 
     "e3sm_developer" : {
-        "inherit" : ("e3sm_land_developer", "e3sm_atm_developer", "e3sm_ice_developer", "e3sm_cryo_developer"),
+        "inherit" : ("e3sm_land_developer", "e3sm_atm_developer", "e3sm_ice_developer", "e3sm_cryo_developer", "e3sm_gcam_developer"),
         "time"    : "0:45:00",
         "tests"   : (
             "ERS.ne4pg2_oQU480_rx1.A",

--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -1139,8 +1139,8 @@ _TESTS = {
     "e3sm_gcam_developer" : {
         "time"  : "1:00:00",
         "tests" : (
-            "SMS.ne30pg2_f09_oEC60to30v3.SSP245_ZATM_BGC",
-            "ERS.ne30pg2_f09_oEC60to30v3.SSP245_ZATM_BGC",
+            "SMS_Vmct.ne30pg2_f09_oEC60to30v3.SSP245_ZATM_BGC",
+            "ERS_Vmct.ne30pg2_f09_oEC60to30v3.SSP245_ZATM_BGC",
             )
     },
 }

--- a/components/eam/bld/namelist_files/use_cases/SSP245_eam_CMIP6_chemUCI-Linoz-mam5-vbs_EHC.xml
+++ b/components/eam/bld/namelist_files/use_cases/SSP245_eam_CMIP6_chemUCI-Linoz-mam5-vbs_EHC.xml
@@ -16,9 +16,6 @@
 <!-- co2 conservation tolerance with human component -->
 <co2_conserv_error_tol_per_year>1.e-5</co2_conserv_error_tol_per_year>
 
-<!-- more robust surface flux coupling: like v2 -->
-<cflx_cpl_opt>1</cflx_cpl_opt>
-
 <!-- External forcing for BAM or MAM.  CMIP6 input4mips data -->
 <ext_frc_type>INTERP_MISSING_MONTHS</ext_frc_type>
 <no2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP245_ne30/emissions-cmip6_ssp245_e3sm_NO2_aircraft_vertical_2015-2100_1.9x2.5_c20240219.nc </no2_ext_file>

--- a/components/eam/bld/namelist_files/use_cases/SSP370_eam_CMIP6_chemUCI-Linoz-mam5-vbs_EHC.xml
+++ b/components/eam/bld/namelist_files/use_cases/SSP370_eam_CMIP6_chemUCI-Linoz-mam5-vbs_EHC.xml
@@ -20,9 +20,6 @@
 <!-- co2 conservation tolerance with human component -->
 <co2_conserv_error_tol_per_year>1.e-5</co2_conserv_error_tol_per_year>
 
-<!-- more robust surface flux coupling: like v2 -->
-<cflx_cpl_opt>1</cflx_cpl_opt>
-
 <!-- External forcing for BAM or MAM.  CMIP6 input4mips data -->
 <ext_frc_type>INTERP_MISSING_MONTHS</ext_frc_type>
 <no2_ext_file         >atm/cam/chem/trop_mozart_aero/emis/CMIP6_SSP370_ne30/emissions-cmip6_ssp370_e3sm_NO2_aircraft_vertical_2015-2100_1.9x2.5_c20240208.nc </no2_ext_file>

--- a/components/eam/src/physics/cam/cflx.F90
+++ b/components/eam/src/physics/cam/cflx.F90
@@ -12,7 +12,7 @@ module cflx
 
 contains
 
-    subroutine cflx_tend (state, cam_in, ztodt, ptend)
+    subroutine cflx_tend (state, cam_in, ztodt, ptend, skip_co2, co2_only)
 
     use physics_types,          only: physics_state, physics_ptend, &
                                       physics_ptend_init, &
@@ -20,7 +20,7 @@ contains
     use physconst,              only: gravit
     use ppgrid,                 only: pver, pcols
     use constituents,           only: pcnst, cnst_get_ind, cnst_type
-    use co2_cycle,              only: co2_cycle_set_cnst_type
+    use co2_cycle,              only: co2_cycle_set_cnst_type, co2_transport, c_i
     use camsrfexch,             only: cam_in_t
 
     implicit none
@@ -30,6 +30,8 @@ contains
     type(physics_state), intent(inout)  :: state                ! Physics state variables
     type(cam_in_t),      intent(in)     :: cam_in               ! contains surface fluxes of constituents
     real(r8),            intent(in)     :: ztodt                ! 2 delta-t        [ s ]
+    logical,             intent(in), optional :: skip_co2        ! if .true., skip CO2 tracers (apply all others)
+    logical,             intent(in), optional :: co2_only        ! if .true., apply CO2 tracers only
 
     ! Output Auguments
 
@@ -42,14 +44,30 @@ contains
 
     real(r8) :: tmp1(pcols)
     real(r8) :: rztodt                                          ! 1./ztodt
-    integer  :: m
+    integer  :: m, k
 
     logical  :: lq(pcnst)
+    logical  :: l_skip_co2, l_co2_only
+    logical  :: co2_mask(pcnst)                                 ! .true. for CO2 tracer indices
 
     character(len=3), dimension(pcnst) :: cnst_type_loc         ! local override option for constituents cnst_type
 
 
     ncol = state%ncol
+
+    ! Process optional arguments
+    l_skip_co2 = .false.
+    if (present(skip_co2)) l_skip_co2 = skip_co2
+    l_co2_only = .false.
+    if (present(co2_only)) l_co2_only = co2_only
+
+    ! Build a mask identifying CO2 tracer indices
+    co2_mask(:) = .false.
+    if (co2_transport()) then
+       do k = 1, size(c_i)
+          if (c_i(k) >= 1 .and. c_i(k) <= pcnst) co2_mask(c_i(k)) = .true.
+       end do
+    end if
 
     !-------------------------------------------------------
     ! Assume 'wet' mixing ratios in surface diffusion code.
@@ -60,9 +78,17 @@ contains
     call set_dry_to_wet(state, cnst_type_loc)
 
     !-------------------------------------------------------
-    ! Initialize ptend
+    ! Initialize ptend with appropriate tracer mask
+    ! skip_co2=.true.: apply all tracers except CO2 (used by tphysbc when cflx_cpl_opt==2)
+    ! co2_only=.true.: apply CO2 tracers only (used by tphysac when cflx_cpl_opt==2)
+    ! default (both .false.): apply all tracers
 
-    lq(:) = .TRUE.
+    if (l_co2_only) then
+       lq(:) = co2_mask(:)
+    else
+       lq(:) = .TRUE.
+       if (l_skip_co2) lq(:) = lq(:) .and. (.not. co2_mask(:))
+    end if
     call physics_ptend_init(ptend, state%psetcols, 'clubb_srf', lq=lq)
 
     !-------------------------------------------------------
@@ -73,6 +99,7 @@ contains
     tmp1(:ncol)            = ztodt * gravit * state%rpdel(:ncol,pver)
 
     do m = 2, pcnst
+      if (.not. lq(m)) cycle
       ptend%q(:ncol,pver,m) = ptend%q(:ncol,pver,m) + tmp1(:ncol) * cam_in%cflx(:ncol,m)
     enddo
 

--- a/components/eam/src/physics/cam/cflx.F90
+++ b/components/eam/src/physics/cam/cflx.F90
@@ -91,6 +91,14 @@ contains
     end if
     call physics_ptend_init(ptend, state%psetcols, 'clubb_srf', lq=lq)
 
+    ! If no tracers are selected, ptend%q is not allocated; exit cleanly.
+    if (.not. any(lq)) then
+       cnst_type_loc(:) = cnst_type(:)
+       call co2_cycle_set_cnst_type(cnst_type_loc, 'wet')
+       call set_wet_to_dry(state, cnst_type_loc)
+       return
+    end if
+
     !-------------------------------------------------------
     ! Calculate tracer mixing ratio tendencies from cflx
 
@@ -107,6 +115,7 @@ contains
 
     ! Convert tendencies of dry constituents to dry basis.
     do m = 1,pcnst
+       if (.not. lq(m)) cycle
        if (cnst_type(m).eq.'dry') then
           ptend%q(:ncol,:pver,m) = ptend%q(:ncol,:pver,m)*state%pdel(:ncol,:pver)/state%pdeldry(:ncol,:pver)
        endif

--- a/components/eam/src/physics/cam/co2_diagnostics.F90
+++ b/components/eam/src/physics/cam/co2_diagnostics.F90
@@ -24,8 +24,8 @@ use constituents   , only: pcnst, cnst_name
 use cam_logfile    , only: iulog
 use spmd_utils     , only: masterproc
 use cam_abortutils , only: endrun
-use time_manager   , only: is_first_step, is_last_step, get_prev_date, &
-                           get_curr_date, is_end_curr_month
+use time_manager   , only: is_first_step, is_first_restart_step, is_last_step, &
+                           get_prev_date, get_curr_date, is_end_curr_month
 
 implicit none
 private
@@ -280,7 +280,7 @@ contains
          end do
       end if
 
-      if ( .not. is_first_step() ) then
+      if ( .not. is_first_step() .or. is_first_restart_step() ) then
          do i = 1, ncol
             state%c_iflx_sfc(i) = state%c_iflx_sfc(i) + (sfc_flux(i)     * dtime)
             state%c_iflx_ocn(i) = state%c_iflx_ocn(i) + (sfc_flux_ocn(i) * dtime)
@@ -365,7 +365,7 @@ contains
             end do
          end if
 
-         if ( .not. is_first_step() ) then
+         if ( .not. is_first_step() .or. is_first_restart_step() ) then
             do i = 1, ncol
                state%c_iflx_air(i) = state%c_iflx_air(i) + (fossil_flux(i) * dtime)
                state%c_mflx_air(i) = state%c_mflx_air(i) + (fossil_flux(i) * dtime)

--- a/components/eam/src/physics/cam/physpkg.F90
+++ b/components/eam/src/physics/cam/physpkg.F90
@@ -1494,18 +1494,6 @@ subroutine phys_run2(phys_state, ztodt, phys_tend, pbuf2d,  cam_out, &
           if ( is_end_curr_month() ) then
              phys_state(c)%tc_mnst(:ncol) = phys_state(c)%tc_curr(:ncol)
           end if
-          ! upon restart with cflx_cpl_opt=2, these need to be re-zeroed
-          ! because get_carbon_sfc_fluxes has not been called yet,
-          ! and co2_diags_read_fields has been called to fill them with old values
-          ! there may still be an issue with the timestep-level values, but don't
-          ! zero them yet so that they can be diagnosed
-          call phys_getopts( cflx_cpl_opt_out = cflx_cpl_opt)
-          if ( is_first_restart_step() .and. is_start_curr_month() .and. cflx_cpl_opt == 2) then
-             phys_state(c)%c_mflx_sfc(:ncol) = 0._r8
-             phys_state(c)%c_mflx_ocn(:ncol) = 0._r8
-             phys_state(c)%c_mflx_sff(:ncol) = 0._r8
-             phys_state(c)%c_mflx_lnd(:ncol) = 0._r8
-         end if
        end do
        call co2_diags_store_fields(phys_state, pbuf2d)
     end if

--- a/components/eam/src/physics/cam/physpkg.F90
+++ b/components/eam/src/physics/cam/physpkg.F90
@@ -2857,7 +2857,7 @@ end if
        ! on tracers for which cam_in%cflx(:,m) is zero at this point.
 
       !if ( do_clubb_sgs .and. (cflx_cpl_opt==2) ) then
-       if ( cflx_cpl_opt==2 ) then
+       if ( (do_clubb_sgs .or. do_shoc_sgs) .and. (cflx_cpl_opt==2) ) then
           ! Apply surface fluxes for all tracers EXCEPT CO2; CO2 is applied in tphysac
           ! to avoid redundant additions during the multi-call init sequence (see GH #8201)
           call cflx_tend( state, cam_in, ztodt, ptend, skip_co2=.true.)

--- a/components/eam/src/physics/cam/physpkg.F90
+++ b/components/eam/src/physics/cam/physpkg.F90
@@ -1915,9 +1915,14 @@ end if ! l_tracer_aero
 
        if (cflx_cpl_opt==1) then
           call cflx_tend( state, cam_in, ztodt, ptend)       
-         call physics_update(state, ptend, ztodt, tend)
-         !!!! todo: delete !!!
-         if (masterproc) write(iulog,*) 'cflx-log: surface flux tendencies applied in tphysac after clubb_surface'
+          call physics_update(state, ptend, ztodt, tend)
+          if (masterproc) write(iulog,*) 'cflx-log: surface flux tendencies applied in tphysac after clubb_surface'
+       elseif (cflx_cpl_opt==2) then
+          ! Apply CO2 tracer fluxes here in tphysac; non-CO2 fluxes were already applied
+          ! in tphysbc (see GH #8201). This avoids duplicate CO2 additions during init.
+          call cflx_tend( state, cam_in, ztodt, ptend, co2_only=.true.)
+          call physics_update(state, ptend, ztodt, tend)
+          if (masterproc) write(iulog,*) 'cflx-log: CO2 surface flux tendencies applied in tphysac after clubb_surface'
        end if
 
        call cnd_diag_checkpoint( diag, 'CFLXAPP', state, pbuf, cam_in, cam_out )
@@ -1948,12 +1953,10 @@ end if ! l_tracer_aero
     end if ! l_vdiff
     endif
 
-    ! collect surface carbon fluxes, but only if they have been updated by cflx_tend above, (cflx_cpl_opt==1)
-    !    or by vertical_diffusion_tend above (l_vdiff==.true.) or if they are not being updated in tphysbc (cflx_cpl_opt /= 2)
-    ! otherwise, this function is called by tphysbc after cflx_tend() and update_physics()
-    if (cflx_cpl_opt /= 2) then
-       call get_carbon_sfc_fluxes(state, cam_in, ztodt)
-    endif
+    ! collect surface carbon fluxes after cflx_tend (or vertical_diffusion_tend) has been applied.
+    ! For cflx_cpl_opt==2, CO2 fluxes are now applied above in tphysac (not tphysbc), so
+    ! get_carbon_sfc_fluxes is always called here (see GH #8201).
+    call get_carbon_sfc_fluxes(state, cam_in, ztodt)
 
 if (l_rayleigh) then
     !===================================================
@@ -2317,7 +2320,6 @@ subroutine tphysbc (ztodt,               &
     use debug_info,      only: get_debug_chunk, get_debug_macmiciter
     use lnd_infodata,    only: precip_downscaling_method
     use cflx,            only: cflx_tend
-    use co2_diagnostics, only: get_carbon_sfc_fluxes
 
     implicit none
 
@@ -2868,11 +2870,12 @@ end if
 
       !if ( do_clubb_sgs .and. (cflx_cpl_opt==2) ) then
        if ( cflx_cpl_opt==2 ) then
-          call cflx_tend( state, cam_in, ztodt, ptend)
+          ! Apply surface fluxes for all tracers EXCEPT CO2; CO2 is applied in tphysac
+          ! to avoid redundant additions during the multi-call init sequence (see GH #8201)
+          call cflx_tend( state, cam_in, ztodt, ptend, skip_co2=.true.)
           call physics_update(state, ptend, ztodt, tend)
-          call get_carbon_sfc_fluxes(state, cam_in, ztodt)
          ! for examining surface cflx update timing - aldivi
-         if (masterproc) write(iulog,*) 'cflx-log: surface flux tendencies applied in tphysbc.'
+         if (masterproc) write(iulog,*) 'cflx-log: surface flux tendencies (non-CO2) applied in tphysbc.'
        end if
 
        !========================================================================================

--- a/components/gcam/tools/run_v3_SSP245_ZATM_BGC_ne30pg2_f09_oEC60to30v3.sh
+++ b/components/gcam/tools/run_v3_SSP245_ZATM_BGC_ne30pg2_f09_oEC60to30v3.sh
@@ -67,18 +67,21 @@ if [ "${MACHINE}" == "chrysalis" ]; then
    readonly CASE_ROOT="/lcrc/group/e3sm/$USER/e3sm_scratch/${CASE_NAME}"
    readonly MACH_QUEUE='compute'
    readonly MACH_QUEUE_DEBUG='debug'
+   readonly WALLTIME_DEBUG='4:00:00'
 fi
 if [ "${MACHINE}" == "compy" ]; then
    readonly din_loc_root=/compyfs/inputdata
    readonly CASE_ROOT="/compyfs/${USER}/e3sm_scratch/${CASE_NAME}"
    readonly MACH_QUEUE='slurm'
    readonly MACH_QUEUE_DEBUG='short'
+   readonly WALLTIME_DEBUG='0:30:00'
 fi
 if [ "${MACHINE}" == "pm-cpu" ]; then
    din_loc_root=/global/cfs/cdirs/e3sm/inputdata
    readonly CASE_ROOT="${SCRATCH}/e3sm_scratch/${CASE_NAME}"
    readonly MACH_QUEUE='regular'
    readonly MACH_QUEUE_DEBUG='debug'
+   readonly WALLTIME_DEBUG='0:30:00'
 fi
 
 # Sub-directories
@@ -128,8 +131,8 @@ if [ "${run}" != "production" ]; then
   readonly REST_N=${STOP_N}
   readonly RESUBMIT=${resubmit}
   readonly DO_SHORT_TERM_ARCHIVING=false
-  
-  readonly WALLTIME="4:00:00"
+
+  readonly WALLTIME=${WALLTIME_DEBUG}
   readonly RUN_QUEUE=${MACH_QUEUE_DEBUG}
 else
 
@@ -200,7 +203,6 @@ cat << EOF >> user_nl_eam
  co2_print_diags_timestep               = .true.
  co2_print_diags_monthly                = .true.
  co2_print_diags_total                  = .true.
- cflx_cpl_opt=1 
  
  ncdata		= '${ncd_string}'
 EOF

--- a/components/gcam/tools/run_v3_SSP245_ZATM_BGC_ne30pg2_f09_oEC60to30v3.sh
+++ b/components/gcam/tools/run_v3_SSP245_ZATM_BGC_ne30pg2_f09_oEC60to30v3.sh
@@ -132,7 +132,7 @@ if [ "${run}" != "production" ]; then
   readonly RESUBMIT=${resubmit}
   readonly DO_SHORT_TERM_ARCHIVING=false
 
-  readonly WALLTIME=${WALLTIME_DEBUG}
+  readonly WALLTIME=${WALLTIME_DEBUG:-0:30:00}
   readonly RUN_QUEUE=${MACH_QUEUE_DEBUG}
 else
 


### PR DESCRIPTION
This PR fixes updating physics state with cflx_tend in tphysbc 
(in cam_run1) which may add redundant, duplicate mass to the atmosphere 

- mainly fixes CO2 duplication with cflx_cpl_opt==2 (#8201) 
- ensure CO2 mass conservation
- add the "e3sm_gcam_developer" suite to `e3sm_developer` test suite. 

Fixes #8201
[non-BFB] for all tests with fully active EAM.