### PR TITLE
port tensor-laplace sponge layer from EAM to EAMxx

### DIFF
--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -6794,6 +6794,11 @@ Bottom of sponge layer in hPa.
 Default: 0 (use default value based on reference pressure at model top).
 </entry>
 
+<entry id="laplace_scaling" type="real" category="se"
+       group="ctl_nl" valid_values="" >
+Default: Set by build-namelist.
+</entry>
+
 <entry id="hypervis_scaling" type="real" category="se"
        group="ctl_nl" valid_values="" >
 Default: Set by build-namelist.

--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -915,6 +915,7 @@ be lost if SCREAM_HACK_XML is not enabled.
     <hv_ref_profiles>6</hv_ref_profiles>                <!-- Default (rough topography) -->
     <hypervis_order>2</hypervis_order>
     <hypervis_scaling>3.0</hypervis_scaling>
+    <laplace_scaling>0.0</laplace_scaling>
     <hypervis_subcycle>1</hypervis_subcycle>
     <hypervis_subcycle_tom>1</hypervis_subcycle_tom>
     <hypervis_subcycle_q>1</hypervis_subcycle_q>

--- a/components/eamxx/src/dynamics/homme/interface/homme_driver_mod.F90
+++ b/components/eamxx/src/dynamics/homme/interface/homme_driver_mod.F90
@@ -183,7 +183,8 @@ contains
   subroutine prim_init_model_f90 () bind(c)
     use prim_driver_mod,   only: prim_init_ref_states_views, &
                                  prim_init_diags_views, prim_init_kokkos_functors, &
-                                 prim_init_state_views, prim_init_tensorvisc
+                                 prim_init_state_views, prim_init_tensorvisc, &
+                                 prim_init_tensorvisc2
     use prim_state_mod,    only: prim_printstate
     use model_init_mod,    only: model_init2
     use global_norms_mod,  only: dss_hvtensor, print_cfl
@@ -214,6 +215,10 @@ contains
     ! constant, geometry views were already sent to C++ earlier, in
     ! prim_complete_init1_phase_f90 -> prim_init_grid_views).
     call prim_init_tensorvisc (elem)
+
+    ! Same as above, but for tensorVisc_2 (the sponge-layer tensor
+    ! coefficient), which dss_hvtensor also updates.
+    call prim_init_tensorvisc2 (elem)
 
     ! Print advective and viscious CFL estimates
     call print_cfl(elem,hybrid,1,nelemd)

--- a/components/eamxx/src/dynamics/homme/interface/homme_params_mod.F90
+++ b/components/eamxx/src/dynamics/homme/interface/homme_params_mod.F90
@@ -112,7 +112,7 @@ contains
   end function get_homme_int_param_f90
 
   function get_homme_real_param_f90 (param_name_c) result(param_value) bind(c)
-    use control_mod,    only: nu, nu_div, nu_p, nu_q, nu_s, hypervis_scaling
+    use control_mod,    only: nu, nu_div, nu_p, nu_q, nu_s, hypervis_scaling, laplace_scaling
     use time_mod,       only: tstep
     !
     ! Input(s)
@@ -140,6 +140,8 @@ contains
         param_value = nu_s
       case("hypervis_scaling")
         param_value = hypervis_scaling
+      case("laplace_scaling")
+        param_value = laplace_scaling
       case("dt")
         param_value = tstep
       case default

--- a/components/homme/src/preqx/share/viscosity_preqx_base.F90
+++ b/components/homme/src/preqx/share/viscosity_preqx_base.F90
@@ -58,12 +58,9 @@ real (kind=real_kind), dimension(np,np) :: tmp
 real (kind=real_kind), dimension(np,np) :: tmp2
 real (kind=real_kind), dimension(np,np,2) :: v
 real (kind=real_kind) :: nu_ratio1, nu_ratio2
-logical var_coef1
 
    !if tensor hyperviscosity with tensor V is used, then biharmonic operator is (\grad\cdot V\grad) (\grad \cdot \grad) 
    !so tensor is only used on second call to laplace_sphere_wk
-   var_coef1 = .true.
-   if(hypervis_scaling > 0)    var_coef1 = .false.
 
    ! note: there is a scaling bug in the treatment of nu_div
    ! nu_ratio is applied twice, once in each laplace operator
@@ -92,11 +89,11 @@ logical var_coef1
 #endif
       do k=1,nlev
          tmp=elem(ie)%state%T(:,:,k,nt) 
-         ptens(:,:,k,ie)=laplace_sphere_wk(tmp,deriv,elem(ie),var_coef=var_coef1)
+         ptens(:,:,k,ie)=laplace_sphere_wk(tmp,deriv,elem(ie),var_coef=.false.)
          tmp=elem(ie)%state%dp3d(:,:,k,nt) 
-         dptens(:,:,k,ie)=laplace_sphere_wk(tmp,deriv,elem(ie),var_coef=var_coef1)
+         dptens(:,:,k,ie)=laplace_sphere_wk(tmp,deriv,elem(ie),var_coef=.false.)
          vtens(:,:,:,k,ie)=vlaplace_sphere_wk(elem(ie)%state%v(:,:,:,k,nt),deriv,elem(ie),&
-              var_coef=var_coef1,nu_ratio=nu_ratio1)
+              var_coef=.false.,nu_ratio=nu_ratio1)
       enddo
       kptr=0
       call edgeVpack_nlyr(edge3, elem(ie)%desc, ptens(1,1,1,ie),nlev,kptr,4*nlev)
@@ -127,13 +124,13 @@ logical var_coef1
 #endif
       do k=1,nlev
          tmp(:,:)=rspheremv(:,:)*ptens(:,:,k,ie)
-         ptens(:,:,k,ie)=laplace_sphere_wk(tmp,deriv,elem(ie),var_coef=.true.)
+         ptens(:,:,k,ie)=laplace_sphere_wk(tmp,deriv,elem(ie),var_coef=(hypervis_scaling>0))
          tmp2(:,:)=rspheremv(:,:)*dptens(:,:,k,ie)
-         dptens(:,:,k,ie)=laplace_sphere_wk(tmp2,deriv,elem(ie),var_coef=.true.)
+         dptens(:,:,k,ie)=laplace_sphere_wk(tmp2,deriv,elem(ie),var_coef=(hypervis_scaling>0))
          v(:,:,1)=rspheremv(:,:)*vtens(:,:,1,k,ie)
          v(:,:,2)=rspheremv(:,:)*vtens(:,:,2,k,ie)
          vtens(:,:,:,k,ie)=vlaplace_sphere_wk(v(:,:,:),deriv,elem(ie),&
-              var_coef=.true.,nu_ratio=nu_ratio2)
+              var_coef=(hypervis_scaling>0),nu_ratio=nu_ratio2)
 
       enddo
    enddo

--- a/components/homme/src/preqx_kokkos/cxx/cxx_f90_interface_preqx.cpp
+++ b/components/homme/src/preqx_kokkos/cxx/cxx_f90_interface_preqx.cpp
@@ -239,8 +239,7 @@ void init_elements_c (const int& num_elems)
   Elements& e = c.create<Elements> ();
   const SimulationParams& params = c.get<SimulationParams>();
 
-  const bool consthv = (params.hypervis_scaling==0.0);
-  e.init (num_elems, consthv, /* alloc_gradphis = */ false,
+  e.init (num_elems, /* alloc_gradphis = */ false,
           params.scale_factor, params.laplacian_rigid_factor,
           /* alloc_sphere_coords = */ false);
 
@@ -312,10 +311,8 @@ void init_elements_2d_c (const int& ie, CF90Ptr& D, CF90Ptr& Dinv, CF90Ptr& fcor
                          CF90Ptr &tensorvisc, CF90Ptr &vec_sph2cart)
 {
   Elements& e = Context::singleton().get<Elements> ();
-  const SimulationParams& params = Context::singleton().get<SimulationParams>();
 
-  const bool consthv = (params.hypervis_scaling==0.0);
-  e.m_geometry.set_elem_data(ie,D,Dinv,fcor,spheremp,rspheremp,metdet,metinv,tensorvisc,vec_sph2cart,consthv);
+  e.m_geometry.set_elem_data(ie,D,Dinv,fcor,spheremp,rspheremp,metdet,metinv,tensorvisc,vec_sph2cart);
   e.m_geometry.set_phis(ie,phis);
 }
 

--- a/components/homme/src/share/control_mod.F90
+++ b/components/homme/src/share/control_mod.F90
@@ -178,6 +178,7 @@ module control_mod
   integer, public :: hypervis_order=0                         ! laplace**hypervis_order.  0=not used  1=regular viscosity, 2=grad**4
 
   real (kind=real_kind), public :: hypervis_scaling=0         ! use tensor hyperviscosity
+  real (kind=real_kind), public :: laplace_scaling=0          ! scaling for tensor viscosity
 
   !three types of hyper viscosity are supported right now:
   ! (1) const hv:    nu * del^2 del^2

--- a/components/homme/src/share/cube_mod.F90
+++ b/components/homme/src/share/cube_mod.F90
@@ -20,7 +20,7 @@ module cube_mod
        change_coordinates
 
   use physical_constants, only : dd_pi, rearth
-  use control_mod, only : hypervis_scaling, cubed_sphere_map
+  use control_mod, only : hypervis_scaling, laplace_scaling, cubed_sphere_map
   use parallel_mod, only : abortmp
   use dimensions_mod, only : np,ne
 
@@ -422,6 +422,20 @@ contains
           V(2,2)=sum(DEL(2,:)*DE(2,:))
 
 	  elem%tensorVisc(i,j,:,:)=V(:,:)
+
+
+!
+!         Tensor with scalings=2 for regular laplace operator (spnge layer)
+	  lamStar1=1/(eig(1)**(laplace_scaling/2.0d0))*(rearth**2.0d0)
+	  lamStar2=1/(eig(2)**(laplace_scaling/2.0d0))*(rearth**2.0d0)
+          DEL(1:2,1) = lamStar1 *eig(1)*DE(1:2,1)
+          DEL(1:2,2) = lamStar2 *eig(2)*DE(1:2,2)
+          V(1,1)=sum(DEL(1,:)*DE(1,:))
+          V(1,2)=sum(DEL(1,:)*DE(2,:))
+          V(2,1)=sum(DEL(2,:)*DE(1,:))
+          V(2,2)=sum(DEL(2,:)*DE(2,:))
+
+	  elem%tensorVisc_2(i,j,:,:)=V(:,:)
 
        end do
     end do

--- a/components/homme/src/share/cxx/Elements.cpp
+++ b/components/homme/src/share/cxx/Elements.cpp
@@ -12,7 +12,7 @@
 
 namespace Homme {
 
-void Elements::init(const int num_elems, const bool consthv, const bool alloc_gradphis,
+void Elements::init(const int num_elems, const bool alloc_gradphis,
                     const Real scale_factor, const Real laplacian_rigid_factor,
                     const bool alloc_sphere_coords) {
   // Sanity check
@@ -20,7 +20,7 @@ void Elements::init(const int num_elems, const bool consthv, const bool alloc_gr
 
   m_num_elems = num_elems;
 
-  m_geometry.init(num_elems,consthv,alloc_gradphis,
+  m_geometry.init(num_elems,alloc_gradphis,
                   scale_factor,
                   laplacian_rigid_factor < 0 ? 1/scale_factor : laplacian_rigid_factor,
                   alloc_sphere_coords);

--- a/components/homme/src/share/cxx/Elements.hpp
+++ b/components/homme/src/share/cxx/Elements.hpp
@@ -41,7 +41,7 @@ public:
 
   int num_elems () const { return m_num_elems; }
 
-  void init (const int num_elems, const bool consthv, const bool alloc_gradphis,
+  void init (const int num_elems, const bool alloc_gradphis,
              // See ElementsGeometry::init for details about these arguments.
              const Real scale_factor, const Real laplacian_rigid_factor=-1,
              const bool alloc_sphere_coords=false);

--- a/components/homme/src/share/cxx/ElementsGeometry.cpp
+++ b/components/homme/src/share/cxx/ElementsGeometry.cpp
@@ -16,14 +16,13 @@
 
 namespace Homme {
 
-void ElementsGeometry::init(const int num_elems, const bool consthv, const bool alloc_gradphis,
+void ElementsGeometry::init(const int num_elems, const bool alloc_gradphis,
                             const Real scale_factor, const Real laplacian_rigid_factor,
                             const bool alloc_sphere_coords) {
   // Sanity check
   assert (num_elems>0);
 
   m_num_elems = num_elems;
-  m_consthv   = consthv;
 
   assert(scale_factor > 0);
   m_scale_factor = scale_factor;
@@ -40,9 +39,14 @@ void ElementsGeometry::init(const int num_elems, const bool consthv, const bool 
   m_metinv = ExecViewManaged<Real * [2][2][NP][NP]>("METINV", m_num_elems);
   m_metdet = ExecViewManaged<Real * [NP][NP]>("METDET", m_num_elems);
 
-  if(!consthv){
-    m_tensorvisc   = ExecViewManaged<Real * [2][2][NP][NP]>("TENSORVISC",   m_num_elems);
-  }
+  // tensorVisc/tensorVisc2 are always allocated and copied (the Fortran
+  // side always computes valid values for them, in metric_atomic(), even
+  // when hypervis_scaling/laplace_scaling are 0). Whether the tensor or
+  // the constant-coefficient operator is actually used at run time is
+  // decided in the timestepping code (see HyperviscosityFunctorImpl's
+  // consthv/constsponge).
+  m_tensorvisc  = ExecViewManaged<Real * [2][2][NP][NP]>("TENSORVISC",  m_num_elems);
+  m_tensorvisc2 = ExecViewManaged<Real * [2][2][NP][NP]>("TENSORVISC2", m_num_elems);
   m_vec_sph2cart = ExecViewManaged<Real * [2][3][NP][NP]>("VEC_SPH2CART", m_num_elems);
 
   m_phis     = ExecViewManaged<Real *    [NP][NP]>("PHIS",          m_num_elems);
@@ -66,21 +70,22 @@ set_elem_data (const int ie,
                CF90Ptr& D, CF90Ptr& Dinv, CF90Ptr& fcor,
                CF90Ptr& spheremp, CF90Ptr& rspheremp,
                CF90Ptr& metdet, CF90Ptr& metinv,
-               CF90Ptr& tensorvisc, CF90Ptr& vec_sph2cart, const bool consthv,
-               const Real* sphere_cart, const Real* sphere_latlon) {
+               CF90Ptr& tensorvisc, CF90Ptr& vec_sph2cart,
+               const Real* sphere_cart, const Real* sphere_latlon,
+               CF90Ptr& tensorvisc2) {
   // Check geometry was inited
   assert (m_num_elems>0);
 
   // Check input
   assert (ie>=0 && ie<m_num_elems);
 
-  // tensorVisc is handled separately by set_tensorvisc(), since (for the
-  // theta-l_kokkos dycore) it is the only field here that is computed AFTER
-  // dss_hvtensor runs; the other fields are constant and are fine to set
-  // here, early (before dss_hvtensor runs).
-  if (!consthv) {
-    set_tensorvisc(ie, tensorvisc);
-  }
+  // tensorVisc and tensorVisc2 are handled separately by set_tensorvisc()/
+  // set_tensorvisc2(), since (for the theta-l_kokkos dycore) they are the
+  // only fields here that are computed AFTER dss_hvtensor runs; the other
+  // fields are constant and are fine to set here, early (before
+  // dss_hvtensor runs).
+  set_tensorvisc(ie, tensorvisc);
+  set_tensorvisc2(ie, tensorvisc2);
 
   using ScalarView   = ExecViewUnmanaged<Real [NP][NP]>;
   using TensorView   = ExecViewUnmanaged<Real [2][2][NP][NP]>;
@@ -191,6 +196,34 @@ set_tensorvisc (const int ie, CF90Ptr& tensorvisc) {
 }
 
 void ElementsGeometry::
+set_tensorvisc2 (const int ie, CF90Ptr& tensorvisc2) {
+  // Check geometry was inited
+  assert (m_num_elems>0);
+
+  // Check input
+  assert (ie>=0 && ie<m_num_elems);
+
+  using TensorView    = ExecViewUnmanaged<Real [2][2][NP][NP]>;
+  using TensorViewF90 = HostViewUnmanaged<const Real [2][2][NP][NP]>;
+
+  TensorView::host_mirror_type h_tensorvisc2 =
+    Kokkos::create_mirror_view(Homme::subview(m_tensorvisc2,ie));
+  TensorViewF90 h_tensorvisc2_f90 (tensorvisc2);
+
+  for (int idim = 0; idim < 2; ++idim) {
+    for (int jdim = 0; jdim < 2; ++jdim) {
+      for (int igp = 0; igp < NP; ++igp) {
+        for (int jgp = 0; jgp < NP; ++jgp) {
+          h_tensorvisc2 (idim,jdim,igp,jgp) = h_tensorvisc2_f90 (idim,jdim,igp,jgp);
+        }
+      }
+    }
+  }
+
+  Kokkos::deep_copy(Homme::subview(m_tensorvisc2,ie), h_tensorvisc2);
+}
+
+void ElementsGeometry::
 set_phis (const int ie, CF90Ptr& phis) {
   // Check geometry was inited
   assert (m_num_elems>0);
@@ -226,6 +259,7 @@ void ElementsGeometry::randomize(const int seed) {
 
   genRandArray(m_spheremp,     engine, random_dist);
   genRandArray(m_tensorvisc,   engine, random_dist);
+  genRandArray(m_tensorvisc2,  engine, random_dist);
   genRandArray(m_vec_sph2cart, engine, random_dist);
 
   genRandArray(m_phis,         engine, random_dist);

--- a/components/homme/src/share/cxx/ElementsGeometry.hpp
+++ b/components/homme/src/share/cxx/ElementsGeometry.hpp
@@ -31,6 +31,9 @@ public:
   ExecViewManaged<Real * [2][2][NP][NP]>  m_metinv;
   ExecViewManaged<Real * [NP][NP]>        m_metdet;
   ExecViewManaged<Real * [2][2][NP][NP]>  m_tensorvisc;
+  // Second tensor viscosity matrix, used by the sponge layer (theta-l_kokkos
+  // only), controlled by laplace_scaling. Always allocated (see init()).
+  ExecViewManaged<Real * [2][2][NP][NP]>  m_tensorvisc2;
   ExecViewManaged<Real * [2][3][NP][NP]>  m_vec_sph2cart;
 
   // Prescribed surface geopotential height at eta = 1
@@ -50,7 +53,7 @@ public:
 
   Real m_scale_factor, m_laplacian_rigid_factor;
 
-  void init (const int num_elems, const bool consthv, const bool alloc_gradphis,
+  void init (const int num_elems, const bool alloc_gradphis,
              // Usually, scale_factor is rearth for sphere-Earth problems and 1
              // for planar problems. Usually, laplacian_rigid_factor is 1/rearth
              // for the sphere and 0 for the plane. If laplacian_rigid_factor is
@@ -70,8 +73,9 @@ public:
                       CF90Ptr& spheremp, CF90Ptr& rspheremp,
                       CF90Ptr& metdet, CF90Ptr& metinv,
                       CF90Ptr& tensorvisc,
-                      CF90Ptr& vec_sph2cart, const bool consthv,
-                      const Real* sphere_cart = nullptr, const Real* sphere_latlon = nullptr);
+                      CF90Ptr& vec_sph2cart,
+                      const Real* sphere_cart = nullptr, const Real* sphere_latlon = nullptr,
+                      CF90Ptr& tensorvisc2 = nullptr);
 
   // Fill (or refresh) just the tensorVisc view for one element. This is
   // separate from set_elem_data() because tensorVisc is the only field in
@@ -81,10 +85,14 @@ public:
   // once, early, by set_elem_data().
   void set_tensorvisc (const int ie, CF90Ptr& tensorvisc);
 
+  // Same as set_tensorvisc(), but for tensorVisc_2 (the sponge-layer tensor
+  // coefficient), which is likewise recomputed by dss_hvtensor after the
+  // initial (constant-field) set_elem_data() copy.
+  void set_tensorvisc2 (const int ie, CF90Ptr& tensorvisc2);
+
   void set_phis (const int ie, CF90Ptr& phis);
 
 private:
-  bool m_consthv;
   int  m_num_elems;
 };
 

--- a/components/homme/src/share/cxx/SimulationParams.hpp
+++ b/components/homme/src/share/cxx/SimulationParams.hpp
@@ -57,6 +57,11 @@ struct SimulationParams
   int       hypervis_subcycle;
   int       hypervis_subcycle_tom;
   double    hypervis_scaling;
+  // Scaling exponent for the sponge-layer (nu_top) tensor viscosity, mirroring
+  // Fortran's laplace_scaling (theta-l_kokkos only; defaults to 0, i.e. constant
+  // coefficient sponge-layer diffusion, for preqx_kokkos and any case that
+  // doesn't set it explicitly).
+  double    laplace_scaling = 0.0;
   double    nu_ratio1, nu_ratio2; // control balance between div and vort components in vector laplace
   int       nsplit = 0;
   int       nsplit_iteration;
@@ -102,6 +107,7 @@ inline void SimulationParams::print (std::ostream& out) {
   out << "   hypervis_subcycle: " << hypervis_subcycle << "\n";
   out << "   hypervis_subcycle_tom: " << hypervis_subcycle_tom << "\n";
   out << "   hypervis_scaling: " << hypervis_scaling << "\n";
+  out << "   laplace_scaling: " << laplace_scaling << "\n";
   out << "   nu_ratio1: " << nu_ratio1 << "\n";
   out << "   nu_ratio2: " << nu_ratio2 << "\n";
   out << "   use_cpstar: " << (use_cpstar ? "yes" : "no") << "\n";

--- a/components/homme/src/share/cxx/SphereOperators.hpp
+++ b/components/homme/src/share/cxx/SphereOperators.hpp
@@ -812,24 +812,25 @@ public:
     laplace_simple<NUM_LEV_OUT,NUM_LEV_IN>(kv, field, laplace, NUM_LEV_REQUEST);
   }//end of laplace_simple
 
-  template<int NUM_LEV_OUT, int NUM_LEV_IN = NUM_LEV_OUT, int NUM_LEV_REQUEST = NUM_LEV_OUT>
+  template<int NUM_LEV_OUT, int NUM_LEV_IN = NUM_LEV_OUT>
   KOKKOS_INLINE_FUNCTION void
   laplace_tensor(const KernelVariables &kv,
                  const ExecViewUnmanaged<const Real   [2][2][NP][NP]>&              tensorVisc,
                  const typename ViewConst<ExecViewUnmanaged<Scalar [NP][NP][NUM_LEV_IN]>>::type&  field,         // input
-                 const ExecViewUnmanaged<Scalar [NP][NP][NUM_LEV_OUT]>& laplace) const
+                 const ExecViewUnmanaged<Scalar [NP][NP][NUM_LEV_OUT]>& laplace,
+                 const int NUM_LEV_REQUEST) const
   {
-    static_assert(NUM_LEV_REQUEST>=0, "Error! Invalid value for NUM_LEV_REQUEST.\n");
-    static_assert(NUM_LEV_REQUEST<=NUM_LEV_IN, "Error! Input view does not have enough levels.\n");
-    static_assert(NUM_LEV_REQUEST<=NUM_LEV_OUT, "Error! Output view does not have enough levels.\n");
+    assert(NUM_LEV_REQUEST>=0);
+    assert(NUM_LEV_REQUEST<=NUM_LEV_IN);
+    assert(NUM_LEV_REQUEST<=NUM_LEV_OUT);
 
     // Make sure the buffers have been created
     assert (vector_buf_ml.size()>0);
 
-    vector_buf<NUM_LEV_REQUEST> grad_s(Homme::subview(vector_buf_ml, kv.team_idx, 1).data());
-    vector_buf<NUM_LEV_REQUEST> sphere_buf(Homme::subview(vector_buf_ml, kv.team_idx, 2).data());
+    vector_buf<NUM_LEV_OUT> grad_s(Homme::subview(vector_buf_ml, kv.team_idx, 1).data());
+    vector_buf<NUM_LEV_OUT> sphere_buf(Homme::subview(vector_buf_ml, kv.team_idx, 2).data());
 
-    gradient_sphere<NUM_LEV_REQUEST,decltype(field),NUM_LEV_REQUEST>(kv, field, grad_s);
+    gradient_sphere<NUM_LEV_OUT,decltype(field)>(kv, field, grad_s, NUM_LEV_REQUEST);
     //now multiply tensorVisc(:,:,i,j)*grad_s(i,j) (matrix*vector, independent of i,j )
     //but it requires a temp var to store a result. the result is then placed to grad_s,
     //or should it be an extra temp var instead of an extra loop?
@@ -847,7 +848,21 @@ public:
     });
     kv.team_barrier();
 
-    divergence_sphere_wk<NUM_LEV_OUT,NUM_LEV_REQUEST,NUM_LEV_REQUEST>(kv, sphere_buf, laplace);
+    divergence_sphere_wk<NUM_LEV_OUT,NUM_LEV_OUT>(kv, sphere_buf, laplace, NUM_LEV_REQUEST);
+  }//end of laplace_tensor
+
+  template<int NUM_LEV_OUT, int NUM_LEV_IN = NUM_LEV_OUT, int NUM_LEV_REQUEST = NUM_LEV_OUT>
+  KOKKOS_INLINE_FUNCTION void
+  laplace_tensor(const KernelVariables &kv,
+                 const ExecViewUnmanaged<const Real   [2][2][NP][NP]>&              tensorVisc,
+                 const typename ViewConst<ExecViewUnmanaged<Scalar [NP][NP][NUM_LEV_IN]>>::type&  field,         // input
+                 const ExecViewUnmanaged<Scalar [NP][NP][NUM_LEV_OUT]>& laplace) const
+  {
+    static_assert(NUM_LEV_REQUEST>=0, "Error! Invalid value for NUM_LEV_REQUEST.\n");
+    static_assert(NUM_LEV_REQUEST<=NUM_LEV_IN, "Error! Input view does not have enough levels.\n");
+    static_assert(NUM_LEV_REQUEST<=NUM_LEV_OUT, "Error! Output view does not have enough levels.\n");
+
+    laplace_tensor<NUM_LEV_OUT,NUM_LEV_IN>(kv, tensorVisc, field, laplace, NUM_LEV_REQUEST);
   }//end of laplace_tensor
 
   template<int NUM_LEV_OUT, int NUM_LEV_IN = NUM_LEV_OUT>
@@ -1015,25 +1030,26 @@ public:
     grad_sphere_wk_testcov<NUM_LEV_OUT,NUM_LEV_IN>(kv, scalar, grads, NUM_LEV_REQUEST);
   }
 
-  template<int NUM_LEV_OUT, int NUM_LEV_IN = NUM_LEV_OUT, int NUM_LEV_REQUEST = NUM_LEV_OUT>
+  template<int NUM_LEV_OUT, int NUM_LEV_IN = NUM_LEV_OUT>
   KOKKOS_INLINE_FUNCTION void
   vlaplace_sphere_wk_cartesian (const KernelVariables &kv,
                                 const ExecViewUnmanaged<const Real [2][2][NP][NP]>&          tensorVisc,
                                 const ExecViewUnmanaged<const Real [2][3][NP][NP]>&          vec_sph2cart,
                                 const typename ViewConst<ExecViewUnmanaged<Scalar [2][NP][NP][NUM_LEV_IN]>>::type& vector,
-                                const ExecViewUnmanaged<Scalar [2][NP][NP][NUM_LEV_OUT]>& laplace) const
+                                const ExecViewUnmanaged<Scalar [2][NP][NP][NUM_LEV_OUT]>& laplace,
+                                const int NUM_LEV_REQUEST) const
   {
-    static_assert(NUM_LEV_REQUEST>=0, "Error! Invalid value for NUM_LEV_REQUEST.\n");
-    static_assert(NUM_LEV_REQUEST<=NUM_LEV_IN, "Error! Input view does not have enough levels.\n");
-    static_assert(NUM_LEV_REQUEST<=NUM_LEV_OUT, "Error! Output view does not have enough levels.\n");
+    assert(NUM_LEV_REQUEST>=0);
+    assert(NUM_LEV_REQUEST<=NUM_LEV_IN);
+    assert(NUM_LEV_REQUEST<=NUM_LEV_OUT);
 
     // Make sure the buffers have been created
     assert (vector_buf_ml.size()>0);
 
     const auto& spheremp = Homme::subview(m_spheremp, kv.ie);
-    scalar_buf<NUM_LEV_REQUEST> laplace0(Homme::subview(scalar_buf_ml,kv.team_idx,0).data());
-    scalar_buf<NUM_LEV_REQUEST> laplace1(Homme::subview(scalar_buf_ml,kv.team_idx,1).data());
-    scalar_buf<NUM_LEV_REQUEST> laplace2(Homme::subview(scalar_buf_ml,kv.team_idx,2).data());
+    scalar_buf<NUM_LEV_OUT> laplace0(Homme::subview(scalar_buf_ml,kv.team_idx,0).data());
+    scalar_buf<NUM_LEV_OUT> laplace1(Homme::subview(scalar_buf_ml,kv.team_idx,1).data());
+    scalar_buf<NUM_LEV_OUT> laplace2(Homme::subview(scalar_buf_ml,kv.team_idx,2).data());
     constexpr int np_squared = NP * NP;
     Kokkos::parallel_for(Kokkos::TeamThreadRange(kv.team, np_squared),
                          [&](const int loop_idx) {
@@ -1050,9 +1066,9 @@ public:
     kv.team_barrier();
 
     // Use laplace* as input, and then overwrite it with the output (saves temporaries)
-    laplace_tensor<NUM_LEV_REQUEST,NUM_LEV_REQUEST,NUM_LEV_REQUEST>(kv,tensorVisc,laplace0,laplace0);
-    laplace_tensor<NUM_LEV_REQUEST,NUM_LEV_REQUEST,NUM_LEV_REQUEST>(kv,tensorVisc,laplace1,laplace1);
-    laplace_tensor<NUM_LEV_REQUEST,NUM_LEV_REQUEST,NUM_LEV_REQUEST>(kv,tensorVisc,laplace2,laplace2);
+    laplace_tensor<NUM_LEV_OUT,NUM_LEV_OUT>(kv,tensorVisc,laplace0,laplace0,NUM_LEV_REQUEST);
+    laplace_tensor<NUM_LEV_OUT,NUM_LEV_OUT>(kv,tensorVisc,laplace1,laplace1,NUM_LEV_REQUEST);
+    laplace_tensor<NUM_LEV_OUT,NUM_LEV_OUT>(kv,tensorVisc,laplace2,laplace2,NUM_LEV_REQUEST);
 
     Kokkos::parallel_for(Kokkos::TeamThreadRange(kv.team, np_squared),
                          [&](const int loop_idx) {
@@ -1083,6 +1099,21 @@ public:
       });
     });
     kv.team_barrier();
+  } // end of vlaplace_sphere_wk_cartesian
+
+  template<int NUM_LEV_OUT, int NUM_LEV_IN = NUM_LEV_OUT, int NUM_LEV_REQUEST = NUM_LEV_OUT>
+  KOKKOS_INLINE_FUNCTION void
+  vlaplace_sphere_wk_cartesian (const KernelVariables &kv,
+                                const ExecViewUnmanaged<const Real [2][2][NP][NP]>&          tensorVisc,
+                                const ExecViewUnmanaged<const Real [2][3][NP][NP]>&          vec_sph2cart,
+                                const typename ViewConst<ExecViewUnmanaged<Scalar [2][NP][NP][NUM_LEV_IN]>>::type& vector,
+                                const ExecViewUnmanaged<Scalar [2][NP][NP][NUM_LEV_OUT]>& laplace) const
+  {
+    static_assert(NUM_LEV_REQUEST>=0, "Error! Invalid value for NUM_LEV_REQUEST.\n");
+    static_assert(NUM_LEV_REQUEST<=NUM_LEV_IN, "Error! Input view does not have enough levels.\n");
+    static_assert(NUM_LEV_REQUEST<=NUM_LEV_OUT, "Error! Output view does not have enough levels.\n");
+
+    vlaplace_sphere_wk_cartesian<NUM_LEV_OUT,NUM_LEV_IN>(kv, tensorVisc, vec_sph2cart, vector, laplace, NUM_LEV_REQUEST);
   } // end of vlaplace_sphere_wk_cartesian
 
   template<int NUM_LEV_OUT, int NUM_LEV_IN = NUM_LEV_OUT>

--- a/components/homme/src/share/derivative_mod.F90
+++ b/components/homme/src/share/derivative_mod.F90
@@ -10,7 +10,7 @@ module derivative_mod
   use quadrature_mod, only : quadrature_t, gauss, gausslobatto,legendre, jacobi
   use parallel_mod,   only : abortmp
   use element_mod,    only : element_t
-  use control_mod,    only : hypervis_scaling
+  use control_mod,    only : hypervis_scaling, laplace_scaling
   use physical_constants, only : scale_factor_inv, laplacian_rigid_factor
 
 implicit none
@@ -77,7 +77,7 @@ private
   public  :: curl_sphere_wk_testcov
 ! public  :: curl_sphere_wk_testcontra  ! not coded
   public  :: divergence_sphere_wk
-  public  :: laplace_sphere_wk
+  public  :: laplace_sphere_wk         ! laplace with hypervis_scaling tensor option
   public  :: vlaplace_sphere_wk
   public  :: vlaplace_sphere_wk_contra
   public  :: vlaplace_sphere_wk_cartesian
@@ -1069,7 +1069,7 @@ contains
 
 
 !DIR$ ATTRIBUTES FORCEINLINE :: laplace_sphere_wk
-  function laplace_sphere_wk(s,deriv,elem,var_coef) result(laplace)
+  function laplace_sphere_wk(s,deriv,elem,var_coef,tensor) result(laplace)
 !
 !   input:  s = scalar
 !   ouput:  -< grad(PHI), grad(s) >   = weak divergence of grad(s)
@@ -1079,6 +1079,8 @@ contains
     logical, intent(in) :: var_coef
     type (derivative_t), intent(in) :: deriv
     type (element_t), intent(in) :: elem
+    real(kind=real_kind), optional, intent(in) :: tensor(np,np,2,2) 
+    
     real(kind=real_kind)             :: laplace(np,np)
     integer :: i,j
 
@@ -1088,9 +1090,17 @@ contains
     grads=gradient_sphere(s,deriv,elem%Dinv)
  
     if (var_coef) then
-       if (hypervis_scaling /=0 ) then
-          ! tensor hv, (3)
-          oldgrads=grads
+       oldgrads=grads
+       if (present(tensor)) then
+          do j=1,np
+             do i=1,np
+                grads(i,j,1) = oldgrads(i,j,1)*tensor(i,j,1,1) + &
+                               oldgrads(i,j,2)*tensor(i,j,1,2)
+                grads(i,j,2) = oldgrads(i,j,1)*tensor(i,j,2,1) + &
+                               oldgrads(i,j,2)*tensor(i,j,2,2)
+             end do
+          end do
+       else 
           do j=1,np
              do i=1,np
                 grads(i,j,1) = oldgrads(i,j,1)*elem%tensorVisc(i,j,1,1) + &
@@ -1099,8 +1109,6 @@ contains
                                oldgrads(i,j,2)*elem%tensorVisc(i,j,2,2)
              end do
           end do
-       else
-          ! do nothing: constant coefficient viscsoity
        endif
     endif
 
@@ -1111,7 +1119,7 @@ contains
   end function laplace_sphere_wk
 
 !DIR$ ATTRIBUTES FORCEINLINE :: vlaplace_sphere_wk
-  function vlaplace_sphere_wk(v,deriv,elem,var_coef,nu_ratio) result(laplace)
+  function vlaplace_sphere_wk(v,deriv,elem,var_coef,nu_ratio,tensor) result(laplace)
 !
 !   input:  v = vector in lat-lon coordinates
 !   ouput:  weak laplacian of v, in lat-lon coordinates
@@ -1127,27 +1135,33 @@ contains
     type (derivative_t), intent(in) :: deriv
     type (element_t), intent(in) :: elem
     real(kind=real_kind), optional :: nu_ratio
+    real(kind=real_kind), optional :: tensor(np,np,2,2)
+
     real(kind=real_kind) :: laplace(np,np,2)
 
 
-    if (hypervis_scaling/=0 .and. var_coef) then
+    if (var_coef) then
        ! tensorHV is turned on - requires cartesian formulation
        if (present(nu_ratio)) then
           if (nu_ratio /= 1) then
              call abortmp('ERROR: tensorHV can not be used with nu_div/=nu')
           endif
        endif
-       laplace=vlaplace_sphere_wk_cartesian(v,deriv,elem,var_coef)
+       if (present(tensor)) then
+          laplace=vlaplace_sphere_wk_cartesian(v,deriv,elem,var_coef,tensor)
+       else
+          laplace=vlaplace_sphere_wk_cartesian(v,deriv,elem,var_coef,elem%tensorVisc)
+       endif
     else  
        ! all other cases, use contra formulation:
-       laplace=vlaplace_sphere_wk_contra(v,deriv,elem,var_coef,nu_ratio)
+       laplace=vlaplace_sphere_wk_contra(v,deriv,elem,nu_ratio)
     endif
 
   end function vlaplace_sphere_wk
 
 
 
-  function vlaplace_sphere_wk_cartesian(v,deriv,elem,var_coef) result(laplace)
+  function vlaplace_sphere_wk_cartesian(v,deriv,elem,var_coef,tensor) result(laplace)
 !
 !   input:  v = vector in lat-lon coordinates
 !   ouput:  weak laplacian of v, in lat-lon coordinates
@@ -1156,6 +1170,7 @@ contains
     logical :: var_coef
     type (derivative_t), intent(in) :: deriv
     type (element_t), intent(in) :: elem
+    real(kind=real_kind) :: tensor(np,np,2,2)
     real(kind=real_kind) :: laplace(np,np,2)
     ! Local
 
@@ -1172,7 +1187,7 @@ contains
 
     ! Do laplace on cartesian comps
     do component=1,3
-       dum_cart(:,:,component) = laplace_sphere_wk(dum_cart(:,:,component),deriv,elem,var_coef)
+       dum_cart(:,:,component) = laplace_sphere_wk(dum_cart(:,:,component),deriv,elem,var_coef,tensor)
     enddo
 
     ! cartesian -> latlon
@@ -1194,7 +1209,7 @@ contains
 
 
 
-  function vlaplace_sphere_wk_contra(v,deriv,elem,var_coef,nu_ratio) result(laplace)
+  function vlaplace_sphere_wk_contra(v,deriv,elem,nu_ratio) result(laplace)
 !
 !   input:  v = vector in lat-lon coordinates
 !   ouput:  weak laplacian of v, in lat-lon coordinates
@@ -1205,7 +1220,6 @@ contains
 !                 = grad_wk(div) - curl_wk(vor)               
 !
     real(kind=real_kind), intent(in) :: v(np,np,2) 
-    logical, intent(in) :: var_coef
     type (derivative_t), intent(in) :: deriv
     type (element_t), intent(in) :: elem
     real(kind=real_kind) :: laplace(np,np,2)

--- a/components/homme/src/share/element_mod.F90
+++ b/components/homme/src/share/element_mod.F90
@@ -58,7 +58,8 @@ module element_mod
 
      real (kind=real_kind)    :: variable_hyperviscosity(np,np)       ! hyperviscosity based on above
      real (kind=real_kind)    :: hv_courant                           ! hyperviscosity courant number
-     real (kind=real_kind)    :: tensorVisc(np,np,2,2)                !og, matrix V for tensor viscosity
+     real (kind=real_kind)    :: tensorVisc(np,np,2,2)                ! matrix V for tensor hyperviscosity
+     real (kind=real_kind)    :: tensorVisc_2(np,np,2,2)              ! matrix V for tensor viscosity
 
      type (GridVertex_t)      :: vertex                               ! element grid vertex information
      type (EdgeDescriptor_t)  :: desc

--- a/components/homme/src/share/global_norms_mod.F90
+++ b/components/homme/src/share/global_norms_mod.F90
@@ -420,7 +420,7 @@ contains
     use dimensions_mod, only : np
     use quadrature_mod, only : gausslobatto, quadrature_t
 
-    use control_mod, only : hypervis_scaling
+    use control_mod, only : hypervis_scaling, laplace_scaling
     use edge_mod, only : initedgebuffer, FreeEdgeBuffer, edgeVpack, edgeVunpack
     use bndry_mod, only : bndry_exchangeV
 
@@ -440,6 +440,12 @@ contains
     !  this block of code will DSS it so the tensor if C0
     !  and also make it bilinear in each element.
     !  Oksana Guba
+    !
+    !  The tensorVisc_2() array (used by the sponge-layer/nu_top tensor
+    !  viscosity, controlled by laplace_scaling) is computed in cube_mod.F90
+    !  in the same way as tensorVisc, and is DSS'd/bilinearized below with
+    !  an independent block, gated on laplace_scaling rather than
+    !  hypervis_scaling (the two controls are independent of one another).
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
     if (hypervis_scaling /= 0) then
@@ -476,6 +482,54 @@ contains
               do j=1,np
                 y = gp%points(j)
                 elem(ie)%tensorVisc(i,j,rowind,colind) = 0.25d0*( &
+                (1.0d0-x)*(1.0d0-y)*sw + &
+                (1.0d0-x)*(y+1.0d0)*nw + &
+                (x+1.0d0)*(1.0d0-y)*se + &
+                (x+1.0d0)*(y+1.0d0)*noreast)
+              end do
+            end do
+          end do
+        enddo !rowind
+      enddo !colind
+
+      deallocate(gp%points)
+      deallocate(gp%weights)
+    endif
+
+    if (laplace_scaling /= 0) then
+      call initEdgeBuffer(hybrid%par,edgebuf,elem,1)
+      do rowind=1,2
+        do colind=1,2
+          do ie=nets,nete
+            zeta(:,:,ie) = elem(ie)%tensorVisc_2(:,:,rowind,colind)*elem(ie)%spheremp(:,:)
+            call edgeVpack(edgebuf,zeta(1,1,ie),1,0,ie)
+          end do
+
+          call bndry_exchangeV(hybrid,edgebuf)
+          do ie=nets,nete
+            call edgeVunpack(edgebuf,zeta(1,1,ie),1,0,ie)
+            elem(ie)%tensorVisc_2(:,:,rowind,colind) = zeta(:,:,ie)*elem(ie)%rspheremp(:,:)
+          end do
+        enddo !rowind
+      enddo !colind
+      call FreeEdgeBuffer(edgebuf)
+
+      gp=gausslobatto(np)
+
+      !IF BILINEAR MAP OF V NEEDED
+      do rowind=1,2
+        do colind=1,2
+          ! replace hypervis w/ bilinear based on continuous corner values
+          do ie=nets,nete
+            noreast = elem(ie)%tensorVisc_2(np,np,rowind,colind)
+            nw = elem(ie)%tensorVisc_2(1,np,rowind,colind)
+            se = elem(ie)%tensorVisc_2(np,1,rowind,colind)
+            sw = elem(ie)%tensorVisc_2(1,1,rowind,colind)
+            do i=1,np
+              x = gp%points(i)
+              do j=1,np
+                y = gp%points(j)
+                elem(ie)%tensorVisc_2(i,j,rowind,colind) = 0.25d0*( &
                 (1.0d0-x)*(1.0d0-y)*sw + &
                 (1.0d0-x)*(y+1.0d0)*nw + &
                 (x+1.0d0)*(1.0d0-y)*se + &

--- a/components/homme/src/share/global_norms_mod.F90
+++ b/components/homme/src/share/global_norms_mod.F90
@@ -255,7 +255,7 @@ contains
     use reduction_mod, only : ParallelMin,ParallelMax
     use physical_constants, only : scale_factor_inv
     use control_mod, only : nu, nu_q, nu_div, hypervis_order, nu_top,  &
-                            hypervis_scaling, dcmip16_mu,dcmip16_mu_s
+                            hypervis_scaling, laplace_scaling, dcmip16_mu,dcmip16_mu_s
     use control_mod, only : tstep_type
 
     type(element_t)      , intent(inout) :: elem(:)
@@ -265,7 +265,7 @@ contains
     ! Element statisics
     real (kind=real_kind) :: min_max_dx ! used for normalizing scalar HV
     real (kind=real_kind) :: max_normDinv  ! used for CFL
-    real (kind=real_kind) :: normDinv_hypervis
+    real (kind=real_kind) :: normDinv_hypervis, normDinv_laplace
     real (kind=real_kind) :: lambda_max, lambda_vis, min_gw, lambda, nu_div_actual, nu_top_actual
     integer :: ie
     type (quadrature_t)    :: gp
@@ -338,6 +338,16 @@ contains
        ! constant coefficient formula:
        normDinv_hypervis = (lambda_vis**2) * (scale_factor_inv*max_normDinv)**4
     endif
+    if (laplace_scaling/=0) then
+       ! tensor laplace.  New eigenvalues are the eigenvalues of the tensor V
+       ! formulas here must match what is in cube_mod.F90
+       lambda = max_normDinv**2
+       normDinv_laplace = (lambda_vis) * (max_normDinv**2) * &
+            (lambda**(-laplace_scaling/2) )
+    else
+       ! constant coefficient formula:
+       normDinv_laplace = (lambda_vis) * (scale_factor_inv*max_normDinv)**2
+    endif
 
      if (hybrid%masterthread) then
        write(iulog,'(a,f10.2)') 'CFL estimates in terms of S=time step stability region'
@@ -375,12 +385,12 @@ contains
        if(nu_top>0) then
 #ifdef MODEL_THETA_L
           nu_top_actual=maxval(nu_scale_top)*nu_top
-          write(iulog,'(a,f10.2,a)') 'scaled nu_top viscosity CFL: dt < S*', &
-               1.0d0/(nu_top_actual*((scale_factor_inv*max_normDinv)**2)*lambda_vis),'s'
+          write(iulog,'(a,f12.4,a)') 'scaled nu_top viscosity CFL: dt < S*', &
+               1.0d0/(nu_top_actual*normDinv_laplace),'s'
 #else
           nu_top_actual=4*nu_top
           write(iulog,'(a,f10.2,a)') '4*nu_top viscosity CFL: dt < S*', &
-               1.0d0/(nu_top_actual*((scale_factor_inv*max_normDinv)**2)*lambda_vis),'s'
+               1.0d0/(nu_top_actual*normDinv_laplace),'s'
 #endif
        end if
 

--- a/components/homme/src/share/namelist_mod.F90
+++ b/components/homme/src/share/namelist_mod.F90
@@ -317,6 +317,7 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
       hypervis_subcycle_tom, &
       hypervis_subcycle_q, &
       hypervis_scaling, &
+      laplace_scaling, &
       smooth_phis_numcycle, &
       smooth_phis_p2filt, &
       smooth_phis_nudt, &
@@ -816,6 +817,7 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
     call MPI_bcast(disable_diagnostics,1,MPIlogical_t,par%root,par%comm,ierr)
     call MPI_bcast(hypervis_order,1,MPIinteger_t   ,par%root,par%comm,ierr)
     call MPI_bcast(hypervis_scaling,1,MPIreal_t   ,par%root,par%comm,ierr)
+    call MPI_bcast(laplace_scaling,1,MPIreal_t   ,par%root,par%comm,ierr)
     call MPI_bcast(hypervis_subcycle,1,MPIinteger_t   ,par%root,par%comm,ierr)
     call MPI_bcast(hypervis_subcycle_tom,1,MPIinteger_t   ,par%root,par%comm,ierr)
     call MPI_bcast(hypervis_subcycle_q,1,MPIinteger_t   ,par%root,par%comm,ierr)

--- a/components/homme/src/share/namelist_mod.F90
+++ b/components/homme/src/share/namelist_mod.F90
@@ -76,6 +76,7 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
     dcmip16_pbl_type,&
     interp_lon0,    &
     hypervis_scaling,   &  ! use tensor HV instead of scalar coefficient
+    laplace_scaling,   &   ! use tensor laplace instead of scalar coefficient
     disable_diagnostics, & ! use to disable diagnostics for timing reasons
     hypervis_order,       &
     hypervis_subcycle,    &
@@ -1223,9 +1224,14 @@ end if
        write(iulog,*)"readnl: internal_diagnostics_level = ",internal_diagnostics_level
 
        if(hypervis_scaling /=0)then
-          write(iulog,*)"Tensor hyperviscosity:  hypervis_scaling=",hypervis_scaling
+          write(iulog,*)"Tensor hyperviscosity: hypervis_scaling=",hypervis_scaling
        else
-          write(iulog,*)"Constant (hyper)viscosity used."
+          write(iulog,*)"Constant (hyper)viscosity.  hypervis_scaling=",hypervis_scaling
+       endif
+       if(laplace_scaling /=0)then
+          write(iulog,*)"Sponge layer viscosity: laplace_scaling=",laplace_scaling
+       else
+          write(iulog,*)"Sponge layer Constant viscosity. laplace_scaling=",laplace_scaling
        endif
 
        write(iulog,*)"hypervis_subcycle     = ",hypervis_subcycle

--- a/components/homme/src/share/sl_advection.F90
+++ b/components/homme/src/share/sl_advection.F90
@@ -910,8 +910,6 @@ contains
 
     !if tensor hyperviscosity with tensor V is used, then biharmonic operator is (\grad\cdot V\grad) (\grad \cdot \grad) 
     !so tensor is only used on second call to laplace_sphere_wk
-    var_coef1 = .true.
-    if(hypervis_scaling > 0)    var_coef1 = .false.
 
     do ie=nets,nete
 #if (defined COLUMN_OPENMP)
@@ -921,7 +919,7 @@ contains
           do k=1,nlev    !  Potential loop inversion (AAM)
              lap_p(:,:)=qtens(:,:,k,q,ie)
              ! Original use of qtens on left and right hand sides caused OpenMP errors (AAM)
-             qtens(:,:,k,q,ie)=laplace_sphere_wk(lap_p,deriv,elem(ie),var_coef=var_coef1)
+             qtens(:,:,k,q,ie)=laplace_sphere_wk(lap_p,deriv,elem(ie),var_coef=.false.)
           enddo
           call edgeVpack_nlyr(edgeq, elem(ie)%desc, qtens(:,:,:,q,ie),nlev,nlev*(q-1),nq*nlev)
        enddo
@@ -941,7 +939,7 @@ contains
           call edgeVunpack_nlyr(edgeq,elem(ie)%desc,qtens(:,:,:,q,ie),nlev,nlev*(q-1),nq*nlev)
           do k=1,nlev    !  Potential loop inversion (AAM)
              lap_p(:,:)=elem(ie)%rspheremp(:,:)*qtens(:,:,k,q,ie)
-             qtens(:,:,k,q,ie)=laplace_sphere_wk(lap_p,deriv,elem(ie),var_coef=.true.)
+             qtens(:,:,k,q,ie)=laplace_sphere_wk(lap_p,deriv,elem(ie),(hypervis_scaling>0))
           enddo
        enddo
     enddo

--- a/components/homme/src/share/viscosity_base.F90
+++ b/components/homme/src/share/viscosity_base.F90
@@ -17,7 +17,8 @@ use dimensions_mod, only : np, nlev,qsize,nelemd
 use hybrid_mod, only : hybrid_t, hybrid_create
 use parallel_mod, only : parallel_t, abortmp
 use element_mod, only : element_t
-use derivative_mod, only : derivative_t, laplace_sphere_wk, vlaplace_sphere_wk, vorticity_sphere, derivinit, divergence_sphere
+use derivative_mod, only : derivative_t, laplace_sphere_wk, vlaplace_sphere_wk, vorticity_sphere, derivinit,&
+     divergence_sphere
 use edgetype_mod, only : EdgeBuffer_t, EdgeDescriptor_t
 use edge_mod, only : edgevpack, edgevunpack, edgevunpackmin, &
     edgevunpackmax, initEdgeBuffer, FreeEdgeBuffer, edgeSunpackmax, edgeSunpackmin,edgeSpack, &
@@ -85,13 +86,6 @@ type (derivative_t)  , intent(in) :: deriv
 ! local
 integer :: k,kptr,i,j,ie,ic,q
 real (kind=real_kind), dimension(np,np) :: lap_p
-logical var_coef1
-
-   !if tensor hyperviscosity with tensor V is used, then biharmonic operator is (\grad\cdot V\grad) (\grad \cdot \grad) 
-   !so tensor is only used on second call to laplace_sphere_wk
-   var_coef1 = .true.
-   if(hypervis_scaling > 0)    var_coef1 = .false.
-
 
 
    do ie=nets,nete
@@ -102,7 +96,7 @@ logical var_coef1
          do k=1,nlev    !  Potential loop inversion (AAM)
             lap_p(:,:)=qtens(:,:,k,q,ie)
 ! Original use of qtens on left and right hand sides caused OpenMP errors (AAM)
-           qtens(:,:,k,q,ie)=laplace_sphere_wk(lap_p,deriv,elem(ie),var_coef=var_coef1)
+           qtens(:,:,k,q,ie)=laplace_sphere_wk(lap_p,deriv,elem(ie),var_coef=.false.)
          enddo
          call edgeVpack_nlyr(edgeq, elem(ie)%desc, qtens(:,:,:,q,ie),nlev,nlev*(q-1),qsize*nlev)
       enddo
@@ -122,7 +116,7 @@ logical var_coef1
         call edgeVunpack_nlyr(edgeq,elem(ie)%desc,qtens(:,:,:,q,ie),nlev,nlev*(q-1),qsize*nlev)
         do k=1,nlev    !  Potential loop inversion (AAM)
            lap_p(:,:)=elem(ie)%rspheremp(:,:)*qtens(:,:,k,q,ie)
-           qtens(:,:,k,q,ie)=laplace_sphere_wk(lap_p,deriv,elem(ie),var_coef=.true.)
+           qtens(:,:,k,q,ie)=laplace_sphere_wk(lap_p,deriv,elem(ie),var_coef=(hypervis_scaling>0))
         enddo
       enddo
    enddo
@@ -645,7 +639,7 @@ subroutine smooth_phis(phis,elem,hybrid,deriv,nets,nete,minf,numcycle,p2filt,xgl
 
 
      do ie=nets,nete
-        pstens(:,:,ie)=laplace_sphere_wk(phis(:,:,ie),deriv,elem(ie),var_coef=.true.)
+        pstens(:,:,ie)=laplace_sphere_wk(phis(:,:,ie),deriv,elem(ie),var_coef=(hypervis_scaling>0))
      enddo
 
      do ie=nets,nete

--- a/components/homme/src/sweqx/viscosity_mod.F90
+++ b/components/homme/src/sweqx/viscosity_mod.F90
@@ -53,8 +53,6 @@ logical var_coef1
 
    !if tensor hyperviscosity with tensor V is used, then biharmonic operator is (\grad\cdot V\grad) (\grad \cdot \grad) 
    !so tensor is only used on second call to laplace_sphere_wk
-   var_coef1 = .true.
-   if(hypervis_scaling > 0)  var_coef1= .false.
 
    ! note: there is a scaling bug in the treatment of nu_div
    ! nu_ratio is applied twice, once in each laplace operator
@@ -85,9 +83,9 @@ logical var_coef1
             enddo
          enddo
         
-         ptens(:,:,k,ie)=laplace_sphere_wk(T(:,:,k),deriv,elem(ie),var_coef=var_coef1)
+         ptens(:,:,k,ie)=laplace_sphere_wk(T(:,:,k),deriv,elem(ie),var_coef=.false.)
          vtens(:,:,:,k,ie)=vlaplace_sphere_wk(elem(ie)%state%v(:,:,:,k,nt),deriv,&
-              elem(ie),var_coef=var_coef1,nu_ratio=nu_ratio1)
+              elem(ie),var_coef=.false.,nu_ratio=nu_ratio1)
 
       enddo
       kptr=0
@@ -116,8 +114,8 @@ logical var_coef1
                v(i,j,2)=rspheremv(i,j)*vtens(i,j,2,k,ie)
             enddo
          enddo
-         ptens(:,:,k,ie)=laplace_sphere_wk(T(:,:,k),deriv,elem(ie),var_coef=.true.)
-         vtens(:,:,:,k,ie)=vlaplace_sphere_wk(v(:,:,:),deriv,elem(ie),var_coef=.true.,&
+         ptens(:,:,k,ie)=laplace_sphere_wk(T(:,:,k),deriv,elem(ie),var_coef=(hypervis_scaling>0))
+         vtens(:,:,:,k,ie)=vlaplace_sphere_wk(v(:,:,:),deriv,elem(ie),var_coef=(hypervis_scaling>0),&
               nu_ratio=nu_ratio2)
       enddo
    enddo

--- a/components/homme/src/theta-l/share/prim_advance_mod.F90
+++ b/components/homme/src/theta-l/share/prim_advance_mod.F90
@@ -18,7 +18,7 @@ module prim_advance_mod
   use control_mod,        only: dcmip16_mu, dcmip16_mu_s, hypervis_order, hypervis_subcycle,&
     integration, nu, nu_div, nu_p, nu_s, nu_top, prescribed_wind, qsplit, rsplit, test_case,&
     theta_hydrostatic_mode, tstep_type, theta_advect_form, hypervis_subcycle_tom, pgrad_correction,&
-    vtheta_thresh, dp3d_thresh
+    vtheta_thresh, dp3d_thresh, laplace_scaling
   use derivative_mod,     only: derivative_t, divergence_sphere, gradient_sphere, laplace_sphere_wk,&
     laplace_z, vorticity_sphere, vlaplace_sphere_wk 
   use derivative_mod,     only: subcell_div_fluxes, subcell_dss_fluxes
@@ -784,11 +784,11 @@ contains
      do ie=nets,nete
         do k=1,nlev_tom
            ! add regular diffusion near top
-           lap_s(:,:,1)=laplace_sphere_wk(elem(ie)%state%dp3d     (:,:,k,nt),deriv,elem(ie),var_coef=.false.)
-           lap_s(:,:,2)=laplace_sphere_wk(elem(ie)%state%vtheta_dp(:,:,k,nt),deriv,elem(ie),var_coef=.false.)
-           lap_s(:,:,3)=laplace_sphere_wk(elem(ie)%state%w_i      (:,:,k,nt),deriv,elem(ie),var_coef=.false.)
-           lap_s(:,:,4)=laplace_sphere_wk(elem(ie)%state%phinh_i  (:,:,k,nt),deriv,elem(ie),var_coef=.false.)
-           lap_v=vlaplace_sphere_wk(elem(ie)%state%v            (:,:,:,k,nt),deriv,elem(ie),var_coef=.false.)
+           lap_s(:,:,1)=laplace_sphere_wk(elem(ie)%state%dp3d     (:,:,k,nt),deriv,elem(ie),var_coef=(laplace_scaling>0),tensor=elem(ie)%tensorVisc_2)
+           lap_s(:,:,2)=laplace_sphere_wk(elem(ie)%state%vtheta_dp(:,:,k,nt),deriv,elem(ie),var_coef=(laplace_scaling>0),tensor=elem(ie)%tensorVisc_2)
+           lap_s(:,:,3)=laplace_sphere_wk(elem(ie)%state%w_i      (:,:,k,nt),deriv,elem(ie),var_coef=(laplace_scaling>0),tensor=elem(ie)%tensorVisc_2)
+           lap_s(:,:,4)=laplace_sphere_wk(elem(ie)%state%phinh_i  (:,:,k,nt),deriv,elem(ie),var_coef=(laplace_scaling>0),tensor=elem(ie)%tensorVisc_2)
+           lap_v=vlaplace_sphere_wk(elem(ie)%state%v            (:,:,:,k,nt),deriv,elem(ie),var_coef=(laplace_scaling>0),tensor=elem(ie)%tensorVisc_2)
            
            xfac=dt*nu_scale_top(k)*nu_top
 

--- a/components/homme/src/theta-l/share/prim_state_mod.F90
+++ b/components/homme/src/theta-l/share/prim_state_mod.F90
@@ -813,7 +813,7 @@ contains
        time0=time1
     endif
        
-
+    call flush(iulog)  
   call t_stopf('prim_printstate')
   end subroutine prim_printstate
    

--- a/components/homme/src/theta-l/share/viscosity_theta.F90
+++ b/components/homme/src/theta-l/share/viscosity_theta.F90
@@ -144,21 +144,21 @@ endif
       ! apply inverse mass matrix, then apply laplace again
       do k=1,nlev
          tmp(:,:)=rspheremv(:,:)*stens(:,:,k,1,ie)
-         stens(:,:,k,1,ie)=laplace_sphere_wk(tmp,deriv,elem(ie),var_coef=.true.)
+         stens(:,:,k,1,ie)=laplace_sphere_wk(tmp,deriv,elem(ie),var_coef=(hypervis_scaling>0))
 
          tmp(:,:)=rspheremv(:,:)*stens(:,:,k,2,ie)
-         stens(:,:,k,2,ie)=laplace_sphere_wk(tmp,deriv,elem(ie),var_coef=.true.)
+         stens(:,:,k,2,ie)=laplace_sphere_wk(tmp,deriv,elem(ie),var_coef=(hypervis_scaling>0))
 
          tmp(:,:)=rspheremv(:,:)*stens(:,:,k,3,ie)
-         stens(:,:,k,3,ie)=laplace_sphere_wk(tmp,deriv,elem(ie),var_coef=.true.)
+         stens(:,:,k,3,ie)=laplace_sphere_wk(tmp,deriv,elem(ie),var_coef=(hypervis_scaling>0))
 
          tmp(:,:)=rspheremv(:,:)*stens(:,:,k,4,ie)
-         stens(:,:,k,4,ie)=laplace_sphere_wk(tmp,deriv,elem(ie),var_coef=.true.)
+         stens(:,:,k,4,ie)=laplace_sphere_wk(tmp,deriv,elem(ie),var_coef=(hypervis_scaling>0))
 
          v(:,:,1)=rspheremv(:,:)*vtens(:,:,1,k,ie)
          v(:,:,2)=rspheremv(:,:)*vtens(:,:,2,k,ie)
          vtens(:,:,:,k,ie)=vlaplace_sphere_wk(v(:,:,:),deriv,elem(ie),&
-              var_coef=.true.,nu_ratio=nu_ratio2)
+              var_coef=(hypervis_scaling>0),nu_ratio=nu_ratio2)
 
       enddo
    enddo

--- a/components/homme/src/theta-l_kokkos/cxx/HyperviscosityFunctorImpl.cpp
+++ b/components/homme/src/theta-l_kokkos/cxx/HyperviscosityFunctorImpl.cpp
@@ -27,7 +27,7 @@ HyperviscosityFunctorImpl (const SimulationParams&     params,
  , m_data (params.hypervis_subcycle,params.hypervis_subcycle_tom,
            params.nu_ratio1,params.nu_ratio2,params.nu_top,params.nu,
            params.nu_p,params.nu_s,params.hypervis_scaling,
-           params.do_3d_turbulence, params.tom_sponge_start)
+           params.do_3d_turbulence, params.tom_sponge_start, params.laplace_scaling)
  , m_state   (state)
  , m_derived (derived)
  , m_geometry (geometry)
@@ -36,7 +36,6 @@ HyperviscosityFunctorImpl (const SimulationParams&     params,
  , m_policy_update_states (Homme::get_default_team_policy<ExecSpace,TagUpdateStates>(m_num_elems))
  , m_policy_first_laplace (Homme::get_default_team_policy<ExecSpace,TagFirstLaplaceHV>(m_num_elems))
  , m_policy_pre_exchange (Homme::get_default_team_policy<ExecSpace, TagHyperPreExchange>(m_num_elems))
- , m_policy_nutop_laplace (Homme::get_default_team_policy<ExecSpace, TagNutopLaplace>(m_num_elems))
  , m_policy_nutop_update_states (Homme::get_default_team_policy<ExecSpace,TagNutopUpdateStates>(m_num_elems))
  , m_policy_sgsturb_laplace (Homme::get_default_team_policy<ExecSpace, TagSGSTurbLaplace>(m_num_elems))
  , m_policy_sgsturb_update_states (Homme::get_default_team_policy<ExecSpace,TagSGSTurbUpdateStates>(m_num_elems))
@@ -54,13 +53,12 @@ HyperviscosityFunctorImpl (const int num_elems, const SimulationParams &params)
   , m_data (params.hypervis_subcycle,params.hypervis_subcycle_tom,
             params.nu_ratio1,params.nu_ratio2,params.nu_top,params.nu,
             params.nu_p,params.nu_s,params.hypervis_scaling,
-            params.do_3d_turbulence, params.tom_sponge_start)
+            params.do_3d_turbulence, params.tom_sponge_start, params.laplace_scaling)
   , m_hvcoord (Context::singleton().get<HybridVCoord>())
   , m_policy_update_states (Homme::get_default_team_policy<ExecSpace,TagUpdateStates>(m_num_elems))
   , m_policy_first_laplace (Homme::get_default_team_policy<ExecSpace,TagFirstLaplaceHV>(m_num_elems))
   , m_policy_pre_exchange (Homme::get_default_team_policy<ExecSpace, TagHyperPreExchange>(m_num_elems))
-  , m_policy_nutop_laplace (Homme::get_default_team_policy<ExecSpace, TagNutopLaplace>(m_num_elems))
-  , m_policy_nutop_update_states (Homme::get_default_team_policy<ExecSpace,TagNutopUpdateStates>(m_num_elems))
+   , m_policy_nutop_update_states (Homme::get_default_team_policy<ExecSpace,TagNutopUpdateStates>(m_num_elems))
   , m_policy_sgsturb_laplace (Homme::get_default_team_policy<ExecSpace, TagSGSTurbLaplace>(m_num_elems))
   , m_policy_sgsturb_update_states (Homme::get_default_team_policy<ExecSpace,TagSGSTurbUpdateStates>(m_num_elems))
   , m_tu(m_policy_update_states)
@@ -391,9 +389,16 @@ void HyperviscosityFunctorImpl::run (const int np1, const Real dt, const Real et
 
   // sponge layer 
   if (m_data.nu_top > 0) {
+    const int ne = m_geometry.num_elems();
     for (int icycle = 0; icycle < m_data.hypervis_subcycle_tom; ++icycle) {
       // laplace(fields) --> ttens, etc.
-      Kokkos::parallel_for(m_policy_nutop_laplace, *this);
+      if ( m_data.constsponge ) {
+        auto policy = Homme::get_default_team_policy<ExecSpace,TagNutopLaplaceConst>(ne);
+        Kokkos::parallel_for(policy, *this);
+      } else {
+        auto policy = Homme::get_default_team_policy<ExecSpace,TagNutopLaplaceTensor>(ne);
+        Kokkos::parallel_for(policy, *this);
+      }
       Kokkos::fence();
 
       // exchange is done on ttens, dptens, vtens, etc.
@@ -435,9 +440,9 @@ void HyperviscosityFunctorImpl::biharmonic_wk_theta() const
   Kokkos::fence();
 } //biharmonic
 
-// Laplace for nu_top
+// Laplace for nu_top, constant coefficient
 KOKKOS_INLINE_FUNCTION
-void HyperviscosityFunctorImpl::operator() (const TagNutopLaplace&, const TeamMember& team) const {
+void HyperviscosityFunctorImpl::operator() (const TagNutopLaplaceConst&, const TeamMember& team) const {
   KernelVariables kv(team, m_tu);
 
   using MidColumn = decltype(Homme::subview(m_buffers.wtens,0,0,0));
@@ -507,7 +512,88 @@ void HyperviscosityFunctorImpl::operator() (const TagNutopLaplace&, const TeamMe
 
         }); // threadvectorrange
     }); // teamthreadrange
-} // TagNutopLaplace
+} // TagNutopLaplaceConst
+
+// Laplace for nu_top, tensor coefficient (laplace_scaling>0), using tensorVisc_2
+KOKKOS_INLINE_FUNCTION
+void HyperviscosityFunctorImpl::operator() (const TagNutopLaplaceTensor&, const TeamMember& team) const {
+  KernelVariables kv(team, m_tu);
+
+  using MidColumn = decltype(Homme::subview(m_buffers.wtens,0,0,0));
+
+  const auto& tensorvisc2 = Homme::subview(m_geometry.m_tensorvisc2,kv.ie);
+
+  // Laplacian of layer thickness
+  m_sphere_ops.laplace_tensor(kv, tensorvisc2,
+                              Homme::subview(m_state.m_dp3d,kv.ie,m_data.np1),
+                              Homme::subview(m_buffers.dptens,kv.ie),
+                              m_nu_scale_top_ilev_pack_lim);
+  // Laplacian of theta
+  m_sphere_ops.laplace_tensor(kv, tensorvisc2,
+                              Homme::subview(m_state.m_vtheta_dp,kv.ie,m_data.np1),
+                              Homme::subview(m_buffers.ttens,kv.ie),
+                              m_nu_scale_top_ilev_pack_lim);
+
+  if (m_process_nh_vars) {
+    // Laplacian of vertical velocity (do not compute last interface)
+    m_sphere_ops.laplace_tensor<NUM_LEV,NUM_LEV_P>(kv, tensorvisc2,
+                                                   Homme::subview(m_state.m_w_i,kv.ie,m_data.np1),
+                                                   Homme::subview(m_buffers.wtens,kv.ie),
+                                                   m_nu_scale_top_ilev_pack_lim);
+    // Laplacian of geopotential (do not compute last interface)
+    m_sphere_ops.laplace_tensor<NUM_LEV,NUM_LEV_P>(kv, tensorvisc2,
+                                                   Homme::subview(m_state.m_phinh_i,kv.ie,m_data.np1),
+                                                   Homme::subview(m_buffers.phitens,kv.ie),
+                                                   m_nu_scale_top_ilev_pack_lim);
+  }
+
+  // Laplacian of velocity
+  m_sphere_ops.vlaplace_sphere_wk_cartesian(kv, tensorvisc2,
+                                         Homme::subview(m_geometry.m_vec_sph2cart,kv.ie),
+                                         Homme::subview(m_state.m_v,kv.ie,m_data.np1),
+                                         Homme::subview(m_buffers.vtens,kv.ie),
+                                         m_nu_scale_top_ilev_pack_lim);
+
+  kv.team_barrier();
+
+  Kokkos::parallel_for(
+    Kokkos::TeamThreadRange(kv.team,NP*NP),
+    [&] (const int idx) {
+      const int igp = idx / NP;
+      const int jgp = idx % NP;
+
+      const auto utens  = Homme::subview(m_buffers.vtens,kv.ie,0,igp,jgp);
+      const auto vtens  = Homme::subview(m_buffers.vtens,kv.ie,1,igp,jgp);
+      const auto ttens  = Homme::subview(m_buffers.ttens,kv.ie,igp,jgp);
+      const auto dptens = Homme::subview(m_buffers.dptens,kv.ie,igp,jgp);
+     
+      MidColumn wtens, phitens;
+      if (m_process_nh_vars) {
+        wtens   = Homme::subview(m_buffers.wtens,kv.ie,igp,jgp);
+        phitens = Homme::subview(m_buffers.phitens,kv.ie,igp,jgp);
+      }
+
+      // Note: only the first m_nu_scale_top_ilev_pack_lim packs are scaled and
+      // used here, exactly as in the constant-coefficient path -- laplace_tensor
+      // and vlaplace_sphere_wk_cartesian above are now passed the same runtime
+      // limit, so unused levels are not even computed.
+      Kokkos::parallel_for(
+        Kokkos::ThreadVectorRange(kv.team, m_nu_scale_top_ilev_pack_lim),
+        [&] (const int ilev) {
+          const auto xf = m_data.dt_hvs_tom  * m_nu_scale_top(ilev) * m_data.nu_top;
+          utens(ilev)  *= xf;
+          vtens(ilev)  *= xf;
+          ttens(ilev)  *= xf;
+          dptens(ilev) *= xf;
+
+          if (m_process_nh_vars) {
+            wtens(ilev)   *= xf;
+            phitens(ilev) *= xf;
+          }
+
+        }); // threadvectorrange
+    }); // teamthreadrange
+} // TagNutopLaplaceTensor
 
 KOKKOS_INLINE_FUNCTION
 void HyperviscosityFunctorImpl::operator() (const TagNutopUpdateStates&, const TeamMember& team) const {

--- a/components/homme/src/theta-l_kokkos/cxx/HyperviscosityFunctorImpl.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/HyperviscosityFunctorImpl.hpp
@@ -41,12 +41,13 @@ public:
                        const Real nu_ratio1_in, const Real nu_ratio2_in, const Real nu_top_in,
                        const Real nu_in, const Real nu_p_in, const Real nu_s_in,
                        const Real hypervis_scaling_in, bool do_3d_turbulence_in,
-                       const double tom_sponge_start_in)
+                       const double tom_sponge_start_in, const Real laplace_scaling_in = 0.0)
                       : hypervis_subcycle(hypervis_subcycle_in) 
                       , hypervis_subcycle_tom(hypervis_subcycle_tom_in)
                       , nu_ratio1(nu_ratio1_in), nu_ratio2(nu_ratio2_in)
                       , nu_top(nu_top_in), nu(nu_in), nu_p(nu_p_in), nu_s(nu_s_in)
                       , consthv(hypervis_scaling_in == 0)
+                      , constsponge(laplace_scaling_in == 0)
                       , do_3d_turbulence(do_3d_turbulence_in)
                       , tom_sponge_start(tom_sponge_start_in) {}
 
@@ -71,6 +72,7 @@ public:
     Real        eta_ave_w;
 
     bool consthv;
+    bool constsponge;
     double tom_sponge_start;
   };//hyperviscosityData
 
@@ -95,7 +97,8 @@ public:
   struct TagApplyInvMass {};
   struct TagHyperPreExchange {};
   struct TagNutopUpdateStates {};
-  struct TagNutopLaplace {};
+  struct TagNutopLaplaceConst {};
+  struct TagNutopLaplaceTensor {};
   struct TagSGSTurbUpdateStates {};
   struct TagSGSTurbLaplace {};
 
@@ -198,7 +201,10 @@ public:
 
   // Laplace for nu_top
   KOKKOS_INLINE_FUNCTION
-  void operator()(const TagNutopLaplace&, const TeamMember& team) const;
+  void operator()(const TagNutopLaplaceConst&, const TeamMember& team) const;
+
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const TagNutopLaplaceTensor&, const TeamMember& team) const;
 
   KOKKOS_INLINE_FUNCTION
   void operator()(const TagNutopUpdateStates&, const TeamMember& team) const;
@@ -424,7 +430,6 @@ protected:
   Kokkos::TeamPolicy<ExecSpace,TagFirstLaplaceHV>   m_policy_first_laplace;
   Kokkos::TeamPolicy<ExecSpace,TagHyperPreExchange> m_policy_pre_exchange;
 
-  Kokkos::TeamPolicy<ExecSpace,TagNutopLaplace>      m_policy_nutop_laplace;
   Kokkos::TeamPolicy<ExecSpace,TagNutopUpdateStates> m_policy_nutop_update_states;
 
   Kokkos::TeamPolicy<ExecSpace,TagSGSTurbLaplace>      m_policy_sgsturb_laplace;

--- a/components/homme/src/theta-l_kokkos/cxx/cxx_f90_interface_theta.cpp
+++ b/components/homme/src/theta-l_kokkos/cxx/cxx_f90_interface_theta.cpp
@@ -42,7 +42,7 @@ void init_simulation_params_c (const int& remap_alg, const int& limiter_option, 
                                const int& time_step_type, const int& qsize, const int& state_frequency,
                                const Real& nu, const Real& nu_p, const Real& nu_q, const Real& nu_s, const Real& nu_div, const Real& nu_top,
                                const int& hypervis_order, const int& hypervis_subcycle, const int& hypervis_subcycle_tom,
-                               const double& hypervis_scaling, const double& dcmip16_mu,
+                               const double& hypervis_scaling, const double& laplace_scaling, const double& dcmip16_mu,
                                const int& ftype, const int& theta_adv_form, const int& prescribed_wind, const int& use_moisture, const int& disable_diagnostics,
                                const int& use_cpstar, const int& transport_alg, const int& theta_hydrostatic_mode, const char** test_case,
                                const int& dt_remap_factor, const int& dt_tracer_factor,
@@ -115,6 +115,7 @@ void init_simulation_params_c (const int& remap_alg, const int& limiter_option, 
   params.hypervis_subcycle             = hypervis_subcycle;
   params.hypervis_subcycle_tom         = hypervis_subcycle_tom;
   params.hypervis_scaling              = hypervis_scaling;
+  params.laplace_scaling               = laplace_scaling;
   params.disable_diagnostics           = (bool)disable_diagnostics;
   params.use_moisture                  = (bool)use_moisture;
   params.use_cpstar                    = (bool)use_cpstar;
@@ -284,8 +285,7 @@ void init_elements_c (const int& num_elems)
   Elements& e = c.create<Elements> ();
   const SimulationParams& params = c.get<SimulationParams>();
 
-  const bool consthv = (params.hypervis_scaling==0.0);
-  e.init (num_elems, consthv, /* alloc_gradphis = */ true,
+  e.init (num_elems, /* alloc_gradphis = */ true,
           params.scale_factor, params.laplacian_rigid_factor,
           /* alloc_sphere_coords = */ params.transport_alg > 0);
 
@@ -462,15 +462,15 @@ void init_elements_2d_c (const int& ie,
                          CF90Ptr& spheremp, CF90Ptr& rspheremp,
                          CF90Ptr& metdet, CF90Ptr& metinv,
                          CF90Ptr &tensorvisc, CF90Ptr &vec_sph2cart,
-                         double* sphere_cart_vec, double* sphere_latlon_vec)
+                         double* sphere_cart_vec, double* sphere_latlon_vec,
+                         CF90Ptr &tensorvisc2)
 {
   auto& c = Context::singleton();
   Elements& e = c.get<Elements> ();
-  const SimulationParams& params = c.get<SimulationParams>();
 
-  const bool consthv = (params.hypervis_scaling==0.0);
   e.m_geometry.set_elem_data(ie,D,Dinv,fcor,spheremp,rspheremp,metdet,metinv,tensorvisc,
-                             vec_sph2cart,consthv,sphere_cart_vec,sphere_latlon_vec);
+                             vec_sph2cart,sphere_cart_vec,sphere_latlon_vec,
+                             tensorvisc2);
 }
 
 // Copies just tensorVisc from f90 arrays into the C++ view. Separate from
@@ -481,13 +481,18 @@ void init_tensorvisc_c (const int& ie, CF90Ptr& tensorvisc)
 {
   auto& c = Context::singleton();
   Elements& e = c.get<Elements> ();
-  const SimulationParams& params = c.get<SimulationParams>();
 
-  if (params.hypervis_scaling==0.0) {
-    // consthv: tensorVisc is not used/allocated.
-    return;
-  }
   e.m_geometry.set_tensorvisc(ie,tensorvisc);
+}
+
+// Same as init_tensorvisc_c(), but for tensorVisc_2 (the sponge-layer
+// tensor coefficient), which is likewise recomputed by dss_hvtensor.
+void init_tensorvisc2_c (const int& ie, CF90Ptr& tensorvisc2)
+{
+  auto& c = Context::singleton();
+  Elements& e = c.get<Elements> ();
+
+  e.m_geometry.set_tensorvisc2(ie,tensorvisc2);
 }
 
 void init_geopotential_c (const int& ie,

--- a/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
+++ b/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
@@ -23,6 +23,7 @@ module prim_driver_mod
   public :: prim_init_elements_views
   public :: prim_init_grid_views
   public :: prim_init_tensorvisc
+  public :: prim_init_tensorvisc2
   public :: prim_init_geopotential_views
   public :: prim_init_state_views
   public :: prim_init_ref_states_views
@@ -86,7 +87,7 @@ contains
     use control_mod,   only : limiter_option, rsplit, qsplit, tstep_type, statefreq,   &
                               nu, nu_p, nu_q, nu_s, nu_div, nu_top, vert_remap_q_alg,  &
                               hypervis_order, hypervis_subcycle, hypervis_subcycle_tom,&
-                              hypervis_scaling,                                        &
+                              hypervis_scaling, laplace_scaling,                       &
                               ftype, prescribed_wind, use_moisture, disable_diagnostics,   &
                               use_cpstar, transport_alg, theta_hydrostatic_mode,       &
                               dcmip16_mu, theta_advect_form, test_case,                &
@@ -129,7 +130,7 @@ contains
     call init_simulation_params_c (vert_remap_q_alg, limiter_option, rsplit, qsplit, tstep_type,  &
                                    qsize, statefreq, nu, nu_p, nu_q, nu_s, nu_div, nu_top,        &
                                    hypervis_order, hypervis_subcycle, hypervis_subcycle_tom,      &
-                                   hypervis_scaling,                                              &
+                                   hypervis_scaling, laplace_scaling,                             &
                                    dcmip16_mu, ftype, theta_advect_form,                          &
                                    prescribed_wind,                                               &
                                    use_moisture_int,                                              &
@@ -175,6 +176,7 @@ contains
     ! Local(s)
     !
     real (kind=real_kind), target, dimension(np,np,2,2)     :: elem_D, elem_Dinv, elem_metinv, elem_tensorvisc
+    real (kind=real_kind), target, dimension(np,np,2,2)     :: elem_tensorvisc2
     real (kind=real_kind), target, dimension(np,np)         :: elem_fcor, elem_spheremp
     real (kind=real_kind), target, dimension(np,np)         :: elem_rspheremp, elem_metdet
     real (kind=real_kind), target, dimension(np,np,3,2)     :: elem_vec_sph2cart
@@ -183,6 +185,7 @@ contains
     type (c_ptr) :: elem_spheremp_ptr, elem_rspheremp_ptr
     type (c_ptr) :: elem_metdet_ptr, elem_metinv_ptr
     type (c_ptr) :: elem_tensorvisc_ptr, elem_vec_sph2cart_ptr
+    type (c_ptr) :: elem_tensorvisc2_ptr
 
     type (cartesian3D_t) :: sphere_cart
     real (kind=real_kind) :: sphere_cart_vec(3,np,np), sphere_latlon_vec(2,np,np)
@@ -199,6 +202,7 @@ contains
     elem_metinv_ptr       = c_loc(elem_metinv)
     elem_tensorvisc_ptr   = c_loc(elem_tensorvisc)
     elem_vec_sph2cart_ptr = c_loc(elem_vec_sph2cart)
+    elem_tensorvisc2_ptr  = c_loc(elem_tensorvisc2)
 
     is_sphere = trim(geometry) /= 'plane'
 
@@ -211,6 +215,7 @@ contains
       elem_metdet       = elem(ie)%metdet
       elem_metinv       = elem(ie)%metinv
       elem_tensorvisc   = elem(ie)%tensorVisc
+      elem_tensorvisc2  = elem(ie)%tensorVisc_2
       elem_vec_sph2cart = elem(ie)%vec_sphere2cart
       do j = 1,np
          do i = 1,np
@@ -233,7 +238,8 @@ contains
                                elem_spheremp_ptr, elem_rspheremp_ptr,     &
                                elem_metdet_ptr, elem_metinv_ptr,          &
                                elem_tensorvisc_ptr, elem_vec_sph2cart_ptr,&
-                               sphere_cart_vec, sphere_latlon_vec)
+                               sphere_cart_vec, sphere_latlon_vec,        &
+                               elem_tensorvisc2_ptr)
     enddo
   end subroutine prim_init_grid_views
 
@@ -264,6 +270,32 @@ contains
       call init_tensorvisc_c (ie-1, elem_tensorvisc_ptr)
     enddo
   end subroutine prim_init_tensorvisc
+
+  ! Same as prim_init_tensorvisc, but for tensorVisc_2 (the sponge-layer
+  ! tensor coefficient), which is likewise recomputed by dss_hvtensor.
+  subroutine prim_init_tensorvisc2 (elem)
+    use iso_c_binding, only : c_ptr, c_loc
+    use element_mod,   only : element_t
+    use theta_f2c_mod, only : init_tensorvisc2_c
+    !
+    ! Input(s)
+    !
+    type (element_t), intent(in) :: elem (:)
+    !
+    ! Local(s)
+    !
+    real (kind=real_kind), target, dimension(np,np,2,2) :: elem_tensorvisc2
+    type (c_ptr) :: elem_tensorvisc2_ptr
+
+    integer :: ie
+
+    elem_tensorvisc2_ptr = c_loc(elem_tensorvisc2)
+
+    do ie=1,nelemd
+      elem_tensorvisc2 = elem(ie)%tensorVisc_2
+      call init_tensorvisc2_c (ie-1, elem_tensorvisc2_ptr)
+    enddo
+  end subroutine prim_init_tensorvisc2
 
   subroutine prim_init_geopotential_views (elem)
     use iso_c_binding, only : c_ptr, c_loc

--- a/components/homme/src/theta-l_kokkos/theta_f2c_mod.F90
+++ b/components/homme/src/theta-l_kokkos/theta_f2c_mod.F90
@@ -10,7 +10,7 @@ interface
   subroutine init_simulation_params_c (remap_alg, limiter_option, rsplit, qsplit, time_step_type,    &
                                        qsize, state_frequency, nu, nu_p, nu_q, nu_s, nu_div, nu_top, &
                                        hypervis_order, hypervis_subcycle, hypervis_subcycle_tom,     &
-                                       hypervis_scaling,                                             &
+                                       hypervis_scaling, laplace_scaling,                            &
                                        dcmip16_mu, ftype, theta_adv_form, prescribed_wind, use_moisture, &
                                        disable_diagnostics, use_cpstar, transport_alg,               &
                                        theta_hydrostatic_mode, test_case_name, dt_remap_factor,      &
@@ -25,7 +25,7 @@ interface
     integer(kind=c_int),  intent(in) :: remap_alg, limiter_option, rsplit, qsplit, time_step_type, nsplit
     integer(kind=c_int),  intent(in) :: dt_remap_factor, dt_tracer_factor, transport_alg
     integer(kind=c_int),  intent(in) :: state_frequency, qsize, internal_diagnostics_level
-    real(kind=c_double),  intent(in) :: nu, nu_p, nu_q, nu_s, nu_div, nu_top, hypervis_scaling, dcmip16_mu, &
+    real(kind=c_double),  intent(in) :: nu, nu_p, nu_q, nu_s, nu_div, nu_top, hypervis_scaling, laplace_scaling, dcmip16_mu, &
                       scale_factor, laplacian_rigid_factor, dp3d_thresh, vtheta_thresh
     integer(kind=c_int),  intent(in) :: hypervis_order, hypervis_subcycle, hypervis_subcycle_tom
     integer(kind=c_int),  intent(in) :: ftype, theta_adv_form
@@ -69,7 +69,8 @@ interface
                                  elem_spheremp_ptr, elem_rspheremp_ptr,   &
                                  elem_metdet_ptr, elem_metinv_ptr,        &
                                  tensorvisc_ptr, vec_sph2cart_ptr,        &
-                                 sphere_cart_vec, sphere_latlon_vec) bind(c)
+                                 sphere_cart_vec, sphere_latlon_vec,      &
+                                 tensorvisc2_ptr) bind(c)
     use iso_c_binding, only: c_int, c_ptr, c_double
     use dimensions_mod, only : np
     !
@@ -81,6 +82,7 @@ interface
     type (c_ptr) , intent(in) :: elem_metdet_ptr, elem_metinv_ptr
     type (c_ptr) , intent(in) :: tensorvisc_ptr, vec_sph2cart_ptr
     real (kind=c_double), intent(in) :: sphere_cart_vec(3,np,np), sphere_latlon_vec(2,np,np)
+    type (c_ptr) , intent(in) :: tensorvisc2_ptr
   end subroutine init_elements_2d_c
 
   ! Copies just tensorVisc from f90 arrays into the C++ view. Used to
@@ -94,6 +96,17 @@ interface
     integer (kind=c_int), intent(in) :: ie
     type (c_ptr) , intent(in) :: tensorvisc_ptr
   end subroutine init_tensorvisc_c
+
+  ! Same as init_tensorvisc_c, but for tensorVisc_2 (the sponge-layer
+  ! tensor coefficient), which is likewise recomputed by dss_hvtensor.
+  subroutine init_tensorvisc2_c (ie, tensorvisc2_ptr) bind(c)
+    use iso_c_binding, only: c_int, c_ptr
+    !
+    ! Inputs
+    !
+    integer (kind=c_int), intent(in) :: ie
+    type (c_ptr) , intent(in) :: tensorvisc2_ptr
+  end subroutine init_tensorvisc2_c
 
   ! Copies geopotential from f90 arrays to C++ views
   subroutine init_geopotential_c (ie, phis_ptr, gradphis_ptr) bind(c)

--- a/components/homme/test_execs/preqx_kokkos_ut/random_init_ut.cpp
+++ b/components/homme/test_execs/preqx_kokkos_ut/random_init_ut.cpp
@@ -62,7 +62,7 @@ TEST_CASE("d_dinv_check", "Testing Elements::random_init") {
   std::cout << "seed: " << seed << (catchRngSeed==0 ? " (catch rng seed was 0)\n" : "\n");
 
   ElementsGeometry geometry;
-  geometry.init(num_elems,false,true,PhysicalConstants::rearth0);
+  geometry.init(num_elems,true,PhysicalConstants::rearth0);
   geometry.randomize(seed);
 
   HostViewManaged<Real * [2][2][NP][NP]> d("host d", num_elems);

--- a/components/homme/test_execs/preqx_kokkos_ut/remap_preqx_ut.cpp
+++ b/components/homme/test_execs/preqx_kokkos_ut/remap_preqx_ut.cpp
@@ -26,7 +26,7 @@ TEST_CASE("remap_interface", "vertical remap") {
   std::cout << "seed: " << seed << (catchRngSeed==0 ? " (catch rng seed was 0)\n" : "\n");
 
   Elements elements;
-  elements.init(num_elems,seed, /*alloc_gradphis = */ false,
+  elements.init(num_elems, /*alloc_gradphis = */ false,
                 PhysicalConstants::rearth0);
   elements.randomize(seed);
 

--- a/components/homme/test_execs/share_kokkos_ut/sphere_op_interface.F90
+++ b/components/homme/test_execs/share_kokkos_ut/sphere_op_interface.F90
@@ -300,7 +300,7 @@ contains
     elem%tensorVisc = tensorVisc
     elem%vec_sphere2cart = vec_sph2cart
 
-    laplace=vlaplace_sphere_wk_cartesian(v,deriv,elem,var_coef)
+    laplace=vlaplace_sphere_wk_cartesian(v,deriv,elem,var_coef,tensorVisc)
 
   end subroutine vlaplace_sphere_wk_cartesian_c_callable
 
@@ -346,7 +346,7 @@ contains
     elem%Dinv = dinv
     elem%rmetdet = rmetdet
 
-    laplace = vlaplace_sphere_wk_contra(v,deriv,elem,.false.,nu_ratio)
+    laplace = vlaplace_sphere_wk_contra(v,deriv,elem,nu_ratio)
 
   end subroutine vlaplace_sphere_wk_contra_c_callable
 

--- a/components/homme/test_execs/thetal_kokkos_ut/caar_ut.cpp
+++ b/components/homme/test_execs/thetal_kokkos_ut/caar_ut.cpp
@@ -116,7 +116,7 @@ TEST_CASE("caar", "caar_testing") {
   const int num_elems = c.get<Connectivity>().get_num_local_elements();
 
   auto& elems = c.create<Elements>();
-  elems.init(num_elems,false,true,PhysicalConstants::rearth0);
+  elems.init(num_elems,true,PhysicalConstants::rearth0);
   const auto max_pressure = 1000.0 + hvcoord.ps0; // This ensures max_p > ps0
   auto& geo = elems.m_geometry;
   elems.m_geometry.randomize(seed); // Only needed for phis and gradphis

--- a/components/homme/test_execs/thetal_kokkos_ut/compose_interface.F90
+++ b/components/homme/test_execs/thetal_kokkos_ut/compose_interface.F90
@@ -85,10 +85,12 @@ contains
          elem_rspheremp, elem_metdet, elem_state_phis
     real (real_kind), target, dimension(np,np,2)   :: elem_gradphis
     real (real_kind), target, dimension(np,np,2,2) :: elem_D, elem_Dinv, elem_metinv, elem_tensorvisc
+    real (real_kind), target, dimension(np,np,2,2) :: elem_tensorvisc2
     real (real_kind), target, dimension(np,np,3,2) :: elem_vec_sph2cart
     type (c_ptr) :: elem_D_ptr, elem_Dinv_ptr, elem_fcor_ptr, elem_spheremp_ptr, &
          elem_rspheremp_ptr, elem_metdet_ptr, elem_metinv_ptr, elem_tensorvisc_ptr, &
          elem_vec_sph2cart_ptr, elem_state_phis_ptr, elem_gradphis_ptr
+    type (c_ptr) :: elem_tensorvisc2_ptr
 
     type (cartesian3D_t) :: sphere_cart
     real (kind=real_kind) :: sphere_cart_vec(3,np,np), sphere_latlon_vec(2,np,np)
@@ -106,6 +108,7 @@ contains
     elem_vec_sph2cart_ptr = c_loc(elem_vec_sph2cart)
     elem_state_phis_ptr   = c_loc(elem_state_phis)
     elem_gradphis_ptr     = c_loc(elem_gradphis)
+    elem_tensorvisc2_ptr  = c_loc(elem_tensorvisc2)
     do ie = 1,nelemd
       elem_D            = elem(ie)%D
       elem_Dinv         = elem(ie)%Dinv
@@ -117,6 +120,7 @@ contains
       elem_state_phis   = elem(ie)%state%phis
       elem_gradphis     = elem(ie)%derived%gradphis
       elem_tensorvisc   = elem(ie)%tensorVisc
+      elem_tensorvisc2  = elem(ie)%tensorVisc_2
       elem_vec_sph2cart = elem(ie)%vec_sphere2cart
       do j = 1,np
          do i = 1,np
@@ -131,7 +135,7 @@ contains
       call init_elements_2d_c(ie-1, elem_D_ptr, elem_Dinv_ptr, elem_fcor_ptr, &
            elem_spheremp_ptr, elem_rspheremp_ptr, elem_metdet_ptr, elem_metinv_ptr, &
            elem_tensorvisc_ptr, elem_vec_sph2cart_ptr, sphere_cart_vec, &
-           sphere_latlon_vec)
+           sphere_latlon_vec, elem_tensorvisc2_ptr)
       call init_geopotential_c(ie-1, elem_state_phis_ptr, elem_gradphis_ptr)
     enddo
   end subroutine init_geometry_f90

--- a/components/homme/test_execs/thetal_kokkos_ut/forcing_ut.cpp
+++ b/components/homme/test_execs/thetal_kokkos_ut/forcing_ut.cpp
@@ -66,7 +66,7 @@ TEST_CASE("forcing", "forcing") {
   hv.random_init(seed);
 
   auto& geo     = c.create<ElementsGeometry>();
-  geo.init(num_elems,true, /* alloc_gradphis = */ true,
+  geo.init(num_elems, /* alloc_gradphis = */ true,
            PhysicalConstants::rearth0);
   geo.randomize(seed);
 

--- a/components/homme/test_execs/thetal_kokkos_ut/hv_ut.cpp
+++ b/components/homme/test_execs/thetal_kokkos_ut/hv_ut.cpp
@@ -200,7 +200,7 @@ TEST_CASE("hvf", "biharmonic") {
   const int num_elems = c.get<Connectivity>().get_num_local_elements();
 
   auto& geo = c.create<ElementsGeometry>();
-  geo.init(num_elems,false,true,PhysicalConstants::rearth0);
+  geo.init(num_elems,true,PhysicalConstants::rearth0);
   geo.randomize(seed);
 
   auto& state = c.create<ElementsState>();

--- a/components/homme/test_execs/thetal_kokkos_ut/remap_theta_ut.cpp
+++ b/components/homme/test_execs/thetal_kokkos_ut/remap_theta_ut.cpp
@@ -106,7 +106,7 @@ TEST_CASE("remap", "remap_testing") {
 
   // Create and init elements/tracers
   auto& elems = c.create<Elements>();
-  elems.init(num_elems,false,true,PhysicalConstants::rearth0);
+  elems.init(num_elems,true,PhysicalConstants::rearth0);
   const auto max_pressure = 1000.0 + hvcoord.ps0; // This ensures max_p > ps0
   auto& geo = elems.m_geometry;
   elems.m_geometry.randomize(seed); // Only needed for phis and gradphis


### PR DESCRIPTION
This adds an option to use a resolution-aware laplacian sponge layer.  This should replace our constant coefficient (fixed resolution) sponge layer.   The resolution-aware approach uses a tensor coefficient that also handles distorted elements.  This tensor approach has long been used in our hyperviscosity, and is necessary for RRM grids.  

Code is well tested in EAM.  Porting to C++ done by Claude

This branch includes PR #8597 , and needs to be merged after PR #8597

update this comment after testing in EAMxx...

[BFB]  due to stealth feature