### PR TITLE
EAMxx: nanofix in test-all-eamxx related to baselines generation

### DIFF
--- a/components/eamxx/cmake/CompareTextFiles.cmake
+++ b/components/eamxx/cmake/CompareTextFiles.cmake
@@ -18,36 +18,32 @@ endif()
 list(GET my_args 0 SRC_FILE)
 list(GET my_args 1 TGT_FILE)
 
-if (SCREAM_ONLY_GENERATE_BASELINES)
-  CopyFile(${SRC_FILE} ${TGT_FILE})
+# Print the files being compared
+message(STATUS "Comparing files: ${SRC_FILE} and ${TGT_FILE}")
+
+# Check if the source file exists
+if(NOT EXISTS ${SRC_FILE})
+  message(FATAL_ERROR "Error: Source file not found: ${SRC_FILE}")
+endif()
+
+# Check if the target file exists
+if(NOT EXISTS ${TGT_FILE})
+  message(FATAL_ERROR "Error: Target file not found: ${TGT_FILE}")
+endif()
+
+# Compare the files (note: works only on UNIX)
+execute_process(
+  COMMAND diff ${SRC_FILE} ${TGT_FILE}
+  RESULT_VARIABLE result
+  OUTPUT_VARIABLE diff_output
+  ERROR_VARIABLE diff_error
+  )
+
+# Check the result of the comparison
+if(result)
+  message(STATUS "Files differ:")
+  message(STATUS "${diff_output}")
+  message(FATAL_ERROR "Comparison failed.")
 else()
-  # Print the files being compared
-  message(STATUS "Comparing files: ${SRC_FILE} and ${TGT_FILE}")
-
-  # Check if the source file exists
-  if(NOT EXISTS ${SRC_FILE})
-    message(FATAL_ERROR "Error: Source file not found: ${SRC_FILE}")
-  endif()
-
-  # Check if the target file exists
-  if(NOT EXISTS ${TGT_FILE})
-    message(FATAL_ERROR "Error: Target file not found: ${TGT_FILE}")
-  endif()
-
-  # Compare the files (note: works only on UNIX)
-  execute_process(
-    COMMAND diff ${SRC_FILE} ${TGT_FILE}
-    RESULT_VARIABLE result
-    OUTPUT_VARIABLE diff_output
-    ERROR_VARIABLE diff_error
-    )
-
-  # Check the result of the comparison
-  if(result)
-    message(STATUS "Files differ:")
-    message(STATUS "${diff_output}")
-    message(FATAL_ERROR "Comparison failed.")
-  else()
-    message(STATUS "Files are identical.")
-  endif()
+  message(STATUS "Files are identical.")
 endif()

--- a/components/eamxx/cmake/CprncTest.cmake.in
+++ b/components/eamxx/cmake/CprncTest.cmake.in
@@ -16,37 +16,33 @@ if (NOT CPRNC)
   message (FATAL_ERROR "This script was not configured correctly (CPRNC_BINARY was not set).")
 endif()
 
-if (SCREAM_ONLY_GENERATE_BASELINES)
-  CopyFile(${SRC_FILE} ${TGT_FILE})
-else()
-  execute_process (
-    COMMAND ${CPRNC} ${SRC_FILE} ${TGT_FILE}
-    RESULT_VARIABLE cprnc_result
-    OUTPUT_VARIABLE cprnc_output
-    ERROR_VARIABLE  cprnc_output)
+execute_process (
+  COMMAND ${CPRNC} ${SRC_FILE} ${TGT_FILE}
+  RESULT_VARIABLE cprnc_result
+  OUTPUT_VARIABLE cprnc_output
+  ERROR_VARIABLE  cprnc_output)
 
-  if (NOT cprnc_result EQUAL 0)
-    string (CONCAT msg
-      "Command\n"
-      "  '${CPRNC} ${SRC_FILE} ${TGT_FILE}'"
-      "returned '${cprnc_result}', and output:\n"
-      "${cprnc_output}")
-    message ("${msg}")
-    message (FATAL_ERROR "Aborting.")
-  endif()
-
-  # Search output for "IDENTICAL". -1 means it does not exist. Use REVERSE on
-  # the off chance that makes it faster, since "IDENTICAL", if it exists, is
-  # near the end of the output.
-  string (FIND "${cprnc_output}" "IDENTICAL" identical_pos REVERSE)
-
-  if (identical_pos EQUAL -1)
-    string (CONCAT msg
-      "Command\n"
-      "  '${CPRNC} ${SRC_FILE} ${TGT_FILE}'\n"
-      "reported differences between the files. Here's the output from cprnc:\n")
-    message ("${msg}")
-    message ("${cprnc_output}")
-    message (FATAL_ERROR "Aborting.")
-  endif ()
+if (NOT cprnc_result EQUAL 0)
+  string (CONCAT msg
+    "Command\n"
+    "  '${CPRNC} ${SRC_FILE} ${TGT_FILE}'"
+    "returned '${cprnc_result}', and output:\n"
+    "${cprnc_output}")
+  message ("${msg}")
+  message (FATAL_ERROR "Aborting.")
 endif()
+
+# Search output for "IDENTICAL". -1 means it does not exist. Use REVERSE on
+# the off chance that makes it faster, since "IDENTICAL", if it exists, is
+# near the end of the output.
+string (FIND "${cprnc_output}" "IDENTICAL" identical_pos REVERSE)
+
+if (identical_pos EQUAL -1)
+  string (CONCAT msg
+    "Command\n"
+    "  '${CPRNC} ${SRC_FILE} ${TGT_FILE}'\n"
+    "reported differences between the files. Here's the output from cprnc:\n")
+  message ("${msg}")
+  message ("${cprnc_output}")
+  message (FATAL_ERROR "Aborting.")
+endif ()

--- a/components/eamxx/cmake/ProcessUtils.cmake
+++ b/components/eamxx/cmake/ProcessUtils.cmake
@@ -29,23 +29,3 @@ function(GetScriptPositionalArguments out_var)
   # Propagate the filtered list back to the caller's scope
   set(${out_var} "${real_args}" PARENT_SCOPE)
 endfunction()
-
-###############################################################################
-function(CopyFile src_file tgt_file)
-###############################################################################
-  execute_process (
-    COMMAND ${CMAKE_COMMAND} -E copy "${src_file}" "${tgt_file}"
-    RESULT_VARIABLE cp_result
-    OUTPUT_VARIABLE cp_output
-    ERROR_VARIABLE  cp_output)
-
-  if (NOT cp_result EQUAL 0)
-    string (CONCAT msg
-      "Command\n"
-      "  '${CMAKE_COMMAND} -E copy ${src_file} ${tgt_file}'"
-      "returned '${cp_result}', and output:\n"
-      "${cp_output}")
-    message ("${msg}")
-    message (FATAL_ERROR "Aborting.")
-  endif()
-endfunction()

--- a/components/eamxx/scripts/test_all_eamxx.py
+++ b/components/eamxx/scripts/test_all_eamxx.py
@@ -7,7 +7,7 @@ import re
 from pathlib import Path
 
 from utils import run_cmd, run_cmd_no_fail, expect, check_minimum_python_version, \
-                  ensure_psutil, SharedArea
+                  ensure_psutil
 from git_utils import get_current_head, get_current_commit
 
 from test_factory import create_tests, COV, CSR
@@ -251,14 +251,6 @@ class TestAllScream(object):
             (test_dir / "data").mkdir(parents=False,exist_ok=True)
 
     ###############################################################################
-    def set_baseline_file_sha(self, test):
-    ###############################################################################
-        sha = get_current_commit()
-        baseline_file = (self.get_preexisting_baseline(test).parent)/"baseline_git_sha"
-        with baseline_file.open("w", encoding="utf-8") as fd:
-            return fd.write(sha)
-
-    ###############################################################################
     def get_test_dir(self, root, test):
     ###############################################################################
         return root/str(test)
@@ -370,13 +362,10 @@ class TestAllScream(object):
         if "SCREAM_DYNAMICS_DYCORE" not in custom_opts_keys:
             result += " -DSCREAM_DYNAMICS_DYCORE=HOMME"
 
-        # NOTE: for generate, don't set baseline dir, since we don't want to overwrite
-        #       existing baselines until we know all tests completed normally
         if self._generate:
-            test_dir = self.get_test_dir(self._work_dir,test)
             result += " -DSCREAM_ENABLE_BASELINE_TESTS=ON"
-            result += f" -DSCREAM_BASELINES_DIR={test_dir}"
             result += " -DSCREAM_ONLY_GENERATE_BASELINES=ON"
+            result += f" -DSCREAM_BASELINES_DIR={self.get_preexisting_baseline(test).parent}"
         elif self._baseline_dir is not None and test.uses_baselines:
             result += " -DSCREAM_ENABLE_BASELINE_TESTS=ON"
             result += f" -DSCREAM_BASELINES_DIR={self.get_preexisting_baseline(test).parent}"
@@ -512,31 +501,17 @@ class TestAllScream(object):
         expect(test.uses_baselines,
                f"Something is off. generate_baseline should have not be called for test {test}")
 
+        # Ensure baselines files copied into the baseline dir get the correct permissions
+        os.umask(0o0002)
+
+        # Run tests
         success = self.run_test(test)
 
-        if success:
-            test_dir = self.get_test_dir(self._work_dir,test)
-            # Read list of nc files to copy to baseline dir
-            baseline_dir = self.get_test_dir(self._baseline_dir, test)
-            with open(test_dir/"data/baseline_list","r",encoding="utf-8") as fd:
-                files = fd.read().splitlines()
-
-                with SharedArea():
-                    for fn in files:
-                        # In case appending to the file leaves an empty line at the end
-                        if fn != "":
-                            src = Path(fn)
-                            dst = baseline_dir / "data" / src.name
-                            shutil.copyfile(src, dst)
-
-            # Some eamxx tests are designed to output directly in <bld_root>/data,
-            # so just copy all content from there into the baseline dir
-            shutil.copytree(test_dir/"data",baseline_dir/"data",dirs_exist_ok=True)
-
-            # Store the sha used for baselines generation. This is only for record
-            # keeping.
-            self.set_baseline_file_sha(test)
-            test.baselines_missing = False
+        # Update the baseline_git_sha file
+        sha = get_current_commit()
+        baseline_file = (self.get_preexisting_baseline(test).parent)/"baseline_git_sha"
+        with baseline_file.open("w", encoding="utf-8") as fd:
+            fd.write(sha)
 
         return success
 

--- a/components/eamxx/scripts/test_all_eamxx.py
+++ b/components/eamxx/scripts/test_all_eamxx.py
@@ -85,7 +85,7 @@ class TestAllScream(object):
         mach_name = machine or os.environ.get('SCREAM_MACHINE') or "local"
         expect (is_machine_supported(mach_name),
                 f"The machine '{mach_name}' is not supported")
-        self._machine = get_machine(machine)
+        self._machine = get_machine(mach_name)
 
         # Compute root dir (where repo is) and work dir (where build/test will happen)
         if not self._root_dir:

--- a/components/eamxx/scripts/test_all_eamxx.py
+++ b/components/eamxx/scripts/test_all_eamxx.py
@@ -194,12 +194,13 @@ class TestAllScream(object):
         if "SCREAM_FAKE_AUTO" in os.environ:
             auto_dir = auto_dir / "fake"
 
-        if self._baseline_dir == "LOCAL":
-            self._baseline_dir = local_baseline_dir
-        elif self._baseline_dir == "AUTO":
-            self._baseline_dir = auto_dir
-        elif self._baseline_dir is not None:
-            self._baseline_dir = Path(self._baseline_dir).absolute()
+        if self._baseline_dir:
+            if self._baseline_dir.lower() == "local":
+                self._baseline_dir = local_baseline_dir
+            elif self._baseline_dir.lower() == "auto":
+                self._baseline_dir = auto_dir
+            elif self._baseline_dir is not None:
+                self._baseline_dir = Path(self._baseline_dir).absolute()
 
         # Make the baseline dir, if not already existing.
         if self._generate:

--- a/components/eamxx/tests/CMakeLists.txt
+++ b/components/eamxx/tests/CMakeLists.txt
@@ -30,21 +30,6 @@ endfunction(CreateADUnitTest)
 #                       The string _np${GEN_TEST_NRANKS}_omp1 will be attached to this
 
 function (CreateBaselineTest TEST_BASE_NAME GEN_TEST_NRANKS OUT_FILE FIXTURES_BASE_NAME)
-  # Get names of src and tgt files
-  set (SRC_FILE ${CMAKE_CURRENT_BINARY_DIR}/${OUT_FILE})
-  set (TGT_FILE ${SCREAM_BASELINES_DIR}/data/${OUT_FILE})
-
-  # Add comparison test using the CprncTest.cmake script shipped by EAMxx
-  add_test (
-    NAME ${TEST_BASE_NAME}_baseline_cmp
-    COMMAND cmake -DSCREAM_ONLY_GENERATE_BASELINES=${SCREAM_ONLY_GENERATE_BASELINES} -P ${CMAKE_BINARY_DIR}/bin/CprncTest.cmake ${SRC_FILE} ${TGT_FILE}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-  set_tests_properties(
-    ${TEST_BASE_NAME}_baseline_cmp
-    PROPERTIES
-    LABELS "baseline_cmp;baseline_gen"
-    FIXTURES_REQUIRED ${FIXTURES_BASE_NAME}_np${TEST_RANK_END}_omp1)
-
   # Add the test that generated the baseline to the baseline_gen label, so scripts/test-all-eamxx
   # can run it when it has to generate baselines
   if (TEST ${TEST_BASE_NAME}_np${GEN_TEST_NRANKS})
@@ -61,12 +46,31 @@ function (CreateBaselineTest TEST_BASE_NAME GEN_TEST_NRANKS OUT_FILE FIXTURES_BA
   endif()
   set_tests_properties (${GEN_TEST_FULL_NAME} PROPERTIES LABELS baseline_gen)
 
-  # test-all-eamxx will read this file to get the list of baseline nc files to
-  # copy into the baseline dir
-  file (APPEND ${SCREAM_TEST_OUTPUT_DIR}/baseline_list
-    "${SRC_FILE}\n"
-  )
+  # Get names of src and tgt files
+  set (SRC_FILE ${CMAKE_CURRENT_BINARY_DIR}/${OUT_FILE})
+  set (TGT_FILE ${SCREAM_BASELINES_DIR}/data/${OUT_FILE})
 
+  # If generating, add test that copies files into baseline dir. Otherwise,add cprnc test
+  if (SCREAM_ONLY_GENERATE_BASELINES)
+    add_test (NAME ${TEST_BASE_NAME}_baseline_gen
+      COMMAND ${CMAKE_COMMAND} -E copy "${SRC_FILE}" "${TGT_FILE}"
+    )
+    set_tests_properties(
+      ${TEST_BASE_NAME}_baseline_gen
+      PROPERTIES
+      LABELS "baseline_gen"
+      FIXTURES_REQUIRED ${FIXTURES_BASE_NAME}_np${TEST_RANK_END}_omp1)
+  else()
+    add_test (
+      NAME ${TEST_BASE_NAME}_baseline_cmp
+      COMMAND ${CMAKE_COMMAND} -P ${CMAKE_BINARY_DIR}/bin/CprncTest.cmake ${SRC_FILE} ${TGT_FILE}
+      WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+      set_tests_properties(
+        ${TEST_BASE_NAME}_baseline_cmp
+        PROPERTIES
+        LABELS "baseline_cmp;baseline_gen"
+        FIXTURES_REQUIRED ${FIXTURES_BASE_NAME}_np${TEST_RANK_END}_omp1)
+  endif()
 endfunction()
 
 if (NOT DEFINED ENV{SCREAM_FAKE_ONLY})

--- a/components/eamxx/tests/single-process/p3/CMakeLists.txt
+++ b/components/eamxx/tests/single-process/p3/CMakeLists.txt
@@ -61,22 +61,30 @@ if (SCREAM_ENABLE_BASELINE_TESTS)
     FIXTURES_REQUIRED ${FIXTURES_BASE_NAME}_np1_omp1
     FIXTURES_SETUP ${TEST_BASE_NAME}_gen_bfb_hash
     EXE_ARGS "--args --log-file atm.log.np1 --output-file p3_bfb_hash.txt"
-    LABELS p3 baseline_gen
+    LABELS p3 baseline_gen baseline_cmp
   )
 
-  # Compare against bfb hashes in baseline dir
   set (SRC_FILE ${CMAKE_CURRENT_BINARY_DIR}/p3_bfb_hash.txt)
   set (TGT_FILE ${SCREAM_BASELINES_DIR}/data/p3_bfb_hash.txt)
-  add_test (NAME ${TEST_BASE_NAME}_bfb_hash_baseline_cmp
-    COMMAND ${CMAKE_COMMAND} -DSCREAM_ONLY_GENERATE_BASELINES=${SCREAM_ONLY_GENERATE_BASELINES} -P ${SCREAM_BASE_DIR}/cmake/CompareTextFiles.cmake ${SRC_FILE} ${TGT_FILE})
 
-  set_tests_properties (
-    ${TEST_BASE_NAME}_bfb_hash_baseline_cmp PROPERTIES
-    FIXTURES_REQUIRED ${TEST_BASE_NAME}_gen_bfb_hash
-    LABELS "p3;baseline_cmp;baseline_gen")
+  # If generating, simply copy the bfb hash file to baseline dir, otherwise compare against the file in baseline dir
+  if (SCREAM_ONLY_GENERATE_BASELINES)
+    add_test (NAME ${TEST_BASE_NAME}_bfb_hash_baseline_gen
+      COMMAND ${CMAKE_COMMAND} -E copy "${SRC_FILE}" "${TGT_FILE}"
+    )
+    set_tests_properties(
+      ${TEST_BASE_NAME}_bfb_hash_baseline_gen
+      PROPERTIES
+      LABELS "p3;baseline_gen"
+      FIXTURES_REQUIRED ${TEST_BASE_NAME}_gen_bfb_hash)
+  else()
+    add_test (NAME ${TEST_BASE_NAME}_bfb_hash_baseline_cmp
+      COMMAND ${CMAKE_COMMAND} -P ${SCREAM_BASE_DIR}/cmake/CompareTextFiles.cmake ${SRC_FILE} ${TGT_FILE})
 
-  # Store p3_bfb_hash.txt in the baseline folder
-  file (APPEND ${SCREAM_TEST_OUTPUT_DIR}/baseline_list
-    "${SRC_FILE}\n"
-  )
+    set_tests_properties (
+      ${TEST_BASE_NAME}_bfb_hash_baseline_cmp
+      PROPERTIES
+      FIXTURES_REQUIRED ${TEST_BASE_NAME}_gen_bfb_hash
+      LABELS "p3;baseline_cmp")
+  endif()
 endif()


### PR DESCRIPTION
Clean up handling of baselines files in test-all-eamxx

[BFB]

---

~The reason our baseline generation is failing is b/c `shutil.copytree` runs `shutil.copy2`, which also attempts to run `os.chmod` on the files. However, ONLY the owner of the file can run chmod on a file. To prevent issues if user A generates baselines and user B tries to update them, the best solution is to remove any file in the baselinedir first (which we can, since the folder has group w permissions), and then run the copy commands. The newly generated files will belong to whomever runs test-all-eamxx, so shutil will be able to invoke os.chmod on them.~

Upon talking with @jgfouca, we came up with a more drastic clean up, removing one of the hackiest part of test-all (the handling of baseline files), handing the copy to the baseline dir directly in CMakeLists files.