### PR TITLE
add zm in cloud water for rad

### DIFF
--- a/components/eam/src/physics/cam/zm/zm_conv.F90
+++ b/components/eam/src/physics/cam/zm/zm_conv.F90
@@ -1928,7 +1928,7 @@ subroutine zm_closure(pcols, ncol, pver, pverp, msg, cape_threshold_in, &
    real(r8), dimension(pcols,pver), intent(in ) :: s_mid             ! ambient dry static energy (normalized)
    real(r8), dimension(pcols,pver), intent(in ) :: q_mid             ! ambient specific humidity
    real(r8), dimension(pcols,pver), intent(in ) :: qs                ! ambient saturation specific humidity
-   real(r8), dimension(pcols,pver), intent(in ) :: ql                ! ambient liquid water mixing ratio
+   real(r8), dimension(pcols,pver), intent(in ) :: ql                ! in-cloud liquid water mixing ratio
    real(r8), dimension(pcols,pver), intent(in ) :: s_int             ! env. normalized dry static energy at intrfcs
    real(r8), dimension(pcols,pver), intent(in ) :: q_int             ! environment specific humidity at interfaces
    real(r8), dimension(pcols),      intent(in ) :: t_pcl_lcl         ! parcel temperature at LCL

--- a/components/eamxx/cime_config/eamxx_buildnml.py
+++ b/components/eamxx/cime_config/eamxx_buildnml.py
@@ -589,6 +589,43 @@ def write_pretty_xml(filepath, xml):
         fd.write(pretty_xml)
 
 ###############################################################################
+def set_atm_procs_list_derived_defaults(eamxx_group):
+###############################################################################
+    """
+    Set default parameter values that depend on which atm processes are present
+    in the process list (rather than on the compset name). Currently this toggles
+    the ZM deep-convective cloud contributions: the deep cloud fraction merge in
+    cld_fraction (do_zm_deep_cldfrac) and the convective water added to radiation
+    in rrtmgp (do_zm_cloud_in_rad) are enabled iff the 'zm' process is in the
+    list. Any explicit atmchange applied afterwards still takes precedence.
+    >>> import xml.etree.ElementTree as ET
+    >>> xml = '''
+    ... <eamxx>
+    ...   <zm/>
+    ...   <cld_fraction><do_zm_deep_cldfrac>false</do_zm_deep_cldfrac></cld_fraction>
+    ...   <rrtmgp><do_zm_cloud_in_rad>false</do_zm_cloud_in_rad></rrtmgp>
+    ... </eamxx>
+    ... '''
+    >>> root = ET.fromstring(xml)
+    >>> set_atm_procs_list_derived_defaults(root)
+    >>> get_child(find_node(root,"cld_fraction"),"do_zm_deep_cldfrac").text
+    'true'
+    >>> get_child(find_node(root,"rrtmgp"),"do_zm_cloud_in_rad").text
+    'true'
+    >>> root2 = ET.fromstring(xml.replace("<zm/>",""))
+    >>> set_atm_procs_list_derived_defaults(root2)
+    >>> get_child(find_node(root2,"rrtmgp"),"do_zm_cloud_in_rad").text
+    'false'
+    """
+    zm_active = find_node(eamxx_group,"zm") is not None
+    # Map each process to the flag that gates its ZM contribution.
+    proc_flags = {"cld_fraction":"do_zm_deep_cldfrac", "rrtmgp":"do_zm_cloud_in_rad"}
+    for proc_name,flag_name in proc_flags.items():
+        proc = find_node(eamxx_group,proc_name)
+        if proc is not None and has_child(proc,flag_name):
+            get_child(proc,flag_name).text = "true" if zm_active else "false"
+
+###############################################################################
 def _create_raw_xml_file_impl(case, xml, filepath=None):
 ###############################################################################
     """
@@ -769,6 +806,10 @@ def _create_raw_xml_file_impl(case, xml, filepath=None):
 
         # Add atm procs node to xml
         xml.append(eamxx_group)
+
+        # Set defaults that depend on which processes are in the list. Done before
+        # applying the atmchange buffer, so explicit user atmchanges still win.
+        set_atm_procs_list_derived_defaults(eamxx_group)
 
         # Apply remaining atm changes
         apply_non_atm_procs_list_changes_from_buffer (case,xml)

--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -289,6 +289,8 @@ be lost if SCREAM_HACK_XML is not enabled.
       <c0_ocn           type="real"    doc="ZM autoconversion coefficient over ocean"  >0.002</c0_ocn>
       <num_cin          type="integer" doc="ZM num of neg buoyancy regions allowed"    >1</num_cin>
       <cldfrc_dp1       type="real"    doc="ZM parameter for radiative in-cld water"   >0.018</cldfrc_dp1>
+      <dlf_tk1          type="real"    doc="ZM T above which detr condensate is liq"   >268.15</dlf_tk1>
+      <dlf_tk2          type="real"    doc="ZM T below which detr condensate is ice"   >238.15</dlf_tk2>
       <!-- MCSP -->
       <mcsp_enabled type="logical" doc="ZM flag to enable MCSP in ZM" >true</mcsp_enabled>
       <mcsp_t_coeff type="real" doc="MCSP temperature coefficient"    >0.3</mcsp_t_coeff>

--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -349,7 +349,10 @@ be lost if SCREAM_HACK_XML is not enabled.
     </mam4_drydep>
 
     <!-- CLD fraction -->
-    <cld_fraction inherit="atm_proc_base"/>
+    <cld_fraction inherit="atm_proc_base">
+      <!-- Default is set by buildnml based on whether 'zm' is in the atm process list -->
+      <do_zm_deep_cldfrac type="logical" doc="Fold ZM deep convective cloud fraction into the total cloud fraction">false</do_zm_deep_cldfrac>
+    </cld_fraction>
 
     <!-- MAM4xx namelist options -->
 
@@ -619,6 +622,8 @@ be lost if SCREAM_HACK_XML is not enabled.
       <rad_frequency hgrid="ne0np4_conus_x4v1_lowcon">4</rad_frequency>
       <do_aerosol_rad type="logical" doc="Flag to turn on/off considering aerosols in radiation calculations">true</do_aerosol_rad>
       <do_aerosol_rad COMPSET=".*SCREAM.*noAero">false</do_aerosol_rad>
+      <!-- Default is set by buildnml based on whether 'zm' is in the atm process list -->
+      <do_zm_cloud_in_rad type="logical" doc="Add ZM deep convective in-cloud water to the cloud water seen by radiation">false</do_zm_cloud_in_rad>
       <enable_column_conservation_checks type="logical">false</enable_column_conservation_checks>
       <extra_clnclrsky_diag
         type="logical"

--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -288,6 +288,7 @@ be lost if SCREAM_HACK_XML is not enabled.
       <c0_lnd           type="real"    doc="ZM autoconversion coefficient over land"   >0.002</c0_lnd>
       <c0_ocn           type="real"    doc="ZM autoconversion coefficient over ocean"  >0.002</c0_ocn>
       <num_cin          type="integer" doc="ZM num of neg buoyancy regions allowed"    >1</num_cin>
+      <cldfrc_dp1       type="real"    doc="ZM parameter for radiative in-cld water"   >0.018</cldfrc_dp1>
       <!-- MCSP -->
       <mcsp_enabled type="logical" doc="ZM flag to enable MCSP in ZM" >true</mcsp_enabled>
       <mcsp_t_coeff type="real" doc="MCSP temperature coefficient"    >0.3</mcsp_t_coeff>

--- a/components/eamxx/src/physics/cld_fraction/cld_fraction_functions.hpp
+++ b/components/eamxx/src/physics/cld_fraction/cld_fraction_functions.hpp
@@ -35,16 +35,18 @@ struct CldFractionFunctions
   using uview_1d = typename ekat::template Unmanaged<view_1d<S> >;
 
   static void main(
-    const Int nj, 
+    const Int nj,
     const Int nk,
     const Real ice_threshold,
     const Real ice_4out_threshold,
-    const view_2d<const Pack>& qi, 
-    const view_2d<const Pack>& liq_cld_frac, 
-    const view_2d<Pack>& ice_cld_frac, 
+    const view_2d<const Pack>& qi,
+    const view_2d<const Pack>& liq_cld_frac,
+    const view_2d<Pack>& ice_cld_frac,
     const view_2d<Pack>& tot_cld_frac,
-    const view_2d<Pack>& ice_cld_frac_4out, 
-    const view_2d<Pack>& tot_cld_frac_4out);
+    const view_2d<Pack>& ice_cld_frac_4out,
+    const view_2d<Pack>& tot_cld_frac_4out,
+    const bool use_zm_cloud,
+    const view_2d<const Pack>& deep_cld_frac);
 
   KOKKOS_FUNCTION
   static void calc_icefrac( 
@@ -55,11 +57,20 @@ struct CldFractionFunctions
     const uview_1d<Pack>&       ice_cld_frac);
 
   KOKKOS_FUNCTION
-  static void calc_totalfrac( 
+  static void calc_totalfrac(
     const MemberType& team,
     const Int& nk,
     const uview_1d<const Pack>& liq_cld_frac,
     const uview_1d<const Pack>& ice_cld_frac,
+    const uview_1d<Pack>&       tot_cld_frac);
+
+  // Add the deep convective cloud fraction (from ZM) into the total cloud
+  // fraction, following EAM's clubb_intr.F90: cld = min(ast + deepcu, 1).
+  KOKKOS_FUNCTION
+  static void add_deep_frac(
+    const MemberType& team,
+    const Int& nk,
+    const uview_1d<const Pack>& deep_cld_frac,
     const uview_1d<Pack>&       tot_cld_frac);
 
 }; // struct Functions

--- a/components/eamxx/src/physics/cld_fraction/cld_fraction_main_impl.hpp
+++ b/components/eamxx/src/physics/cld_fraction/cld_fraction_main_impl.hpp
@@ -22,7 +22,9 @@ void CldFractionFunctions<S,D>
   const view_2d<Pack>& ice_cld_frac,
   const view_2d<Pack>& tot_cld_frac,
   const view_2d<Pack>& ice_cld_frac_4out,
-  const view_2d<Pack>& tot_cld_frac_4out)
+  const view_2d<Pack>& tot_cld_frac_4out,
+  const bool use_zm_cloud,
+  const view_2d<const Pack>& deep_cld_frac)
 {
   using ExeSpace = typename KT::ExeSpace;
   using TPF = ekat::TeamPolicyFactory<ExeSpace>;
@@ -48,6 +50,15 @@ void CldFractionFunctions<S,D>
 
     calc_totalfrac(team,nk,oliq_cld_frac,oice_cld_frac,otot_cld_frac);
     calc_totalfrac(team,nk,oliq_cld_frac,oice_cld_frac_4out,otot_cld_frac_4out);
+
+    // Fold the ZM deep convective cloud fraction into the total cloud fraction
+    // seen by downstream processes (incl. radiation). Applied to both the model
+    // total and the "for_analysis" total.
+    if (use_zm_cloud) {
+      const auto odeep_cld_frac = ekat::subview(deep_cld_frac, i);
+      add_deep_frac(team,nk,odeep_cld_frac,otot_cld_frac);
+      add_deep_frac(team,nk,odeep_cld_frac,otot_cld_frac_4out);
+    }
   });
   Kokkos::fence();
 } // main
@@ -92,6 +103,25 @@ void CldFractionFunctions<S,D>
   }); // Kokkos_parallel_for nk_pack
   team.team_barrier();
 } // calc_totalfrac
+/*-----------------------------------------------------------------*/
+template <typename S, typename D>
+KOKKOS_FUNCTION
+void CldFractionFunctions<S,D>
+::add_deep_frac(
+  const MemberType& team,
+  const Int& nk,
+  const uview_1d<const Pack>& deep_cld_frac,
+  const uview_1d<Pack>&       tot_cld_frac)
+{
+  team.team_barrier();
+  const Int nk_pack = ekat::npack<Pack>(nk);
+  Kokkos::parallel_for(
+    Kokkos::TeamVectorRange(team, nk_pack), [&] (Int k) {
+      // Mirror EAM clubb_intr.F90: cloud_frac = min(ast + deepcu, 1)
+      tot_cld_frac(k) = min(tot_cld_frac(k) + deep_cld_frac(k), 1.0);
+  }); // Kokkos_parallel_for nk_pack
+  team.team_barrier();
+} // add_deep_frac
 /*-----------------------------------------------------------------*/
 
 } // namespace cld_fraction

--- a/components/eamxx/src/physics/cld_fraction/eamxx_cld_fraction_process_interface.cpp
+++ b/components/eamxx/src/physics/cld_fraction/eamxx_cld_fraction_process_interface.cpp
@@ -41,6 +41,13 @@ void CldFraction::create_requests()
   add_tracer<Required>("qi", m_grid, kg/kg, ps);
   add_field<Required>("cldfrac_liq", scalar3d_layout_mid, none, grid_name,ps);
 
+  // When ZM deep convection is active, its diagnosed deep convective cloud
+  // fraction is folded into the total cloud fraction (see run_impl).
+  m_do_zm_deep_cldfrac = m_params.get<bool>("do_zm_deep_cldfrac", false);
+  if (m_do_zm_deep_cldfrac) {
+    add_field<Required>("zm_dp_frac", scalar3d_layout_mid, none, grid_name,ps);
+  }
+
   // Set of fields used strictly as output
   add_field<Computed>("cldfrac_tot", scalar3d_layout_mid, none, grid_name,ps);
   add_field<Computed>("cldfrac_ice", scalar3d_layout_mid, none, grid_name,ps);
@@ -146,8 +153,15 @@ void CldFraction::run_impl (const double /* dt */)
   auto ice_cld_frac_4out_v = ice_cld_frac_4out.get_view<Pack**>();
   auto tot_cld_frac_4out_v = tot_cld_frac_4out.get_view<Pack**>();
 
+  // ZM deep convective cloud fraction (only present/required when enabled).
+  CldFractionFunc::view_2d<const Pack> deep_cld_frac_v;
+  if (m_do_zm_deep_cldfrac) {
+    deep_cld_frac_v = get_field_in("zm_dp_frac").get_view<const Pack**>();
+  }
+
   CldFractionFunc::main(m_num_cols,m_num_levs,m_icecloud_threshold,m_icecloud_for_analysis_threshold,
-    qi_v,liq_cld_frac_v,ice_cld_frac_v,tot_cld_frac_v,ice_cld_frac_4out_v,tot_cld_frac_4out_v);
+    qi_v,liq_cld_frac_v,ice_cld_frac_v,tot_cld_frac_v,ice_cld_frac_4out_v,tot_cld_frac_4out_v,
+    m_do_zm_deep_cldfrac,deep_cld_frac_v);
 }
 
 // =========================================================================================

--- a/components/eamxx/src/physics/cld_fraction/eamxx_cld_fraction_process_interface.hpp
+++ b/components/eamxx/src/physics/cld_fraction/eamxx_cld_fraction_process_interface.hpp
@@ -47,6 +47,10 @@ protected:
   Real m_icecloud_threshold;
   Real m_icecloud_for_analysis_threshold;
 
+  // Flag to control whether the ZM deep convective cloud fraction is combined
+  // into the total. Default to false unless ZM scheme is active - or set via namelist.
+  bool m_do_zm_deep_cldfrac;
+
   std::shared_ptr<const AbstractGrid> m_grid;
 }; // class CldFraction
 

--- a/components/eamxx/src/physics/rrtmgp/eamxx_rrtmgp_process_interface.cpp
+++ b/components/eamxx/src/physics/rrtmgp/eamxx_rrtmgp_process_interface.cpp
@@ -153,6 +153,16 @@ void RRTMGPRadiation::create_requests() {
   add_field<Required>("eff_radius_qi", scalar3d_mid, micron, grid_name);
   add_field<Required>("qv",scalar3d_mid,kg/kg,grid_name);
   add_field<Required>("surf_lw_flux_up",scalar2d,W/(m*m),grid_name);
+
+  // When ZM deep convection is active, add its convective in-cloud water to the
+  // grid-mean cloud water seen by radiation (see run_impl). These fields are
+  // produced by the ZM process; require them only when the feature is enabled.
+  m_do_zm_cloud_in_rad = m_params.get<bool>("do_zm_cloud_in_rad", false);
+  if (m_do_zm_cloud_in_rad) {
+    add_field<Required>("zm_icw_liq", scalar3d_mid, kg/kg, grid_name);
+    add_field<Required>("zm_icw_ice", scalar3d_mid, kg/kg, grid_name);
+    add_field<Required>("zm_dp_frac", scalar3d_mid, none,  grid_name);
+  }
   // Set of required gas concentration fields
   for (auto& it : m_gas_names) {
     // Add gas VOLUME mixing ratios (moles of gas / moles of air; what actually gets input to RRTMGP)
@@ -363,6 +373,8 @@ void RRTMGPRadiation::init_buffers(const ATMBufferManager &buffer_manager)
   mem += m_buffer.lwp_k.size();
   m_buffer.iwp_k = decltype(m_buffer.iwp_k)(mem, m_col_chunk_size, m_nlay);
   mem += m_buffer.iwp_k.size();
+  m_buffer.zm_q_rad_k = decltype(m_buffer.zm_q_rad_k)(mem, m_col_chunk_size, m_nlay);
+  mem += m_buffer.zm_q_rad_k.size();
   m_buffer.sw_heating_k = decltype(m_buffer.sw_heating_k)(mem, m_col_chunk_size, m_nlay);
   mem += m_buffer.sw_heating_k.size();
   m_buffer.lw_heating_k = decltype(m_buffer.lw_heating_k)(mem, m_col_chunk_size, m_nlay);
@@ -566,6 +578,14 @@ void RRTMGPRadiation::run_impl (const double dt) {
   auto d_rel = get_field_in("eff_radius_qc").get_view<const Real**>();
   auto d_rei = get_field_in("eff_radius_qi").get_view<const Real**>();
   auto d_surf_lw_flux_up = get_field_in("surf_lw_flux_up").get_view<const Real*>();
+  // ZM deep convective in-cloud water and deep cloud fraction (only present
+  // when m_do_zm_cloud_in_rad). Left empty otherwise; never read in that case.
+  decltype(d_qc) d_zm_icw_liq, d_zm_icw_ice, d_zm_dp_frac;
+  if (m_do_zm_cloud_in_rad) {
+    d_zm_icw_liq      = get_field_in("zm_icw_liq").get_view<const Real**>();
+    d_zm_icw_ice      = get_field_in("zm_icw_ice").get_view<const Real**>();
+    d_zm_dp_frac = get_field_in("zm_dp_frac").get_view<const Real**>();
+  }
   // Output fields
   auto d_tmid = get_field_out("T_mid").get_view<Real**>();
   auto d_cldfrac_rad = get_field_out("cldfrac_rad").get_view<Real**>();
@@ -982,8 +1002,40 @@ void RRTMGPRadiation::run_impl (const double dt) {
       Kokkos::fence();
 
       // Compute layer cloud mass (per unit area)
-      interface_t::mixing_ratio_to_cloud_mass(qc_k, cldfrac_tot_k, p_del_k, lwp_k);
-      interface_t::mixing_ratio_to_cloud_mass(qi_k, cldfrac_tot_k, p_del_k, iwp_k);
+      if (m_do_zm_cloud_in_rad) {
+        // Add ZM deep convective in-cloud water to the grid-mean cloud water
+        // seen by radiation, without modifying the prognostic qc/qi. Following
+        // EAM's conv_water_4rad: grid-mean total = stratiform grid-mean plus
+        // deep_frac * in-cloud convective. cldfrac_tot_k already includes the
+        // deep contribution (merged upstream in the cld_fraction process), so
+        // mixing_ratio_to_cloud_mass recovers the blended in-cloud value.
+        // Reuse one scratch buffer for liquid, then ice. Trim to the current
+        // chunk's column count so its extent(0) matches the other (trimmed)
+        // inputs to mixing_ratio_to_cloud_mass (which derives ncol from it).
+        auto q_rad_k = Kokkos::subview(m_buffer.zm_q_rad_k, Kokkos::make_pair(0,ncol), Kokkos::ALL);
+        const auto policy = TPF::get_default_team_policy(ncol, m_nlay);
+        Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
+          const int i = team.league_rank();
+          const int icol = i + beg;
+          Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlay), [&] (const int& k) {
+            q_rad_k(i,k) = d_qc(icol,k) + d_zm_dp_frac(icol,k)*d_zm_icw_liq(icol,k);
+          });
+        });
+        Kokkos::fence();
+        interface_t::mixing_ratio_to_cloud_mass(q_rad_k, cldfrac_tot_k, p_del_k, lwp_k);
+        Kokkos::parallel_for(policy, KOKKOS_LAMBDA(const MemberType& team) {
+          const int i = team.league_rank();
+          const int icol = i + beg;
+          Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlay), [&] (const int& k) {
+            q_rad_k(i,k) = d_qi(icol,k) + d_zm_dp_frac(icol,k)*d_zm_icw_ice(icol,k);
+          });
+        });
+        Kokkos::fence();
+        interface_t::mixing_ratio_to_cloud_mass(q_rad_k, cldfrac_tot_k, p_del_k, iwp_k);
+      } else {
+        interface_t::mixing_ratio_to_cloud_mass(qc_k, cldfrac_tot_k, p_del_k, lwp_k);
+        interface_t::mixing_ratio_to_cloud_mass(qi_k, cldfrac_tot_k, p_del_k, iwp_k);
+      }
       // Convert to g/m2 (needed by RRTMGP)
       {
       const auto policy = TPF::get_default_team_policy(ncol, m_nlay);

--- a/components/eamxx/src/physics/rrtmgp/eamxx_rrtmgp_process_interface.hpp
+++ b/components/eamxx/src/physics/rrtmgp/eamxx_rrtmgp_process_interface.hpp
@@ -80,6 +80,10 @@ public:
 
   // Whether we use aerosol forcing in radiation
   bool m_do_aerosol_rad;
+
+  // Whether to add ZM deep convective in-cloud water into the cloud water
+  // seen by radiation. Defaults false; enabled (via namelist) when ZM is active.
+  bool m_do_zm_cloud_in_rad;
   // Whether we do extra aerosol forcing calls
   bool m_extra_clnsky_diag;
   bool m_extra_clnclrsky_diag;
@@ -135,7 +139,7 @@ public:
   // Structure for storing local variables initialized using the ATMBufferManager
   struct Buffer {
     static constexpr int num_1d_ncol        = 8;
-    static constexpr int num_2d_nlay        = 16;
+    static constexpr int num_2d_nlay        = 17;
     static constexpr int num_2d_nlay_p1     = 23;
     static constexpr int num_2d_nswbands    = 2;
     static constexpr int num_3d_nlev_nswbands = 4;
@@ -170,6 +174,9 @@ public:
     ureal2dk tmp2d_k;
     ureal2dk lwp_k;
     ureal2dk iwp_k;
+    // Scratch for combined (stratiform + ZM deep convective) grid-mean cloud
+    // water; reused for liquid then ice. Only used when m_do_zm_cloud_in_rad.
+    ureal2dk zm_q_rad_k;
     ureal2dk sw_heating_k;
     ureal2dk lw_heating_k;
 

--- a/components/eamxx/src/physics/zm/eamxx_zm_process_interface.cpp
+++ b/components/eamxx/src/physics/zm/eamxx_zm_process_interface.cpp
@@ -607,8 +607,8 @@ void ZMDeepConvection::run_impl (const double dt)
     // diagnose deep cloud fraction based on the deep convective mass flux
     // (see "deepcu" calculation in clubb_tend_cam() / clubb_intr.F90)
     zm_dp_frac(i,k) = zm_opts.cldfrc_dp1 * Kokkos::log( Real(1) + Real(500)*loc_zm_output_mass_flux(i,k+1) );
-    zm_dp_frac(i,k) = Kokkos::min(zm_dp_frac(i,k),ZMF::ZMC::deep_cldfrac_max);
-    zm_dp_frac(i,k) = Kokkos::max(zm_dp_frac(i,k),ZMF::ZMC::deep_cldfrac_min);
+    zm_dp_frac(i,k) = Kokkos::min(zm_dp_frac(i,k),Real(ZMF::ZMC::deep_cldfrac_max));
+    zm_dp_frac(i,k) = Kokkos::max(zm_dp_frac(i,k),Real(ZMF::ZMC::deep_cldfrac_min));
     // Zero negligible deep cloud (matches EAM clubb_intr.F90): require both a
     // minimum cloud fraction and a minimum in-cloud water amount. Weighting the
     // radiation water contribution by this fraction then keeps the fraction and

--- a/components/eamxx/src/physics/zm/eamxx_zm_process_interface.cpp
+++ b/components/eamxx/src/physics/zm/eamxx_zm_process_interface.cpp
@@ -81,11 +81,16 @@ void ZMDeepConvection::create_requests ()
   add_field<Computed>("zm_t_prev",            scalar3d_mid, K,      grid_name);
   add_field<Computed>("zm_q_prev",            scalar3d_mid, kg/kg,  grid_name);
 
+  // in-cloud water for radiation
+  add_field<Computed>("zm_icw_liq",           scalar3d_mid, kg/kg,  grid_name);
+  add_field<Computed>("zm_icw_ice",           scalar3d_mid, kg/kg,  grid_name);
+  add_field<Computed>("zm_dp_frac",           scalar3d_mid, none,   grid_name);
+
   // Diagnostic Outputs
   add_field<Computed>("zm_prec",              scalar2d,     m/s,    grid_name);
   add_field<Computed>("zm_snow",              scalar2d,     m/s,    grid_name);
   add_field<Computed>("zm_cape",              scalar2d,     J/kg,   grid_name);
-  add_field<Computed>("zm_dcape",             scalar2d,   J/kg/s,   grid_name);
+  add_field<Computed>("zm_dcape",             scalar2d,     J/kg/s, grid_name);
   add_field<Computed>("zm_activity",          scalar2d,     none,   grid_name);
 
   add_field<Computed>("zm_detr_qc",           scalar3d_mid, kg/kg/s,grid_name, pack_size);
@@ -287,6 +292,7 @@ void ZMDeepConvection::run_impl (const double dt)
   const auto loc_zm_output_ql               = zm_output.ql;
   const auto loc_zm_output_rliq             = zm_output.rliq;
   const auto loc_zm_output_dlf              = zm_output.dlf;
+  const auto loc_zm_output_mass_flux        = zm_output.mass_flux;
 
   //----------------------------------------------------------------------------
   // calculate altitude on interfaces (z_int) and mid-points (z_mid)
@@ -528,6 +534,16 @@ void ZMDeepConvection::run_impl (const double dt)
   }
 
   //----------------------------------------------------------------------------
+  // perform unit conversions
+
+  Kokkos::parallel_for("zm_unit_conversion_int",
+    KT::RangePolicy(0, m_ncol*nlev_int), KOKKOS_LAMBDA (const int idx) {
+    const int i = idx/nlev_int;
+    const int k = idx%nlev_int;
+    loc_zm_output_mass_flux(i,k) = loc_zm_output_mass_flux(i,k) * ZMF::ZMC::mb_to_pa / PC::gravit.value;
+  });
+
+  //----------------------------------------------------------------------------
   // update prognostic fields
 
   // accumulate surface precipitation fluxes
@@ -543,6 +559,9 @@ void ZMDeepConvection::run_impl (const double dt)
   const auto& zm_detr_qi = get_field_out("zm_detr_qi").get_view<Real**>();
   const auto& zm_detr_nc = get_field_out("zm_detr_nc").get_view<Real**>();
   const auto& zm_detr_ni = get_field_out("zm_detr_ni").get_view<Real**>();
+  const auto& zm_icw_liq = get_field_out("zm_icw_liq").get_view<Real**>();
+  const auto& zm_icw_ice = get_field_out("zm_icw_ice").get_view<Real**>();
+  const auto& zm_dp_frac = get_field_out("zm_dp_frac").get_view<Real**>();
   Kokkos::parallel_for("zm_update_prognostic",
     KT::RangePolicy(0, m_ncol*nlev_mid), KOKKOS_LAMBDA (const int idx) {
     const int i = idx/nlev_mid;
@@ -582,6 +601,14 @@ void ZMDeepConvection::run_impl (const double dt)
     // update "previous" T/qv variabiables for DCAPE
     t_prev(i,k) = T_mid(i,k);
     q_prev(i,k) = qv   (i,k);
+    // update in-cloud water for radiation
+    zm_icw_liq(i,k) = (1 - ice_frac) * loc_zm_output_ql(i,k);
+    zm_icw_ice(i,k) = ice_frac       * loc_zm_output_ql(i,k);
+    // diagnose deep cloud fraction based on the deep convective mass flux
+    // (see "deepcu" calculation in clubb_tend_cam() / clubb_intr.F90)
+    zm_dp_frac(i,k) = zm_opts.cldfrc_dp1 * Kokkos::log( Real(1) + Real(500)*loc_zm_output_mass_flux(i,k+1) );
+    zm_dp_frac(i,k) = Kokkos::min(zm_dp_frac(i,k),ZMF::ZMC::deep_cldfrac_max);
+    zm_dp_frac(i,k) = Kokkos::max(zm_dp_frac(i,k),ZMF::ZMC::deep_cldfrac_min);
   });
 
   //----------------------------------------------------------------------------
@@ -619,7 +646,6 @@ void ZMDeepConvection::run_impl (const double dt)
   });
 
   // 3D interface output
-  const auto loc_zm_output_mass_flux = zm_output.mass_flux;
   const auto& mass_flux_int = get_field_out("zm_mass_flux_int").get_view<Real**>();
   Kokkos::parallel_for("zm_diag_outputs_3D_int",
     KT::RangePolicy(0, m_ncol*nlev_int), KOKKOS_LAMBDA (const int idx) {

--- a/components/eamxx/src/physics/zm/eamxx_zm_process_interface.cpp
+++ b/components/eamxx/src/physics/zm/eamxx_zm_process_interface.cpp
@@ -86,14 +86,6 @@ void ZMDeepConvection::create_requests ()
   add_field<Computed>("zm_icw_ice",           scalar3d_mid, kg/kg,  grid_name, pack_size);
   add_field<Computed>("zm_dp_frac",           scalar3d_mid, none,   grid_name, pack_size);
 
-  // Vertically integrated ZM in-cloud water, weighted by the deep cloud fraction
-  // to give the grid-mean contribution - i.e. the amount of water that ZM adds to
-  // the water seen by radiation. These are meant to be combined with the standard
-  // LiqWaterPath / IceWaterPath diagnostics (which are unaffected by ZM) via the
-  // binary op diagnostic, ex: "LiqWaterPath_plus_zm_icw_liq_path"
-  add_field<Computed>("zm_icw_liq_path",      scalar2d,     kg/m2,  grid_name);
-  add_field<Computed>("zm_icw_ice_path",      scalar2d,     kg/m2,  grid_name);
-
   // Diagnostic Outputs
   add_field<Computed>("zm_prec",              scalar2d,     m/s,    grid_name);
   add_field<Computed>("zm_snow",              scalar2d,     m/s,    grid_name);
@@ -625,27 +617,6 @@ void ZMDeepConvection::run_impl (const double dt)
         loc_zm_output_ql(i,k) < ZMF::ZMC::deep_icw_limit) {
       zm_dp_frac(i,k) = 0;
     }
-  });
-
-  //----------------------------------------------------------------------------
-  // Vertically integrate the ZM in-cloud water to obtain the contribution to the
-  // liquid and ice water path. The dp_frac weighting is applied here so that this
-  // is consistent with the grid-mean water that RRTMGP sees when the ZM in-cloud
-  // water is included in radiation (see eamxx_rrtmgp_process_interface.cpp)
-
-  const auto& zm_icw_liq_path = get_field_out("zm_icw_liq_path").get_view<Real*>();
-  const auto& zm_icw_ice_path = get_field_out("zm_icw_ice_path").get_view<Real*>();
-  const auto loc_p_del = zm_input.p_del;
-  Kokkos::parallel_for("zm_icw_path", team_policy, KOKKOS_LAMBDA (const KT::MemberType& team) {
-    const int i = team.league_rank();
-    Kokkos::parallel_reduce(Kokkos::TeamVectorRange(team, nlev_mid),
-                            [&] (const int& k, Real& lsum) {
-      lsum += zm_dp_frac(i,k) * zm_icw_liq(i,k) * loc_p_del(i,k) / PC::gravit.value;
-    }, zm_icw_liq_path(i));
-    Kokkos::parallel_reduce(Kokkos::TeamVectorRange(team, nlev_mid),
-                            [&] (const int& k, Real& lsum) {
-      lsum += zm_dp_frac(i,k) * zm_icw_ice(i,k) * loc_p_del(i,k) / PC::gravit.value;
-    }, zm_icw_ice_path(i));
   });
 
   //----------------------------------------------------------------------------

--- a/components/eamxx/src/physics/zm/eamxx_zm_process_interface.cpp
+++ b/components/eamxx/src/physics/zm/eamxx_zm_process_interface.cpp
@@ -86,6 +86,14 @@ void ZMDeepConvection::create_requests ()
   add_field<Computed>("zm_icw_ice",           scalar3d_mid, kg/kg,  grid_name, pack_size);
   add_field<Computed>("zm_dp_frac",           scalar3d_mid, none,   grid_name, pack_size);
 
+  // Vertically integrated ZM in-cloud water, weighted by the deep cloud fraction
+  // to give the grid-mean contribution - i.e. the amount of water that ZM adds to
+  // the water seen by radiation. These are meant to be combined with the standard
+  // LiqWaterPath / IceWaterPath diagnostics (which are unaffected by ZM) via the
+  // binary op diagnostic, ex: "LiqWaterPath_plus_zm_icw_liq_path"
+  add_field<Computed>("zm_icw_liq_path",      scalar2d,     kg/m2,  grid_name);
+  add_field<Computed>("zm_icw_ice_path",      scalar2d,     kg/m2,  grid_name);
+
   // Diagnostic Outputs
   add_field<Computed>("zm_prec",              scalar2d,     m/s,    grid_name);
   add_field<Computed>("zm_snow",              scalar2d,     m/s,    grid_name);
@@ -617,6 +625,27 @@ void ZMDeepConvection::run_impl (const double dt)
         loc_zm_output_ql(i,k) < ZMF::ZMC::deep_icw_limit) {
       zm_dp_frac(i,k) = 0;
     }
+  });
+
+  //----------------------------------------------------------------------------
+  // Vertically integrate the ZM in-cloud water to obtain the contribution to the
+  // liquid and ice water path. The dp_frac weighting is applied here so that this
+  // is consistent with the grid-mean water that RRTMGP sees when the ZM in-cloud
+  // water is included in radiation (see eamxx_rrtmgp_process_interface.cpp)
+
+  const auto& zm_icw_liq_path = get_field_out("zm_icw_liq_path").get_view<Real*>();
+  const auto& zm_icw_ice_path = get_field_out("zm_icw_ice_path").get_view<Real*>();
+  const auto loc_p_del = zm_input.p_del;
+  Kokkos::parallel_for("zm_icw_path", team_policy, KOKKOS_LAMBDA (const KT::MemberType& team) {
+    const int i = team.league_rank();
+    Kokkos::parallel_reduce(Kokkos::TeamVectorRange(team, nlev_mid),
+                            [&] (const int& k, Real& lsum) {
+      lsum += zm_dp_frac(i,k) * zm_icw_liq(i,k) * loc_p_del(i,k) / PC::gravit.value;
+    }, zm_icw_liq_path(i));
+    Kokkos::parallel_reduce(Kokkos::TeamVectorRange(team, nlev_mid),
+                            [&] (const int& k, Real& lsum) {
+      lsum += zm_dp_frac(i,k) * zm_icw_ice(i,k) * loc_p_del(i,k) / PC::gravit.value;
+    }, zm_icw_ice_path(i));
   });
 
   //----------------------------------------------------------------------------

--- a/components/eamxx/src/physics/zm/eamxx_zm_process_interface.cpp
+++ b/components/eamxx/src/physics/zm/eamxx_zm_process_interface.cpp
@@ -78,13 +78,13 @@ void ZMDeepConvection::create_requests ()
   add_field <Updated>("precip_ice_surf_mass", scalar2d,     kg/m2,  grid_name, "ACCUMULATED");
 
   // T/qv from previous time step for DCAPE
-  add_field<Computed>("zm_t_prev",            scalar3d_mid, K,      grid_name);
-  add_field<Computed>("zm_q_prev",            scalar3d_mid, kg/kg,  grid_name);
+  add_field<Computed>("zm_t_prev",            scalar3d_mid, K,      grid_name, pack_size);
+  add_field<Computed>("zm_q_prev",            scalar3d_mid, kg/kg,  grid_name, pack_size);
 
   // in-cloud water for radiation
-  add_field<Computed>("zm_icw_liq",           scalar3d_mid, kg/kg,  grid_name);
-  add_field<Computed>("zm_icw_ice",           scalar3d_mid, kg/kg,  grid_name);
-  add_field<Computed>("zm_dp_frac",           scalar3d_mid, none,   grid_name);
+  add_field<Computed>("zm_icw_liq",           scalar3d_mid, kg/kg,  grid_name, pack_size);
+  add_field<Computed>("zm_icw_ice",           scalar3d_mid, kg/kg,  grid_name, pack_size);
+  add_field<Computed>("zm_dp_frac",           scalar3d_mid, none,   grid_name, pack_size);
 
   // Diagnostic Outputs
   add_field<Computed>("zm_prec",              scalar2d,     m/s,    grid_name);

--- a/components/eamxx/src/physics/zm/eamxx_zm_process_interface.cpp
+++ b/components/eamxx/src/physics/zm/eamxx_zm_process_interface.cpp
@@ -609,6 +609,14 @@ void ZMDeepConvection::run_impl (const double dt)
     zm_dp_frac(i,k) = zm_opts.cldfrc_dp1 * Kokkos::log( Real(1) + Real(500)*loc_zm_output_mass_flux(i,k+1) );
     zm_dp_frac(i,k) = Kokkos::min(zm_dp_frac(i,k),ZMF::ZMC::deep_cldfrac_max);
     zm_dp_frac(i,k) = Kokkos::max(zm_dp_frac(i,k),ZMF::ZMC::deep_cldfrac_min);
+    // Zero negligible deep cloud (matches EAM clubb_intr.F90): require both a
+    // minimum cloud fraction and a minimum in-cloud water amount. Weighting the
+    // radiation water contribution by this fraction then keeps the fraction and
+    // water contributions consistent (both vanish together).
+    if (zm_dp_frac(i,k) <= ZMF::ZMC::deep_frac_limit ||
+        loc_zm_output_ql(i,k) < ZMF::ZMC::deep_icw_limit) {
+      zm_dp_frac(i,k) = 0;
+    }
   });
 
   //----------------------------------------------------------------------------

--- a/components/eamxx/src/physics/zm/fortran_bridge/zm_eamxx_bridge_main.F90
+++ b/components/eamxx/src/physics/zm/fortran_bridge/zm_eamxx_bridge_main.F90
@@ -299,7 +299,7 @@ subroutine zm_eamxx_bridge_run_c( ncol, dtime, is_first_step, &
   ! apply tendencies from zm_conv_main() & MCSP to local copy of state variables
 
   call zm_physics_update( ncol, dtime, &
-                          state_phis, local_state_zm, local_state_zi, &
+                          local_state_zm, local_state_zi, &
                           state_p_mid, state_p_int, state_p_del, &
                           local_state_t, local_state_qv, &
                           output_tend_s, output_tend_q)

--- a/components/eamxx/src/physics/zm/fortran_bridge/zm_eamxx_bridge_methods.F90
+++ b/components/eamxx/src/physics/zm/fortran_bridge/zm_eamxx_bridge_methods.F90
@@ -111,7 +111,7 @@ end subroutine
 ! This combines functionality of:
 ! - physics_update()      [see physics_update_mod.F90]
 ! - physics_update_main() [see physics_types.F90]
-subroutine zm_physics_update( ncol, dt, state_phis, state_zm, state_zi, &
+subroutine zm_physics_update( ncol, dt, state_zm, state_zi, &
                               state_p_mid, state_p_int, state_p_del, &
                               state_t, state_qv, ptend_s, ptend_q)
   use zm_eamxx_bridge_physconst, only: cpair
@@ -120,7 +120,7 @@ subroutine zm_physics_update( ncol, dt, state_phis, state_zm, state_zi, &
   ! Arguments
   integer,                        intent(in   ) :: ncol             ! number of local columns
   real(r8),                       intent(in   ) :: dt               ! time step
-  real(r8), dimension(ncol),      intent(in   ) :: state_phis       ! input state surface geopotential height
+  ! real(r8), dimension(ncol),      intent(in   ) :: state_phis       ! input state surface geopotential height
   real(r8), dimension(ncol,pver), intent(inout) :: state_zm         ! input state altitude at mid-levels
   real(r8), dimension(ncol,pverp),intent(inout) :: state_zi         ! input state altitude at interfaces
   real(r8), dimension(ncol,pver), intent(in   ) :: state_p_mid      ! input state mid-point pressure
@@ -144,7 +144,7 @@ subroutine zm_physics_update( ncol, dt, state_phis, state_zm, state_zi, &
     end do
   end do
 
-  call zm_geopotential_t( ncol, state_p_int, state_p_mid, state_p_del, state_t, state_qv, state_zi, state_zm )
+  call zm_geopotential_t( ncol, state_p_mid, state_p_del, state_t, state_qv, state_zi, state_zm )
 
   ! skip DSE update for EAMxx
   ! do i = 1,ncol
@@ -159,7 +159,7 @@ end subroutine zm_physics_update
 !===================================================================================================
 
 ! copied and modified from geopotential.F90
-subroutine zm_geopotential_t( ncol, pint, pmid, pdel, t, q, zi, zm )
+subroutine zm_geopotential_t( ncol, pmid, pdel, t, q, zi, zm )
   use zm_eamxx_bridge_physconst, only: zvir, rair, gravit
   use zm_eamxx_bridge_params, only: pverp, pver
   !-----------------------------------------------------------------------
@@ -168,7 +168,6 @@ subroutine zm_geopotential_t( ncol, pint, pmid, pdel, t, q, zi, zm )
   !-----------------------------------------------------------------------------
   ! Arguments
   integer,                        intent(in   ) :: ncol    ! Number of columns
-  real(r8), dimension(ncol,pverp),intent(in   ) :: pint    ! Interface pressures
   real(r8), dimension(ncol,pver), intent(in   ) :: pmid    ! Midpoint pressures
   real(r8), dimension(ncol,pver), intent(in   ) :: pdel    ! layer thickness
   real(r8), dimension(ncol,pver), intent(in   ) :: t       ! temperature

--- a/components/eamxx/src/physics/zm/impl/zm_closure_impl.hpp
+++ b/components/eamxx/src/physics/zm/impl/zm_closure_impl.hpp
@@ -35,7 +35,7 @@ void Functions<S,D>::zm_closure(
   const uview_1d<const Real>& s_mid, // ambient dry static energy (normalized)
   const uview_1d<const Real>& q_mid, // ambient specific humidity
   const uview_1d<const Real>& qs, // ambient saturation specific humidity
-  const uview_1d<const Real>& ql, // ambient liquid water mixing ratio
+  const uview_1d<const Real>& ql, // in-cloud liquid water mixing ratio
   const uview_1d<const Real>& s_int, // env. normalized dry static energy at intrfcs
   const uview_1d<const Real>& q_int, // environment specific humidity at interfaces
   const Real& t_pcl_lcl, // parcel temperature at LCL

--- a/components/eamxx/src/physics/zm/zm_functions.hpp
+++ b/components/eamxx/src/physics/zm/zm_functions.hpp
@@ -115,6 +115,8 @@ struct Functions {
     static inline constexpr Real momcd                     = 0.4;      // pressure gradient term constant for downdrafts
     static inline constexpr Real mse_min_diff              = 100;      // min MSE buoyancy difference for Taylor series in entrainment [J/kg]
     static inline constexpr Real tpert_limiter             = 2;        // upper limit on temperature perturbation in input state [K]
+    static inline constexpr Real deep_cldfrac_max          = 0.6;      // upper limit on diagnosed deep convective cloud fraction
+    static inline constexpr Real deep_cldfrac_min          = 0.0;      // lower limit on diagnosed deep convective cloud fraction
     // MCSP parameters
     static inline constexpr Real MCSP_storm_speed_pref     = 600e2;    // pressure level for winds in MCSP calculation Pa]
     static inline constexpr Real MCSP_conv_depth_min       = 700e2;    // pressure thickness of convective heating [Pa]
@@ -130,6 +132,7 @@ struct Functions {
     static inline constexpr Real dmpdz                     = -0.7e-3;  // default convective entrainment parameter [1/m]
     static inline constexpr Real tiedke_add                = 0.8;      // default Tiedke temperature perturbation addition [K]
     static inline constexpr Real c0                        = 0.0020;   // default autoconversion coefficient
+    static inline constexpr Real cldfrc_dp1                = 0.018;    // default parameter for radiative in-cld water
 
     // Table of saturation vapor pressure values (estbl) from tmin to
     // tmax+1 Kelvin, in one degree increments. ttrice defines the transition
@@ -150,8 +153,9 @@ struct Functions {
     ZmRuntimeOpt() = default;
 
     void load_runtime_options(ekat::ParameterList& params) {
-      apply_detr_tend     = params.get<bool>("apply_detr_tend",     true);
       use_fortran_bridge  = params.get<bool>("use_fortran_bridge",  true);
+      apply_detr_tend     = params.get<bool>("apply_detr_tend",     true);
+      conv_water_in_rad   = params.get<bool>("conv_water_in_rad",   true);
       upper_limit_pref    = params.get<Real>("upper_limit_pref",    40e2);
       tau                 = params.get<Real>("tau",                 3600);
       alfa                = params.get<Real>("alfa",                ZMC::alfa);
@@ -168,6 +172,7 @@ struct Functions {
       trig_ull            = params.get<bool>("trig_ull",            true);
       clos_dyn_adj        = params.get<bool>("clos_dyn_adj",        false);
       no_deep_pbl         = params.get<bool>("no_deep_pbl",         false);
+      cldfrc_dp1          = params.get<Real>("cldfrc_dp1",          ZMC::cldfrc_dp1);
       // ZM micro parameters
       zm_microp           = params.get<bool>("zm_microp",           false);
       old_snow            = params.get<bool>("old_snow",            true);
@@ -228,35 +233,44 @@ struct Functions {
       os << std::boolalpha;
       os << "\n";
       os << "ZM deep convection parameter values:\n";
-      os << indent << "tau             : " << tau            << "\n";
-      os << indent << "alfa            : " << alfa           << "\n";
-      os << indent << "ke              : " << ke             << "\n";
-      os << indent << "dmpdz           : " << dmpdz          << "\n";
-      os << indent << "tpert_fix       : " << tpert_fix      << "\n";
-      os << indent << "tpert_fac       : " << tpert_fac      << "\n";
-      os << indent << "tiedke_add      : " << tiedke_add     << "\n";
-      os << indent << "c0_lnd          : " << c0_lnd         << "\n";
-      os << indent << "c0_ocn          : " << c0_ocn         << "\n";
-      os << indent << "num_cin         : " << num_cin        << "\n";
-      os << indent << "limcnv          : " << limcnv         << "\n";
-      os << indent << "mx_bot_lyr_adj  : " << mx_bot_lyr_adj << "\n";
-      os << indent << "trig_dcape      : " << trig_dcape     << "\n";
-      os << indent << "trig_ull        : " << trig_ull       << "\n";
-      os << indent << "clos_dyn_adj    : " << clos_dyn_adj   << "\n";
-      os << indent << "no_deep_pbl     : " << no_deep_pbl    << "\n";
+      os << indent << "use_fortran_bridge : " << use_fortran_bridge << "\n";
+      os << indent << "apply_detr_tend    : " << apply_detr_tend    << "\n";
+      os << indent << "conv_water_in_rad  : " << conv_water_in_rad  << "\n";
+      os << indent << "upper_limit_pref   : " << upper_limit_pref   << "\n";
+      os << indent << "tau                : " << tau                << "\n";
+      os << indent << "alfa               : " << alfa               << "\n";
+      os << indent << "ke                 : " << ke                 << "\n";
+      os << indent << "dmpdz              : " << dmpdz              << "\n";
+      os << indent << "tpert_fix          : " << tpert_fix          << "\n";
+      os << indent << "tpert_fac          : " << tpert_fac          << "\n";
+      os << indent << "tiedke_add         : " << tiedke_add         << "\n";
+      os << indent << "c0_lnd             : " << c0_lnd             << "\n";
+      os << indent << "c0_ocn             : " << c0_ocn             << "\n";
+      os << indent << "num_cin            : " << num_cin            << "\n";
+      os << indent << "limcnv             : " << limcnv             << "\n";
+      os << indent << "mx_bot_lyr_adj     : " << mx_bot_lyr_adj     << "\n";
+      os << indent << "trig_dcape         : " << trig_dcape         << "\n";
+      os << indent << "trig_ull           : " << trig_ull           << "\n";
+      os << indent << "clos_dyn_adj       : " << clos_dyn_adj       << "\n";
+      os << indent << "no_deep_pbl        : " << no_deep_pbl        << "\n";
+      os << indent << "cldfrc_dp1         : " << cldfrc_dp1         << "\n";
       // ZM micro parameters
-      os << indent << "zm_microp       : " << zm_microp      << "\n";
-      os << indent << "old_snow        : " << old_snow       << "\n";
+      os << indent << "zm_microp          : " << zm_microp          << "\n";
+      os << indent << "old_snow           : " << old_snow           << "\n";
       // MCSP parameters
-      os << indent << "mcsp_enabled    : " << mcsp_enabled   << "\n";
-      os << indent << "mcsp_t_coeff    : " << mcsp_t_coeff   << "\n";
-      os << indent << "mcsp_q_coeff    : " << mcsp_q_coeff   << "\n";
-      os << indent << "mcsp_u_coeff    : " << mcsp_u_coeff   << "\n";
-      os << indent << "mcsp_v_coeff    : " << mcsp_v_coeff   << "\n";
+      os << indent << "mcsp_enabled       : " << mcsp_enabled       << "\n";
+      os << indent << "mcsp_t_coeff       : " << mcsp_t_coeff       << "\n";
+      os << indent << "mcsp_q_coeff       : " << mcsp_q_coeff       << "\n";
+      os << indent << "mcsp_u_coeff       : " << mcsp_u_coeff       << "\n";
+      os << indent << "mcsp_v_coeff       : " << mcsp_v_coeff       << "\n";
       os << std::endl;
       os.flags(saved_flags);
     }
 
+    bool use_fortran_bridge;// flag to use EAM's ZM via fortran brigde
+    bool apply_detr_tend;   // flag to apply ZM liq/ice detrainment tendencies
+    bool conv_water_in_rad; // flag to use ZM in-cloud water for radiation
+    Real upper_limit_pref;  // pressure limit above which deep convection is not allowed [Pa] (used to set limcnv)
     Real tau;               // convective adjustment time scale
     Real alfa;              // max downdraft mass flux fraction
     Real ke;                // evaporation efficiency
@@ -267,15 +281,13 @@ struct Functions {
     Real c0_lnd;            // autoconversion coefficient over land
     Real c0_ocn;            // autoconversion coefficient over ocean
     int num_cin;            // num of neg buoyancy regions allowed before the conv top and CAPE calc are completed
-    Real upper_limit_pref;  // pressure limit above which deep convection is not allowed [Pa] (used to set limcnv)
     int limcnv;             // upper pressure interface level to limit deep convection
     int mx_bot_lyr_adj;     // bot layer index adjustment for launch level search
     bool trig_dcape;        // true if to using DCAPE trigger - based on CAPE generation by the dycor
     bool trig_ull;          // true if to using the "unrestricted launch level" (ULL) mode
     bool clos_dyn_adj;      // flag for mass flux adjustment to CAPE closure
     bool no_deep_pbl;       // flag to eliminate deep convection within PBL
-    bool apply_detr_tend;
-    bool use_fortran_bridge;
+    Real cldfrc_dp1;        // parameter for radiative in-cld water
     // ZM micro parameters
     bool zm_microp;         // switch for convective microphysics
     bool old_snow;          // switch to calculate snow prod in zm_conv_evap() (old treatment before zm_microp was implemented)
@@ -439,7 +451,7 @@ struct Functions {
     uview_2d<Real>   flxsnow;        // Convective flux of snow at interfaces   [kg/m2/s]
     uview_2d<Real>   prec_flux;      // output convective prec flux             [kg/m2/s]
     uview_2d<Real>   snow_flux;      // output convective snow flux             [kg/m2/s]
-    uview_2d<Real>   mass_flux;      // output convective mass flux             [mb/s]
+    uview_2d<Real>   mass_flux;      // output convective mass flux             [kg/m2/s] (converted from [mb/s] after zm_conv_main)
     // variables only needed for calling the C++ version of ZM
     uview_1d<Int>    msemax_klev;    // level indices of max MSE
     uview_1d<Int>    jctop;          // top-of-deep-convection indices

--- a/components/eamxx/src/physics/zm/zm_functions.hpp
+++ b/components/eamxx/src/physics/zm/zm_functions.hpp
@@ -135,6 +135,8 @@ struct Functions {
     static inline constexpr Real tiedke_add                = 0.8;      // default Tiedke temperature perturbation addition [K]
     static inline constexpr Real c0                        = 0.0020;   // default autoconversion coefficient
     static inline constexpr Real cldfrc_dp1                = 0.018;    // default parameter for radiative in-cld water
+    static inline constexpr Real dlf_tk1                   = 268.15;   // T at/above which detrained condensate (dlf) is assumed to be liquid
+    static inline constexpr Real dlf_tk2                   = 238.15;   // T at/below which detrained condensate (dlf) is assumed to be ice
 
     // Table of saturation vapor pressure values (estbl) from tmin to
     // tmax+1 Kelvin, in one degree increments. ttrice defines the transition
@@ -144,8 +146,6 @@ struct Functions {
     static inline constexpr Real h2otrip = 273.16;
     static inline constexpr Real ttrice  = 20.0;  // transition range from es over H2O to es over ice
 
-    static inline constexpr Real dlf_tk1 = 268.15; // T at/above which detrained condensate (dlf) is assumed to be liquid
-    static inline constexpr Real dlf_tk2 = 238.15; // T at/below which detrained condensate (dlf) is assumed to be ice
   };
 
   //----------------------------------------------------------------------------
@@ -177,6 +177,8 @@ struct Functions {
       // ZM micro parameters
       zm_microp           = params.get<bool>("zm_microp",           false);
       old_snow            = params.get<bool>("old_snow",            true);
+      dlf_tk1             = params.get<Real>("dlf_tk1",             ZMC::dlf_tk1);
+      dlf_tk2             = params.get<Real>("dlf_tk2",             ZMC::dlf_tk2);
       // MCSP parameters
       mcsp_enabled        = params.get<bool>("mcsp_enabled",        true);
       mcsp_t_coeff        = params.get<Real>("mcsp_t_coeff",        ZMC::MCSP_t_coeff_default);
@@ -257,6 +259,8 @@ struct Functions {
       // ZM micro parameters
       os << indent << "zm_microp          : " << zm_microp          << "\n";
       os << indent << "old_snow           : " << old_snow           << "\n";
+      os << indent << "dlf_tk1            : " << dlf_tk1            << "\n";
+      os << indent << "dlf_tk2            : " << dlf_tk2            << "\n";
       // MCSP parameters
       os << indent << "mcsp_enabled       : " << mcsp_enabled       << "\n";
       os << indent << "mcsp_t_coeff       : " << mcsp_t_coeff       << "\n";
@@ -290,6 +294,8 @@ struct Functions {
     // ZM micro parameters
     bool zm_microp;         // switch for convective microphysics
     bool old_snow;          // switch to calculate snow prod in zm_conv_evap() (old treatment before zm_microp was implemented)
+    Real dlf_tk1;           // T at/above which detrained condensate (dlf) is assumed to be liquid
+    Real dlf_tk2;           // T at/below which detrained condensate (dlf) is assumed to be ice
     // MCSP parameters
     bool mcsp_enabled;      // flag for mesoscale coherent structure parameterization (MSCP)
     Real mcsp_t_coeff;      // MCSP coefficient for temperature tendencies
@@ -1092,4 +1098,3 @@ struct Functions {
 # include "impl/zm_calc_output_tend_impl.hpp"
 #endif // GPU && !KOKKOS_ENABLE_*_RELOCATABLE_DEVICE_CODE
 #endif // ZM_FUNCTIONS_HPP
-                                                                                                                                                                                                                                            

--- a/components/eamxx/src/physics/zm/zm_functions.hpp
+++ b/components/eamxx/src/physics/zm/zm_functions.hpp
@@ -117,6 +117,8 @@ struct Functions {
     static inline constexpr Real tpert_limiter             = 2;        // upper limit on temperature perturbation in input state [K]
     static inline constexpr Real deep_cldfrac_max          = 0.6;      // upper limit on diagnosed deep convective cloud fraction
     static inline constexpr Real deep_cldfrac_min          = 0.0;      // lower limit on diagnosed deep convective cloud fraction
+    static inline constexpr Real deep_frac_limit           = 0.01;     // min deep cloud fraction below which it is zeroed (EAM frac_limit)
+    static inline constexpr Real deep_icw_limit            = 1.e-12;   // min deep in-cloud water below which deep cloud fraction is zeroed (EAM ic_limit)
     // MCSP parameters
     static inline constexpr Real MCSP_storm_speed_pref     = 600e2;    // pressure level for winds in MCSP calculation Pa]
     static inline constexpr Real MCSP_conv_depth_min       = 700e2;    // pressure thickness of convective heating [Pa]
@@ -155,7 +157,6 @@ struct Functions {
     void load_runtime_options(ekat::ParameterList& params) {
       use_fortran_bridge  = params.get<bool>("use_fortran_bridge",  true);
       apply_detr_tend     = params.get<bool>("apply_detr_tend",     true);
-      conv_water_in_rad   = params.get<bool>("conv_water_in_rad",   true);
       upper_limit_pref    = params.get<Real>("upper_limit_pref",    40e2);
       tau                 = params.get<Real>("tau",                 3600);
       alfa                = params.get<Real>("alfa",                ZMC::alfa);
@@ -235,7 +236,6 @@ struct Functions {
       os << "ZM deep convection parameter values:\n";
       os << indent << "use_fortran_bridge : " << use_fortran_bridge << "\n";
       os << indent << "apply_detr_tend    : " << apply_detr_tend    << "\n";
-      os << indent << "conv_water_in_rad  : " << conv_water_in_rad  << "\n";
       os << indent << "upper_limit_pref   : " << upper_limit_pref   << "\n";
       os << indent << "tau                : " << tau                << "\n";
       os << indent << "alfa               : " << alfa               << "\n";
@@ -269,7 +269,6 @@ struct Functions {
 
     bool use_fortran_bridge;// flag to use EAM's ZM via fortran brigde
     bool apply_detr_tend;   // flag to apply ZM liq/ice detrainment tendencies
-    bool conv_water_in_rad; // flag to use ZM in-cloud water for radiation
     Real upper_limit_pref;  // pressure limit above which deep convection is not allowed [Pa] (used to set limcnv)
     Real tau;               // convective adjustment time scale
     Real alfa;              // max downdraft mass flux fraction
@@ -1093,3 +1092,4 @@ struct Functions {
 # include "impl/zm_calc_output_tend_impl.hpp"
 #endif // GPU && !KOKKOS_ENABLE_*_RELOCATABLE_DEVICE_CODE
 #endif // ZM_FUNCTIONS_HPP
+                                                                                                                                                                                                                                            

--- a/components/eamxx/src/physics/zm/zm_functions.hpp
+++ b/components/eamxx/src/physics/zm/zm_functions.hpp
@@ -271,7 +271,7 @@ struct Functions {
       os.flags(saved_flags);
     }
 
-    bool use_fortran_bridge;// flag to use EAM's ZM via fortran brigde
+    bool use_fortran_bridge;// flag to use EAM's ZM via fortran bridge
     bool apply_detr_tend;   // flag to apply ZM liq/ice detrainment tendencies
     Real upper_limit_pref;  // pressure limit above which deep convection is not allowed [Pa] (used to set limcnv)
     Real tau;               // convective adjustment time scale


### PR DESCRIPTION
This introduces new features to the allow deep convective in-cloud water to influence radiation in EAMxx, similar to what EAM does. When the ZM process is present, the deep convective cloud fraction and in-cloud water are included in cloud fraction and radiation calculations. These features are enabled by default when ZM is active, but can be overridden by explicit user configuration.

**Physics and Process Integration**

* The `cld_fraction` process now automatically folds the ZM deep convective cloud fraction into the total cloud fraction if ZM is active, using the new `do_zm_deep_cldfrac` parameter. This is handled in both the process interface and core calculation routines.
* The `rrtmgp` radiation process now optionally adds ZM deep convective in-cloud water to the grid-mean cloud water seen by radiation, controlled by the new `do_zm_cloud_in_rad` parameter. This includes allocating buffer space, requesting the required fields, and updating the calculation logic.

**Configuration and Defaults**

* Added logic to automatically set `do_zm_deep_cldfrac` and `do_zm_cloud_in_rad` defaults in the XML configuration based on whether ZM is present in the process list, ensuring sensible defaults while allowing user override.
* Updated `namelist_defaults_eamxx.xml` to include new ZM parameters and document the new defaulting behavior for the relevant flags.

**ZM Process Outputs**

* The ZM process now outputs the required diagnostic fields (`zm_icw_liq`, `zm_icw_ice`, `zm_dp_frac`) for use by downstream processes, ensuring that all necessary information is available when ZM-radiation coupling is enabled. 

These changes improve the physical realism and usability of the model by ensuring the interaction between deep convection and cloud/radiation processes is handled in a consistent, configurable, and automated way.