### PR TITLE
EAMxx: Simplifies field manager finalization to handle improperly initialized cases.

### DIFF
--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -1771,7 +1771,7 @@ void AtmosphereDriver::finalize ( /* inputs? */ ) {
   m_grids_manager = nullptr;
 
   // Destroy all the fields manager
-  m_field_mgr->clean_up();
+  m_field_mgr = nullptr;
 
   // Write all timers to file, and possibly finalize gptl
   if (not m_gptl_externally_handled) {


### PR DESCRIPTION
@mingxuanwupnnl and I were experiencing a segfault in a single-precision single-process unit test in PR #8561. It turns out that a parameter was specified in the wrong precision, which triggered an exception that caused the AD to finalize itself without having first created the field manager. I fixed this segfault by adding the code in this PR, after which we got the helpful message that allowed us to figure out what's going on:

```
/home/jeff/projects/sandia/E3SM/components/eamxx/tests/eamxx_ad_test.cpp:28: FAILED:
due to unexpected exception with message:
  Error! Attempting to access parameter using the wrong type.
     - list name : mam4_srf_online_emiss
     - param name: srf_emis_scale_factor_for_dust
     - param type: d
     - input type: f'.
```

[BFB]