### PR TITLE
EAMxx: make DataInterpolation file-readability checks collective across MPI ranks

### DIFF
--- a/components/eamxx/src/share/algorithm/eamxx_data_interpolation.cpp
+++ b/components/eamxx/src/share/algorithm/eamxx_data_interpolation.cpp
@@ -324,6 +324,30 @@ setup_periodic_time_database (const strvec_t& input_files,
 }
 
 void DataInterpolation::
+check_files_readable (const strvec_t& input_files) const
+{
+  // Check readability of each file collectively across m_comm. We MUST NOT
+  // let a single rank throw here while other ranks proceed to the
+  // *collective* scorpio::register_file/PIOc_openfile call below: if a
+  // transient filesystem hiccup makes std::ifstream::good() spuriously fail
+  // on just one rank, that rank would throw/abort while its peers are stuck
+  // waiting in the collective open, hanging until wallclock instead of
+  // failing cleanly. So we all_reduce the readability flag first, and either
+  // all ranks throw the same error, or none do.
+  for (const auto& fname : input_files) {
+    int readable = 1;
+    {
+      std::ifstream file(fname);
+      readable = file.good() ? 1 : 0;
+    }
+    m_comm.all_reduce(&readable,1,MPI_MIN);
+    EKAT_REQUIRE_MSG (readable==1,
+        "[DataInterpolation] Error! One of the input files is not readable on at least one rank.\n"
+        " - file: " + fname + "\n");
+  }
+}
+
+void DataInterpolation::
 setup_static_database (const strvec_t& input_files, int time_index)
 {
   EKAT_REQUIRE_MSG (not m_input_db_created,
@@ -331,16 +355,7 @@ setup_static_database (const strvec_t& input_files, int time_index)
   EKAT_REQUIRE_MSG (not input_files.empty(),
       "[DataInterpolation] Error! Input files list is empty.\n");
 
-  auto file_readable = [] (const std::string& fileName) {
-    std::ifstream file(fileName);
-    return file.good();
-  };
-
-  for (const auto& fname : input_files) {
-    EKAT_REQUIRE_MSG (file_readable(fname),
-        "[DataInterpolation] Error! One of the input files is not readable.\n"
-        " - file: " + fname + "\n");
-  }
+  check_files_readable(input_files);
 
   // Populate m_time_database.files so that get_input_files_dimlen works
   m_time_database.files = input_files;
@@ -370,20 +385,15 @@ build_time_database_slices (const strvec_t& input_files,
       "[DataInterpolation] Error! The input files list contains duplicates.\n"
       " - input_files:\n     " + ekat::join(input_files,"\n     ") + "\n");
 
-  // We perform a bunch of checks on the input files
-  auto file_readable = [] (const std::string& fileName) {
-    std::ifstream file(fileName);
-    return file.good(); // Check if the file can be opened
-  };
+  // We perform a bunch of checks on the input files (collectively, so that a
+  // spurious per-rank filesystem hiccup can't cause one rank to throw while
+  // its peers proceed into the collective scorpio::register_file call below)
+  check_files_readable(input_files);
 
   // Read what time stamps we have in each file
   auto ts2str = [](const util::TimeStamp& t) { return t.to_string(); };
   std::vector<std::pair<std::string,std::vector<util::TimeStamp>>> file_times;
   for (const auto& fname : input_files) {
-    EKAT_REQUIRE_MSG (file_readable(fname),
-        "Error! One of the input files is not readable.\n"
-        " - file   : " + fname + "\n");
-
     scorpio::register_file(fname,scorpio::Read);
 
     if (not scorpio::has_time_dim(fname)) {

--- a/components/eamxx/src/share/algorithm/eamxx_data_interpolation.hpp
+++ b/components/eamxx/src/share/algorithm/eamxx_data_interpolation.hpp
@@ -116,6 +116,16 @@ protected:
 
   int get_input_files_dimlen (const std::string& dimname) const;
 
+  // Verify (collectively, across m_comm) that all input files can be opened
+  // for reading. Throws the same error on ALL ranks if any rank cannot open
+  // a file, rather than letting a single rank throw while other ranks are
+  // still headed into the collective scorpio::register_file/PIOc_openfile
+  // call below. A per-rank-only check (e.g. a lone rank hitting a transient
+  // filesystem hiccup) can otherwise cause that lone rank to abort while its
+  // peers hang forever inside the collective open, since MPI_Abort on a
+  // sub-communicator is not guaranteed to tear down the other ranks.
+  void check_files_readable (const strvec_t& input_files) const;
+
   // ----------- Internal data types ---------- //
 
   struct DataSlice {


### PR DESCRIPTION
Fix a potential hang in DataInterpolation. The input file readability check
was done independently on each rank with no synchronization. If a transient
filesystem hiccup caused std::ifstream::good() to spuriously fail on just one
rank, that rank would throw/abort while its peer ranks proceeded into the
collective scorpio::register_file/PIOc_openfile call, causing those peers to
hang until wallclock instead of failing cleanly. This change adds a new
check_files_readable helper that MPI_MIN all_reduces the readability flag
across the communicator before deciding whether to throw, so either all
ranks throw the same error or none do. Both setup_static_database and
build_time_database_slices now use this shared helper instead of duplicated
per-rank-only lambdas.

Note https://github.com/E3SM-Project/E3SM/issues/8563

[bfb]