### PR TITLE
Fix short term archiver matching for EAMxx and MPAS AM restart files

### DIFF
--- a/cime_config/config_archive.xml
+++ b/cime_config/config_archive.xml
@@ -28,12 +28,24 @@
   <comp_archive_spec compname="scream" compclass="atm">
     <rest_file_extension>r\.(INSTANT|AVERAGE|MAX|MIN)\.n(step|sec|min|hour|day|month|year)s_x\d*</rest_file_extension>
     <rest_file_extension>rhist\.(INSTANT|AVERAGE|MAX|MIN)\.n(step|sec|min|hour|day|month|year)s_x\d*</rest_file_extension>
-    <!-- The following matches "hi.AVGTYPE.FREQUNITS_xFREQ.TIMESTAMP.nc"-->
-    <hist_file_extension>.*\.h\.(?!rhist\.).*\.nc$</hist_file_extension>
+    <!-- Matches "[STREAM.]h.AVGTYPE.FREQUNITS_xFREQ.TIMESTAMP.nc". The STREAM label is
+         optional: an output yaml that does not set filename_prefix gets the default
+         "$CASE.scream.h", so there is nothing between "scream" and "h". History restart
+         files ("[STREAM.]h.rhist.*") are excluded, they are picked up as restarts above. -->
+    <hist_file_extension>(.*\.)?h\.(?!rhist\.).*\.nc$</hist_file_extension>
+    <rest_history_varname>unset</rest_history_varname>
     <rpointer>
       <rpointer_file>rpointer.atm$NINST_STRING</rpointer_file>
-      <rpointer_content>$CASE.scream$NINST_STRING.r.$DATENAME.nc </rpointer_content>
+      <!-- EAMxx writes rpointer.atm itself, listing the model restart file plus one
+           line per history restart file, so there is nothing to synthesize here. -->
+      <rpointer_content>unset</rpointer_content>
     </rpointer>
+    <test_file_names>
+      <tfile disposition="copy">casename.scream.r.INSTANT.nmonths_x1.1976-01-01-00000.nc</tfile>
+      <tfile disposition="copy">casename.scream.1dailyAVG.h.rhist.AVERAGE.ndays_x1.1976-01-01-00000.nc</tfile>
+      <tfile disposition="move">casename.scream.h.AVERAGE.nmonths_x1.1975-12.nc</tfile>
+      <tfile disposition="move">casename.scream.1dailyAVG.h.AVERAGE.ndays_x1.1975-12-31-00000.nc</tfile>
+    </test_file_names>
   </comp_archive_spec>
 
   <comp_archive_spec compname="elm" compclass="lnd">
@@ -87,7 +99,8 @@
 
   <comp_archive_spec compname="mpassi" compclass="ice" exclude_testing="true">
     <rest_file_extension>rst</rest_file_extension>
-    <rest_file_extension>rst.am.timeSeriesStatsMonthly</rest_file_extension>
+    <!-- Covers every timeSeriesStats AM: Daily, Monthly, MonthlyMax, MonthlyMin, ... -->
+    <rest_file_extension>rst\.am\.timeSeriesStats\w+</rest_file_extension>
     <hist_file_extension>hist</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
@@ -98,6 +111,7 @@
       <tfile disposition="copy">rpointer.ice</tfile>
       <tfile disposition="copy">casename.mpassi.rst.1976-01-01_00000.nc</tfile>
       <tfile disposition="copy">casename.mpassi.rst.am.timeSeriesStatsMonthly.1976-01-01_00000.nc</tfile>
+      <tfile disposition="copy">casename.mpassi.rst.am.timeSeriesStatsDaily.1976-01-01_00000.nc</tfile>
       <tfile disposition="move">casename.mpassi.hist.1976-01-01_00000.nc</tfile>
       <tfile disposition="move">casename.mpassi.hist.am.regionalStatistics.0001.01.nc</tfile>
     </test_file_names>
@@ -105,7 +119,8 @@
 
   <comp_archive_spec compname="mpaso" compclass="ocn" exclude_testing="true">
     <rest_file_extension>rst</rest_file_extension>
-    <rest_file_extension>rst.am.timeSeriesStatsMonthly</rest_file_extension>
+    <!-- Covers every timeSeriesStats AM: Daily, Monthly, MonthlyMax, MonthlyMin, ... -->
+    <rest_file_extension>rst\.am\.timeSeriesStats\w+</rest_file_extension>
     <hist_file_extension>hist</hist_file_extension>
     <rest_history_varname>unset</rest_history_varname>
     <rpointer>
@@ -116,6 +131,8 @@
       <tfile disposition="copy">rpointer.ocn</tfile>
       <tfile disposition="copy">casename.mpaso.rst.1976-01-01_00000.nc</tfile>
       <tfile disposition="copy">casename.mpaso.rst.am.timeSeriesStatsMonthly.1976-01-01_00000.nc</tfile>
+      <tfile disposition="copy">casename.mpaso.rst.am.timeSeriesStatsMonthlyMax.1976-01-01_00000.nc</tfile>
+      <tfile disposition="copy">casename.mpaso.rst.am.timeSeriesStatsMonthlyMin.1976-01-01_00000.nc</tfile>
       <tfile disposition="move">casename.mpaso.hist.am.globalStats.1976-01-01.nc</tfile>
       <tfile disposition="move">casename.mpaso.hist.am.highFrequencyOutput.1976-01-01_00.00.00.nc</tfile>
     </test_file_names>


### PR DESCRIPTION
Fix the CIME short term archiver so that EAMxx history files and MPAS analysis member restart files are archived instead of being left behind in the run directory. The scream archive spec could not match the file names EAMxx produces by default, so no EAMxx history file was ever moved to the atm/hist archive directory. This also adds the missing rest_history_varname entry, stops the archiver from synthesizing an incorrect rpointer.atm, covers all timeSeriesStats analysis member restart files for mpaso and mpassi, and adds test file names so the scream spec is finally exercised by the archiver test.

Fixes #6190.

## EAMxx history files were never matched

`ArchiveBase.get_all_hist_files()` builds its match regex as

```
<compname> + r"\d?_?(\d{4})?(_d\d{2})?\." + <hist_file_extension>
```

With `compname=scream` (i.e. `COMP_ATM`) and the old extension `.*\.h\.(?!rhist\.).*\.nc$`, a file matched only if it looked like `$CASE.scream.<label>.h.<AVGTYPE>.<FREQ_UNITS>_x<N>.<TIMESTAMP>.nc`.

But `AtmosphereDriver::create_output_managers` defaults `filename_prefix` to `$CASE.scream.h` (`components/eamxx/src/control/atmosphere_driver.cpp`), which produces e.g.

```
$CASE.scream.h.AVERAGE.nmonths_x1.0001-01.nc
```

`.*\.h\.` requires a `.h.` segment that is *not* the first segment after `scream.`, so this never matched. Making the stream label optional — `(.*\.)?h\.(?!rhist\.).*\.nc$` — matches both shapes, while still excluding `.h.rhist.` history restarts (picked up by `rest_file_extension`) and the `.r.` model restart.

The only reason the existing spec appeared to work is that the `eamxx/prod` testmod rewrites its prefixes via `sed "s|eamxx_output.decadal|${case_name}.scream|"`, which happens to produce the labelled shape.

## Other fixes in the scream spec

- **`rest_history_varname`** was missing, so `get_histfiles_for_restarts()` formatted a Python `None` into the command and ran `ncdump -v None <restart>` for every scream restart file, failing rc=1 and logging a warning each time. Every other component sets this to `unset`. (Where `ncdump` is not on `PATH`, the `expect(ncdump, "ncdump not found in path")` immediately above turns this into a hard st_archive failure.)
- **`rpointer_content`** was `$CASE.scream$NINST_STRING.r.$DATENAME.nc`, which cannot reproduce a real EAMxx `rpointer.atm` — that file is `...scream.r.INSTANT.n<unit>s_x<N>.<date>.nc` plus one line per history restart file. It is only used to *synthesize* an rpointer for interim restart directories, so it was latent, but `unset` is correct: EAMxx always writes the real file, and the archiver still copies it.
- **`test_file_names`** were absent, which is why this regressed silently — neither `test_st_archive` nor `test_env_archive` touched the scream spec.

## MPAS analysis member restart files

`mpaso` and `mpassi` only declared `rst.am.timeSeriesStatsMonthly`, and the match anchors a `.` plus the date immediately after it, so `...timeSeriesStatsMonthlyMax`, `...timeSeriesStatsMonthlyMin` and `...timeSeriesStatsDaily` were never archived (reported in #6190). Replaced with `rst\.am\.timeSeriesStats\w+`.

## Verification

Run against this branch's `config_archive.xml` with the CIME version this commit points at:

- Schema: `xmllint --schema cime/CIME/data/config/xml_schemas/config_archive.xsd` validates.
- `ArchiveBase.get_all_hist_files("$CASE", "scream", rundir)` now returns both the default-prefix and labelled-prefix history files, and still excludes rhist and model restart files. Before this change it returned nothing for the default prefix.
- The restart patterns from `_archive_restarts_date_comp` match the model restart, both rhist forms, and all four MPAS `rst`/`rst.am.timeSeriesStats*` files (three of which were previously missed).
- Replaying `test_env_archive`'s logic for an EAMxx coupled case (`drv, scream, elm, mosart, mpaso, mpassi, mali, ww3`): **FAIL** with the old regex and the new `test_file_names` (`Failed to move file casename.scream.h.AVERAGE.nmonths_x1.1975-12.nc to archive`), **PASS** with this change. So the new `test_file_names` are genuine regression coverage for the STARCHIVE phase.
- Replaying `test_st_archive` (all components) passes both before and after, because `eam`'s `hist_file_extension` incidentally matches EAMxx files — CIME searches for the bare substring `eam`, which occurs inside `scream`. That masking only happens when both specs are loaded, which never occurs in a real case. Anchoring the component token in `get_all_hist_files` would be a good follow-up in ESMCI/cime.

## Not included

EAMxx accepts any `filename_prefix` from an output yaml, so a production run can still choose names the archiver cannot see — e.g. `output.scream.ne256_coupled_test.1dailyAVG.…`, which fails `get_all_hist_files`' requirement that the name start with the casename. Validating `filename_prefix` in `eamxx_buildnml.py` is proposed separately in #6190, since it would reject existing user yamls and needs sign-off. Renaming the middle token from `scream` to `eamxx`, as requested in that issue, additionally requires renaming `COMP_ATM` in lockstep and is left as its own change.

BFB: this only changes CIME archiver configuration; no model output is affected.


_Analysis and patch produced by Claude (Claude Code)._
