### PR TITLE
Fix ZM restart tests

### DIFF
--- a/components/eamxx/src/physics/zm/eamxx_zm_process_interface.cpp
+++ b/components/eamxx/src/physics/zm/eamxx_zm_process_interface.cpp
@@ -78,8 +78,8 @@ void ZMDeepConvection::create_requests ()
   add_field <Updated>("precip_ice_surf_mass", scalar2d,     kg/m2,  grid_name, "ACCUMULATED");
 
   // T/qv from previous time step for DCAPE
-  add_field<Computed>("zm_t_prev",            scalar3d_mid, K,      grid_name);
-  add_field<Computed>("zm_q_prev",            scalar3d_mid, kg/kg,  grid_name);
+  add_field<Updated>("zm_t_prev",             scalar3d_mid, K,      grid_name, pack_size);
+  add_field<Updated>("zm_q_prev",             scalar3d_mid, kg/kg,  grid_name, pack_size);
 
   // Diagnostic Outputs
   add_field<Computed>("zm_prec",              scalar2d,     m/s,    grid_name);


### PR DESCRIPTION
This pull request updates the way previous time step temperature and specific humidity fields are handled in the `ZMDeepConvection` process interface. The fields `zm_t_prev` and `zm_q_prev` are now registered as `Updated` fields instead of `Computed`, and they now explicitly specify the `pack_size` parameter.

Fixes ERS test with F2010xx-ZM

[BFB] except for ERS test with F2010xx-ZM