### PR TITLE
Revert erroneous name change intel -> oneapi-ifx

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -2968,7 +2968,7 @@
         <command name="load">cmake/3.26.3</command>
         <command name="load">mkl/2022.1.0</command>
       </modules>
-      <modules compiler="intel">
+      <modules compiler="oneapi-ifx">
         <command name="load">intel/2023.2.1-magic</command>
 	<command name="use">/usr/workspace/e3sm/spack/dane/intel/modules/Core</command>
 	<command name="load">intel-oneapi-runtime/2023.2.0</command>


### PR DESCRIPTION
Name change was introduces in https://github.com/E3SM-Project/E3SM/pull/8079. 

Closes https://github.com/E3SM-Project/E3SM/issues/8569.

[BFB]