### PR TITLE
Use default binding of tasks to cores in non-xstrid PE-layouts on Frontier

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -1592,7 +1592,7 @@
       <env name="MPICH_CXX">$SHELL{which hipcc}</env>
       <env name="GPUS_PER_NODE">--gpus-per-node=8</env>
       <env name="NTASKS_PER_GPU">--ntasks-per-gpu=$SHELL{echo "`./xmlquery --value MAX_MPITASKS_PER_NODE`/8"|bc}</env>
-      <env name="GPU_BIND_ARGS">--gpu-bind=closest --distribution=*:block</env>
+      <env name="GPU_BIND_ARGS">--gpu-bind=closest $SHELL{mpn=`./xmlquery --value MAX_MPITASKS_PER_NODE`; if [ 56 -le $mpn ]; then echo --distribution=*:block; fi;} </env>
     </environment_variables>
 
     <environment_variables BUILD_THREADED="TRUE">


### PR DESCRIPTION
Use default binding of tasks to cores in non-xstrid PE-layouts on Frontier.

Fixes E3SM-Project/E3SM#8557

[BFB]

---
Testing: this reverts to prior default (cyclic/round-robin) distribution at 8 mpi tasks per node; and sets the needed `--distribution=*:block` at fully occupied node with 56 mpi tasks per node.