### PR TITLE
Update to c++20 for EAMxx and Homme

### DIFF
--- a/cime_config/machines/cmake_macros/aurora_oneapi-ifxgpu.cmake
+++ b/cime_config/machines/cmake_macros/aurora_oneapi-ifxgpu.cmake
@@ -4,7 +4,7 @@ if (compile_threaded)
   string(APPEND CMAKE_EXE_LINKER_FLAGS " -fiopenmp -fopenmp-targets=spir64")
 endif()
 
-string(APPEND KOKKOS_OPTIONS " -DCMAKE_CXX_STANDARD=17 -DKokkos_ENABLE_SERIAL=On -DKokkos_ARCH_INTEL_PVC=On -DKokkos_ENABLE_SYCL=On -DKokkos_ENABLE_EXPLICIT_INSTANTIATION=Off -DCMAKE_POSITION_INDEPENDENT_CODE=ON")
+string(APPEND KOKKOS_OPTIONS " -DKokkos_ENABLE_SERIAL=On -DKokkos_ARCH_INTEL_PVC=On -DKokkos_ENABLE_SYCL=On -DKokkos_ENABLE_EXPLICIT_INSTANTIATION=Off -DCMAKE_POSITION_INDEPENDENT_CODE=ON")
 string(APPEND SYCL_FLAGS " -fsycl -fsycl-targets=spir64_gen -mlong-double-64 ")
 string(APPEND OMEGA_SYCL_EXE_LINKER_FLAGS " -Xsycl-target-backend \"-device pvc\" ")
 

--- a/cime_config/machines/cmake_macros/frontier_craycray-mphipcc.cmake
+++ b/cime_config/machines/cmake_macros/frontier_craycray-mphipcc.cmake
@@ -17,8 +17,6 @@ if (compile_threaded)
   string(APPEND CMAKE_EXE_LINKER_FLAGS " -fopenmp")
 endif()
 
-string(APPEND CMAKE_CXX_FLAGS " -std=c++17")
-
 string(APPEND CMAKE_Fortran_FLAGS " -hipa0 -hzero -f free")
 string(APPEND CMAKE_EXE_LINKER_FLAGS " -L$ENV{CRAY_MPICH_ROOTDIR}/gtl/lib -lmpi_gtl_hsa")
 string(APPEND CMAKE_EXE_LINKER_FLAGS " -L$ENV{ROCM_PATH}/lib -lamdhip64")

--- a/cime_config/machines/cmake_macros/frontier_craycray.cmake
+++ b/cime_config/machines/cmake_macros/frontier_craycray.cmake
@@ -17,8 +17,6 @@ if (compile_threaded)
   string(APPEND CMAKE_EXE_LINKER_FLAGS " -fopenmp")
 endif()
 
-string(APPEND CMAKE_CXX_FLAGS " -std=c++17")
-
 string(APPEND CMAKE_Fortran_FLAGS " -hipa0 -hzero -f free")
 
 # Crusher: this resolves a crash in mct in docn init

--- a/components/eamxx/CMakeLists.txt
+++ b/components/eamxx/CMakeLists.txt
@@ -51,11 +51,6 @@ if (SCREAM_CIME_BUILD)
     ${CMAKE_CURRENT_SOURCE_DIR}/cmake/cime)
 endif ()
 
-if (NOT CMAKE_CXX_STANDARD)
-  # Default to C++17 in EAMxx
-  set(CMAKE_CXX_STANDARD 17)
-endif()
-
 if (NOT SCREAM_CIME_BUILD)
   project(SCREAM CXX C Fortran)
 

--- a/components/eamxx/src/share/physics/tests/CMakeLists.txt
+++ b/components/eamxx/src/share/physics/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ endif()
 
 CreateUnitTest(physics_saturation_run_and_cmp
   SOURCES physics_saturation_run_and_cmp.cpp
+  EXCLUDE_MAIN_CPP
   LIBS eamxx_physics_share
   EXE_ARGS "${SCREAM_BASELINE_FILE_ARG}"
   THREADS ${SCREAM_BASELINE_TEST_THREADS}

--- a/components/homme/cmake/machineFiles/aurora-aot.cmake
+++ b/components/homme/cmake/machineFiles/aurora-aot.cmake
@@ -37,21 +37,19 @@ SET(Kokkos_ENABLE_SYCL ON CACHE BOOL "")
 SET(Kokkos_ENABLE_DEBUG OFF CACHE BOOL "")
 SET(Kokkos_ENABLE_DEBUG_BOUNDS_CHECK OFF CACHE BOOL "")
 
-SET(CMAKE_CXX_STANDARD 17)
-
 SET(CMAKE_C_COMPILER "mpicc" CACHE STRING "")
 SET(CMAKE_Fortran_COMPILER "mpifort" CACHE STRING "")
 SET(CMAKE_CXX_COMPILER "mpicxx" CACHE STRING "")
 
 #AOT flags
-#SET(SYCL_COMPILE_FLAGS "-std=c++17 -fsycl -fsycl-device-code-split=per_kernel -fno-sycl-id-queries-fit-in-int -fsycl-unnamed-lambda -Xclang -fsycl-allow-virtual-functions")
-SET(SYCL_COMPILE_FLAGS "-std=c++17 -fsycl -fsycl-device-code-split=per_kernel -fno-sycl-id-queries-fit-in-int -fsycl-unnamed-lambda")
+#SET(SYCL_COMPILE_FLAGS "-fsycl -fsycl-device-code-split=per_kernel -fno-sycl-id-queries-fit-in-int -fsycl-unnamed-lambda -Xclang -fsycl-allow-virtual-functions")
+SET(SYCL_COMPILE_FLAGS "-fsycl -fsycl-device-code-split=per_kernel -fno-sycl-id-queries-fit-in-int -fsycl-unnamed-lambda")
 SET(SYCL_LINK_FLAGS "-Wl,--no-relax -flink-huge-device-code -fsycl-max-parallel-link-jobs=32 -fsycl -fsycl-device-code-split=per_kernel -fsycl-targets=intel_gpu_pvc")
 
 SET(ADD_Fortran_FLAGS "-fc=ifx -fpscomp logicals -O3 -DNDEBUG -DCPRINTEL -g" CACHE STRING "")
 SET(ADD_C_FLAGS "-O3 -DNDEBUG " CACHE STRING "")
 
-SET(ADD_CXX_FLAGS "-std=c++17 -fp-model=precise -O3 -DNDEBUG ${SYCL_COMPILE_FLAGS}" CACHE STRING "")
+SET(ADD_CXX_FLAGS "-fp-model=precise -O3 -DNDEBUG ${SYCL_COMPILE_FLAGS}" CACHE STRING "")
 SET(ADD_LINKER_FLAGS "-O3 -DNDEBUG ${SYCL_LINK_FLAGS} -fortlib" CACHE STRING "")
 
 set (ENABLE_OPENMP OFF CACHE BOOL "")

--- a/components/homme/cmake/machineFiles/aurora-jit.cmake
+++ b/components/homme/cmake/machineFiles/aurora-jit.cmake
@@ -27,20 +27,18 @@ SET(USE_TRILINOS OFF CACHE BOOL "")
 
 SET(HOMME_ENABLE_COMPOSE FALSE CACHE BOOL "")
 
-SET(CMAKE_CXX_STANDARD 17)
-
 SET(CMAKE_C_COMPILER "mpicc" CACHE STRING "")
 SET(CMAKE_Fortran_COMPILER "mpifort" CACHE STRING "")
 SET(CMAKE_CXX_COMPILER "mpicxx" CACHE STRING "")
 
 #AOT flags
-SET(SYCL_COMPILE_FLAGS "-std=c++17 -fsycl -fsycl-device-code-split=per_kernel -fno-sycl-id-queries-fit-in-int -fsycl-unnamed-lambda")
+SET(SYCL_COMPILE_FLAGS "-fsycl -fsycl-device-code-split=per_kernel -fno-sycl-id-queries-fit-in-int -fsycl-unnamed-lambda")
 SET(SYCL_LINK_FLAGS "-fsycl-max-parallel-link-jobs=32 -fsycl")
 
 SET(ADD_Fortran_FLAGS "-fc=ifx -fpscomp logicals -O3 -DNDEBUG -DCPRINTEL -g" CACHE STRING "")
 SET(ADD_C_FLAGS "-O3 -DNDEBUG " CACHE STRING "")
 
-SET(ADD_CXX_FLAGS "-std=c++17 -fp-model=precise -O3 -DNDEBUG ${SYCL_COMPILE_FLAGS}" CACHE STRING "")
+SET(ADD_CXX_FLAGS "-fp-model=precise -O3 -DNDEBUG ${SYCL_COMPILE_FLAGS}" CACHE STRING "")
 SET(ADD_LINKER_FLAGS "-O3 -DNDEBUG ${SYCL_LINK_FLAGS} -fortlib" CACHE STRING "")
 
 set (ENABLE_OPENMP OFF CACHE BOOL "")

--- a/components/homme/cmake/machineFiles/chrysalis-bfb.cmake
+++ b/components/homme/cmake/machineFiles/chrysalis-bfb.cmake
@@ -76,3 +76,6 @@ ELSE()
   SET (HOMME_FIND_BLASLAPACK TRUE CACHE BOOL "")
 ENDIF()
 
+#FIXME: Remove when updating to Kokkos 5, then
+#       homme will inherit c++20 from Kokkos.
+set(CMAKE_CXX_STANDARD 20)

--- a/components/homme/cmake/machineFiles/chrysalis.cmake
+++ b/components/homme/cmake/machineFiles/chrysalis.cmake
@@ -75,3 +75,6 @@ ELSE()
   SET (HOMME_FIND_BLASLAPACK TRUE CACHE BOOL "")
 ENDIF()
 
+#FIXME: Remove when updating to Kokkos 5, then
+#       homme will inherit c++20 from Kokkos.
+set(CMAKE_CXX_STANDARD 20)

--- a/components/homme/cmake/machineFiles/pm-cpu-bfb.cmake
+++ b/components/homme/cmake/machineFiles/pm-cpu-bfb.cmake
@@ -139,3 +139,7 @@ SET(USE_NUM_PROCS 24 CACHE STRING "") # only default
 SET(USE_MPIEXEC "srun" CACHE STRING "")
 SET(USE_MPI_OPTIONS "-K --cpu-bind=cores" CACHE STRING "")
 SET(HOMME_TESTING_TIMELIMIT 1800 CACHE STRING "")
+
+#FIXME: Remove when updating to Kokkos 5, then
+#       homme will inherit c++20 from Kokkos.
+set(CMAKE_CXX_STANDARD 20)

--- a/components/homme/cmake/machineFiles/pm-cpu.cmake
+++ b/components/homme/cmake/machineFiles/pm-cpu.cmake
@@ -85,3 +85,7 @@ SET(USE_NUM_PROCS 24 CACHE STRING "") # only default
 SET(USE_MPIEXEC "srun" CACHE STRING "")
 SET(USE_MPI_OPTIONS "-K --cpu-bind=cores" CACHE STRING "")
 SET(HOMME_TESTING_TIMELIMIT 1800 CACHE STRING "")
+
+#FIXME: Remove when updating to Kokkos 5, then
+#       homme will inherit c++20 from Kokkos.
+set(CMAKE_CXX_STANDARD 20)

--- a/components/homme/cmake/machineFiles/spot-aot-AB2.cmake
+++ b/components/homme/cmake/machineFiles/spot-aot-AB2.cmake
@@ -32,21 +32,18 @@ SET(USE_TRILINOS OFF CACHE BOOL "")
 
 SET(HOMME_ENABLE_COMPOSE FALSE CACHE BOOL "")
 
-#SET(CMAKE_CXX_STANDARD 17)
-SET(CMAKE_CXX_STANDARD 17 CACHE STRING "CXX Standard")
-
 SET(CMAKE_C_COMPILER "mpicc" CACHE STRING "")
 SET(CMAKE_Fortran_COMPILER "mpifort" CACHE STRING "")
 SET(CMAKE_CXX_COMPILER "mpicxx" CACHE STRING "")
 
-SET(SYCL_COMPILE_FLAGS "-std=c++17 -fsycl -fsycl-device-code-split=per_kernel -fno-sycl-id-queries-fit-in-int -fsycl-unnamed-lambda")
+SET(SYCL_COMPILE_FLAGS "-fsycl -fsycl-device-code-split=per_kernel -fno-sycl-id-queries-fit-in-int -fsycl-unnamed-lambda")
 SET(SYCL_LINK_FLAGS "-fsycl-max-parallel-link-jobs=32 -fsycl-link-huge-device-code -fsycl -fsycl-device-code-split=per_kernel -fsycl-targets=spir64_gen -Xsycl-target-backend \"-device 12.60.7\"")
 
 #-fpscomp does not actually solve the issue with bools in here,another suggestion was -fp-model=precise, not working either
 SET(ADD_Fortran_FLAGS " -fc=ifx -fpscomp logicals -O3 -DNDEBUG -DCPRINTEL -g" CACHE STRING "")
 SET(ADD_C_FLAGS "-O3 -DNDEBUG " CACHE STRING "") 
 
-SET(ADD_CXX_FLAGS " -std=c++17 -O3 -DNDEBUG ${SYCL_COMPILE_FLAGS}" CACHE STRING "")
+SET(ADD_CXX_FLAGS " -O3 -DNDEBUG ${SYCL_COMPILE_FLAGS}" CACHE STRING "")
 SET(ADD_LINKER_FLAGS "-O3 -DNDEBUG ${SYCL_LINK_FLAGS} -fortlib" CACHE STRING "")
 
 set (ENABLE_OPENMP OFF CACHE BOOL "")

--- a/share/build/buildlib.ekat
+++ b/share/build/buildlib.ekat
@@ -135,7 +135,7 @@ def buildlib(bldroot, installpath, case):
         if case.get_value("EXTRA_DEBUG"):
             ekat_cmake_options += " -DKokkos_ENABLE_DEBUG_BOUNDS_CHECK=On"
 
-    gen_makefile_cmd = f"cmake {kokkos_options} {cc} {cxx} -DCMAKE_CXX_STANDARD=17 {ekat_cmake_options} -DCMAKE_INSTALL_PREFIX={installpath} {ekat_dir}"
+    gen_makefile_cmd = f"cmake {kokkos_options} {cc} {cxx} {ekat_cmake_options} -DCMAKE_INSTALL_PREFIX={installpath} {ekat_dir}"
 
     # When later we use find_package to get kokkos in CMake, the folder
     # install_sharedpath/kokkos (which is bldroot here) gets picked over


### PR DESCRIPTION
Update EAMxx and Homme to C++20. Changes:
- ~Update EKAT (now requires C++20)~ (Updated as a part of https://github.com/E3SM-Project/E3SM/pull/8604)
- Remove setting CXX_STANDARD in EAMxx
- Remove setting CXX_STANDARD in machine/cime build files
- Update homme standalone testing to use C++20

[non-BFB] Potentially for EAMxx/homme standalone cases