### PR TITLE
Update C++ tensorVisc after dss_hvtensor runs

### DIFF
--- a/components/eamxx/src/dynamics/homme/interface/homme_driver_mod.F90
+++ b/components/eamxx/src/dynamics/homme/interface/homme_driver_mod.F90
@@ -183,7 +183,7 @@ contains
   subroutine prim_init_model_f90 () bind(c)
     use prim_driver_mod,   only: prim_init_ref_states_views, &
                                  prim_init_diags_views, prim_init_kokkos_functors, &
-                                 prim_init_state_views
+                                 prim_init_state_views, prim_init_tensorvisc
     use prim_state_mod,    only: prim_printstate
     use model_init_mod,    only: model_init2
     use global_norms_mod,  only: dss_hvtensor, print_cfl
@@ -209,6 +209,11 @@ contains
 
     ! Apply dss and bilinear projection to tensor coefficients
     call dss_hvtensor(elem,hybrid,1,nelemd)
+
+    ! Update the C++ tensorVisc view with dss_hvtensor's result (the other,
+    ! constant, geometry views were already sent to C++ earlier, in
+    ! prim_complete_init1_phase_f90 -> prim_init_grid_views).
+    call prim_init_tensorvisc (elem)
 
     ! Print advective and viscious CFL estimates
     call print_cfl(elem,hybrid,1,nelemd)

--- a/components/homme/src/share/cxx/ElementsGeometry.cpp
+++ b/components/homme/src/share/cxx/ElementsGeometry.cpp
@@ -74,6 +74,14 @@ set_elem_data (const int ie,
   // Check input
   assert (ie>=0 && ie<m_num_elems);
 
+  // tensorVisc is handled separately by set_tensorvisc(), since (for the
+  // theta-l_kokkos dycore) it is the only field here that is computed AFTER
+  // dss_hvtensor runs; the other fields are constant and are fine to set
+  // here, early (before dss_hvtensor runs).
+  if (!consthv) {
+    set_tensorvisc(ie, tensorvisc);
+  }
+
   using ScalarView   = ExecViewUnmanaged<Real [NP][NP]>;
   using TensorView   = ExecViewUnmanaged<Real [2][2][NP][NP]>;
   using Tensor23View = ExecViewUnmanaged<Real [2][3][NP][NP]>;
@@ -90,11 +98,7 @@ set_elem_data (const int ie,
   TensorView::host_mirror_type h_d         = Kokkos::create_mirror_view(Homme::subview(m_d,ie));
   TensorView::host_mirror_type h_dinv      = Kokkos::create_mirror_view(Homme::subview(m_dinv,ie));
 
-  TensorView::host_mirror_type h_tensorvisc;
   Tensor23View::host_mirror_type h_vec_sph2cart;
-  if( !consthv ){
-    h_tensorvisc   = Kokkos::create_mirror_view(Homme::subview(m_tensorvisc,ie));
-  }
   h_vec_sph2cart = Kokkos::create_mirror_view(Homme::subview(m_vec_sph2cart,ie));
 
   ScalarViewF90 h_fcor_f90         (fcor);
@@ -104,7 +108,6 @@ set_elem_data (const int ie,
   TensorViewF90 h_metinv_f90       (metinv);
   TensorViewF90 h_d_f90            (D);
   TensorViewF90 h_dinv_f90         (Dinv);
-  TensorViewF90 h_tensorvisc_f90   (tensorvisc);
   Tensor23ViewF90 h_vec_sph2cart_f90 (vec_sph2cart);
   
   // 2d scalars
@@ -130,17 +133,6 @@ set_elem_data (const int ie,
     }
   }
   
-  if(!consthv) {
-    for (int idim = 0; idim < 2; ++idim) {
-      for (int jdim = 0; jdim < 2; ++jdim) {
-        for (int igp = 0; igp < NP; ++igp) {
-          for (int jgp = 0; jgp < NP; ++jgp) {
-            h_tensorvisc   (idim,jdim,igp,jgp) = h_tensorvisc_f90   (idim,jdim,igp,jgp);
-          }
-        }
-      }
-    }
-  }//end if consthv
   for (int idim = 0; idim < 2; ++idim) {
     for (int jdim = 0; jdim < 3; ++jdim) {
       for (int igp = 0; igp < NP; ++igp) {
@@ -158,9 +150,6 @@ set_elem_data (const int ie,
   Kokkos::deep_copy(Homme::subview(m_rspheremp,ie), h_rspheremp);
   Kokkos::deep_copy(Homme::subview(m_d,ie), h_d);
   Kokkos::deep_copy(Homme::subview(m_dinv,ie), h_dinv);
-  if( !consthv ) {
-    Kokkos::deep_copy(Homme::subview(m_tensorvisc,ie), h_tensorvisc);
-  }
   Kokkos::deep_copy(Homme::subview(m_vec_sph2cart,ie), h_vec_sph2cart);
 
   if (sphere_cart && m_sphere_cart.size() != 0) {
@@ -171,6 +160,34 @@ set_elem_data (const int ie,
     const auto fsl = HostViewUnmanaged<const Real [NP][NP][2]>(sphere_latlon);
     Kokkos::deep_copy(Homme::subview(m_sphere_latlon, ie), fsl);
   }
+}
+
+void ElementsGeometry::
+set_tensorvisc (const int ie, CF90Ptr& tensorvisc) {
+  // Check geometry was inited
+  assert (m_num_elems>0);
+
+  // Check input
+  assert (ie>=0 && ie<m_num_elems);
+
+  using TensorView    = ExecViewUnmanaged<Real [2][2][NP][NP]>;
+  using TensorViewF90 = HostViewUnmanaged<const Real [2][2][NP][NP]>;
+
+  TensorView::host_mirror_type h_tensorvisc =
+    Kokkos::create_mirror_view(Homme::subview(m_tensorvisc,ie));
+  TensorViewF90 h_tensorvisc_f90 (tensorvisc);
+
+  for (int idim = 0; idim < 2; ++idim) {
+    for (int jdim = 0; jdim < 2; ++jdim) {
+      for (int igp = 0; igp < NP; ++igp) {
+        for (int jgp = 0; jgp < NP; ++jgp) {
+          h_tensorvisc (idim,jdim,igp,jgp) = h_tensorvisc_f90 (idim,jdim,igp,jgp);
+        }
+      }
+    }
+  }
+
+  Kokkos::deep_copy(Homme::subview(m_tensorvisc,ie), h_tensorvisc);
 }
 
 void ElementsGeometry::

--- a/components/homme/src/share/cxx/ElementsGeometry.hpp
+++ b/components/homme/src/share/cxx/ElementsGeometry.hpp
@@ -73,6 +73,14 @@ public:
                       CF90Ptr& vec_sph2cart, const bool consthv,
                       const Real* sphere_cart = nullptr, const Real* sphere_latlon = nullptr);
 
+  // Fill (or refresh) just the tensorVisc view for one element. This is
+  // separate from set_elem_data() because tensorVisc is the only field in
+  // prim_init_grid_views's payload that is computed AFTER dss_hvtensor runs;
+  // all other geometry fields (D, Dinv, fcor, spheremp, rspheremp, metdet,
+  // metinv, vec_sph2cart, sphere_cart/latlon) are constant and are copied
+  // once, early, by set_elem_data().
+  void set_tensorvisc (const int ie, CF90Ptr& tensorvisc);
+
   void set_phis (const int ie, CF90Ptr& phis);
 
 private:

--- a/components/homme/src/theta-l_kokkos/cxx/cxx_f90_interface_theta.cpp
+++ b/components/homme/src/theta-l_kokkos/cxx/cxx_f90_interface_theta.cpp
@@ -473,6 +473,23 @@ void init_elements_2d_c (const int& ie,
                              vec_sph2cart,consthv,sphere_cart_vec,sphere_latlon_vec);
 }
 
+// Copies just tensorVisc from f90 arrays into the C++ view. Separate from
+// init_elements_2d_c() so that it can be called again, after dss_hvtensor
+// has updated tensorVisc, without re-copying the other (constant) geometry
+// fields.
+void init_tensorvisc_c (const int& ie, CF90Ptr& tensorvisc)
+{
+  auto& c = Context::singleton();
+  Elements& e = c.get<Elements> ();
+  const SimulationParams& params = c.get<SimulationParams>();
+
+  if (params.hypervis_scaling==0.0) {
+    // consthv: tensorVisc is not used/allocated.
+    return;
+  }
+  e.m_geometry.set_tensorvisc(ie,tensorvisc);
+}
+
 void init_geopotential_c (const int& ie,
                           CF90Ptr& phis, CF90Ptr& gradphis)
 {

--- a/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
+++ b/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
@@ -22,6 +22,7 @@ module prim_driver_mod
   public :: prim_run_subcycle
   public :: prim_init_elements_views
   public :: prim_init_grid_views
+  public :: prim_init_tensorvisc
   public :: prim_init_geopotential_views
   public :: prim_init_state_views
   public :: prim_init_ref_states_views
@@ -235,6 +236,34 @@ contains
                                sphere_cart_vec, sphere_latlon_vec)
     enddo
   end subroutine prim_init_grid_views
+
+  ! Copies just tensorVisc into the C++ ElementsGeometry. This is used to
+  ! (re)populate tensorVisc after dss_hvtensor() has updated it, without
+  ! re-copying the other (constant) geometry fields that prim_init_grid_views
+  ! already sent to C++ earlier.
+  subroutine prim_init_tensorvisc (elem)
+    use iso_c_binding, only : c_ptr, c_loc
+    use element_mod,   only : element_t
+    use theta_f2c_mod, only : init_tensorvisc_c
+    !
+    ! Input(s)
+    !
+    type (element_t), intent(in) :: elem (:)
+    !
+    ! Local(s)
+    !
+    real (kind=real_kind), target, dimension(np,np,2,2) :: elem_tensorvisc
+    type (c_ptr) :: elem_tensorvisc_ptr
+
+    integer :: ie
+
+    elem_tensorvisc_ptr = c_loc(elem_tensorvisc)
+
+    do ie=1,nelemd
+      elem_tensorvisc = elem(ie)%tensorVisc
+      call init_tensorvisc_c (ie-1, elem_tensorvisc_ptr)
+    enddo
+  end subroutine prim_init_tensorvisc
 
   subroutine prim_init_geopotential_views (elem)
     use iso_c_binding, only : c_ptr, c_loc

--- a/components/homme/src/theta-l_kokkos/theta_f2c_mod.F90
+++ b/components/homme/src/theta-l_kokkos/theta_f2c_mod.F90
@@ -83,6 +83,18 @@ interface
     real (kind=c_double), intent(in) :: sphere_cart_vec(3,np,np), sphere_latlon_vec(2,np,np)
   end subroutine init_elements_2d_c
 
+  ! Copies just tensorVisc from f90 arrays into the C++ view. Used to
+  ! (re)populate tensorVisc after dss_hvtensor has updated it, without
+  ! touching the other (constant) geometry fields.
+  subroutine init_tensorvisc_c (ie, tensorvisc_ptr) bind(c)
+    use iso_c_binding, only: c_int, c_ptr
+    !
+    ! Inputs
+    !
+    integer (kind=c_int), intent(in) :: ie
+    type (c_ptr) , intent(in) :: tensorvisc_ptr
+  end subroutine init_tensorvisc_c
+
   ! Copies geopotential from f90 arrays to C++ views
   subroutine init_geopotential_c (ie, phis_ptr, gradphis_ptr) bind(c)
     use iso_c_binding, only: c_int, c_ptr


### PR DESCRIPTION
prim_init_grid_views (called in prim_complete_init1_phase_f90, before dss_hvtensor) copies tensorVisc to C++ along with the other, constant geometry fields (D, Dinv, fcor, spheremp, rspheremp, metdet, metinv, vec_sph2cart, sphere_cart/latlon). But dss_hvtensor (called later, in prim_init_model_f90) updates elem(:)%tensorVisc afterwards, so the C++ copy of tensorVisc is stale by the time the model actually runs.

This adds a new, narrow prim_init_tensorvisc subroutine (backed by a new init_tensorvisc_c/ElementsGeometry::set_tensorvisc C++ path) that re-copies just tensorVisc to C++ right after dss_hvtensor runs, without touching (or requiring recomputation of) the other geometry fields, which are constant and are still copied once, early, by the existing prim_init_grid_views call.

Claude suggested that we can not simply move prim_init_grid_views to later in the initialization sequence, since it initializes  D and Dinv, which are needed by fv_phys_initialize_impl

this PR is larger than roundoff with minor changes to climate due to smoother hyperviscosity

RCS tests  (RCS_Vmct_C16.ne30pg2_ne30pg2.F2010-SCREAMv1.pm-gpu_gnugpu.eamxx-perturb) PASS, suggesting these changes do not change the climate signficantly.

[BFB] for all EAM cases
[non-BFB] for EAMxx cases
