### PR TITLE
Jgfouca/cleanup tests baselines

### DIFF
--- a/components/eamxx/src/physics/p3/tests/p3_autoconversion_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_autoconversion_unit_tests.cpp
@@ -123,7 +123,7 @@ void cloud_water_autoconversion_unit_bfb_tests() {
 
   void validate_autoconversion_parameters() {
     auto runtime = p3::Functions<Real,DefaultDevice>::P3Runtime();
-    
+
     // Sanity bounds: Ensure parameters are physically reasonable
     // These catch catastrophic configuration errors (typos, unit mistakes, etc.)
     REQUIRE(runtime.autoconversion_radius > 1e-6);      // > 1 μm (activated droplet)
@@ -131,7 +131,7 @@ void cloud_water_autoconversion_unit_bfb_tests() {
     REQUIRE(runtime.autoconversion_prefactor > 0);
     REQUIRE(runtime.autoconversion_qc_exponent > 0);
     REQUIRE(runtime.autoconversion_nc_exponent > 0);
-    
+
     // Informational output: Display current parameter values
     // Note: These are tunable parameters that may differ from KK2000 reference values
     std::cout << "\n=== Autoconversion Parameters ===\n";
@@ -150,19 +150,19 @@ void cloud_water_autoconversion_unit_bfb_tests() {
     int n_qc;
     int n_nc;
     int num_cases;
-    
+
     // Input host views
     typename view_1d<Real>::host_mirror_type qc_host;
     typename view_1d<Real>::host_mirror_type nc_host;
-    
+
     // Output host views
     typename view_1d<Real>::host_mirror_type qc2qr_host;
     typename view_1d<Real>::host_mirror_type nc2nr_host;
     typename view_1d<Real>::host_mirror_type ncautr_host;
-    
+
     // Runtime parameters
     Real autoconversion_radius;
-    
+
     // Tolerance definitions
     Real identity_tol;
     Real physics_tol;
@@ -177,7 +177,7 @@ void cloud_water_autoconversion_unit_bfb_tests() {
   AutoconversionTestData setup_parameter_sweep() {
     // Get runtime parameters for use in property checks
     auto runtime = p3::Functions<Real,DefaultDevice>::P3Runtime();
-    
+
     validate_autoconversion_parameters();
 
     // =========================================================================
@@ -200,13 +200,13 @@ void cloud_water_autoconversion_unit_bfb_tests() {
     // P3 Autoconversion Physics Property Testing Plan
     // =========================================================================
     // This suite validates that the `cloud_water_autoconversion` implementation
-    // adheres to the fundamental physical principles of the Khairoutdinov and 
+    // adheres to the fundamental physical principles of the Khairoutdinov and
     // Kogan (2000) parameterization.
     //
     // Strategy:
-    // Uses a deterministic grid-sampling strategy that sweeps the parameter 
-    // space logarithmically to cover regimes ranging from sub-threshold 
-    // (qc < 1e-8) through incipient cloud to heavy precipitation, and 
+    // Uses a deterministic grid-sampling strategy that sweeps the parameter
+    // space logarithmically to cover regimes ranging from sub-threshold
+    // (qc < 1e-8) through incipient cloud to heavy precipitation, and
     // pristine to polluted conditions.
     // =========================================================================
 
@@ -217,7 +217,7 @@ void cloud_water_autoconversion_unit_bfb_tests() {
     const int n_nc = 40;
     const int num_cases = n_qc * n_nc;
 
-    const Real log_qc_min = std::log10(5.0e-9);   
+    const Real log_qc_min = std::log10(5.0e-9);
     const Real log_qc_max = std::log10(1.0e-2);
     const Real log_nc_min = std::log10(1.0e6);
     const Real log_nc_max = std::log10(1.0e9);
@@ -226,7 +226,7 @@ void cloud_water_autoconversion_unit_bfb_tests() {
     view_1d<Real> nc_dev("nc_dev", num_cases);
     view_1d<Real> rho_dev("rho_dev", num_cases);
     view_1d<Real> inv_qc_relvar_dev("inv_qc_relvar_dev", num_cases);
-    
+
     view_1d<Real> qc2qr_dev("qc2qr_dev", num_cases);
     view_1d<Real> nc2nr_dev("nc2nr_dev", num_cases);
     view_1d<Real> ncautr_dev("ncautr_dev", num_cases);
@@ -247,7 +247,7 @@ void cloud_water_autoconversion_unit_bfb_tests() {
 
         qc_host(idx) = qc;
         nc_host(idx) = nc;
-        rho_host(idx) = 1.0; 
+        rho_host(idx) = 1.0;
         inv_qc_relvar_host(idx) = 1.0;
       }
     }
@@ -262,10 +262,10 @@ void cloud_water_autoconversion_unit_bfb_tests() {
 
     Kokkos::parallel_for("P3_Property_Test_Kernel", num_packs, KOKKOS_LAMBDA(const Int& ip) {
       const int offset = ip * pack_size;
-      
+
       Pack rho, qc, nc, inv_qc_relvar;
       Pack qc2qr, nc2nr, ncautr;
-      
+
       bool any_valid = false;
       for (int s = 0; s < pack_size; ++s) {
         int idx = offset + s;
@@ -285,12 +285,12 @@ void cloud_water_autoconversion_unit_bfb_tests() {
 
       if (any_valid) {
           Functions::cloud_water_autoconversion(
-              rho, qc, nc, inv_qc_relvar, 
+              rho, qc, nc, inv_qc_relvar,
               qc2qr, nc2nr, ncautr,
               p3::Functions<Real,DefaultDevice>::P3Runtime()
           );
       }
-      
+
       for (int s = 0; s < pack_size; ++s) {
         int idx = offset + s;
         if (idx < num_cases) {
@@ -302,7 +302,7 @@ void cloud_water_autoconversion_unit_bfb_tests() {
     });
 
     Kokkos::fence();
-    
+
     auto qc2qr_host = Kokkos::create_mirror_view(qc2qr_dev);
     auto nc2nr_host = Kokkos::create_mirror_view(nc2nr_dev);
     auto ncautr_host = Kokkos::create_mirror_view(ncautr_dev);
@@ -310,13 +310,13 @@ void cloud_water_autoconversion_unit_bfb_tests() {
     Kokkos::deep_copy(qc2qr_host, qc2qr_dev);
     Kokkos::deep_copy(nc2nr_host, nc2nr_dev);
     Kokkos::deep_copy(ncautr_host, ncautr_dev);
-    
+
     return AutoconversionTestData{
       n_qc, n_nc, num_cases,
       qc_host, nc_host,
       qc2qr_host, nc2nr_host, ncautr_host,
       runtime.autoconversion_radius,
-      identity_tol, physics_tol, small_droplet_regime_floor, 
+      identity_tol, physics_tol, small_droplet_regime_floor,
       absolute_floor, detect_threshold
     };
   }
@@ -334,7 +334,7 @@ void cloud_water_autoconversion_unit_bfb_tests() {
         Real qc = data.qc_host(idx);
         Real R = data.qc2qr_host(idx);
         Real N_loss = data.nc2nr_host(idx);
-        Real R_ncautr = data.ncautr_host(idx); 
+        Real R_ncautr = data.ncautr_host(idx);
 
         // Check for non-zero below threshold
         if (qc < 1e-8) {
@@ -348,7 +348,7 @@ void cloud_water_autoconversion_unit_bfb_tests() {
         if (R < 1e-30) R = 0.0;
         if (N_loss < 1e-30) N_loss = 0.0;
         if (R_ncautr < 1e-30) R_ncautr = 0.0;
-        
+
         // =====================================================================
         // Physical Sensitivity Tests (Monotonicity)
         // =====================================================================
@@ -359,21 +359,21 @@ void cloud_water_autoconversion_unit_bfb_tests() {
             int idx_next = (j + 1) * data.n_qc + i;
             Real R_next = data.qc2qr_host(idx_next);
             if (R_next < 1e-30) R_next = 0.0;
-            
+
             // A. Colloidal Stability (Inverse Nc Dependency): dR/dNc < 0
             // R_next (high Nc) must be strictly less than R (low Nc).
             if (R > data.absolute_floor) {
                 // FAIL if R_next is greater than or equal to R.
-                // We do not use the loose 'relative_tolerance' here because the physics 
+                // We do not use the loose 'relative_tolerance' here because the physics
                 // requires strict monotonicity.
                 if (R_next >= R) {
-                     std::cout << "Monotonicity Nc Fail: R increased or stayed same with Nc. qc=" << qc 
+                     std::cout << "Monotonicity Nc Fail: R increased or stayed same with Nc. qc=" << qc
                                << " R=" << R << " R_next=" << R_next << "\n";
                      failures++;
                 }
             }
         }
-        
+
         if (i < data.n_qc - 1) {
             int idx_next = j * data.n_qc + (i + 1);
             Real R_next = data.qc2qr_host(idx_next);
@@ -381,10 +381,10 @@ void cloud_water_autoconversion_unit_bfb_tests() {
             // B. Water Content Sensitivity (Positive qc Dependency): dR/dqc > 0
             // R_next (high qc) should be greater than R (low qc).
             if (R_next > data.absolute_floor) {
-                // If R_next < R, it's a failure. 
+                // If R_next < R, it's a failure.
                 Real min_allowed_R_next = R * (1.0 - relative_tolerance);
                 if (R_next < min_allowed_R_next) {
-                     std::cout << "Monotonicity qc Fail: R decreased with qc. qc=" << qc 
+                     std::cout << "Monotonicity qc Fail: R decreased with qc. qc=" << qc
                                << " R=" << R << " R_next=" << R_next << "\n";
                      failures++;
                 }
@@ -420,7 +420,7 @@ void cloud_water_autoconversion_unit_bfb_tests() {
              // Verifies: nc2nr_autoconv_tend = qc2qr_autoconv_tend * (nc/qc)
              Real expected_N_loss = R * nc / qc;
              Real rel_error = std::abs(N_loss - expected_N_loss) / std::max(data.absolute_floor, expected_N_loss);
-             
+
              if (rel_error > data.identity_tol) {
                  std::cout << "Specific Loss Conservation Fail (should be near machine precision):\n";
                  std::cout << "  Expected: " << expected_N_loss << "\n";
@@ -435,11 +435,11 @@ void cloud_water_autoconversion_unit_bfb_tests() {
              // B. Rain Embryo Size Consistency (Configuration Parameter)
              // Verifies: autoconversion_radius parameter is preserved through calculation
              Real mass_drop = R / R_ncautr;
-             
+
              using C = scream::physics::Constants<Real>;
              const Real r_expected = data.autoconversion_radius;  // Use runtime config
              const Real expected_mass = (4.0/3.0) * C::Pi * 1000.0 * std::pow(r_expected, 3);
-             
+
              if (std::abs(mass_drop - expected_mass) / expected_mass > data.physics_tol) {
                   std::cout << "Embryo Size Fail (configuration mismatch):\n";
                   std::cout << "  Computed mass: " << mass_drop << " kg\n";
@@ -468,15 +468,15 @@ void cloud_water_autoconversion_unit_bfb_tests() {
         Real R = data.qc2qr_host(idx);
 
         if (R < 1e-30) R = 0.0;
-        
+
         Real mean_mass = qc / nc;
         // Correct formula: r = (3*m / (4*pi*rho))^(1/3)
         // rho_w = 1000.
         using C = scream::physics::Constants<Real>;
         Real mean_rad = std::pow((3.0 * mean_mass) / (4.0 * C::Pi * 1000.0), 1.0/3.0);
-        
+
         // A. Small Droplet Regime Limit (Physical Relevance Check)
-        // For very small activated droplets (r < 1 μm), autoconversion rates 
+        // For very small activated droplets (r < 1 μm), autoconversion rates
         // should be physically negligible due to low collision efficiency.
         // This regime represents incipient cloud or sub-threshold conditions.
         // Note: Implementation threshold is qc < 1e-8, not radius-based.
@@ -499,35 +499,35 @@ void cloud_water_autoconversion_unit_bfb_tests() {
   void run_variance_check() {
     const int n_qc = 40;
     view_1d<Real> var_rate_1("rate_1", n_qc);
-    view_1d<Real> var_rate_2("rate_2", n_qc); 
-    
-    Real fixed_nc = 100.0e6; 
+    view_1d<Real> var_rate_2("rate_2", n_qc);
+
+    Real fixed_nc = 100.0e6;
 
     Kokkos::parallel_for("Variance_Check", n_qc, KOKKOS_LAMBDA(const int& i) {
         Real alpha = (Real)i / (Real)(n_qc - 1);
         Real qc = std::pow(10.0, -6.0 + alpha * 4.0);
-        
+
         Pack s_rho(1.0), s_qc(qc), s_nc(fixed_nc);
         Pack s_rate_1, s_rate_2, dummy;
-        
+
         // Run 1: Homogeneous
         Functions::cloud_water_autoconversion(
-            s_rho, s_qc, s_nc, Pack(1.0), 
-            s_rate_1, dummy, dummy, 
+            s_rho, s_qc, s_nc, Pack(1.0),
+            s_rate_1, dummy, dummy,
             p3::Functions<Real,DefaultDevice>::P3Runtime()
         );
-        
+
         // Run 2: High Variance
         Functions::cloud_water_autoconversion(
-            s_rho, s_qc, s_nc, Pack(0.1), 
-            s_rate_2, dummy, dummy, 
+            s_rho, s_qc, s_nc, Pack(0.1),
+            s_rate_2, dummy, dummy,
             p3::Functions<Real,DefaultDevice>::P3Runtime()
         );
-        
+
         var_rate_1(i) = s_rate_1[0];
         var_rate_2(i) = s_rate_2[0];
     });
-    
+
     Kokkos::fence();
     auto h_rate_1 = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), var_rate_1);
     auto h_rate_2 = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), var_rate_2);
@@ -544,7 +544,7 @@ void cloud_water_autoconversion_unit_bfb_tests() {
             // Detection: Do standard and variance rates differ?
             if (std::abs(ratio - 1.0) > variance_detect_eps) {
                 is_variance_scaling_active = true;
-                
+
                 // Validation: If active, is the rate suppressed? (Physical violation)
                 // Jensen's inequality for convex functions implies enhancement (ratio > 1).
                 // We fail if ratio < 1.0 (minus tolerance).
@@ -590,30 +590,29 @@ TEST_CASE("p3_cloud_water_autoconversion_test", "[p3_cloud_water_autoconversion_
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestP3CloudWaterAutoconversion;
 
   T t;
-  
+
   SECTION("monotonicity") {
     auto data = t.setup_parameter_sweep();
     t.run_monotonicity_checks(data);
   }
-  
+
   SECTION("consistency") {
     auto data = t.setup_parameter_sweep();
     t.run_consistency_checks(data);
   }
-  
+
   SECTION("limits") {
     auto data = t.setup_parameter_sweep();
     t.run_limit_checks(data);
   }
-  
+
   SECTION("variance") {
     t.run_variance_check();
   }
-  
+
   SECTION("bfb") {
     t.run_bfb();
   }
 }
 
 } // namespace
-

--- a/components/eamxx/src/physics/p3/tests/p3_autoconversion_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_autoconversion_unit_tests.cpp
@@ -586,7 +586,7 @@ void cloud_water_autoconversion_unit_bfb_tests() {
 
 namespace {
 
-TEST_CASE("p3_cloud_water_autoconversion_test", "[p3_cloud_water_autoconversion_test]"){
+TEST_CASE("p3_cloud_water_autoconversion_bfb", "[p3_cloud_water_autoconversion_test]"){
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestP3CloudWaterAutoconversion;
 
   T t;

--- a/components/eamxx/src/physics/p3/tests/p3_autoconversion_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_autoconversion_unit_tests.cpp
@@ -586,7 +586,7 @@ void cloud_water_autoconversion_unit_bfb_tests() {
 
 namespace {
 
-TEST_CASE("p3_cloud_water_autoconversion_bfb", "[p3_cloud_water_autoconversion_test]"){
+TEST_CASE("p3_cloud_water_autoconversion_prop", "[p3_cloud_water_autoconversion_test]"){
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestP3CloudWaterAutoconversion;
 
   T t;
@@ -609,10 +609,13 @@ TEST_CASE("p3_cloud_water_autoconversion_bfb", "[p3_cloud_water_autoconversion_t
   SECTION("variance") {
     t.run_variance_check();
   }
+}
 
-  SECTION("bfb") {
-    t.run_bfb();
-  }
+TEST_CASE("p3_cloud_water_autoconversion_bfb", "[p3_cloud_water_autoconversion_test]"){
+  using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestP3CloudWaterAutoconversion;
+
+  T t;
+  t.run_bfb();
 }
 
 } // namespace

--- a/components/eamxx/src/physics/p3/tests/p3_back_to_cell_average_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_back_to_cell_average_unit_tests.cpp
@@ -863,7 +863,7 @@ struct UnitWrap::UnitTest<D>::TestP3BackToCellAverage : public UnitWrap::UnitTes
 
 namespace {
 
-TEST_CASE("p3_back_to_cell_average", "[p3_back_to_cell_average]") {
+TEST_CASE("p3_back_to_cell_average_bfb", "[p3_back_to_cell_average]") {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestP3BackToCellAverage;
 
   T t;

--- a/components/eamxx/src/physics/p3/tests/p3_back_to_cell_average_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_back_to_cell_average_unit_tests.cpp
@@ -863,15 +863,11 @@ struct UnitWrap::UnitTest<D>::TestP3BackToCellAverage : public UnitWrap::UnitTes
 
 namespace {
 
-TEST_CASE("p3_back_to_cell_average_bfb", "[p3_back_to_cell_average]") {
+TEST_CASE("p3_back_to_cell_average_prop", "[p3_back_to_cell_average]") {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestP3BackToCellAverage;
 
   T t;
 
-  // Each section runs independently so failures isolate quickly.
-  // Tautological algebra checks (e.g., generic bounds from multiplying by
-  // factors in [0,1]) are intentionally omitted in favor of mapping-focused
-  // and known-answer coverage.
   SECTION("process_location") {
     const auto data = t.setup_parameter_sweep();
     t.run_process_location_checks(data);
@@ -898,10 +894,13 @@ TEST_CASE("p3_back_to_cell_average_bfb", "[p3_back_to_cell_average]") {
   SECTION("extreme_values") {
     t.run_extreme_value_checks();
   }
+}
 
-  SECTION("bfb") {
-    t.run_bfb();
-  }
+TEST_CASE("p3_back_to_cell_average_bfb", "[p3_back_to_cell_average]") {
+  using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestP3BackToCellAverage;
+
+  T t;
+  t.run_bfb();
 }
 
 } // anonymous namespace

--- a/components/eamxx/src/physics/p3/tests/p3_calc_liq_relaxation_timescale_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_calc_liq_relaxation_timescale_unit_tests.cpp
@@ -695,18 +695,20 @@ struct UnitWrap::UnitTest<D>::TestCalcLiqRelaxationTimescale : public UnitWrap::
 
 namespace {
 
+TEST_CASE("p3_calc_liq_relaxation_timescale_prop", "[p3_functions]")
+{
+  using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestCalcLiqRelaxationTimescale;
+
+  T t;
+  t.run_phys();
+}
+
 TEST_CASE("p3_calc_liq_relaxation_timescale_bfb", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestCalcLiqRelaxationTimescale;
 
   T t;
-  SECTION("properties") {
-    t.run_phys();
-  }
-
-  SECTION("bfb") {
-    t.run_bfb();
-  }
+  t.run_bfb();
 }
 
 }

--- a/components/eamxx/src/physics/p3/tests/p3_calc_liq_relaxation_timescale_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_calc_liq_relaxation_timescale_unit_tests.cpp
@@ -695,7 +695,7 @@ struct UnitWrap::UnitTest<D>::TestCalcLiqRelaxationTimescale : public UnitWrap::
 
 namespace {
 
-TEST_CASE("p3_calc_liq_relaxation_timescale", "[p3_functions]")
+TEST_CASE("p3_calc_liq_relaxation_timescale_bfb", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestCalcLiqRelaxationTimescale;
 

--- a/components/eamxx/src/physics/p3/tests/p3_calc_rime_density_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_calc_rime_density_unit_tests.cpp
@@ -809,7 +809,7 @@ void run_bfb()
 
 namespace {
 
-TEST_CASE("p3_calc_rime_density", "[p3_functions]")
+TEST_CASE("p3_calc_rime_density_bfb", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestCalcRimeDensity;
 

--- a/components/eamxx/src/physics/p3/tests/p3_calc_rime_density_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_calc_rime_density_unit_tests.cpp
@@ -809,18 +809,20 @@ void run_bfb()
 
 namespace {
 
+TEST_CASE("p3_calc_rime_density_prop", "[p3_functions]")
+{
+  using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestCalcRimeDensity;
+
+  T t;
+  t.run_phys();
+}
+
 TEST_CASE("p3_calc_rime_density_bfb", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestCalcRimeDensity;
 
   T t;
-  SECTION("properties") {
-    t.run_phys();
-  }
-
-  SECTION("bfb") {
-    t.run_bfb();
-  }
+  t.run_bfb();
 }
 
 } // namespace

--- a/components/eamxx/src/physics/p3/tests/p3_cldliq_imm_freezing_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_cldliq_imm_freezing_unit_tests.cpp
@@ -670,18 +670,20 @@ void run_bfb()
 
 namespace {
 
+TEST_CASE("p3_cldliq_immersion_freezing_prop", "[p3_functions]")
+{
+  using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestCldliqImmersionFreezing;
+
+  T t;
+  t.run_phys();
+}
+
 TEST_CASE("p3_cldliq_immersion_freezing_bfb", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestCldliqImmersionFreezing;
 
   T t;
-  SECTION("properties") {
-    t.run_phys();
-  }
-
-  SECTION("bfb") {
-    t.run_bfb();
-  }
+  t.run_bfb();
 }
 
 } // namespace

--- a/components/eamxx/src/physics/p3/tests/p3_cldliq_imm_freezing_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_cldliq_imm_freezing_unit_tests.cpp
@@ -670,7 +670,7 @@ void run_bfb()
 
 namespace {
 
-TEST_CASE("p3_cldliq_immersion_freezing", "[p3_functions]")
+TEST_CASE("p3_cldliq_immersion_freezing_bfb", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestCldliqImmersionFreezing;
 

--- a/components/eamxx/src/physics/p3/tests/p3_cloud_rain_acc_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_cloud_rain_acc_unit_tests.cpp
@@ -133,7 +133,7 @@ void run_bfb()
 
 namespace {
 
-TEST_CASE("p3_cloud_rain_accretion", "[p3_functions]")
+TEST_CASE("p3_cloud_rain_accretion_bfb", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestCloudRainAccretion;
 

--- a/components/eamxx/src/physics/p3/tests/p3_cloud_rain_acc_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_cloud_rain_acc_unit_tests.cpp
@@ -133,13 +133,18 @@ void run_bfb()
 
 namespace {
 
+TEST_CASE("p3_cloud_rain_accretion_prop", "[p3_functions]")
+{
+  using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestCloudRainAccretion;
+
+  T t;  t.run_phys();
+}
+
 TEST_CASE("p3_cloud_rain_accretion_bfb", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestCloudRainAccretion;
 
-  T t;
-  t.run_phys();
-  t.run_bfb();
+  T t;  t.run_bfb();
 }
 
 } // namespace

--- a/components/eamxx/src/physics/p3/tests/p3_cloud_sed_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_cloud_sed_unit_tests.cpp
@@ -100,13 +100,18 @@ void run_bfb()
 
 namespace {
 
+TEST_CASE("p3_cloud_sed_prop", "[p3_functions]")
+{
+  using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestCloudSed;
+
+  T t;  t.run_phys();
+}
+
 TEST_CASE("p3_cloud_sed_bfb", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestCloudSed;
 
-  T t;
-  t.run_phys();
-  t.run_bfb();
+  T t;  t.run_bfb();
 }
 
 } // namespace

--- a/components/eamxx/src/physics/p3/tests/p3_cloud_sed_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_cloud_sed_unit_tests.cpp
@@ -100,7 +100,7 @@ void run_bfb()
 
 namespace {
 
-TEST_CASE("p3_cloud_sed", "[p3_functions]")
+TEST_CASE("p3_cloud_sed_bfb", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestCloudSed;
 

--- a/components/eamxx/src/physics/p3/tests/p3_droplet_self_coll_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_droplet_self_coll_unit_tests.cpp
@@ -128,7 +128,7 @@ void run_bfb()
 
 namespace {
 
-TEST_CASE("p3_droplet_self_collection", "[p3_functions]")
+TEST_CASE("p3_droplet_self_collection_bfb", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestDropletSelfCollection;
 

--- a/components/eamxx/src/physics/p3/tests/p3_droplet_self_coll_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_droplet_self_coll_unit_tests.cpp
@@ -128,13 +128,18 @@ void run_bfb()
 
 namespace {
 
+TEST_CASE("p3_droplet_self_collection_prop", "[p3_functions]")
+{
+  using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestDropletSelfCollection;
+
+  T t;  t.run_phys();
+}
+
 TEST_CASE("p3_droplet_self_collection_bfb", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestDropletSelfCollection;
 
-  T t;
-  t.run_phys();
-  t.run_bfb();
+  T t;  t.run_bfb();
 }
 
 } // namespace

--- a/components/eamxx/src/physics/p3/tests/p3_dsd2_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_dsd2_unit_tests.cpp
@@ -214,7 +214,7 @@ struct UnitWrap::UnitTest<D>::TestDsd2 : public UnitWrap::UnitTest<D>::Base {
 
 namespace {
 
-TEST_CASE("p3_cloud_dsd2", "[p3_functions]")
+TEST_CASE("p3_cloud_dsd2_bfb", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestDsd2;
 
@@ -223,7 +223,7 @@ TEST_CASE("p3_cloud_dsd2", "[p3_functions]")
   t.run_cloud_bfb();
 }
 
-TEST_CASE("p3_rain_dsd2", "[p3_functions]")
+TEST_CASE("p3_rain_dsd2_bfb", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestDsd2;
 

--- a/components/eamxx/src/physics/p3/tests/p3_dsd2_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_dsd2_unit_tests.cpp
@@ -214,13 +214,28 @@ struct UnitWrap::UnitTest<D>::TestDsd2 : public UnitWrap::UnitTest<D>::Base {
 
 namespace {
 
-TEST_CASE("p3_cloud_dsd2_bfb", "[p3_functions]")
+TEST_CASE("p3_cloud_dsd2_prop", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestDsd2;
 
   T t;
   t.run_cloud_phys();
+}
+
+TEST_CASE("p3_cloud_dsd2_bfb", "[p3_functions]")
+{
+  using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestDsd2;
+
+  T t;
   t.run_cloud_bfb();
+}
+
+TEST_CASE("p3_rain_dsd2_prop", "[p3_functions]")
+{
+  using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestDsd2;
+
+  T t;
+  t.run_rain_phys();
 }
 
 TEST_CASE("p3_rain_dsd2_bfb", "[p3_functions]")
@@ -228,7 +243,6 @@ TEST_CASE("p3_rain_dsd2_bfb", "[p3_functions]")
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestDsd2;
 
   T t;
-  t.run_rain_phys();
   t.run_rain_bfb();
 }
 

--- a/components/eamxx/src/physics/p3/tests/p3_evaporate_rain_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_evaporate_rain_unit_tests.cpp
@@ -271,7 +271,7 @@ namespace {
     t.run_property();
   }
 
-  TEST_CASE("p3_evaporate_rain_test", "p3_unit_tests")
+  TEST_CASE("p3_evaporate_rain_bfb", "p3_unit_tests")
   {
     using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestEvapSublPrecip;
 

--- a/components/eamxx/src/physics/p3/tests/p3_evaporate_rain_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_evaporate_rain_unit_tests.cpp
@@ -267,7 +267,7 @@ namespace {
   {
     using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestEvapSublPrecip;
 
-    T t(true);
+    T t;
     t.run_property();
   }
 

--- a/components/eamxx/src/physics/p3/tests/p3_evaporate_rain_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_evaporate_rain_unit_tests.cpp
@@ -267,7 +267,7 @@ namespace {
   {
     using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestEvapSublPrecip;
 
-    T t;
+    T t(true);
     t.run_property();
   }
 

--- a/components/eamxx/src/physics/p3/tests/p3_ice_cldliq_wet_growth_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ice_cldliq_wet_growth_unit_tests.cpp
@@ -144,7 +144,7 @@ struct UnitWrap::UnitTest<D>::TestIceCldliqWetGrowth : public UnitWrap::UnitTest
 
 namespace {
 
-TEST_CASE("p3_ice_cldliq_wet_growth", "[p3_functions]")
+TEST_CASE("p3_ice_cldliq_wet_growth_bfb", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestIceCldliqWetGrowth;
 

--- a/components/eamxx/src/physics/p3/tests/p3_ice_cldliq_wet_growth_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ice_cldliq_wet_growth_unit_tests.cpp
@@ -144,13 +144,18 @@ struct UnitWrap::UnitTest<D>::TestIceCldliqWetGrowth : public UnitWrap::UnitTest
 
 namespace {
 
+TEST_CASE("p3_ice_cldliq_wet_growth_prop", "[p3_functions]")
+{
+  using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestIceCldliqWetGrowth;
+
+  T t;  t.run_ice_cldliq_wet_growth_phys();
+}
+
 TEST_CASE("p3_ice_cldliq_wet_growth_bfb", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestIceCldliqWetGrowth;
 
-  T t;
-  t.run_ice_cldliq_wet_growth_phys();
-  t.run_ice_cldliq_wet_growth_bfb();
+  T t;  t.run_ice_cldliq_wet_growth_bfb();
 }
 
 }

--- a/components/eamxx/src/physics/p3/tests/p3_ice_collection_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ice_collection_unit_tests.cpp
@@ -314,7 +314,7 @@ struct UnitWrap::UnitTest<D>::TestIceCollection : public UnitWrap::UnitTest<D>::
 
 namespace {
 
-TEST_CASE("p3_ice_cldliq", "[p3_functions]")
+TEST_CASE("p3_ice_cldliq_bfb", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestIceCollection;
 
@@ -323,7 +323,7 @@ TEST_CASE("p3_ice_cldliq", "[p3_functions]")
   t.run_ice_cldliq_bfb();
 }
 
-TEST_CASE("p3_ice_rain", "[p3_functions]")
+TEST_CASE("p3_ice_rain_bfb", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestIceCollection;
 
@@ -332,7 +332,7 @@ TEST_CASE("p3_ice_rain", "[p3_functions]")
   t.run_ice_rain_bfb();
 }
 
-TEST_CASE("p3_ice_self", "[p3_functions]")
+TEST_CASE("p3_ice_self_bfb", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestIceCollection;
 

--- a/components/eamxx/src/physics/p3/tests/p3_ice_collection_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ice_collection_unit_tests.cpp
@@ -314,13 +314,28 @@ struct UnitWrap::UnitTest<D>::TestIceCollection : public UnitWrap::UnitTest<D>::
 
 namespace {
 
-TEST_CASE("p3_ice_cldliq_bfb", "[p3_functions]")
+TEST_CASE("p3_ice_cldliq_prop", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestIceCollection;
 
   T t;
   t.run_ice_cldliq_phys();
+}
+
+TEST_CASE("p3_ice_cldliq_bfb", "[p3_functions]")
+{
+  using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestIceCollection;
+
+  T t;
   t.run_ice_cldliq_bfb();
+}
+
+TEST_CASE("p3_ice_rain_prop", "[p3_functions]")
+{
+  using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestIceCollection;
+
+  T t;
+  t.run_ice_rain_phys();
 }
 
 TEST_CASE("p3_ice_rain_bfb", "[p3_functions]")
@@ -328,8 +343,15 @@ TEST_CASE("p3_ice_rain_bfb", "[p3_functions]")
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestIceCollection;
 
   T t;
-  t.run_ice_rain_phys();
   t.run_ice_rain_bfb();
+}
+
+TEST_CASE("p3_ice_self_prop", "[p3_functions]")
+{
+  using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestIceCollection;
+
+  T t;
+  t.run_ice_self_phys();
 }
 
 TEST_CASE("p3_ice_self_bfb", "[p3_functions]")
@@ -337,7 +359,6 @@ TEST_CASE("p3_ice_self_bfb", "[p3_functions]")
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestIceCollection;
 
   T t;
-  t.run_ice_self_phys();
   t.run_ice_self_bfb();
 }
 

--- a/components/eamxx/src/physics/p3/tests/p3_ice_deposition_sublimation_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ice_deposition_sublimation_tests.cpp
@@ -167,7 +167,7 @@ TEST_CASE("ice_deposition_sublimation_property", "[p3]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestIceDepositionSublimation;
 
-  T t;
+  T t(true);
   t.run_property();
 }
 

--- a/components/eamxx/src/physics/p3/tests/p3_ice_deposition_sublimation_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ice_deposition_sublimation_tests.cpp
@@ -167,7 +167,7 @@ TEST_CASE("ice_deposition_sublimation_property", "[p3]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestIceDepositionSublimation;
 
-  T t(true);
+  T t;
   t.run_property();
 }
 

--- a/components/eamxx/src/physics/p3/tests/p3_ice_melting_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ice_melting_unit_tests.cpp
@@ -121,7 +121,7 @@ void ice_melting_bfb() {
 
 namespace {
 
-TEST_CASE("p3_ice_melting_test", "[p3_ice_melting_test]") {
+TEST_CASE("p3_ice_melting_bfb", "[p3_ice_melting_test]") {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestP3IceMelting;
 
   T t;

--- a/components/eamxx/src/physics/p3/tests/p3_ice_nucleation_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ice_nucleation_unit_tests.cpp
@@ -122,7 +122,7 @@ struct UnitWrap::UnitTest<D>::TestIceNucleation : public UnitWrap::UnitTest<D>::
 
 namespace {
 
-TEST_CASE("p3_ice_nucleation", "[p3_functions]")
+TEST_CASE("p3_ice_nucleation_bfb", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestIceNucleation;
 

--- a/components/eamxx/src/physics/p3/tests/p3_ice_nucleation_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ice_nucleation_unit_tests.cpp
@@ -122,13 +122,18 @@ struct UnitWrap::UnitTest<D>::TestIceNucleation : public UnitWrap::UnitTest<D>::
 
 namespace {
 
+TEST_CASE("p3_ice_nucleation_prop", "[p3_functions]")
+{
+  using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestIceNucleation;
+
+  T t;  t.run_ice_nucleation_phys();
+}
+
 TEST_CASE("p3_ice_nucleation_bfb", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestIceNucleation;
 
-  T t;
-  t.run_ice_nucleation_phys();
-  t.run_ice_nucleation_bfb();
+  T t;  t.run_ice_nucleation_bfb();
 }
 
 }

--- a/components/eamxx/src/physics/p3/tests/p3_ice_relaxation_timescale_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ice_relaxation_timescale_unit_tests.cpp
@@ -118,7 +118,7 @@ struct UnitWrap::UnitTest<D>::TestIceRelaxationTimescale : public UnitWrap::Unit
 
 namespace {
 
-TEST_CASE("p3_ice_relaxation_timescale", "[p3_functions]")
+TEST_CASE("p3_ice_relaxation_timescale_bfb", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestIceRelaxationTimescale;
 

--- a/components/eamxx/src/physics/p3/tests/p3_ice_relaxation_timescale_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ice_relaxation_timescale_unit_tests.cpp
@@ -118,13 +118,18 @@ struct UnitWrap::UnitTest<D>::TestIceRelaxationTimescale : public UnitWrap::Unit
 
 namespace {
 
+TEST_CASE("p3_ice_relaxation_timescale_prop", "[p3_functions]")
+{
+  using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestIceRelaxationTimescale;
+
+  T t;  t.run_ice_relaxation_timescale_phys();
+}
+
 TEST_CASE("p3_ice_relaxation_timescale_bfb", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestIceRelaxationTimescale;
 
-  T t;
-  t.run_ice_relaxation_timescale_phys();
-  t.run_ice_relaxation_timescale_bfb();
+  T t;  t.run_ice_relaxation_timescale_bfb();
 }
 
 }

--- a/components/eamxx/src/physics/p3/tests/p3_ice_sed_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ice_sed_unit_tests.cpp
@@ -288,7 +288,7 @@ void run_bfb()
 
 namespace {
 
-TEST_CASE("p3_ice_sed", "[p3_functions]")
+TEST_CASE("p3_ice_sed_bfb", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestIceSed;
 

--- a/components/eamxx/src/physics/p3/tests/p3_ice_sed_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ice_sed_unit_tests.cpp
@@ -288,13 +288,18 @@ void run_bfb()
 
 namespace {
 
+TEST_CASE("p3_ice_sed_prop", "[p3_functions]")
+{
+  using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestIceSed;
+
+  T t;  t.run_phys();
+}
+
 TEST_CASE("p3_ice_sed_bfb", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestIceSed;
 
-  T t;
-  t.run_phys();
-  t.run_bfb();
+  T t;  t.run_bfb();
 }
 
 } // namespace

--- a/components/eamxx/src/physics/p3/tests/p3_ice_tables_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ice_tables_unit_tests.cpp
@@ -329,7 +329,7 @@ struct UnitWrap::UnitTest<D>::TestTableIce : public UnitWrap::UnitTest<D>::Base 
 
 namespace {
 
-TEST_CASE("p3_ice_tables", "[p3_functions]")
+TEST_CASE("p3_ice_tables_bfb", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestTableIce;
 

--- a/components/eamxx/src/physics/p3/tests/p3_ice_tables_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_ice_tables_unit_tests.cpp
@@ -329,13 +329,18 @@ struct UnitWrap::UnitTest<D>::TestTableIce : public UnitWrap::UnitTest<D>::Base 
 
 namespace {
 
+TEST_CASE("p3_ice_tables_prop", "[p3_functions]")
+{
+  using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestTableIce;
+
+  T t;  t.run_phys();
+}
+
 TEST_CASE("p3_ice_tables_bfb", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestTableIce;
 
-  T t;
-  t.run_phys();
-  t.run_bfb();
+  T t;  t.run_bfb();
 }
 
 }

--- a/components/eamxx/src/physics/p3/tests/p3_incloud_mixingratios_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_incloud_mixingratios_unit_tests.cpp
@@ -146,7 +146,7 @@ struct UnitWrap::UnitTest<D>::TestIncloudMixing : public UnitWrap::UnitTest<D>::
 
 namespace {
 
-TEST_CASE("p3_incloud_mixingratios", "[p3_functions]")
+TEST_CASE("p3_incloud_mixingratios_bfb", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestIncloudMixing;
 

--- a/components/eamxx/src/physics/p3/tests/p3_incloud_mixingratios_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_incloud_mixingratios_unit_tests.cpp
@@ -146,13 +146,18 @@ struct UnitWrap::UnitTest<D>::TestIncloudMixing : public UnitWrap::UnitTest<D>::
 
 namespace {
 
+TEST_CASE("p3_incloud_mixingratios_prop", "[p3_functions]")
+{
+  using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestIncloudMixing;
+
+  T t;  t.run_incloud_mixing_phys();
+}
+
 TEST_CASE("p3_incloud_mixingratios_bfb", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestIncloudMixing;
 
-  T t;
-  t.run_incloud_mixing_phys();
-  t.run_incloud_mixing_bfb();
+  T t;  t.run_incloud_mixing_bfb();
 }
 
 }

--- a/components/eamxx/src/physics/p3/tests/p3_main_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_main_unit_tests.cpp
@@ -525,13 +525,18 @@ void run_bfb()
 
 namespace {
 
+TEST_CASE("p3_main_prop", "[p3_functions]")
+{
+  using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestP3Main;
+
+  T t;  t.run_phys();
+}
+
 TEST_CASE("p3_main_bfb", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestP3Main;
 
-  T t;
-  t.run_phys();
-  t.run_bfb();
+  T t;  t.run_bfb();
 }
 
 } // namespace

--- a/components/eamxx/src/physics/p3/tests/p3_main_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_main_unit_tests.cpp
@@ -525,7 +525,7 @@ void run_bfb()
 
 namespace {
 
-TEST_CASE("p3_main", "[p3_functions]")
+TEST_CASE("p3_main_bfb", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestP3Main;
 

--- a/components/eamxx/src/physics/p3/tests/p3_rain_imm_freezing_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_rain_imm_freezing_unit_tests.cpp
@@ -127,13 +127,18 @@ void run_bfb()
 
 namespace {
 
+TEST_CASE("p3_rain_immersion_freezing_prop", "[p3_functions]")
+{
+  using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestRainImmersionFreezing;
+
+  T t;  t.run_phys();
+}
+
 TEST_CASE("p3_rain_immersion_freezing_bfb", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestRainImmersionFreezing;
 
-  T t;
-  t.run_phys();
-  t.run_bfb();
+  T t;  t.run_bfb();
 }
 
 } // namespace

--- a/components/eamxx/src/physics/p3/tests/p3_rain_imm_freezing_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_rain_imm_freezing_unit_tests.cpp
@@ -127,7 +127,7 @@ void run_bfb()
 
 namespace {
 
-TEST_CASE("p3_rain_immersion_freezing", "[p3_functions]")
+TEST_CASE("p3_rain_immersion_freezing_bfb", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestRainImmersionFreezing;
 

--- a/components/eamxx/src/physics/p3/tests/p3_rain_sed_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_rain_sed_unit_tests.cpp
@@ -227,7 +227,7 @@ void run_bfb()
 
 namespace {
 
-TEST_CASE("p3_rain_sed", "[p3_functions]")
+TEST_CASE("p3_rain_sed_bfb", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestRainSed;
 

--- a/components/eamxx/src/physics/p3/tests/p3_rain_sed_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_rain_sed_unit_tests.cpp
@@ -227,13 +227,18 @@ void run_bfb()
 
 namespace {
 
+TEST_CASE("p3_rain_sed_prop", "[p3_functions]")
+{
+  using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestRainSed;
+
+  T t;  t.run_phys();
+}
+
 TEST_CASE("p3_rain_sed_bfb", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestRainSed;
 
-  T t;
-  t.run_phys();
-  t.run_bfb();
+  T t;  t.run_bfb();
 }
 
 } // namespace

--- a/components/eamxx/src/physics/p3/tests/p3_rain_self_collection_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_rain_self_collection_tests.cpp
@@ -118,7 +118,7 @@ struct UnitWrap::UnitTest<D>::TestRainSelfCollection : public UnitWrap::UnitTest
 
 namespace {
 
-TEST_CASE("p3_rain_self_collection_bfb", "[p3_rain_self_collection_test"){
+TEST_CASE("p3_rain_self_collection_bfb", "[p3_rain_self_collection_test]"){
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestRainSelfCollection;
 
   T t;

--- a/components/eamxx/src/physics/p3/tests/p3_rain_self_collection_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_rain_self_collection_tests.cpp
@@ -118,7 +118,7 @@ struct UnitWrap::UnitTest<D>::TestRainSelfCollection : public UnitWrap::UnitTest
 
 namespace {
 
-TEST_CASE("p3_rain_self_collection_test", "[p3_rain_self_collection_test"){
+TEST_CASE("p3_rain_self_collection_bfb", "[p3_rain_self_collection_test"){
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestRainSelfCollection;
 
   T t;

--- a/components/eamxx/src/physics/p3/tests/p3_subgrid_variance_scaling_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_subgrid_variance_scaling_unit_tests.cpp
@@ -193,12 +193,18 @@ struct UnitWrap::UnitTest<D>::TestP3SubgridVarianceScaling : public UnitWrap::Un
 
 namespace {
 
-TEST_CASE("p3_subgrid_variance_scaling_test", "[p3_subgrid_variance_scaling_test]"){
+TEST_CASE("p3_subgrid_variance_scaling_property", "[p3_subgrid_variance_scaling_test]"){
+  using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestP3SubgridVarianceScaling;
+
+  T t;
+  t.run_property_tests();
+}
+
+TEST_CASE("p3_subgrid_variance_scaling_bfb", "[p3_subgrid_variance_scaling_test]"){
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestP3SubgridVarianceScaling;
 
   T t;
   t.run_bfb_tests();
-  t.run_property_tests();
 }
 
 } // namespace

--- a/components/eamxx/src/physics/p3/tests/p3_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_unit_tests.cpp
@@ -1156,11 +1156,17 @@ struct UnitWrap::UnitTest<D>::TestP3FunctionsImposeMaxTotalNi : public UnitWrap:
 
 namespace {
 
-TEST_CASE("p3_conservation_bfb", "[p3_unit_tests]"){
+TEST_CASE("p3_conservation_prop", "[p3_unit_tests]"){
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestP3Conservation;
 
   T t;
   t.run();
+}
+
+TEST_CASE("p3_conservation_bfb", "[p3_unit_tests]"){
+  using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestP3Conservation;
+
+  T t;
   t.run_bfb();
 }
 

--- a/components/eamxx/src/physics/p3/tests/p3_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_unit_tests.cpp
@@ -1156,7 +1156,7 @@ struct UnitWrap::UnitTest<D>::TestP3FunctionsImposeMaxTotalNi : public UnitWrap:
 
 namespace {
 
-TEST_CASE("p3_conservation_test", "[p3_unit_tests]"){
+TEST_CASE("p3_conservation_bfb", "[p3_unit_tests]"){
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestP3Conservation;
 
   T t;
@@ -1164,28 +1164,28 @@ TEST_CASE("p3_conservation_test", "[p3_unit_tests]"){
   t.run_bfb();
 }
 
-TEST_CASE("p3_get_time_space_phys_variables_test", "[p3_unit_tests]"){
+TEST_CASE("p3_get_time_space_phys_variables_bfb", "[p3_unit_tests]"){
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestGetTimeSpacePhysVariables;
 
   T t;
   t.run_bfb();
 }
 
-TEST_CASE("p3_update_prognostic_ice_test", "[p3_unit_tests]"){
+TEST_CASE("p3_update_prognostic_ice_bfb", "[p3_unit_tests]"){
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestP3UpdatePrognosticIce;
 
   T t;
   t.run_bfb();
 }
 
-TEST_CASE("p3_update_prognostic_liquid_test", "[p3_unit_tests]"){
+TEST_CASE("p3_update_prognostic_liquid_bfb", "[p3_unit_tests]"){
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestP3UpdatePrognosticLiq;
 
   T t;
   t.run_bfb();
 }
 
-TEST_CASE("p3_impose_max_total_ni_test", "[p3_unit_tests]"){
+TEST_CASE("p3_impose_max_total_ni_bfb", "[p3_unit_tests]"){
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestP3FunctionsImposeMaxTotalNi;
 
   T t;

--- a/components/eamxx/src/physics/p3/tests/p3_upwind_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_upwind_unit_tests.cpp
@@ -368,7 +368,7 @@ void run_bfb()
 
 namespace {
 
-TEST_CASE("p3_upwind", "[p3_functions]")
+TEST_CASE("p3_upwind_bfb", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestUpwind;
 
@@ -377,7 +377,7 @@ TEST_CASE("p3_upwind", "[p3_functions]")
   t.run_bfb();
 }
 
-TEST_CASE("p3_gen_sed", "[p3_functions]")
+TEST_CASE("p3_gen_sed_bfb", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestGenSed;
 

--- a/components/eamxx/src/physics/p3/tests/p3_upwind_unit_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_upwind_unit_tests.cpp
@@ -368,13 +368,28 @@ void run_bfb()
 
 namespace {
 
-TEST_CASE("p3_upwind_bfb", "[p3_functions]")
+TEST_CASE("p3_upwind_prop", "[p3_functions]")
 {
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestUpwind;
 
   T t;
   t.run_phys();
+}
+
+TEST_CASE("p3_upwind_bfb", "[p3_functions]")
+{
+  using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestUpwind;
+
+  T t;
   t.run_bfb();
+}
+
+TEST_CASE("p3_gen_sed_prop", "[p3_functions]")
+{
+  using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestGenSed;
+
+  T t;
+  t.run_phys();
 }
 
 TEST_CASE("p3_gen_sed_bfb", "[p3_functions]")
@@ -382,7 +397,6 @@ TEST_CASE("p3_gen_sed_bfb", "[p3_functions]")
   using T = scream::p3::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestGenSed;
 
   T t;
-  t.run_phys();
   t.run_bfb();
 }
 

--- a/components/eamxx/src/physics/tms/tests/compute_tms_tests.cpp
+++ b/components/eamxx/src/physics/tms/tests/compute_tms_tests.cpp
@@ -91,6 +91,14 @@ struct UnitWrap::UnitTest<D>::TestComputeTMS : public UnitWrap::UnitTest<D>::Bas
 
 namespace {
 
+TEST_CASE("compute_tms_property", "tms")
+{
+  using TestStruct = scream::tms::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestComputeTMS;
+
+  TestStruct t;
+  t.run_property();
+}
+
 TEST_CASE("compute_tms_bfb", "tms")
 {
   using TestStruct = scream::tms::unit_test::UnitWrap::UnitTest<scream::DefaultDevice>::TestComputeTMS;

--- a/components/eamxx/src/share/physics/physics_test_data.hpp
+++ b/components/eamxx/src/share/physics/physics_test_data.hpp
@@ -509,7 +509,7 @@ struct UnitBase
       }
       else if (m_baseline_action == GENERATE) {
         m_ofile.open(baseline_name,std::ios::binary);
-        EKAT_REQUIRE_MSG(m_ofile.good(), "Coult not open baseline file for write: " + baseline_name + "\n");
+        EKAT_REQUIRE_MSG(m_ofile.good(), "Could not open baseline file for write: " + baseline_name + "\n");
       }
     }
   }

--- a/components/eamxx/src/share/physics/physics_test_data.hpp
+++ b/components/eamxx/src/share/physics/physics_test_data.hpp
@@ -478,20 +478,23 @@ struct UnitBase
   std::ifstream   m_ifile;
   std::ofstream   m_ofile;
 
-  UnitBase() :
+  UnitBase(const bool property=false) :
     m_baseline_path(""),
     m_test_name(Catch::getResultCapture().getCurrentTestName()),
     m_baseline_action(NONE)
   {
     auto& ts = ekat::TestSession::get();
-    if (ts.flags["c"]) {
-      m_baseline_action = COMPARE;
-    }
-    else if (ts.flags["g"]) {
-      m_baseline_action = GENERATE;
-    }
-    else if (ts.flags["n"]) {
-      m_baseline_action = NONE;
+    // Property tests do not use baselines
+    if (!property) {
+      if (ts.flags["c"]) {
+        m_baseline_action = COMPARE;
+      }
+      else if (ts.flags["g"]) {
+        m_baseline_action = GENERATE;
+      }
+      else if (ts.flags["n"]) {
+        m_baseline_action = NONE;
+      }
     }
     m_baseline_path = ts.params["b"];
 

--- a/components/eamxx/src/share/physics/physics_test_data.hpp
+++ b/components/eamxx/src/share/physics/physics_test_data.hpp
@@ -483,30 +483,34 @@ struct UnitBase
     m_test_name(Catch::getResultCapture().getCurrentTestName()),
     m_baseline_action(NONE)
   {
-    auto& ts = ekat::TestSession::get();
-    if (ts.flags["c"]) {
-      m_baseline_action = COMPARE;
-    }
-    else if (ts.flags["g"]) {
-      m_baseline_action = GENERATE;
-    }
-    else if (ts.flags["n"]) {
-      m_baseline_action = NONE;
-    }
-    m_baseline_path = ts.params["b"];
+    const bool is_bfb = (m_test_name.size() >= 3 &&
+                         m_test_name.substr(m_test_name.size() - 3) == "bfb");
+    if (is_bfb) {
+      auto& ts = ekat::TestSession::get();
+      if (ts.flags["c"]) {
+        m_baseline_action = COMPARE;
+      }
+      else if (ts.flags["g"]) {
+        m_baseline_action = GENERATE;
+      }
+      else if (ts.flags["n"]) {
+        m_baseline_action = NONE;
+      }
+      m_baseline_path = ts.params["b"];
 
-    EKAT_REQUIRE_MSG( !(m_baseline_action != NONE && m_baseline_path == ""),
-                      "Unit test flags problem: baseline actions were requested but no baseline path was provided");
+      EKAT_REQUIRE_MSG( !(m_baseline_action != NONE && m_baseline_path == ""),
+                        "Unit test flags problem: baseline actions were requested but no baseline path was provided");
 
-    std::string baseline_name = m_baseline_path + "/" + m_test_name;
+      std::string baseline_name = m_baseline_path + "/" + m_test_name;
 
-    if (m_baseline_action == COMPARE) {
-      m_ifile.open(baseline_name,std::ios::binary);
-      EKAT_REQUIRE_MSG(m_ifile.good(), "Missing baselines: " + baseline_name + "\n");
-    }
-    else if (m_baseline_action == GENERATE) {
-      m_ofile.open(baseline_name,std::ios::binary);
-      EKAT_REQUIRE_MSG(m_ofile.good(), "Coult not open baseline file for write: " + baseline_name + "\n");
+      if (m_baseline_action == COMPARE) {
+        m_ifile.open(baseline_name,std::ios::binary);
+        EKAT_REQUIRE_MSG(m_ifile.good(), "Missing baselines: " + baseline_name + "\n");
+      }
+      else if (m_baseline_action == GENERATE) {
+        m_ofile.open(baseline_name,std::ios::binary);
+        EKAT_REQUIRE_MSG(m_ofile.good(), "Coult not open baseline file for write: " + baseline_name + "\n");
+      }
     }
   }
 

--- a/components/eamxx/src/share/physics/physics_test_data.hpp
+++ b/components/eamxx/src/share/physics/physics_test_data.hpp
@@ -478,23 +478,20 @@ struct UnitBase
   std::ifstream   m_ifile;
   std::ofstream   m_ofile;
 
-  UnitBase(const bool property=false) :
+  UnitBase() :
     m_baseline_path(""),
     m_test_name(Catch::getResultCapture().getCurrentTestName()),
     m_baseline_action(NONE)
   {
     auto& ts = ekat::TestSession::get();
-    // Property tests do not use baselines
-    if (!property) {
-      if (ts.flags["c"]) {
-        m_baseline_action = COMPARE;
-      }
-      else if (ts.flags["g"]) {
-        m_baseline_action = GENERATE;
-      }
-      else if (ts.flags["n"]) {
-        m_baseline_action = NONE;
-      }
+    if (ts.flags["c"]) {
+      m_baseline_action = COMPARE;
+    }
+    else if (ts.flags["g"]) {
+      m_baseline_action = GENERATE;
+    }
+    else if (ts.flags["n"]) {
+      m_baseline_action = NONE;
     }
     m_baseline_path = ts.params["b"];
 


### PR DESCRIPTION
Separate out property tests from bfb tests. This is important for a couple reasons:
1) So property tests do not generate (empty) baseline files
2) So property tests do not reuse random seeds which limits coverage

Changes UnitBase struct to not do baseline actions unless the test ends with the string "bfb". This is a little hacky, but is easier than adding arguments everywhere to the hundreds of unit test structs. If a developer forgets to follow this pattern, it should be fairly obvious since there will be no valid file descriptor when they try to read/write baseline stuff.

[BFB]