### PR TITLE
Update domain tool ocean fraction calculation using mask

### DIFF
--- a/tools/generate_domain_files/generate_domain_files_E3SM.py
+++ b/tools/generate_domain_files/generate_domain_files_E3SM.py
@@ -237,7 +237,7 @@ def main():
 
   # Get ocn mask on ocn grid
   omask = get_mask(ds,opts,suffix='_a')
-  ofrac = xr.ones_like(ds['omask'])
+  ofrac = xr.where( omask!=0, xr.ones_like(ds['area_a']), xr.zeros_like(ds['area_a']) )
 
   ds_out = xr.Dataset()
 


### PR DESCRIPTION
This pull request makes a targeted update to the way the ocean fraction (`ofrac`) is calculated in the `main()` function of `generate_domain_files_E3SM.py`. The new approach ensures that `ofrac` is set to 1 only where the ocean mask is nonzero and 0 elsewhere, improving the accuracy of the mask application.

- Calculation logic improvement:
  * Updated the calculation of `ofrac` to use `xr.where`, so that it is 1 where `omask` is not zero and 0 otherwise, instead of assigning ones everywhere. This ensures the ocean fraction correctly reflects the mask. (`tools/generate_domain_files/generate_domain_files_E3SM.py`)