### PR TITLE
Add missing EXCLUDE_MAIN_CPP from p3 test

### DIFF
--- a/components/eamxx/src/share/physics/tests/CMakeLists.txt
+++ b/components/eamxx/src/share/physics/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ endif()
 
 CreateUnitTest(physics_saturation_run_and_cmp
   SOURCES physics_saturation_run_and_cmp.cpp
+  EXCLUDE_MAIN_CPP
   LIBS eamxx_physics_share
   EXE_ARGS "${SCREAM_BASELINE_FILE_ARG}"
   THREADS ${SCREAM_BASELINE_TEST_THREADS}


### PR DESCRIPTION
This bug was introduced in https://github.com/E3SM-Project/E3SM/pull/8604 when updating ekat to use C++20. See https://github.com/E3SM-Project/E3SM/pull/8559#discussion_r3679686442 for discussion of why this occurs. 

[BFB]