### PR TITLE
Change ocean fraction initialization to ones_like

### DIFF
--- a/tools/generate_domain_files/generate_domain_files_E3SM.py
+++ b/tools/generate_domain_files/generate_domain_files_E3SM.py
@@ -237,7 +237,7 @@ def main():
 
   # Get ocn mask on ocn grid
   omask = get_mask(ds,opts,suffix='_a')
-  ofrac = xr.zeros_like(ds['area_a'])
+  ofrac = xr.ones_like(ds['omask'])
 
   ds_out = xr.Dataset()
 


### PR DESCRIPTION
This pull request makes a small change to how the ocean fraction variable is initialized in the `main()` function of 
`generate_domain_files_E3SM.py`. The code now initializes `ofrac` with ones instead of zeros, and uses the shape of 
`ds['omask']` rather than `ds['area_a']`.

* Changed initialization of `ofrac` to use ones with the shape of `ds['omask']` instead of zeros with the shape of
`ds['area_a']` in `generate_domain_files_E3SM.py`.