### PR TITLE
Fix compose calc_own_q to be bit-for-bit independent of task count

### DIFF
--- a/components/homme/src/share/compose/compose_slmm_islmpi_interpolate.hpp
+++ b/components/homme/src/share/compose/compose_slmm_islmpi_interpolate.hpp
@@ -124,18 +124,6 @@ SLMM_KIF Real calc_q_tgt (const Real rx[4], const Real ry[4], const Real qs[16])
           ry[3]*(rx[0]*qs[12] + rx[1]*qs[13] + rx[2]*qs[14] + rx[3]*qs[15]));
 }
 
-SLMM_KIF Real calc_q_tgt (const Real rx[4], const Real ry[4], const Real qdp[16],
-                          const Real dp[16]) {
-  return (ry[0]*(rx[0]*(qdp[ 0]/dp[ 0]) + rx[1]*(qdp[ 1]/dp[ 1])  +
-                 rx[2]*(qdp[ 2]/dp[ 2]) + rx[3]*(qdp[ 3]/dp[ 3])) +
-          ry[1]*(rx[0]*(qdp[ 4]/dp[ 4]) + rx[1]*(qdp[ 5]/dp[ 5])  +
-                 rx[2]*(qdp[ 6]/dp[ 6]) + rx[3]*(qdp[ 7]/dp[ 7])) +
-          ry[2]*(rx[0]*(qdp[ 8]/dp[ 8]) + rx[1]*(qdp[ 9]/dp[ 9])  +
-                 rx[2]*(qdp[10]/dp[10]) + rx[3]*(qdp[11]/dp[11])) +
-          ry[3]*(rx[0]*(qdp[12]/dp[12]) + rx[1]*(qdp[13]/dp[13])  +
-                 rx[2]*(qdp[14]/dp[14]) + rx[3]*(qdp[15]/dp[15])));
-}
-
 } // namespace islmpi
 } // namespace homme
 

--- a/components/homme/src/share/compose/compose_slmm_islmpi_q.cpp
+++ b/components/homme/src/share/compose/compose_slmm_islmpi_q.cpp
@@ -49,6 +49,10 @@ void calc_q (const IslMpi<MT>& cm, const Int& src_lid, const Int& lev,
     }
   } else {
     // q from calc_q_extrema is being overwritten, so have to use qdp/dp.
+    // pre-divide qdp/dp once per node, then use the same
+    // divide-then-sum calc_q_tgt overload calc_rmt_q_pass2 uses, instead
+    // of the divide-inside-sum overload, so this "own" path is bit-for-bit
+    // identical to the "remote" path regardless of domain decomposition.
     const Real* const dp = ed.dp + levos;
     const Real* const qdp0 = ed.qdp + levos;
     for (Int iqo = 0; iqo < qsize; iqo += blocksize) {
@@ -56,14 +60,18 @@ void calc_q (const IslMpi<MT>& cm, const Int& src_lid, const Int& lev,
         Real tmp[blocksize];
         for (Int iqi = 0; iqi < blocksize; ++iqi) {
           const Real* const qdp = qdp0 + (iqo + iqi)*np2nlev;
-          tmp[iqi] = calc_q_tgt(rx, ry, qdp, dp);
+          Real qs[16];
+          for (Int k = 0; k < 16; ++k) qs[k] = qdp[k]/dp[k];
+          tmp[iqi] = calc_q_tgt(rx, ry, qs);
         }
         for (Int iqi = 0; iqi < blocksize; ++iqi)
           q_tgt[iqo + iqi] = tmp[iqi];
       } else {
         for (Int iq = iqo; iq < qsize; ++iq) {
           const Real* const qdp = qdp0 + iq*np2nlev;
-          q_tgt[iq] = calc_q_tgt(rx, ry, qdp, dp);
+          Real qs[16];
+          for (Int k = 0; k < 16; ++k) qs[k] = qdp[k]/dp[k];
+          q_tgt[iq] = calc_q_tgt(rx, ry, qs);
         }
       }
     }
@@ -201,6 +209,10 @@ void calc_own_q (IslMpi<MT>& cm, const Int& nets, const Int& nete,
     calc_coefs<np,MT>(s2r, local_meshes(slid), alg, slid, tgt_lev,
                       &dep_points(tci, tgt_lev, tgt_k, 0), rx, ry);
     // q from calc_q_extrema is being overwritten, so have to use qdp/dp.
+    // pre-divide qdp/dp once per node, then use the same
+    // divide-then-sum calc_q_tgt overload calc_rmt_q_pass2 uses, instead
+    // of the divide-inside-sum overload, so this "own" path is bit-for-bit
+    // identical to the "remote" path regardless of domain decomposition.
     Real dp[16];
     for (Int k = 0; k < 16; ++k) dp[k] = dp_src(slid, k, tgt_lev);
     // Block for auto-vectorization.
@@ -209,17 +221,19 @@ void calc_own_q (IslMpi<MT>& cm, const Int& nets, const Int& nete,
         Real tmp[blocksize];
         for (Int iqi = 0; iqi < blocksize; ++iqi) {
           const Int iq = iqo + iqi;
-          Real qdp[16];
+          Real qdp[16], qs[16];
           for (Int k = 0; k < 16; ++k) qdp[k] = qdp_src(slid, qtl, iq, k, tgt_lev);
-          tmp[iqi] = calc_q_tgt(rx, ry, qdp, dp);
+          for (Int k = 0; k < 16; ++k) qs[k] = qdp[k]/dp[k];
+          tmp[iqi] = calc_q_tgt(rx, ry, qs);
         }
         for (Int iqi = 0; iqi < blocksize; ++iqi)
           q_tgt(tci, iqo + iqi, tgt_k, tgt_lev) = tmp[iqi];
       } else {
         for (Int iq = iqo; iq < qsize; ++iq) {
-          Real qdp[16];
+          Real qdp[16], qs[16];
           for (Int k = 0; k < 16; ++k) qdp[k] = qdp_src(slid, qtl, iq, k, tgt_lev);
-          q_tgt(tci, iq, tgt_k, tgt_lev) = calc_q_tgt(rx, ry, qdp, dp);
+          for (Int k = 0; k < 16; ++k) qs[k] = qdp[k]/dp[k];
+          q_tgt(tci, iq, tgt_k, tgt_lev) = calc_q_tgt(rx, ry, qs);
         }
       }
     }

--- a/components/homme/src/share/compose/compose_slmm_islmpi_q.cpp
+++ b/components/homme/src/share/compose/compose_slmm_islmpi_q.cpp
@@ -48,11 +48,10 @@ void calc_q (const IslMpi<MT>& cm, const Int& src_lid, const Int& lev,
       }
     }
   } else {
-    // q from calc_q_extrema is being overwritten, so have to use qdp/dp.
-    // pre-divide qdp/dp once per node, then use the same
-    // divide-then-sum calc_q_tgt overload calc_rmt_q_pass2 uses, instead
-    // of the divide-inside-sum overload, so this "own" path is bit-for-bit
-    // identical to the "remote" path regardless of domain decomposition.
+    // NOTE: we used to have a calc_q_tgt overload that took qdp and dp,
+    //       computing qdp/dp on the fly. This was not bit-for-bit identical
+    //       to the "remote" path. Hence, we removed that overload, and
+    //       pre-compute qdp/dp
     const Real* const dp = ed.dp + levos;
     const Real* const qdp0 = ed.qdp + levos;
     for (Int iqo = 0; iqo < qsize; iqo += blocksize) {
@@ -208,11 +207,10 @@ void calc_own_q (IslMpi<MT>& cm, const Int& nets, const Int& nete,
     Real rx[4], ry[4];
     calc_coefs<np,MT>(s2r, local_meshes(slid), alg, slid, tgt_lev,
                       &dep_points(tci, tgt_lev, tgt_k, 0), rx, ry);
-    // q from calc_q_extrema is being overwritten, so have to use qdp/dp.
-    // pre-divide qdp/dp once per node, then use the same
-    // divide-then-sum calc_q_tgt overload calc_rmt_q_pass2 uses, instead
-    // of the divide-inside-sum overload, so this "own" path is bit-for-bit
-    // identical to the "remote" path regardless of domain decomposition.
+    // NOTE: we used to have a calc_q_tgt overload that took qdp and dp,
+    //       computing qdp/dp on the fly. This was not bit-for-bit identical
+    //       to the "remote" path. Hence, we removed that overload, and
+    //       pre-compute qdp/dp
     Real dp[16];
     for (Int k = 0; k < 16; ++k) dp[k] = dp_src(slid, k, tgt_lev);
     // Block for auto-vectorization.


### PR DESCRIPTION
- HOMME/compose semi-Lagrangian tracer transport produced
  answers that changed with the number of MPI tasks (observed with the
  Intel compiler), because element data owned by a rank was combined
  differently than element data received from a remote rank.
- The "own" path in calc_q (non-COMPOSE_PORT) and calc_own_q
  (COMPOSE_PORT) computed q by dividing qdp/dp inside the interpolation
  weighted sum, using the calc_q_tgt(rx, ry, qdp, dp) overload. The
  "remote" path in calc_rmt_q_pass2 instead pre-divides qdp/dp into a q
  array and calls the calc_q_tgt(rx, ry, qs) overload. These two
  orderings of floating point operations are not guaranteed to produce
  identical results, so an element's q value differed depending on
  whether it was computed on its owning rank or received from a remote
  rank, which in turn depends on the domain decomposition (i.e. NTASKS).
- This change makes calc_q and calc_own_q pre-divide qdp/dp and call the
  same divide-then-sum calc_q_tgt overload used by calc_rmt_q_pass2, so
  the own and remote paths are now bit-for-bit identical, and answers no
  longer depend on the number of MPI tasks used.
- No change in the numerical algorithm; this is a bit-for-bit
  reproducibility fix only.

Note https://github.com/E3SM-Project/E3SM/issues/6834, but this fix alone does not resolve the issue

NBFB (as the baseline may change)