### PR TITLE
fix zm proc name and averaging logic

### DIFF
--- a/components/eamxx/src/physics/zm/eamxx_zm_process_interface.hpp
+++ b/components/eamxx/src/physics/zm/eamxx_zm_process_interface.hpp
@@ -36,7 +36,7 @@ class ZMDeepConvection : public AtmosphereProcess
     AtmosphereProcessType type() const override { return AtmosphereProcessType::Physics; }
 
     // The name of the subcomponent
-    std::string name() const override { return "ZM"; }
+    std::string name() const override { return "zm"; }
 
     // Create grid-dependent field requests
     void create_requests() override;

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -623,9 +623,12 @@ run (const std::string& filename, const util::TimeStamp& ts,
     if (is_write_step) {
       // NOTE: we don't divide by the avg cnt for checkpoint output
       if (output_step and m_avg_type==OutputAvgType::Average) {
-        // Even if m_track_avg_cnt=true, this field may not need it
-        if (m_track_avg_cnt) {
-          auto avg_count = m_field_to_avg_count.at(field_name);
+        // Even if m_track_avg_cnt=true, this field may not need it.
+        // Note: a missing entry is safe ONLY for fields that cannot contain
+        // fill values; the may_be_filled check above guarantees that.
+        auto avg_count_it = m_field_to_avg_count.find(field_name);
+        if (m_track_avg_cnt and avg_count_it!=m_field_to_avg_count.end()) {
+          auto avg_count = avg_count_it->second;
 
           f_out.scale_inv(avg_count);
 


### PR DESCRIPTION
This introduces a minor naming convention update and a safety improvement for output averaging logic. This fixes a crash in EAMxx output when an averaged stream contains a field that has  no "avg-count" entry.

* The `name()` method in the `ZMDeepConvection` class now returns `"zm"` instead of `"ZM"`, ensuring consistent lowercase naming for the process identifier.

* The output averaging logic in `scorpio_output.cpp` now safely checks for the existence of an average count entry before accessing it, preventing potential errors when a field is missing from the average count map.

[BFB]