### PR TITLE
Reduce data copy from C++ to Fortran or CPU to GPU

### DIFF
--- a/components/homme/src/share/cxx/Tracers.cpp
+++ b/components/homme/src/share/cxx/Tracers.cpp
@@ -72,6 +72,14 @@ void Tracers::push_qdp(F90Ptr &state_qdp) const {
   sync_to_host(qdp, state_qdp_f90);
 }
 
+void Tracers::push_qdp(F90Ptr &state_qdp, const int src_qdp_tl,
+                       const int dst_qdp_tl) const {
+  HostViewUnmanaged<
+      Real * [Q_NUM_TIME_LEVELS][QSIZE_D][NUM_PHYSICAL_LEV][NP][NP]>
+  state_qdp_f90(state_qdp, qdp.extent_int(0));
+  sync_to_host(qdp, state_qdp_f90, src_qdp_tl, dst_qdp_tl);
+}
+
 HashType Tracers::hash (const int tl) const {  
   HashType accum = 0;
   Homme::hash(tl, qdp, NUM_PHYSICAL_LEV, accum);

--- a/components/homme/src/share/cxx/Tracers.hpp
+++ b/components/homme/src/share/cxx/Tracers.hpp
@@ -22,6 +22,10 @@ struct Tracers {
 
   void pull_qdp(CF90Ptr &state_qdp);
   void push_qdp(F90Ptr &state_qdp) const;
+  // Push a single qdp time level: source level src_qdp_tl -> F90 level dst_qdp_tl.
+  // The two differ in general, because the qdp levels are rotated before the
+  // vertical remap while the dynamics levels are rotated after it.
+  void push_qdp(F90Ptr &state_qdp, const int src_qdp_tl, const int dst_qdp_tl) const;
 
   KOKKOS_INLINE_FUNCTION
   int num_tracers() const {

--- a/components/homme/src/share/cxx/utilities/SyncUtils.hpp
+++ b/components/homme/src/share/cxx/utilities/SyncUtils.hpp
@@ -314,6 +314,131 @@ sync_to_host_p2i(Source_T source, Dest_T dest)
   }
 }
 
+// ============ SYNC A SINGLE TIME LEVEL FROM DEVICE TO HOST ================= //
+//
+// These are trimmed twins of the sync_to_host overloads above, for the case where
+// only one time level of a state array is actually consumed on the Fortran side
+// (which is all CAM/EAM and SCREAM ever read after a step). They copy source time
+// level src_tl into destination time level dst_tl and leave the other destination
+// slots untouched, so the Fortran array keeps its full NUM_TIME_LEVELS extent and
+// its layout/strides are unchanged.
+//
+// src_tl and dst_tl are separate because they are not always the same slot: the
+// qdp levels are rotated by TimeLevel::update_tracers_levels() before the vertical
+// remap, while the dynamics levels are rotated afterwards, so the freshly-remapped
+// tracer mass lives in np1_qdp while Fortran readers index with TimeLevel_Qdp().
+// Pass the same value twice when they do coincide.
+//
+// NOTE: the create_mirror_view/deep_copy pair below is deliberately left full
+// width. On a host build it is a no-op alias plus a self-copy that Kokkos
+// short-circuits, so the entire cost is the repack loop that we are trimming here.
+// Narrowing the transfer itself would require packing one time level on the device
+// first, since a Kokkos::subview slice is LayoutStride and neither the *_mappable
+// predicates above nor cross-space deep_copy accept that.
+
+// Single time level of m_w_i / m_phinh_i
+template <typename Source_T, typename Dest_T>
+typename std::enable_if
+  <
+    (exec_view_mappable<Source_T, Scalar * [NUM_TIME_LEVELS][NP][NP][NUM_LEV_P]>::value &&
+     host_view_mappable<Dest_T, Real * [NUM_TIME_LEVELS][NUM_INTERFACE_LEV][NP][NP]>::value),
+    void
+  >::type
+sync_to_host(Source_T source, Dest_T dest, const int src_tl, const int dst_tl)
+{
+  typename Source_T::host_mirror_type source_mirror = Kokkos::create_mirror_view(source);
+  Kokkos::deep_copy(source_mirror, source);
+  for (int ie = 0; ie < source.extent_int(0); ++ie) {
+    for (int level = 0; level < NUM_INTERFACE_LEV; ++level) {
+      const int ilev = level / VECTOR_SIZE;
+      const int ivec = level % VECTOR_SIZE;
+      for (int igp = 0; igp < NP; ++igp) {
+        for (int jgp = 0; jgp < NP; ++jgp) {
+          dest(ie, dst_tl, level, igp, jgp) = source_mirror(ie, src_tl, igp, jgp, ilev)[ivec];
+        }
+      }
+    }
+  }
+}
+
+// Single time level of m_vtheta_dp / m_dp3d
+template <typename Source_T, typename Dest_T>
+typename std::enable_if
+  <
+    (exec_view_mappable<Source_T, Scalar ** [NP][NP][NUM_LEV]>::value &&
+     host_view_mappable<Dest_T, Real ** [NUM_PHYSICAL_LEV][NP][NP]>::value),
+    void
+  >::type
+sync_to_host(Source_T source, Dest_T dest, const int src_tl, const int dst_tl)
+{
+  typename Source_T::host_mirror_type source_mirror = Kokkos::create_mirror_view(source);
+  Kokkos::deep_copy(source_mirror, source);
+  for (int ie = 0; ie < source.extent_int(0); ++ie) {
+    for (int level = 0; level < NUM_PHYSICAL_LEV; ++level) {
+      const int ilev = level / VECTOR_SIZE;
+      const int ivec = level % VECTOR_SIZE;
+      for (int igp = 0; igp < NP; ++igp) {
+        for (int jgp = 0; jgp < NP; ++jgp) {
+          dest(ie, dst_tl, level, igp, jgp) = source_mirror(ie, src_tl, igp, jgp, ilev)[ivec];
+        }
+      }
+    }
+  }
+}
+
+// Single time level of m_v (2 horizontal components)
+template <typename Source_T, typename Dest_T>
+typename std::enable_if
+  <
+    (exec_view_mappable<Source_T, Scalar * [NUM_TIME_LEVELS][2][NP][NP][NUM_LEV]>::value &&
+     host_view_mappable<Dest_T, Real * [NUM_TIME_LEVELS][NUM_PHYSICAL_LEV][2][NP][NP]>::value),
+    void
+  >::type
+sync_to_host(Source_T source, Dest_T dest, const int src_tl, const int dst_tl)
+{
+  typename Source_T::host_mirror_type source_mirror = Kokkos::create_mirror_view(source);
+  Kokkos::deep_copy(source_mirror, source);
+  for (int ie = 0; ie < source.extent_int(0); ++ie) {
+    for (int level = 0; level < NUM_PHYSICAL_LEV; ++level) {
+      const int ilev = level / VECTOR_SIZE;
+      const int ivec = level % VECTOR_SIZE;
+      for (int igp = 0; igp < NP; ++igp) {
+        for (int jgp = 0; jgp < NP; ++jgp) {
+          dest(ie, dst_tl, level, 0, igp, jgp) = source_mirror(ie, src_tl, 0, igp, jgp, ilev)[ivec];
+          dest(ie, dst_tl, level, 1, igp, jgp) = source_mirror(ie, src_tl, 1, igp, jgp, ilev)[ivec];
+        }
+      }
+    }
+  }
+}
+
+// Single qdp time level (all tracers)
+template <typename Source_T, typename Dest_T>
+typename std::enable_if
+  <
+    (exec_view_mappable<Source_T, Scalar * [Q_NUM_TIME_LEVELS][QSIZE_D][NP][NP][NUM_LEV]>::value &&
+     host_view_mappable<Dest_T, Real * [Q_NUM_TIME_LEVELS][QSIZE_D][NUM_PHYSICAL_LEV][NP][NP]>::value),
+    void
+  >::type
+sync_to_host(Source_T source, Dest_T dest, const int src_tl, const int dst_tl)
+{
+  typename Source_T::host_mirror_type source_mirror = Kokkos::create_mirror_view(source);
+  Kokkos::deep_copy(source_mirror, source);
+  for (int ie = 0; ie < source.extent_int(0); ++ie) {
+    for (int tracer = 0; tracer < QSIZE_D; ++tracer) {
+      for (int level = 0; level < NUM_PHYSICAL_LEV; ++level) {
+        const int ilev = level / VECTOR_SIZE;
+        const int ivec = level % VECTOR_SIZE;
+        for (int igp = 0; igp < NP; ++igp) {
+          for (int jgp = 0; jgp < NP; ++jgp) {
+            dest(ie, dst_tl, tracer, level, igp, jgp) = source_mirror(ie, src_tl, tracer, igp, jgp, ilev)[ivec];
+          }
+        }
+      }
+    }
+  }
+}
+
 // ===================== SYNC FROM HOST TO DEVICE ============================ //
 
 template <typename Source_T, typename Dest_T>

--- a/components/homme/src/theta-l_kokkos/cxx/ElementsState.cpp
+++ b/components/homme/src/theta-l_kokkos/cxx/ElementsState.cpp
@@ -353,6 +353,24 @@ void ElementsState::push_to_f90_pointers (F90Ptr& state_v, F90Ptr& state_w_i, F9
   sync_to_host(m_dp3d,      state_dp3d_f90);
 }
 
+void ElementsState::push_to_f90_pointers (F90Ptr& state_v, F90Ptr& state_w_i, F90Ptr& state_vtheta_dp,
+                                          F90Ptr& state_phinh_i, F90Ptr& state_dp3d,
+                                          const int tl) const {
+  HostViewUnmanaged<Real *[NUM_TIME_LEVELS][NUM_PHYSICAL_LEV ][2][NP][NP]> state_v_f90         (state_v,m_num_elems);
+  HostViewUnmanaged<Real *[NUM_TIME_LEVELS][NUM_INTERFACE_LEV]   [NP][NP]> state_w_i_f90       (state_w_i,m_num_elems);
+  HostViewUnmanaged<Real *[NUM_TIME_LEVELS][NUM_PHYSICAL_LEV ]   [NP][NP]> state_vtheta_dp_f90 (state_vtheta_dp,m_num_elems);
+  HostViewUnmanaged<Real *[NUM_TIME_LEVELS][NUM_INTERFACE_LEV]   [NP][NP]> state_phinh_i_f90   (state_phinh_i,m_num_elems);
+  HostViewUnmanaged<Real *[NUM_TIME_LEVELS][NUM_PHYSICAL_LEV ]   [NP][NP]> state_dp3d_f90      (state_dp3d,m_num_elems);
+
+  // Source and destination time level coincide for the dynamics state: the
+  // caller passes the (0-based) level that Fortran will read.
+  sync_to_host(m_v,         state_v_f90,         tl, tl);
+  sync_to_host(m_w_i,       state_w_i_f90,       tl, tl);
+  sync_to_host(m_vtheta_dp, state_vtheta_dp_f90, tl, tl);
+  sync_to_host(m_phinh_i,   state_phinh_i_f90,   tl, tl);
+  sync_to_host(m_dp3d,      state_dp3d_f90,      tl, tl);
+}
+
 static bool all_good_elems (const ElementsState& s, const int tlvl) {
   using Kokkos::ALL;
   using Kokkos::parallel_for;

--- a/components/homme/src/theta-l_kokkos/cxx/ElementsState.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/ElementsState.hpp
@@ -77,9 +77,15 @@ public:
                               CF90Ptr& state_vtheta_dp, CF90Ptr& state_phinh_i,
                               CF90Ptr& state_dp3d,      CF90Ptr& state_ps_v);
 
-  // Push the results from the exec space views to the F90 pointers
+  // Push the results from the exec space views to the F90 pointers, all time levels.
   void push_to_f90_pointers(F90Ptr& state_v, F90Ptr& state_w_i, F90Ptr& state_vtheta_dp,
                             F90Ptr& state_phinh_i, F90Ptr& state_dp) const;
+
+  // As above, but copy only time level tl; the other time levels of the F90
+  // arrays are left untouched. Used on the per-step CAM path, where nothing on
+  // the Fortran side reads the others after a step.
+  void push_to_f90_pointers(F90Ptr& state_v, F90Ptr& state_w_i, F90Ptr& state_vtheta_dp,
+                            F90Ptr& state_phinh_i, F90Ptr& state_dp, const int tl) const;
 
   HashType hash(const int time_level) const;
 

--- a/components/homme/src/theta-l_kokkos/cxx/cxx_f90_interface_theta.cpp
+++ b/components/homme/src/theta-l_kokkos/cxx/cxx_f90_interface_theta.cpp
@@ -268,6 +268,18 @@ void cxx_push_results_to_f90_tl(F90Ptr &elem_state_v_ptr,         F90Ptr &elem_s
 
   // The freshly remapped tracer mass is in np1_qdp (see update_q in
   // prim_run_subcycle_c); Fortran reads the level TimeLevel_Qdp gives it.
+  //
+  // Those two always coincide: each tracer step flips the qdp parity, both here
+  // (TimeLevel::update_tracers_levels, keyed on nstep/qsplit) and in f90
+  // (TimeLevel_Qdp, keyed on nstep/dt_tracer_factor, with dt_tracer_factor ==
+  // qsplit), so the last np1_qdp written is the n0_qdp the advanced nstep asks
+  // for. push_qdp still takes the pair separately -- the qdp levels rotate
+  // before the vertical remap and the dynamics levels after it, so the two
+  // conventions are not interchangeable in general -- and this pins the
+  // invariant down instead of leaving it to a comment.
+  Errors::runtime_check(qdp_dst == tl.np1_qdp,
+                        "cxx_push_results_to_f90_tl: Fortran n0_qdp disagrees with C++ TimeLevel::np1_qdp");
+
   c.get<Tracers>().push_qdp(elem_state_Qdp_ptr, tl.np1_qdp, qdp_dst);
 
   push_results_to_f90_tl_free(elem_state_ps_v_ptr, elem_Q_ptr, elem_derived_omega_p_ptr);

--- a/components/homme/src/theta-l_kokkos/cxx/cxx_f90_interface_theta.cpp
+++ b/components/homme/src/theta-l_kokkos/cxx/cxx_f90_interface_theta.cpp
@@ -191,19 +191,16 @@ void init_hvcoord_c (const Real& ps0, CRCPtr& hybrid_am_ptr, CRCPtr& hybrid_ai_p
   hvcoord.init(ps0,hybrid_am_ptr,hybrid_ai_ptr,hybrid_bm_ptr,hybrid_bi_ptr);
 }
 
-void cxx_push_results_to_f90(F90Ptr &elem_state_v_ptr,         F90Ptr &elem_state_w_i_ptr,
-                             F90Ptr &elem_state_vtheta_dp_ptr, F90Ptr &elem_state_phinh_i_ptr,
-                             F90Ptr &elem_state_dp3d_ptr,      F90Ptr &elem_state_ps_v_ptr,
-                             F90Ptr &elem_state_Qdp_ptr,       F90Ptr &elem_Q_ptr,
-                             F90Ptr &elem_derived_omega_p_ptr) {
-  ElementsState &state = Context::singleton().get<ElementsState>();
+// Shared tail of the two cxx_push_results_to_f90 entry points below: the fields
+// with no time-level dimension, plus ps_v, whose copy is a cheap contiguous
+// memcpy and so is not worth a trimmed variant.
+static void push_results_to_f90_tl_free (F90Ptr &elem_state_ps_v_ptr,
+                                         F90Ptr &elem_Q_ptr,
+                                         F90Ptr &elem_derived_omega_p_ptr) {
+  auto &c = Context::singleton();
+  ElementsState &state = c.get<ElementsState>();
+  Tracers &tracers = c.get<Tracers>();
   const int num_elems = state.num_elems();
-
-  state.push_to_f90_pointers(elem_state_v_ptr, elem_state_w_i_ptr, elem_state_vtheta_dp_ptr,
-                             elem_state_phinh_i_ptr, elem_state_dp3d_ptr);
-
-  Tracers &tracers = Context::singleton().get<Tracers>();
-  tracers.push_qdp(elem_state_Qdp_ptr);
 
   // F90 ptrs to arrays (np,np,num_time_levels,nelemd) can be stuffed directly
   // in an unmanaged view
@@ -216,13 +213,64 @@ void cxx_push_results_to_f90(F90Ptr &elem_state_v_ptr,         F90Ptr &elem_stat
   Kokkos::deep_copy(ps_v_host, state.m_ps_v);
   Kokkos::deep_copy(ps_v_f90, ps_v_host);
 
-  ElementsDerivedState &derived = Context::singleton().get<ElementsDerivedState>();
+  ElementsDerivedState &derived = c.get<ElementsDerivedState>();
   sync_to_host(derived.m_omega_p,
                HostViewUnmanaged<Real * [NUM_PHYSICAL_LEV][NP][NP]>(
                    elem_derived_omega_p_ptr, num_elems));
   sync_to_host(tracers.Q,
                HostViewUnmanaged<Real * [QSIZE_D][NUM_PHYSICAL_LEV][NP][NP]>(
                    elem_Q_ptr, num_elems));
+}
+
+// Copy back ALL time levels. Used at init time, where the f90 side does need a
+// fully populated state (e.g. EAMxx's prim_copy_cxx_to_f90 before model_init2).
+void cxx_push_results_to_f90(F90Ptr &elem_state_v_ptr,         F90Ptr &elem_state_w_i_ptr,
+                             F90Ptr &elem_state_vtheta_dp_ptr, F90Ptr &elem_state_phinh_i_ptr,
+                             F90Ptr &elem_state_dp3d_ptr,      F90Ptr &elem_state_ps_v_ptr,
+                             F90Ptr &elem_state_Qdp_ptr,       F90Ptr &elem_Q_ptr,
+                             F90Ptr &elem_derived_omega_p_ptr) {
+  auto &c = Context::singleton();
+
+  c.get<ElementsState>().push_to_f90_pointers(
+      elem_state_v_ptr, elem_state_w_i_ptr, elem_state_vtheta_dp_ptr,
+      elem_state_phinh_i_ptr, elem_state_dp3d_ptr);
+  c.get<Tracers>().push_qdp(elem_state_Qdp_ptr);
+
+  push_results_to_f90_tl_free(elem_state_ps_v_ptr, elem_Q_ptr, elem_derived_omega_p_ptr);
+}
+
+// Copy back only the time levels the f90 side will actually read. Used on the
+// per-step CAM path.
+void cxx_push_results_to_f90_tl(F90Ptr &elem_state_v_ptr,         F90Ptr &elem_state_w_i_ptr,
+                                F90Ptr &elem_state_vtheta_dp_ptr, F90Ptr &elem_state_phinh_i_ptr,
+                                F90Ptr &elem_state_dp3d_ptr,      F90Ptr &elem_state_ps_v_ptr,
+                                F90Ptr &elem_state_Qdp_ptr,       F90Ptr &elem_Q_ptr,
+                                F90Ptr &elem_derived_omega_p_ptr,
+                                const int &n0_f, const int &n0_qdp_f) {
+  auto &c = Context::singleton();
+
+  // Fortran passes the 1-based time levels its readers will use; convert to the
+  // 0-based C++ convention (same as init_time_level_c). Only those levels are
+  // copied back -- nothing on the Fortran side reads the others after a step.
+  const TimeLevel &tl = c.get<TimeLevel>();
+  const int dyn_tl  = n0_f     - 1;
+  const int qdp_dst = n0_qdp_f - 1;
+
+  // The dynamics levels are rotated inside prim_run_subcycle_c before we get
+  // here, so Fortran's tl%n0 must already agree with the C++ TimeLevel. If this
+  // trips, the two sides have gone out of sync and the copy would be garbage.
+  Errors::runtime_check(dyn_tl == tl.n0,
+                        "cxx_push_results_to_f90_tl: Fortran n0 disagrees with C++ TimeLevel::n0");
+
+  c.get<ElementsState>().push_to_f90_pointers(
+      elem_state_v_ptr, elem_state_w_i_ptr, elem_state_vtheta_dp_ptr,
+      elem_state_phinh_i_ptr, elem_state_dp3d_ptr, dyn_tl);
+
+  // The freshly remapped tracer mass is in np1_qdp (see update_q in
+  // prim_run_subcycle_c); Fortran reads the level TimeLevel_Qdp gives it.
+  c.get<Tracers>().push_qdp(elem_state_Qdp_ptr, tl.np1_qdp, qdp_dst);
+
+  push_results_to_f90_tl_free(elem_state_ps_v_ptr, elem_Q_ptr, elem_derived_omega_p_ptr);
 }
 
 //currently, we do not need FVTheta and FPHI, because they are computed from FT and FQ

--- a/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
+++ b/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
@@ -441,7 +441,10 @@ contains
     use parallel_mod,   only : abortmp
     use perf_mod,       only : t_startf, t_stopf
     use prim_state_mod, only : prim_printstate
-    use theta_f2c_mod,  only : prim_run_subcycle_c, cxx_push_results_to_f90_tl
+    use theta_f2c_mod,  only : prim_run_subcycle_c, cxx_push_results_to_f90
+#ifdef CAM
+    use theta_f2c_mod,  only : cxx_push_results_to_f90_tl
+#endif
     use theta_f2c_mod,  only : push_forcing_to_c, sync_diagnostics_to_host_c
     !
     ! Inputs
@@ -534,17 +537,27 @@ contains
       elem_state_ps_v_ptr      = c_loc(elem_state_ps_v)
       elem_derived_omega_p_ptr = c_loc(elem_derived_omega_p)
 
-      ! Recompute the qdp time levels: the ones from before prim_run_subcycle_c
+#ifdef CAM
+      ! CAM reads only n0 / n0_qdp after a step, so copy back just those levels.
+      ! Recompute the qdp levels first: those from before prim_run_subcycle_c
       ! are stale, since tl%nstep has since advanced. n0_qdp is the level that
       ! every f90 reader of elem_state_Qdp will index with.
       call TimeLevel_Qdp(tl, dt_tracer_factor, n0_qdp, np1_qdp)
+#endif
 
       ! Copy cxx arrays back to f90 structures
       call t_startf('push_to_f90')
+#ifdef CAM
       call cxx_push_results_to_f90_tl(elem_state_v_ptr, elem_state_w_i_ptr, elem_state_vtheta_dp_ptr,   &
                                       elem_state_phinh_i_ptr, elem_state_dp3d_ptr, elem_state_ps_v_ptr, &
                                       elem_state_Qdp_ptr, elem_state_Q_ptr, elem_derived_omega_p_ptr,   &
                                       tl%n0, n0_qdp)
+#else
+      ! EAMxx may use current and previous timelevels for statefreq diagnostics, so keep the all-time-levels copy
+      call cxx_push_results_to_f90(elem_state_v_ptr, elem_state_w_i_ptr, elem_state_vtheta_dp_ptr,   &
+                                   elem_state_phinh_i_ptr, elem_state_dp3d_ptr, elem_state_ps_v_ptr, &
+                                   elem_state_Qdp_ptr, elem_state_Q_ptr, elem_derived_omega_p_ptr)
+#endif
       call t_stopf('push_to_f90')
     endif
 
@@ -619,10 +632,10 @@ contains
     logical                          :: push_to_f, time_for_homme_output
 
     push_to_f = .false.
-    ! Only the standalone branch below consumes this. Computing it in a CAM or
-    ! SCREAM build would be a dead read of nextOutputStep, which those builds
-    ! never assign.
-#if !defined(HOMMEXX_BENCHMARK_NOFORCING) && !defined(SCREAM) && !defined(CAM)
+    ! The CAM branch below no longer consumes this, and computing it there would
+    ! be a dead read of nextOutputStep, which a CAM build never assigns. Other
+    ! configurations keep the original behavior.
+#ifndef CAM
     time_for_homme_output = &
          (MODULO(tl%nstep,statefreq)==0 .or. tl%nstep >= nextOutputStep .or. compute_diagnostics)
 #endif

--- a/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
+++ b/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
@@ -442,7 +442,7 @@ contains
     use perf_mod,       only : t_startf, t_stopf
     use prim_state_mod, only : prim_printstate
     use theta_f2c_mod,  only : prim_run_subcycle_c, cxx_push_results_to_f90
-#ifdef CAM
+#if defined(CAM) && !defined(SCREAM)
     use theta_f2c_mod,  only : cxx_push_results_to_f90_tl
 #endif
     use theta_f2c_mod,  only : push_forcing_to_c, sync_diagnostics_to_host_c
@@ -537,7 +537,7 @@ contains
       elem_state_ps_v_ptr      = c_loc(elem_state_ps_v)
       elem_derived_omega_p_ptr = c_loc(elem_derived_omega_p)
 
-#ifdef CAM
+#if defined(CAM) && !defined(SCREAM)
       ! CAM reads only n0 / n0_qdp after a step, so copy back just those levels.
       ! Recompute the qdp levels first: those from before prim_run_subcycle_c
       ! are stale, since tl%nstep has since advanced. n0_qdp is the level that
@@ -547,7 +547,7 @@ contains
 
       ! Copy cxx arrays back to f90 structures
       call t_startf('push_to_f90')
-#ifdef CAM
+#if defined(CAM) && !defined(SCREAM)
       call cxx_push_results_to_f90_tl(elem_state_v_ptr, elem_state_w_i_ptr, elem_state_vtheta_dp_ptr,   &
                                       elem_state_phinh_i_ptr, elem_state_dp3d_ptr, elem_state_ps_v_ptr, &
                                       elem_state_Qdp_ptr, elem_state_Q_ptr, elem_derived_omega_p_ptr,   &
@@ -629,12 +629,16 @@ contains
     integer,              intent(in) :: statefreq, nextOutputStep, nsplit_iter
     logical,              intent(in) :: compute_diagnostics
 
-    logical                          :: push_to_f, time_for_homme_output
+    logical                          :: push_to_f
+    ! The CAM branch below no longer consumes this, and computing it there would
+    ! be a dead read of nextOutputStep, which a CAM build never assigns. Declaring
+    ! it under the same guard as its only assignment keeps the CAM build free of
+    ! unused-variable warnings. Other configurations keep the original behavior.
+#ifndef CAM
+    logical                          :: time_for_homme_output
+#endif
 
     push_to_f = .false.
-    ! The CAM branch below no longer consumes this, and computing it there would
-    ! be a dead read of nextOutputStep, which a CAM build never assigns. Other
-    ! configurations keep the original behavior.
 #ifndef CAM
     time_for_homme_output = &
          (MODULO(tl%nstep,statefreq)==0 .or. tl%nstep >= nextOutputStep .or. compute_diagnostics)

--- a/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
+++ b/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
@@ -441,7 +441,7 @@ contains
     use parallel_mod,   only : abortmp
     use perf_mod,       only : t_startf, t_stopf
     use prim_state_mod, only : prim_printstate
-    use theta_f2c_mod,  only : prim_run_subcycle_c, cxx_push_results_to_f90
+    use theta_f2c_mod,  only : prim_run_subcycle_c, cxx_push_results_to_f90_tl
     use theta_f2c_mod,  only : push_forcing_to_c, sync_diagnostics_to_host_c
     !
     ! Inputs
@@ -534,11 +534,17 @@ contains
       elem_state_ps_v_ptr      = c_loc(elem_state_ps_v)
       elem_derived_omega_p_ptr = c_loc(elem_derived_omega_p)
 
+      ! Recompute the qdp time levels: the ones from before prim_run_subcycle_c
+      ! are stale, since tl%nstep has since advanced. n0_qdp is the level that
+      ! every f90 reader of elem_state_Qdp will index with.
+      call TimeLevel_Qdp(tl, dt_tracer_factor, n0_qdp, np1_qdp)
+
       ! Copy cxx arrays back to f90 structures
       call t_startf('push_to_f90')
-      call cxx_push_results_to_f90(elem_state_v_ptr, elem_state_w_i_ptr, elem_state_vtheta_dp_ptr,   &
-                                   elem_state_phinh_i_ptr, elem_state_dp3d_ptr, elem_state_ps_v_ptr, &
-                                   elem_state_Qdp_ptr, elem_state_Q_ptr, elem_derived_omega_p_ptr)
+      call cxx_push_results_to_f90_tl(elem_state_v_ptr, elem_state_w_i_ptr, elem_state_vtheta_dp_ptr,   &
+                                      elem_state_phinh_i_ptr, elem_state_dp3d_ptr, elem_state_ps_v_ptr, &
+                                      elem_state_Qdp_ptr, elem_state_Q_ptr, elem_derived_omega_p_ptr,   &
+                                      tl%n0, n0_qdp)
       call t_stopf('push_to_f90')
     endif
 
@@ -613,8 +619,13 @@ contains
     logical                          :: push_to_f, time_for_homme_output
 
     push_to_f = .false.
+    ! Only the standalone branch below consumes this. Computing it in a CAM or
+    ! SCREAM build would be a dead read of nextOutputStep, which those builds
+    ! never assign.
+#if !defined(HOMMEXX_BENCHMARK_NOFORCING) && !defined(SCREAM) && !defined(CAM)
     time_for_homme_output = &
          (MODULO(tl%nstep,statefreq)==0 .or. tl%nstep >= nextOutputStep .or. compute_diagnostics)
+#endif
 
 #ifdef HOMMEXX_BENCHMARK_NOFORCING
 !standalone homme, only benchmarks
@@ -625,16 +636,18 @@ contains
     push_to_f = compute_diagnostics
 
 #elif defined(CAM)
-!CAM run, push at the end of nsplit loop
-    if (nsplit_iter == nsplit) then
-       push_to_f = .true.
-    endif
-
-!CAM also needs some of homme output
-    !if (MODULO(tl%nstep,statefreq)==0 .or. tl%nstep >= nextOutputStep .or. compute_diagnostics) then
-    if ( time_for_homme_output ) then
-       push_to_f = .true.
-    endif
+!CAM run, push at the end of nsplit loop, plus whenever prim_printstate runs.
+!
+!Do NOT use time_for_homme_output here. It tests tl%nstep >= nextOutputStep, and
+!nextOutputStep is only ever assigned by the standalone driver (prim_main.F90),
+!which is not part of a CAM build -- so it reads 0 and the test is always true,
+!making this push fire on every nsplit iteration instead of just the last one.
+!HOMME's own output (prim_movie_output et al.) is not in the CAM build at all, so
+!there is nothing here for that term to guard. compute_diagnostics already covers
+!the statefreq test, because tl%nstep == nstep_end once prim_run_subcycle_c has
+!returned, and it is the gate on the only f90 reader in this routine
+!(prim_printstate). This mirrors the SCREAM branch above.
+    push_to_f = (nsplit_iter == nsplit) .or. compute_diagnostics
 
 #else
 !standalone homme, not benchmarks

--- a/components/homme/src/theta-l_kokkos/theta_f2c_mod.F90
+++ b/components/homme/src/theta-l_kokkos/theta_f2c_mod.F90
@@ -208,6 +208,23 @@ interface
     type (c_ptr), intent(in) :: elem_state_Qdp_ptr, elem_state_Q_ptr, elem_derived_omega_p_ptr
   end subroutine cxx_push_results_to_f90
 
+  ! As above, but copy back only the time levels the f90 side will read. Used on
+  ! the per-step path; the all-time-levels version above is for init.
+  subroutine cxx_push_results_to_f90_tl(elem_state_v_ptr, elem_state_w_i_ptr, elem_state_vtheta_dp_ptr, &
+                                        elem_state_phinh_i_ptr, elem_state_dp3d_ptr, elem_state_ps_v_ptr, &
+                                        elem_state_Qdp_ptr, elem_state_Q_ptr, elem_derived_omega_p_ptr, &
+                                        n0_f, n0_qdp_f) bind(c)
+    use iso_c_binding, only: c_ptr, c_int
+    !
+    ! Inputs
+    !
+    type (c_ptr), intent(in) :: elem_state_v_ptr, elem_state_w_i_ptr, elem_state_vtheta_dp_ptr
+    type (c_ptr), intent(in) :: elem_state_phinh_i_ptr, elem_state_dp3d_ptr, elem_state_ps_v_ptr
+    type (c_ptr), intent(in) :: elem_state_Qdp_ptr, elem_state_Q_ptr, elem_derived_omega_p_ptr
+    ! 1-based time levels that the f90 side will read: only these are copied back
+    integer (kind=c_int), intent(in) :: n0_f, n0_qdp_f
+  end subroutine cxx_push_results_to_f90_tl
+
   subroutine push_test_state_to_c( &
        ! state
        ps_v, dp3d, vtheta_dp, phinh_i, v, w_i, &


### PR DESCRIPTION
When I ran the `theta-l_kokkos` dycore in CAM, I found two issues:

- `push_to_f90` runs twice per coupling step, where the code intends only once (`nsplit_iter == nsplit`).
- All time levels are copied when only one is read. The `sync_to_host` overloads loop `NUM_TIME_LEVELS` and `Q_NUM_TIME_LEVELS` unconditionally, but no Fortran reader on the CAM path reads anything but `n0` / the `TimeLevel_Qdp` level.

This PR fixes these two issues and should not change any answers. It is done by Claude under my supervisory.