### PR TITLE
EAMxx: add scale factors for dust and seasalt emission in MAMxx

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -459,6 +459,9 @@ be lost if SCREAM_HACK_XML is not enabled.
       <!-- scale factors (applied to data read from file) -->
       <srf_emis_scale_factor_for_dms type="real" doc="Surface emissions scale factor for DMS">1.0</srf_emis_scale_factor_for_dms>
 
+      <srf_emis_scale_factor_for_seasalt type="real" doc="Surface emissions scale factor for seasalt">0.6</srf_emis_scale_factor_for_seasalt>
+
+      <srf_emis_scale_factor_for_dust type="real" doc="Surface emissions scale factor for dust">1.5</srf_emis_scale_factor_for_dust>
       <dust_emis_scheme type="integer" doc="Dust emission scheme, 1: Zender et al. (2003), 2: Kok et al. (2014)">1</dust_emis_scheme>
       <soil_erodibility_file type="file" doc="File containing soil erodibility">${DIN_LOC_ROOT}/atm/scream/mam4xx/emissions/ne30pg2/dst_ne30pg2_c20241028.nc</soil_erodibility_file>
       <soil_erodibility_file hgrid="ne4np4.pg2" type="file" doc="File containing soil erodibility">${DIN_LOC_ROOT}/atm/scream/mam4xx/emissions/ne4pg2/dst_ne4pg2_c20241028.nc</soil_erodibility_file>

--- a/components/eamxx/src/physics/mam/eamxx_mam_srf_and_online_emissions_functions.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_srf_and_online_emissions_functions.hpp
@@ -44,6 +44,8 @@ void compute_online_dust_nacl_emiss(
     const const_view_1d &mpoly, const const_view_1d &mprot,
     const const_view_1d &mlip, const const_view_1d &soil_erodibility,
     const const_view_2d &z_mid,
+    const Real &dust_emis_scale_factor,
+    const Real &seasalt_emis_scale_factor,
     // output
     view_2d &constituent_fluxes) {
   const int surf_lev = nlev - 1;  // surface level
@@ -63,6 +65,7 @@ void compute_online_dust_nacl_emiss(
             sst(icol), ocnfrac(icol), u_wind(icol, surf_lev),
             v_wind(icol, surf_lev), z_mid(icol, surf_lev), dstflx_icol,
             soil_erodibility(icol), mpoly(icol), mprot(icol), mlip(icol),
+            dust_emis_scale_factor, seasalt_emis_scale_factor,
             // out
             fluxes_col);
       });

--- a/components/eamxx/src/physics/mam/eamxx_mam_srf_and_online_emissions_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_srf_and_online_emissions_process_interface.cpp
@@ -20,7 +20,12 @@ using soilErodibilityFunc =
 MAMSrfOnlineEmiss::MAMSrfOnlineEmiss(const ekat::Comm &comm,
                                      const ekat::ParameterList &params)
     : MAMGenericInterface(comm, params) {
-  // FIXME: Do we want to read dust emiss factor from the namelist??
+
+  dust_emis_scale_factor =
+      m_params.get<Real>("srf_emis_scale_factor_for_dust", 1.0);
+  seasalt_emis_scale_factor =
+      m_params.get<Real>("srf_emis_scale_factor_for_seasalt", 1.0);
+
   /* Anything that can be initialized without grid information can be
    * initialized here. Like universal constants.
    */
@@ -439,6 +444,8 @@ void MAMSrfOnlineEmiss::run_impl(const double dt) {
   compute_online_dust_nacl_emiss(ncol_, nlev_, ocnfrac, sst, u_wind, v_wind,
                                  dstflx, mpoly, mprot, mlip, soil_erodibility,
                                  z_mid,
+                                 dust_emis_scale_factor,
+                                 seasalt_emis_scale_factor,
                                  // output
                                  constituent_fluxes);
   Kokkos::fence();

--- a/components/eamxx/src/physics/mam/eamxx_mam_srf_and_online_emissions_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_srf_and_online_emissions_process_interface.cpp
@@ -21,10 +21,12 @@ MAMSrfOnlineEmiss::MAMSrfOnlineEmiss(const ekat::Comm &comm,
                                      const ekat::ParameterList &params)
     : MAMGenericInterface(comm, params) {
 
-  dust_emis_scale_factor =
-      m_params.get<Real>("srf_emis_scale_factor_for_dust", 1.0);
-  seasalt_emis_scale_factor =
-      m_params.get<Real>("srf_emis_scale_factor_for_seasalt", 1.0);
+  // FIXME: temporary solution to fix the sp test fails for the PR
+  double dbl_dust_emis_scale_factor = m_params.get<double>("srf_emis_scale_factor_for_dust", 1.0);
+  dust_emis_scale_factor = static_cast<Real>(dbl_dust_emis_scale_factor);
+
+  double dbl_seasalt_emis_scale_factor = m_params.get<double>("srf_emis_scale_factor_for_seasalt", 1.0);
+  seasalt_emis_scale_factor = static_cast<Real>(dbl_seasalt_emis_scale_factor);
 
   /* Anything that can be initialized without grid information can be
    * initialized here. Like universal constants.

--- a/components/eamxx/src/physics/mam/eamxx_mam_srf_and_online_emissions_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_srf_and_online_emissions_process_interface.hpp
@@ -44,6 +44,10 @@ class MAMSrfOnlineEmiss final : public MAMGenericInterface {
   // Constituent fluxes of species in [kg/m2/s]
   view_2d constituent_fluxes_;
 
+  // Runtime scale factors for online emissions from namelist.
+  Real dust_emis_scale_factor;
+  Real seasalt_emis_scale_factor;
+
   // Work array to store fluxes after unit conversions to kg/m2/s
   view_1d fluxes_in_mks_units_;
 

--- a/components/eamxx/tests/multi-process/physics_only/mam/mam4_srf_online_emiss_mam4_constituent_fluxes/input.yaml
+++ b/components/eamxx/tests/multi-process/physics_only/mam/mam4_srf_online_emiss_mam4_constituent_fluxes/input.yaml
@@ -24,7 +24,10 @@ eamxx:
     srf_emis_specifier_for_so4_a1: ${SCREAM_DATA_DIR}/mam4xx/emissions/ne2np4/surface/cmip6_mam4_so4_a1_surf_ne2np4_2010_clim_c20240726.nc
     srf_emis_specifier_for_so4_a2: ${SCREAM_DATA_DIR}/mam4xx/emissions/ne2np4/surface/cmip6_mam4_so4_a2_surf_ne2np4_2010_clim_c20240726.nc
 
+    srf_emis_scale_factor_for_dust: 1.5
     soil_erodibility_file: ${SCREAM_DATA_DIR}/mam4xx/emissions/ne2np4/dst_ne2np4_c20241028.nc
+
+    srf_emis_scale_factor_for_seasalt: 0.6
     marine_organics_file: ${SCREAM_DATA_DIR}/mam4xx/emissions/ne2np4/monthly_macromolecules_0.1deg_bilinear_year01_merge_ne2np4_c20241030.nc
 grids_manager:
   type: mesh_free

--- a/components/eamxx/tests/single-process/mam/emissions/input.yaml
+++ b/components/eamxx/tests/single-process/mam/emissions/input.yaml
@@ -24,7 +24,10 @@ eamxx:
     srf_emis_specifier_for_so4_a1: ${SCREAM_DATA_DIR}/mam4xx/emissions/ne2np4/surface/cmip6_mam4_so4_a1_surf_ne2np4_2010_clim_c20240726.nc
     srf_emis_specifier_for_so4_a2: ${SCREAM_DATA_DIR}/mam4xx/emissions/ne2np4/surface/cmip6_mam4_so4_a2_surf_ne2np4_2010_clim_c20240726.nc
 
+    srf_emis_scale_factor_for_dust: 1.5
     soil_erodibility_file: ${SCREAM_DATA_DIR}/mam4xx/emissions/ne2np4/dst_ne2np4_c20241028.nc
+
+    srf_emis_scale_factor_for_seasalt: 0.6
     marine_organics_file: ${SCREAM_DATA_DIR}/mam4xx/emissions/ne2np4/monthly_macromolecules_0.1deg_bilinear_year01_merge_ne2np4_c20241030.nc
 grids_manager:
   type: mesh_free


### PR DESCRIPTION
Current MAMxx uses hard-wired emission factors. This PR adds two scale factors

srf_emis_scale_factor_for_seasalt (default value is 0.6)
srf_emis_scale_factor_for_dust (default value is 1.5)

as namelist variables for dust and seasalt emission in MAMxx.

[BFB]