### PR TITLE
Address bug in specification of organic matter fraction

### DIFF
--- a/components/elm/bld/namelist_files/namelist_defaults.xml
+++ b/components/elm/bld/namelist_files/namelist_defaults.xml
@@ -113,6 +113,9 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- Do variable soil thickness -->
 <use_var_soil_thick>.false.</use_var_soil_thick>
 
+<!-- Use squared organic matter fraction -->
+<squareomfrac>.true.</squareomfrac>
+
 <!-- Do downscaling to topounit -->
 <precip_downscaling_method>ERMM</precip_downscaling_method>
 <!-- Do lake water storage -->

--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -2149,6 +2149,15 @@ Runtime flag to turn on/off PETSc based thermal model.
 Runtime flag to turn on/off variable soil thickness.
 </entry>
 
+<!-- ========================================================================================  -->
+
+<entry id="squareomfrac" type="logical" category="default_settings"
+        group="elm_inparm" valid_values="">
+Flag to use squared organic matter fraction in soil calculations. If true (default), uses the squared
+formulation (organic3d/organic_max)**2. If false, uses the unsquared formulation min(organic3d/organic_max, 1.0)
+following CLM5.0 and Lawrence and Slater (2008).
+</entry>
+
 <!-- ======================================================================================== -->
 <!-- Namelist options for lake water storage                                                  -->
 <!-- ======================================================================================== -->

--- a/components/elm/src/biogeophys/SoilHydrologyType.F90
+++ b/components/elm/src/biogeophys/SoilHydrologyType.F90
@@ -480,7 +480,7 @@ contains
                          if (squareomfrac) then
                             om_frac = (organic3d(g,ti,1)/organic_max)**2._r8
                          else
-                            om_frac = min(organic3d(g,ti,1)/organic_max, 1._r8)
+                            om_frac = max(0.0_r8, min(organic3d(g,ti,1)/organic_max, 1._r8))
                          endif
                       else if (lev <= nlevsoi) then
                          do j = 1,nlevsoifl-1
@@ -490,7 +490,7 @@ contains
                                if (squareomfrac) then
                                   om_frac = (organic3d(g,ti,j+1)/organic_max)**2._r8
                                else
-                                  om_frac = min(organic3d(g,ti,j+1)/organic_max, 1._r8)
+                                  om_frac = max(0.0_r8, min(organic3d(g,ti,j+1)/organic_max, 1._r8))
                                endif
                             endif
                          end do
@@ -507,7 +507,7 @@ contains
                          if (squareomfrac) then
                             om_frac = (organic3d(g,ti,lev)/organic_max)**2._r8
                          else
-                            om_frac = min(organic3d(g,ti,lev)/organic_max, 1._r8)
+                            om_frac = max(0.0_r8, min(organic3d(g,ti,lev)/organic_max, 1._r8))
                          endif
                       else
                          clay    = clay3d(g,ti,nlevsoi)

--- a/components/elm/src/biogeophys/SoilHydrologyType.F90
+++ b/components/elm/src/biogeophys/SoilHydrologyType.F90
@@ -237,7 +237,7 @@ contains
     use shr_log_mod     , only : errMsg => shr_log_errMsg
     use shr_spfn_mod    , only : shr_spfn_erf
     use shr_kind_mod    , only : r8 => shr_kind_r8
-    use elm_varctl      , only : fsurdat, iulog, use_vichydro, use_var_soil_thick
+    use elm_varctl      , only : fsurdat, iulog, use_vichydro, use_var_soil_thick, squareomfrac
     use elm_varpar      , only : nlevsoi, nlevgrnd, nlevsno, nlevlak, nlevurb
     use elm_varcon      , only : denice, denh2o, sb, bdsno
     use elm_varcon      , only : h2osno_max, zlnd, tfrz, spval
@@ -477,13 +477,21 @@ contains
                       if (lev .eq. 1) then
                          clay    = clay3d(g,ti,1)
                          sand    = sand3d(g,ti,1)
-                         om_frac = min(organic3d(g,ti,1)/organic_max, 1._r8)
+                         if (squareomfrac) then
+                            om_frac = (organic3d(g,ti,1)/organic_max)**2._r8
+                         else
+                            om_frac = min(organic3d(g,ti,1)/organic_max, 1._r8)
+                         endif
                       else if (lev <= nlevsoi) then
                          do j = 1,nlevsoifl-1
                             if (zisoi(lev) >= zisoifl(j) .AND. zisoi(lev) < zisoifl(j+1)) then
                                clay    = clay3d(g,ti,j+1)
                                sand    = sand3d(g,ti,j+1)
-                               om_frac = min(organic3d(g,ti,j+1)/organic_max, 1._r8) 
+                               if (squareomfrac) then
+                                  om_frac = (organic3d(g,ti,j+1)/organic_max)**2._r8
+                               else
+                                  om_frac = min(organic3d(g,ti,j+1)/organic_max, 1._r8)
+                               endif
                             endif
                          end do
                       else
@@ -496,7 +504,11 @@ contains
                       if (lev <= nlevsoi) then
                          clay    = clay3d(g,ti,lev)
                          sand    = sand3d(g,ti,lev)
-                         om_frac = min(organic3d(g,ti,lev)/organic_max, 1._r8)
+                         if (squareomfrac) then
+                            om_frac = (organic3d(g,ti,lev)/organic_max)**2._r8
+                         else
+                            om_frac = min(organic3d(g,ti,lev)/organic_max, 1._r8)
+                         endif
                       else
                          clay    = clay3d(g,ti,nlevsoi)
                          sand    = sand3d(g,ti,nlevsoi)

--- a/components/elm/src/biogeophys/SoilHydrologyType.F90
+++ b/components/elm/src/biogeophys/SoilHydrologyType.F90
@@ -477,21 +477,13 @@ contains
                       if (lev .eq. 1) then
                          clay    = clay3d(g,ti,1)
                          sand    = sand3d(g,ti,1)
-                         if (squareomfrac) then
-                            om_frac = (organic3d(g,ti,1)/organic_max)**2._r8
-                         else
-                            om_frac = max(0.0_r8, min(organic3d(g,ti,1)/organic_max, 1._r8))
-                         endif
+                         om_frac = max(0.0_r8, min(organic3d(g,ti,1)/organic_max, 1._r8))
                       else if (lev <= nlevsoi) then
                          do j = 1,nlevsoifl-1
                             if (zisoi(lev) >= zisoifl(j) .AND. zisoi(lev) < zisoifl(j+1)) then
                                clay    = clay3d(g,ti,j+1)
                                sand    = sand3d(g,ti,j+1)
-                               if (squareomfrac) then
-                                  om_frac = (organic3d(g,ti,j+1)/organic_max)**2._r8
-                               else
-                                  om_frac = max(0.0_r8, min(organic3d(g,ti,j+1)/organic_max, 1._r8))
-                               endif
+                               om_frac = max(0.0_r8, min(organic3d(g,ti,j+1)/organic_max, 1._r8))
                             endif
                          end do
                       else

--- a/components/elm/src/biogeophys/SoilHydrologyType.F90
+++ b/components/elm/src/biogeophys/SoilHydrologyType.F90
@@ -477,13 +477,13 @@ contains
                       if (lev .eq. 1) then
                          clay    = clay3d(g,ti,1)
                          sand    = sand3d(g,ti,1)
-                         om_frac = organic3d(g,ti,1)/organic_max 
+                         om_frac = min(organic3d(g,ti,1)/organic_max, 1._r8)
                       else if (lev <= nlevsoi) then
                          do j = 1,nlevsoifl-1
                             if (zisoi(lev) >= zisoifl(j) .AND. zisoi(lev) < zisoifl(j+1)) then
                                clay    = clay3d(g,ti,j+1)
                                sand    = sand3d(g,ti,j+1)
-                               om_frac = organic3d(g,ti,j+1)/organic_max    
+                               om_frac = min(organic3d(g,ti,j+1)/organic_max, 1._r8) 
                             endif
                          end do
                       else
@@ -496,7 +496,7 @@ contains
                       if (lev <= nlevsoi) then
                          clay    = clay3d(g,ti,lev)
                          sand    = sand3d(g,ti,lev)
-                         om_frac = (organic3d(g,ti,lev)/organic_max)**2._r8
+                         om_frac = min(organic3d(g,ti,lev)/organic_max, 1._r8)
                       else
                          clay    = clay3d(g,ti,nlevsoi)
                          sand    = sand3d(g,ti,nlevsoi)

--- a/components/elm/src/biogeophys/SoilStateType.F90
+++ b/components/elm/src/biogeophys/SoilStateType.F90
@@ -684,22 +684,14 @@ contains
                    clay = clay3d(g,ti,1)
                    sand = sand3d(g,ti,1)
                    gravel = grvl3d(g,ti,1)
-                   if (squareomfrac) then
-                      om_frac = (organic3d(g,ti,1)/organic_max)**2._r8
-                   else
-                      om_frac = max(0.0_r8, min(organic3d(g,ti,1)/organic_max, 1._r8))
-                   endif
+                   om_frac = max(0.0_r8, min(organic3d(g,ti,1)/organic_max, 1._r8))
                 else if (lev <= min(nlevbed,nlevsoi)) then
                    do j = 1,nlevsoifl-1
                       if (zisoi(lev) >= zisoifl(j) .AND. zisoi(lev) < zisoifl(j+1)) then
                          clay = clay3d(g,ti,j+1)
                          sand = sand3d(g,ti,j+1)
                          gravel = grvl3d(g,ti,j+1)
-                         if (squareomfrac) then
-                            om_frac = (organic3d(g,ti,j+1)/organic_max)**2._r8
-                         else
-                            om_frac = max(0.0_r8, min(organic3d(g,ti,j+1)/organic_max, 1._r8))
-                         endif
+                         om_frac = max(0.0_r8, min(organic3d(g,ti,j+1)/organic_max, 1._r8))
                       endif
                    end do
                 else

--- a/components/elm/src/biogeophys/SoilStateType.F90
+++ b/components/elm/src/biogeophys/SoilStateType.F90
@@ -683,14 +683,14 @@ contains
                    clay = clay3d(g,ti,1)
                    sand = sand3d(g,ti,1)
                    gravel = grvl3d(g,ti,1)
-                   om_frac = organic3d(g,ti,1)/organic_max 
-                else if (lev <= nlevsoi) then
+                   om_frac = min(organic3d(g,ti,1)/organic_max, 1._r8)
+                else if (lev <= min(nlevbed,nlevsoi)) then
                    do j = 1,nlevsoifl-1
                       if (zisoi(lev) >= zisoifl(j) .AND. zisoi(lev) < zisoifl(j+1)) then
                          clay = clay3d(g,ti,j+1)
                          sand = sand3d(g,ti,j+1)
                          gravel = grvl3d(g,ti,j+1)
-                         om_frac = organic3d(g,ti,j+1)/organic_max    
+                         om_frac = min(organic3d(g,ti,j+1)/organic_max, 1._r8)
                       endif
                    end do
                 else
@@ -704,7 +704,7 @@ contains
                    clay = clay3d(g,ti,lev)
                    sand = sand3d(g,ti,lev)
                    gravel = grvl3d(g,ti,lev)
-                   om_frac = (organic3d(g,ti,lev)/organic_max)**2._r8
+                   om_frac = min((organic3d(g,ti,lev)/organic_max), 1._r8)
                 else
                    clay = clay3d(g,ti,nlevsoi)
                    sand = sand3d(g,ti,nlevsoi)
@@ -840,7 +840,7 @@ contains
                 clay    =  this%cellclay_col(c,lev)
                 sand    =  this%cellsand_col(c,lev)
                 gravel  =  this%cellgrvl_col(c,lev)
-                om_frac = (this%cellorg_col(c,lev)/organic_max)**2._r8
+                om_frac =  min((this%cellorg_col(c,lev)/organic_max), 1._r8)
              else
                 clay    = this%cellclay_col(c,nlevsoi)
                 sand    = this%cellsand_col(c,nlevsoi)

--- a/components/elm/src/biogeophys/SoilStateType.F90
+++ b/components/elm/src/biogeophys/SoilStateType.F90
@@ -21,6 +21,7 @@ module SoilStateType
   use elm_varctl      , only : use_cn, use_lch4,use_dynroot, use_fates
   use elm_varctl      , only : use_erosion
   use elm_varctl      , only : use_var_soil_thick
+  use elm_varctl      , only : squareomfrac
   use elm_varctl      , only : iulog, fsurdat, hist_wrtch4diag
   use CH4varcon       , only : allowlakeprod
   use LandunitType    , only : lun_pp                
@@ -683,14 +684,22 @@ contains
                    clay = clay3d(g,ti,1)
                    sand = sand3d(g,ti,1)
                    gravel = grvl3d(g,ti,1)
-                   om_frac = min(organic3d(g,ti,1)/organic_max, 1._r8)
+                   if (squareomfrac) then
+                      om_frac = (organic3d(g,ti,1)/organic_max)**2._r8
+                   else
+                      om_frac = min(organic3d(g,ti,1)/organic_max, 1._r8)
+                   endif
                 else if (lev <= min(nlevbed,nlevsoi)) then
                    do j = 1,nlevsoifl-1
                       if (zisoi(lev) >= zisoifl(j) .AND. zisoi(lev) < zisoifl(j+1)) then
                          clay = clay3d(g,ti,j+1)
                          sand = sand3d(g,ti,j+1)
                          gravel = grvl3d(g,ti,j+1)
-                         om_frac = min(organic3d(g,ti,j+1)/organic_max, 1._r8)
+                         if (squareomfrac) then
+                            om_frac = (organic3d(g,ti,j+1)/organic_max)**2._r8
+                         else
+                            om_frac = min(organic3d(g,ti,j+1)/organic_max, 1._r8)
+                         endif
                       endif
                    end do
                 else
@@ -704,7 +713,11 @@ contains
                    clay = clay3d(g,ti,lev)
                    sand = sand3d(g,ti,lev)
                    gravel = grvl3d(g,ti,lev)
-                   om_frac = min((organic3d(g,ti,lev)/organic_max), 1._r8)
+                   if (squareomfrac) then
+                      om_frac = (organic3d(g,ti,lev)/organic_max)**2._r8
+                   else
+                      om_frac = min((organic3d(g,ti,lev)/organic_max), 1._r8)
+                   endif
                 else
                    clay = clay3d(g,ti,nlevsoi)
                    sand = sand3d(g,ti,nlevsoi)
@@ -840,7 +853,11 @@ contains
                 clay    =  this%cellclay_col(c,lev)
                 sand    =  this%cellsand_col(c,lev)
                 gravel  =  this%cellgrvl_col(c,lev)
-                om_frac =  min((this%cellorg_col(c,lev)/organic_max), 1._r8)
+                if (squareomfrac) then
+                   om_frac = (this%cellorg_col(c,lev)/organic_max)**2._r8
+                else
+                   om_frac = min((this%cellorg_col(c,lev)/organic_max), 1._r8)
+                endif
              else
                 clay    = this%cellclay_col(c,nlevsoi)
                 sand    = this%cellsand_col(c,nlevsoi)

--- a/components/elm/src/biogeophys/SoilStateType.F90
+++ b/components/elm/src/biogeophys/SoilStateType.F90
@@ -687,7 +687,7 @@ contains
                    if (squareomfrac) then
                       om_frac = (organic3d(g,ti,1)/organic_max)**2._r8
                    else
-                      om_frac = min(organic3d(g,ti,1)/organic_max, 1._r8)
+                      om_frac = max(0.0_r8, min(organic3d(g,ti,1)/organic_max, 1._r8))
                    endif
                 else if (lev <= min(nlevbed,nlevsoi)) then
                    do j = 1,nlevsoifl-1
@@ -698,7 +698,7 @@ contains
                          if (squareomfrac) then
                             om_frac = (organic3d(g,ti,j+1)/organic_max)**2._r8
                          else
-                            om_frac = min(organic3d(g,ti,j+1)/organic_max, 1._r8)
+                            om_frac = max(0.0_r8, min(organic3d(g,ti,j+1)/organic_max, 1._r8))
                          endif
                       endif
                    end do
@@ -716,7 +716,7 @@ contains
                    if (squareomfrac) then
                       om_frac = (organic3d(g,ti,lev)/organic_max)**2._r8
                    else
-                      om_frac = min((organic3d(g,ti,lev)/organic_max), 1._r8)
+                      om_frac = max(0.0_r8, min((organic3d(g,ti,lev)/organic_max), 1._r8))
                    endif
                 else
                    clay = clay3d(g,ti,nlevsoi)
@@ -856,7 +856,7 @@ contains
                 if (squareomfrac) then
                    om_frac = (this%cellorg_col(c,lev)/organic_max)**2._r8
                 else
-                   om_frac = min((this%cellorg_col(c,lev)/organic_max), 1._r8)
+                   om_frac = max(0.0_r8, min((this%cellorg_col(c,lev)/organic_max), 1._r8))
                 endif
              else
                 clay    = this%cellclay_col(c,nlevsoi)

--- a/components/elm/src/main/controlMod.F90
+++ b/components/elm/src/main/controlMod.F90
@@ -46,7 +46,7 @@ module controlMod
   use elm_varpar              , only: elmfates_carbon_only
   use elm_varpar              , only: elmfates_cnp
   use elm_varctl, only: nu_com, use_dynroot, use_fan, fan_mode, fan_to_bgc_veg, &
-                        use_var_soil_thick, use_lake_wat_storage, &
+                        use_var_soil_thick, use_lake_wat_storage, squareomfrac, &
                         forest_fert_exp, ECA_Pconst_RGspin, NFIX_PTASE_plant, &
                         use_pheno_flux_limiter, startdate_add_temperature, &
                         startdate_add_co2, add_temperature, add_co2, &
@@ -1124,6 +1124,7 @@ contains
     write(iulog,*) '    use_lch4 = ', use_lch4
     write(iulog,*) '    use_vertsoilc = ', use_vertsoilc
     write(iulog,*) '    use_var_soil_thick = ', use_var_soil_thick
+    write(iulog,*) '    squareomfrac = ', squareomfrac
     write(iulog,*) '    use_lake_wat_storage = ', use_lake_wat_storage
     write(iulog,*) '    use_extralakelayers = ', use_extralakelayers
     write(iulog,*) '    use_extrasnowlayers = ', use_extrasnowlayers

--- a/components/elm/src/main/controlMod.F90
+++ b/components/elm/src/main/controlMod.F90
@@ -362,6 +362,8 @@ contains
 
     namelist /elm_inparm/ use_var_soil_thick, use_lake_wat_storage
 
+    namelist /elm_inparm/ squareomfrac
+
     namelist /elm_inparm/ &
          use_vsfm, vsfm_satfunc_type, vsfm_use_dynamic_linesearch, &
          vsfm_lateral_model_type, vsfm_include_seepage_bc

--- a/components/elm/src/main/elm_varctl.F90
+++ b/components/elm/src/main/elm_varctl.F90
@@ -397,6 +397,7 @@ module elm_varctl
   logical, public :: use_mexicocity      = .false.
   logical, public :: use_noio            = .false.
   logical, public :: use_var_soil_thick  = .false.
+  logical, public :: squareomfrac        = .true.   ! use squared organic matter fraction in soil calculations
   logical, public :: use_T_rho_dependent_snowthk     = .false.
   logical, public :: use_atm_downscaling_to_topunit  = .false.
   character(len = SHR_KIND_CS), public :: precip_downscaling_method  = 'ERMM' ! Precip downscaling method values can be ERMM or FNM
@@ -548,6 +549,7 @@ module elm_varctl
   !$acc declare copyin(use_mexicocity     )
   !$acc declare copyin(use_noio           )
   !$acc declare copyin(use_var_soil_thick )
+  !$acc declare copyin(squareomfrac       )
   !$acc declare copyin(tw_irr)
   !$acc declare copyin(use_vsfm                   )
   !$acc declare copyin(vsfm_use_dynamic_linesearch)


### PR DESCRIPTION
There appears to be a bug in `SoilHydrologyType.F90` and `SoilStateType.F90` during initialization that squares the organic matter fraction when `more_vertlayers .eq. false` but not when `more_vertlayers .eq. true` that came over when E3SM was initialized. This appears to be applied only to places where `om_frac` modifies thermal_conductivity, meaning that `om_frac` can be different in different places in the code. (h/t @gretamiller for finding this issue and working on the solution)

The `more_vertlayers .eq. true` branch is the correct one based on the Slater and Lawrence (2008) implementation of this feature, and the bug has been fixed in upstream CLM. 

However, by default, `more_vertlayers .eq. false` and so the default configuration will underestimate the organic matter fraction except at 0 and 1, and therefore likely be too conductive. @gretamiller reached out to David Lawrence and confirmed that this was essentially a tuning knob to compensate for other issues in the soil when it was implemented.

This fix allows turning off this "squared" relationship with a namelist option, and as a result, the e3sm_land_developer suite is BFB on pm-cpu.