### PR TITLE
Add flags to chrysalis_intel.cmake

### DIFF
--- a/cime_config/machines/cmake_macros/chrysalis_intel.cmake
+++ b/cime_config/machines/cmake_macros/chrysalis_intel.cmake
@@ -21,6 +21,13 @@ endif()
 string(APPEND CMAKE_CXX_FLAGS " -fp-model precise")
 string(APPEND CMAKE_Fortran_FLAGS_DEBUG " -O0 -g ")
 
+if (COMP_NAME STREQUAL gcam)
+  string(APPEND CMAKE_EXE_LINKER_FLAGS " -Wl,--no-relax")
+  string(APPEND CMAKE_Fortran_FLAGS " -mcmodel=medium")
+  string(APPEND CMAKE_C_FLAGS " -mcmodel=medium")
+  string(APPEND CMAKE_CXX_FLAGS " -DNDEBUG")
+endif()
+
 set(MPIFC "mpifort")
 set(SCC "icx")
 set(SCXX "icpx")


### PR DESCRIPTION
These flags were accidentally removed in https://github.com/E3SM-Project/E3SM/pull/8079.

[BFB]