### PR TITLE
Add default layouts for TL319_IcoswISC30E3r5_wQU225Icos30E3r5 grid

### DIFF
--- a/components/mpas-ocean/cime_config/config_pes.xml
+++ b/components/mpas-ocean/cime_config/config_pes.xml
@@ -354,6 +354,56 @@
       </pes>
     </mach>
   </grid>
+  <grid name="oi%IcoswISC30E3r5.+w%wQU225Icos30E3r5">
+    <mach name="chrysalis">
+      <pes compset="DATM.+MPASO.+WW3" pesize="any">
+        <comment>none</comment>
+        <ntasks>
+          <ntasks_atm>640</ntasks_atm>
+          <ntasks_lnd>640</ntasks_lnd>
+          <ntasks_rof>640</ntasks_rof>
+          <ntasks_ice>640</ntasks_ice>
+          <ntasks_ocn>640</ntasks_ocn>
+          <ntasks_glc>1</ntasks_glc>
+          <ntasks_cpl>640</ntasks_cpl>
+          <ntasks_wav>640</ntasks_wav>
+        </ntasks>
+        <nthrds>
+          <nthrds_atm>1</nthrds_atm>
+          <nthrds_lnd>1</nthrds_lnd>
+          <nthrds_rof>1</nthrds_rof>
+          <nthrds_ice>1</nthrds_ice>
+          <nthrds_ocn>1</nthrds_ocn>
+          <nthrds_glc>1</nthrds_glc>
+          <nthrds_cpl>1</nthrds_cpl>
+          <nthrds_wav>1</nthrds_wav>
+        </nthrds>
+        <rootpe>
+          <rootpe_atm>0</rootpe_atm>
+          <rootpe_lnd>0</rootpe_lnd>
+          <rootpe_rof>0</rootpe_rof>
+          <rootpe_ice>0</rootpe_ice>
+          <rootpe_ocn>0</rootpe_ocn>
+          <rootpe_glc>0</rootpe_glc>
+          <rootpe_cpl>0</rootpe_cpl>
+          <rootpe_wav>640</rootpe_wav>
+        </rootpe>
+      </pes>
+    </mach>
+    <mach name="pm-cpu">
+      <pes compset="DATM.+MPASO.+WW3" pesize="any">
+        <comment>--res TL319_IcoswISC30E3r5_wQU225Icos30E3r5 --compset GMPAS-JRA1p5-WW3</comment>
+        <ntasks>
+          <ntasks_atm>-1</ntasks_atm>
+          <ntasks_rof>-1</ntasks_rof>
+          <ntasks_ice>-4</ntasks_ice>
+          <ntasks_ocn>-4</ntasks_ocn>
+          <ntasks_cpl>-4</ntasks_cpl>
+          <ntasks_wav>-4</ntasks_wav>
+        </ntasks>
+      </pes>
+    </mach>
+  </grid>
   <grid name="oi%ECwISC30to60E2r1">
     <mach name="chrysalis">
       <pes compset="DATM.+MPASO.+SWAV" pesize="any">


### PR DESCRIPTION
Adds default layouts on chrysalis and pm-cpu for the v3.2 TL319_IcoswISC30E3r5_wQU225Icos30E3r5 grid configuration. Current prod testing on pm-cpu times out because it tries to run on a single node, so this increases the layout to eight nodes.

[BFB] for all currently tested configurations