### PR TITLE
[MPAS-Framework standalone] Use GEN_F90=true for intel-cray to avoid ifx fpp macro bug

### DIFF
--- a/components/mpas-framework/Makefile
+++ b/components/mpas-framework/Makefile
@@ -412,6 +412,8 @@ gnu-cray:
 	"USE_SHTNS = $(USE_SHTNS)" \
 	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI $(FILE_OFFSET) $(ZOLTAN_DEFINE)" )
 
+# ifx (Intel oneAPI) fpp mishandles the COMMA macro-argument idiom used in the
+# MPAS framework, so preprocess .F with GNU cpp via GEN_F90=true instead.
 intel-cray:
 	( $(MAKE) all \
 	"FC_PARALLEL = ftn" \
@@ -438,6 +440,7 @@ intel-cray:
 	"USE_PAPI = $(USE_PAPI)" \
 	"OPENMP = $(OPENMP)" \
 	"USE_SHTNS = $(USE_SHTNS)" \
+	"GEN_F90 = true" \
 	"CPPFLAGS = $(MODEL_FORMULATION) -D_MPI" )
 
 cray-cray:


### PR DESCRIPTION
Intel oneAPI (ifx) fpp mishandles the COMMA macro-argument idiom used throughout the MPAS framework (e.g. DMPAR_DEBUG_WRITE in mpas_dmpar.F), miscounting a single macro argument as several and failing with "number of arguments doesn't match". Preprocess .F files with GNU cpp via GEN_F90=true instead, which handles the idiom correctly.

Fixes #8573

Fixes https://github.com/E3SM-Project/polaris/issues/503