### PR TITLE
EAMxx: 3D Turbulence Finisher (bug fixes, enhancements, numerical stability improvements)

### DIFF
--- a/components/eamxx/cime_config/eamxx_buildnml.py
+++ b/components/eamxx/cime_config/eamxx_buildnml.py
@@ -163,6 +163,15 @@ def perform_consistency_checks(case, xml):
     CIME.utils.CIMEError: ERROR: rrtmgp::rad_frequency incompatible with restart frequency.
      Please, ensure restart happens on a step when rad is ON
      For daily (or less frequent) restart, rad_frequency must divide ATM_NCPL
+    >>> turbulence_xml = ET.fromstring('''
+    ... <params>
+    ...   <homme><do_3d_turbulence_homme>false</do_3d_turbulence_homme></homme>
+    ...   <ctl_nl><do_3d_turbulence>true</do_3d_turbulence></ctl_nl>
+    ... </params>
+    ... ''')
+    >>> perform_consistency_checks(MockCase({}), turbulence_xml)
+    >>> find_node(find_node(turbulence_xml, "homme"), "do_3d_turbulence_homme").text
+    'true'
     """
 
     # RRTMGP can be supercycled. Restarts cannot fall in the middle
@@ -218,6 +227,31 @@ def perform_consistency_checks(case, xml):
                     "rrtmgp::rad_frequency incompatible with restart frequency.\n"
                     " Please, ensure restart happens on a step when rad is ON\n"
                     " For daily (or less frequent) restart, rad_frequency must divide ATM_NCPL")
+
+    ctl_nl = find_node(xml, "ctl_nl")
+    if ctl_nl is not None:
+        # HOMME reads do_3d_turbulence from ctl_nl, while the atmosphere
+        # driver needs the same value in HOMME's process parameters in order
+        # to forward it to SHOC. Keep the process parameter as a locked mirror
+        # so ctl_nl remains the single user-facing source of truth.
+        homme = find_node(xml, "homme")
+        do_3d_turbulence = find_node(ctl_nl, "do_3d_turbulence")
+        if homme is not None and do_3d_turbulence is not None:
+            homme_do_3d_turbulence = find_node(homme, "do_3d_turbulence_homme")
+            expect(homme_do_3d_turbulence is not None,
+                   "Missing locked homme::do_3d_turbulence_homme mirror")
+            homme_do_3d_turbulence.text = do_3d_turbulence.text
+
+        hypervis_subcycle = find_node(ctl_nl, "hypervis_subcycle")
+        horiz_turb_subcycle = find_node(ctl_nl, "horiz_turb_subcycle")
+        if hypervis_subcycle is not None and horiz_turb_subcycle is not None:
+            if int(horiz_turb_subcycle.text) == -1:
+                horiz_turb_subcycle.text = hypervis_subcycle.text
+        hypervis_subcycle_q = find_node(ctl_nl, "hypervis_subcycle_q")
+        horiz_turb_subcycle_q = find_node(ctl_nl, "horiz_turb_subcycle_q")
+        if hypervis_subcycle_q is not None and horiz_turb_subcycle_q is not None:
+            if int(horiz_turb_subcycle_q.text) < 0:
+                horiz_turb_subcycle_q.text = hypervis_subcycle_q.text
 
 ###############################################################################
 def ordered_dump(data, item, Dumper=yaml.SafeDumper, **kwds):

--- a/components/eamxx/cime_config/eamxx_buildnml.py
+++ b/components/eamxx/cime_config/eamxx_buildnml.py
@@ -163,6 +163,15 @@ def perform_consistency_checks(case, xml):
     CIME.core.exceptions.CIMEError: ERROR: rrtmgp::rad_frequency incompatible with restart frequency.
      Please, ensure restart happens on a step when rad is ON
      For daily (or less frequent) restart, rad_frequency must divide ATM_NCPL
+    >>> turbulence_xml = ET.fromstring('''
+    ... <params>
+    ...   <homme><do_3d_turbulence_homme>false</do_3d_turbulence_homme></homme>
+    ...   <ctl_nl><do_3d_turbulence>true</do_3d_turbulence></ctl_nl>
+    ... </params>
+    ... ''')
+    >>> perform_consistency_checks(MockCase({}), turbulence_xml)
+    >>> find_node(find_node(turbulence_xml, "homme"), "do_3d_turbulence_homme").text
+    'true'
     """
 
     # RRTMGP can be supercycled. Restarts cannot fall in the middle
@@ -218,6 +227,31 @@ def perform_consistency_checks(case, xml):
                     "rrtmgp::rad_frequency incompatible with restart frequency.\n"
                     " Please, ensure restart happens on a step when rad is ON\n"
                     " For daily (or less frequent) restart, rad_frequency must divide ATM_NCPL")
+
+    ctl_nl = find_node(xml, "ctl_nl")
+    if ctl_nl is not None:
+        # HOMME reads do_3d_turbulence from ctl_nl, while the atmosphere
+        # driver needs the same value in HOMME's process parameters in order
+        # to forward it to SHOC. Keep the process parameter as a locked mirror
+        # so ctl_nl remains the single user-facing source of truth.
+        homme = find_node(xml, "homme")
+        do_3d_turbulence = find_node(ctl_nl, "do_3d_turbulence")
+        if homme is not None and do_3d_turbulence is not None:
+            homme_do_3d_turbulence = find_node(homme, "do_3d_turbulence_homme")
+            expect(homme_do_3d_turbulence is not None,
+                   "Missing locked homme::do_3d_turbulence_homme mirror")
+            homme_do_3d_turbulence.text = do_3d_turbulence.text
+
+        hypervis_subcycle = find_node(ctl_nl, "hypervis_subcycle")
+        horiz_turb_subcycle = find_node(ctl_nl, "horiz_turb_subcycle")
+        if hypervis_subcycle is not None and horiz_turb_subcycle is not None:
+            if int(horiz_turb_subcycle.text) == -1:
+                horiz_turb_subcycle.text = hypervis_subcycle.text
+        hypervis_subcycle_q = find_node(ctl_nl, "hypervis_subcycle_q")
+        horiz_turb_subcycle_q = find_node(ctl_nl, "horiz_turb_subcycle_q")
+        if hypervis_subcycle_q is not None and horiz_turb_subcycle_q is not None:
+            if int(horiz_turb_subcycle_q.text) < 0:
+                horiz_turb_subcycle_q.text = hypervis_subcycle_q.text
 
 ###############################################################################
 def ordered_dump(data, item, Dumper=yaml.SafeDumper, **kwds):

--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -187,6 +187,9 @@ be lost if SCREAM_HACK_XML is not enabled.
     <!-- Homme dynamics -->
     <homme inherit="atm_proc_base">
       <moisture>moist</moisture>
+      <!-- This value is synchronized with ctl_nl::do_3d_turbulence by
+           eamxx_buildnml.py and forwarded by the driver to SHOC. -->
+      <do_3d_turbulence_homme type="logical" locked="true">false</do_3d_turbulence_homme>
       <!-- Frequency in physics steps to output a global hash over the dycore's
            in-fields. <= 0 disables hashing. -->
       <enable_column_conservation_checks>false</enable_column_conservation_checks>
@@ -265,6 +268,8 @@ be lost if SCREAM_HACK_XML is not enabled.
       <c_diag_3rd_mom type="real" doc="Third moment vertical velocity damping factor">7.0</c_diag_3rd_mom>
       <coeff_kh type="real" doc="Eddy diffusivity coefficient for heat">0.1</coeff_kh>
       <coeff_km type="real" doc="Eddy diffusivity coefficient for momentum">0.1</coeff_km>
+      <coeff_kh_horiz type="real" doc="Horizontal eddy diffusivity coefficient for heat">0.1</coeff_kh_horiz>
+      <coeff_km_horiz type="real" doc="Horizontal eddy diffusivity coefficient for momentum">0.1</coeff_km_horiz>
       <extra_shoc_diags type="logical" doc="Extra SHOC diagnostics">false</extra_shoc_diags>
       <shoc_1p5tke type="logical" doc="turn off SGS variability in SHOC, effectively reducing it to a 1.5 TKE closure">false</shoc_1p5tke>
     </shoc>
@@ -929,8 +934,10 @@ be lost if SCREAM_HACK_XML is not enabled.
     <hypervis_scaling>3.0</hypervis_scaling>
     <laplace_scaling>0.0</laplace_scaling>
     <hypervis_subcycle>1</hypervis_subcycle>
+    <horiz_turb_subcycle>1</horiz_turb_subcycle>
     <hypervis_subcycle_tom>1</hypervis_subcycle_tom>
     <hypervis_subcycle_q>1</hypervis_subcycle_q>
+    <horiz_turb_subcycle_q>1</horiz_turb_subcycle_q>
     <nu>3.4e-08</nu>
     <nu COMPSET=".*DP-EAMxx">0.216784</nu>
     <nu_top>UNSET</nu_top>
@@ -1005,6 +1012,7 @@ be lost if SCREAM_HACK_XML is not enabled.
     <!-- SL transport settings. SL defaults to on for pg2 configs. -->
     <dt_tracer_factor hgrid=".*pg2">6</dt_tracer_factor>
     <hypervis_subcycle_q hgrid=".*pg2">6</hypervis_subcycle_q>
+    <horiz_turb_subcycle_q hgrid=".*pg2">-1</horiz_turb_subcycle_q>
     <transport_alg hgrid=".*pg2" doc="0 (Eulerian) or 12 (semi-Lagrangian) tracer transport">12</transport_alg>
     <semi_lagrange_trajectory_nsubstep doc="Controls trajectory method. 0: original method. 1: New method. 2 or more: New method with this many trajectory substeps per tracer time step.">0</semi_lagrange_trajectory_nsubstep>
     <semi_lagrange_trajectory_nvelocity doc="Number of velocity slices to use in new method. 2 or less maps to 2">-1</semi_lagrange_trajectory_nvelocity>

--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -187,6 +187,9 @@ be lost if SCREAM_HACK_XML is not enabled.
     <!-- Homme dynamics -->
     <homme inherit="atm_proc_base">
       <moisture>moist</moisture>
+      <!-- This value is synchronized with ctl_nl::do_3d_turbulence by
+           eamxx_buildnml.py and forwarded by the driver to SHOC. -->
+      <do_3d_turbulence_homme type="logical" locked="true">false</do_3d_turbulence_homme>
       <!-- Frequency in physics steps to output a global hash over the dycore's
            in-fields. <= 0 disables hashing. -->
       <enable_column_conservation_checks>false</enable_column_conservation_checks>
@@ -265,6 +268,8 @@ be lost if SCREAM_HACK_XML is not enabled.
       <c_diag_3rd_mom type="real" doc="Third moment vertical velocity damping factor">7.0</c_diag_3rd_mom>
       <coeff_kh type="real" doc="Eddy diffusivity coefficient for heat">0.1</coeff_kh>
       <coeff_km type="real" doc="Eddy diffusivity coefficient for momentum">0.1</coeff_km>
+      <coeff_kh_horiz type="real" doc="Horizontal eddy diffusivity coefficient for heat">0.1</coeff_kh_horiz>
+      <coeff_km_horiz type="real" doc="Horizontal eddy diffusivity coefficient for momentum">0.1</coeff_km_horiz>
       <extra_shoc_diags type="logical" doc="Extra SHOC diagnostics">false</extra_shoc_diags>
       <shoc_1p5tke type="logical" doc="turn off SGS variability in SHOC, effectively reducing it to a 1.5 TKE closure">false</shoc_1p5tke>
     </shoc>
@@ -916,8 +921,10 @@ be lost if SCREAM_HACK_XML is not enabled.
     <hypervis_order>2</hypervis_order>
     <hypervis_scaling>3.0</hypervis_scaling>
     <hypervis_subcycle>1</hypervis_subcycle>
+    <horiz_turb_subcycle>1</horiz_turb_subcycle>
     <hypervis_subcycle_tom>1</hypervis_subcycle_tom>
     <hypervis_subcycle_q>1</hypervis_subcycle_q>
+    <horiz_turb_subcycle_q>1</horiz_turb_subcycle_q>
     <nu>3.4e-08</nu>
     <nu COMPSET=".*DP-EAMxx">0.216784</nu>
     <nu_top>UNSET</nu_top>
@@ -992,6 +999,7 @@ be lost if SCREAM_HACK_XML is not enabled.
     <!-- SL transport settings. SL defaults to on for pg2 configs. -->
     <dt_tracer_factor hgrid=".*pg2">6</dt_tracer_factor>
     <hypervis_subcycle_q hgrid=".*pg2">6</hypervis_subcycle_q>
+    <horiz_turb_subcycle_q hgrid=".*pg2">-1</horiz_turb_subcycle_q>
     <transport_alg hgrid=".*pg2" doc="0 (Eulerian) or 12 (semi-Lagrangian) tracer transport">12</transport_alg>
     <semi_lagrange_trajectory_nsubstep doc="Controls trajectory method. 0: original method. 1: New method. 2 or more: New method with this many trajectory substeps per tracer time step.">0</semi_lagrange_trajectory_nsubstep>
     <semi_lagrange_trajectory_nvelocity doc="Number of velocity slices to use in new method. 2 or less maps to 2">-1</semi_lagrange_trajectory_nvelocity>

--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -748,6 +748,8 @@ be lost if SCREAM_HACK_XML is not enabled.
     <sgs_buoy_flux     >0.0</sgs_buoy_flux>
     <eddy_diff_mom     >0.0</eddy_diff_mom>
     <eddy_diff_heat    >0.0</eddy_diff_heat>
+    <eddy_diff_mom_horiz>0.0</eddy_diff_mom_horiz>
+    <eddy_diff_heat_horiz>0.0</eddy_diff_heat_horiz>
     <T_prev_micro_step >0.0</T_prev_micro_step>
     <qv_prev_micro_step>0.0</qv_prev_micro_step>
     <!-- Initialize microphysics fields not on IC to zero; note that this is consistent with EAM init -->

--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -760,6 +760,8 @@ be lost if SCREAM_HACK_XML is not enabled.
     <sgs_buoy_flux     >0.0</sgs_buoy_flux>
     <eddy_diff_mom     >0.0</eddy_diff_mom>
     <eddy_diff_heat    >0.0</eddy_diff_heat>
+    <eddy_diff_mom_horiz>0.0</eddy_diff_mom_horiz>
+    <eddy_diff_heat_horiz>0.0</eddy_diff_heat_horiz>
     <T_prev_micro_step >0.0</T_prev_micro_step>
     <qv_prev_micro_step>0.0</qv_prev_micro_step>
     <!-- Initialize microphysics fields not on IC to zero; note that this is consistent with EAM init -->

--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -999,7 +999,7 @@ be lost if SCREAM_HACK_XML is not enabled.
     <!-- SL transport settings. SL defaults to on for pg2 configs. -->
     <dt_tracer_factor hgrid=".*pg2">6</dt_tracer_factor>
     <hypervis_subcycle_q hgrid=".*pg2">6</hypervis_subcycle_q>
-    <horiz_turb_subcycle_q hgrid=".*pg2">-1</horiz_turb_subcycle_q>
+    <horiz_turb_subcycle_q hgrid=".*pg2">1</horiz_turb_subcycle_q>
     <transport_alg hgrid=".*pg2" doc="0 (Eulerian) or 12 (semi-Lagrangian) tracer transport">12</transport_alg>
     <semi_lagrange_trajectory_nsubstep doc="Controls trajectory method. 0: original method. 1: New method. 2 or more: New method with this many trajectory substeps per tracer time step.">0</semi_lagrange_trajectory_nsubstep>
     <semi_lagrange_trajectory_nvelocity doc="Number of velocity slices to use in new method. 2 or less maps to 2">-1</semi_lagrange_trajectory_nvelocity>

--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -1012,7 +1012,7 @@ be lost if SCREAM_HACK_XML is not enabled.
     <!-- SL transport settings. SL defaults to on for pg2 configs. -->
     <dt_tracer_factor hgrid=".*pg2">6</dt_tracer_factor>
     <hypervis_subcycle_q hgrid=".*pg2">6</hypervis_subcycle_q>
-    <horiz_turb_subcycle_q hgrid=".*pg2">-1</horiz_turb_subcycle_q>
+    <horiz_turb_subcycle_q hgrid=".*pg2">1</horiz_turb_subcycle_q>
     <transport_alg hgrid=".*pg2" doc="0 (Eulerian) or 12 (semi-Lagrangian) tracer transport">12</transport_alg>
     <semi_lagrange_trajectory_nsubstep doc="Controls trajectory method. 0: original method. 1: New method. 2 or more: New method with this many trajectory substeps per tracer time step.">0</semi_lagrange_trajectory_nsubstep>
     <semi_lagrange_trajectory_nvelocity doc="Number of velocity slices to use in new method. 2 or less maps to 2">-1</semi_lagrange_trajectory_nvelocity>

--- a/components/eamxx/docs/technical/physics/shoc_3d_turbulence.md
+++ b/components/eamxx/docs/technical/physics/shoc_3d_turbulence.md
@@ -1,0 +1,101 @@
+# SHOC-HOMME 3D Turbulence Coupling
+
+This note documents the EAMxx 3D-turbulence path that couples SHOC and HOMME.
+It has two main pieces:
+
+1. SHOC diagnoses horizontal eddy diffusivities and passes them to HOMME so the
+   dycore can apply horizontal turbulent diffusion.
+2. HOMME provides horizontal velocity-gradient information back to SHOC so SHOC
+   can use a three-dimensional shear-production term in the TKE equation.
+
+## Horizontal Eddy Diffusivity Passed to HOMME
+
+When `ctl_nl::do_3d_turbulence=true`, SHOC computes horizontal eddy
+diffusivities on the physics grid after the main SHOC update. The formulation
+is
+
+$$
+K_{H,h} = C_{kh,h}\,L_h\,\sqrt{\mathrm{TKE}},
+\qquad
+K_{M,h} = C_{km,h}\,L_h\,\sqrt{\mathrm{TKE}},
+$$
+
+where the horizontal length scale is
+
+$$
+L_h = \sqrt{\Delta x\,\Delta y}.
+$$
+
+In the current implementation, SHOC obtains `\Delta x` and `\Delta y` from the
+grid geometry and uses the runtime parameters
+`shoc::coeff_kh_horiz` and `shoc::coeff_km_horiz`, both of which default to
+`0.1`.
+
+After SHOC computes `eddy_diff_heat_horiz` and `eddy_diff_mom_horiz`, EAMxx
+forwards those fields to HOMME:
+
+1. On the standard physics-grid path, the physics-to-dynamics remapper
+   registers the SHOC fields with HOMME helper fields `Kh_dyn` and `Km_dyn`.
+2. On pgN finite-volume physics grids, the same fields are supplied to
+   `GllFvRemap::run_fv_phys_to_dyn`, which remaps them into HOMME's dynamics
+   representation.
+3. HOMME then binds the remapped fields into its derived-state turbulence slots
+   `m_turb_diff_heat` and `m_turb_diff_mom`, which are consumed by the dycore's
+   horizontal turbulent-diffusion machinery.
+
+This split keeps the turbulence closure in SHOC while leaving the actual
+horizontal diffusion operator in HOMME, where the horizontal discretization and
+metric terms already live.
+
+## Three-Dimensional Shear Production of TKE
+
+In the legacy one-dimensional SHOC path, shear production uses only vertical
+shear of the horizontal wind. In the 3D-turbulence path, SHOC instead forms the
+full local strain invariant and uses it in the TKE tendency.
+
+The shear-production contribution is
+
+$$
+\begin{align}
+  -P_s
+  &= 2K_M \Bigg[
+      \left(\frac{\partial u}{\partial x}\right)^{2}
+    + \left(\frac{\partial v}{\partial y}\right)^{2}
+    + \left(\frac{\partial w}{\partial z}\right)^{2} \notag\\
+  &\quad
+    + \tfrac{1}{2}\Big(
+        \left(\frac{\partial u}{\partial y}+\frac{\partial v}{\partial x}\right)^{2}
+      + \left(\frac{\partial u}{\partial z}+\frac{\partial w}{\partial x}\right)^{2}
+      + \left(\frac{\partial v}{\partial z}+\frac{\partial w}{\partial y}\right)^{2}
+      \Big)
+  \Bigg].
+\end{align}
+$$
+
+In code, SHOC stores the bracketed strain invariant as
+`tke_shear_strain3d = 2 S_{ij}S_{ij}` and then advances TKE with
+
+$$
+\text{shear production} = C_k K_M \left(2 S_{ij}S_{ij}\right),
+$$
+
+with `C_k = 0.1`, consistent with the existing SHOC TKE closure.
+
+The calculation is split across HOMME and SHOC:
+
+1. After each HOMME dynamics step, HOMME computes horizontal derivatives of the
+   local Cartesian velocity components on the dynamics grid.
+2. Those derivatives are projected back to the local basis to form the six
+   horizontal pieces of the velocity-gradient tensor:
+   `du/dx`, `du/dy`, `dv/dx`, `dv/dy`, `dw/dx`, and `dw/dy`.
+3. EAMxx remaps those six components onto the physics grid as
+   `tke_shear_strain3d_components`.
+4. Inside SHOC, vertical derivatives `du/dz`, `dv/dz`, and `dw/dz` are computed
+   on interface levels and then interpolated to midpoint levels, matching
+   SHOC's native staggered-grid treatment.
+5. SHOC assembles the full symmetric strain tensor and forms the invariant
+   `2 S_{ij}S_{ij}`, which is then used in the TKE equation.
+
+The same assembled 3D strain is also converted back to a midpoint shear
+magnitude for SHOC's cold-surface fallback in the eddy-diffusivity calculation,
+so the 3D path remains consistent with the rest of the closure.

--- a/components/eamxx/docs/user/model_configuration.md
+++ b/components/eamxx/docs/user/model_configuration.md
@@ -107,8 +107,10 @@ We can do that by using the `--grep` flag:
 $ ./atmquery --grep sub
     iop_options::iop_dosubsidence: false
     ctl_nl::hypervis_subcycle: 1
+    ctl_nl::horiz_turb_subcycle: 1
     ctl_nl::hypervis_subcycle_tom: 1
     ctl_nl::hypervis_subcycle_q: 6
+    ctl_nl::horiz_turb_subcycle_q: 1
     atmosphere_processes::number_of_subcycles: 1
     sc_import::number_of_subcycles: 1
     homme::number_of_subcycles: 1

--- a/components/eamxx/docs/user/model_configuration.md
+++ b/components/eamxx/docs/user/model_configuration.md
@@ -230,6 +230,66 @@ $ ./atmquery --grep number_of_subcycles
     sc_export::number_of_subcycles: 3
 ```
 
+## Enabling 3D Turbulence Coupling Between SHOC and HOMME
+
+EAMxx exposes the 3D-turbulence option through the HOMME control-namelist
+parameter `ctl_nl::do_3d_turbulence`. This is the setting that users should
+change.
+
+To enable the feature, run
+
+``` {.shell .copy}
+./atmchange ctl_nl::do_3d_turbulence=true
+```
+
+After changing the setting, rebuild the generated namelists before the next
+run in the usual way, for example via `case.submit` or by re-running the case
+setup/build workflow used for your case.
+
+### What This Switch Does
+
+When `ctl_nl::do_3d_turbulence=true`:
+
+1. HOMME enables its 3D-turbulence path.
+2. `eamxx_buildnml.py` mirrors that value into the locked EAMxx parameter
+   `homme::do_3d_turbulence_homme`.
+3. During atmosphere-driver initialization, that HOMME-facing flag is copied
+   into SHOC's internal runtime option `do_3d_turbulence_shoc`.
+4. SHOC computes horizontal eddy diffusivities for heat and momentum and passes
+   them back to HOMME.
+5. HOMME computes horizontal shear components and passes them to SHOC, which
+   uses them to form the 3D shear-production term in the TKE equation.
+
+Users should NOT edit `homme::do_3d_turbulence_homme` directly. That parameter
+is intentionally locked and is maintained automatically from
+`ctl_nl::do_3d_turbulence`.
+
+### Related SHOC Parameters
+
+The following SHOC parameters remain user-configurable and are relevant when
+3D turbulence is enabled:
+
+- `shoc::coeff_kh_horiz`: horizontal eddy-diffusivity coefficient for heat.
+- `shoc::coeff_km_horiz`: horizontal eddy-diffusivity coefficient for momentum.
+- `shoc::coeff_kh`: vertical eddy-diffusivity coefficient for heat.
+- `shoc::coeff_km`: vertical eddy-diffusivity coefficient for momentum.
+
+For example:
+
+``` {.shell .copy}
+./atmquery shoc::coeff_kh_horiz
+./atmquery shoc::coeff_km_horiz
+./atmchange shoc::coeff_kh_horiz=0.1
+./atmchange shoc::coeff_km_horiz=0.1
+```
+
+Note that 0.1 represents the default values for coeff_kh_horiz and coeff_km_horiz.
+While these are tunable parameters, early testing suggests that valuess of 0.1 are optimal
+to retain appropriate isotropic and anisotropic turbulence behavior as resolution changes.  
+While an exhaustive analysis of these parameters has yet to be performed, setting these values 
+much greater than 1.0 appears to significantly reduce the effective resolution of the model 
+and should be avoided.  
+
 In addition, "ANY" can be used in a "scoped" string, to limit the set of matches:
 
 ``` {.shell .copy}

--- a/components/eamxx/docs/user/model_configuration.md
+++ b/components/eamxx/docs/user/model_configuration.md
@@ -230,65 +230,8 @@ $ ./atmquery --grep number_of_subcycles
     sc_export::number_of_subcycles: 3
 ```
 
-## Enabling 3D Turbulence Coupling Between SHOC and HOMME
-
-EAMxx exposes the 3D-turbulence option through the HOMME control-namelist
-parameter `ctl_nl::do_3d_turbulence`. This is the setting that users should
-change.
-
-To enable the feature, run
-
-``` {.shell .copy}
-./atmchange ctl_nl::do_3d_turbulence=true
-```
-
-After changing the setting, rebuild the generated namelists before the next
-run in the usual way, for example via `case.submit` or by re-running the case
-setup/build workflow used for your case.
-
-### What This Switch Does
-
-When `ctl_nl::do_3d_turbulence=true`:
-
-1. HOMME enables its 3D-turbulence path.
-2. `eamxx_buildnml.py` mirrors that value into the locked EAMxx parameter
-   `homme::do_3d_turbulence_homme`.
-3. During atmosphere-driver initialization, that HOMME-facing flag is copied
-   into SHOC's internal runtime option `do_3d_turbulence_shoc`.
-4. SHOC computes horizontal eddy diffusivities for heat and momentum and passes
-   them back to HOMME.
-5. HOMME computes horizontal shear components and passes them to SHOC, which
-   uses them to form the 3D shear-production term in the TKE equation.
-
-Users should NOT edit `homme::do_3d_turbulence_homme` directly. That parameter
-is intentionally locked and is maintained automatically from
-`ctl_nl::do_3d_turbulence`.
-
-### Related SHOC Parameters
-
-The following SHOC parameters remain user-configurable and are relevant when
-3D turbulence is enabled:
-
-- `shoc::coeff_kh_horiz`: horizontal eddy-diffusivity coefficient for heat.
-- `shoc::coeff_km_horiz`: horizontal eddy-diffusivity coefficient for momentum.
-- `shoc::coeff_kh`: vertical eddy-diffusivity coefficient for heat.
-- `shoc::coeff_km`: vertical eddy-diffusivity coefficient for momentum.
-
-For example:
-
-``` {.shell .copy}
-./atmquery shoc::coeff_kh_horiz
-./atmquery shoc::coeff_km_horiz
-./atmchange shoc::coeff_kh_horiz=0.1
-./atmchange shoc::coeff_km_horiz=0.1
-```
-
-Note that 0.1 represents the default values for coeff_kh_horiz and coeff_km_horiz.
-While these are tunable parameters, early testing suggests that valuess of 0.1 are optimal
-to retain appropriate isotropic and anisotropic turbulence behavior as resolution changes.  
-While an exhaustive analysis of these parameters has yet to be performed, setting these values 
-much greater than 1.0 appears to significantly reduce the effective resolution of the model 
-and should be avoided.  
+For the SHOC-HOMME 3D turbulence option and its user-facing parameters, see
+[SHOC-HOMME 3D Turbulence](shoc_homme_3d_turbulence.md).
 
 In addition, "ANY" can be used in a "scoped" string, to limit the set of matches:
 

--- a/components/eamxx/docs/user/shoc_homme_3d_turbulence.md
+++ b/components/eamxx/docs/user/shoc_homme_3d_turbulence.md
@@ -1,0 +1,64 @@
+# SHOC-HOMME 3D Turbulence
+
+This page describes how to enable the 3D-turbulence coupling between SHOC and
+HOMME, along with the main user-facing parameters associated with it.
+
+## Enabling 3D Turbulence Coupling Between SHOC and HOMME
+
+EAMxx exposes the 3D-turbulence option through the HOMME control-namelist
+parameter `ctl_nl::do_3d_turbulence`. This is the setting that users should
+change.
+
+To enable the feature, run
+
+``` {.shell .copy}
+./atmchange ctl_nl::do_3d_turbulence=true
+```
+
+After changing the setting, rebuild the generated namelists before the next
+run in the usual way, for example via `case.submit` or by re-running the case
+setup/build workflow used for your case.
+
+### What This Switch Does
+
+When `ctl_nl::do_3d_turbulence=true`:
+
+1. HOMME enables its 3D-turbulence path.
+2. `eamxx_buildnml.py` mirrors that value into the locked EAMxx parameter
+   `homme::do_3d_turbulence_homme`.
+3. During atmosphere-driver initialization, that HOMME-facing flag is copied
+   into SHOC's internal runtime option `do_3d_turbulence_shoc`.
+4. SHOC computes horizontal eddy diffusivities for heat and momentum and passes
+   them back to HOMME.
+5. HOMME computes horizontal shear components and passes them to SHOC, which
+   uses them to form the 3D shear-production term in the TKE equation.
+
+Users should NOT edit `homme::do_3d_turbulence_homme` directly. That parameter
+is intentionally locked and is maintained automatically from
+`ctl_nl::do_3d_turbulence`.
+
+### Related SHOC Parameters
+
+The following SHOC parameters remain user-configurable and are relevant when
+3D turbulence is enabled:
+
+- `shoc::coeff_kh_horiz`: horizontal eddy-diffusivity coefficient for heat.
+- `shoc::coeff_km_horiz`: horizontal eddy-diffusivity coefficient for momentum.
+- `shoc::coeff_kh`: vertical eddy-diffusivity coefficient for heat.
+- `shoc::coeff_km`: vertical eddy-diffusivity coefficient for momentum.
+
+For example:
+
+``` {.shell .copy}
+./atmquery shoc::coeff_kh_horiz
+./atmquery shoc::coeff_km_horiz
+./atmchange shoc::coeff_kh_horiz=0.1
+./atmchange shoc::coeff_km_horiz=0.1
+```
+
+Note that 0.1 represents the default values for coeff_kh_horiz and coeff_km_horiz.
+While these are tunable parameters, early testing suggests that valuess of 0.1 are optimal
+to retain appropriate isotropic and anisotropic turbulence behavior as resolution changes.  
+While an exhaustive analysis of these parameters has yet to be performed, setting these values 
+much greater than 1.0 appears to significantly reduce the effective resolution of the model 
+and should be avoided.  

--- a/components/eamxx/docs/user/shoc_homme_3d_turbulence.md
+++ b/components/eamxx/docs/user/shoc_homme_3d_turbulence.md
@@ -56,9 +56,11 @@ For example:
 ./atmchange shoc::coeff_km_horiz=0.1
 ```
 
-Note that 0.1 represents the default values for coeff_kh_horiz and coeff_km_horiz.
-While these are tunable parameters, early testing suggests that valuess of 0.1 are optimal
-to retain appropriate isotropic and anisotropic turbulence behavior as resolution changes.  
-While an exhaustive analysis of these parameters has yet to be performed, setting these values 
-much greater than 1.0 appears to significantly reduce the effective resolution of the model 
-and should be avoided.  
+The default values of `coeff_kh_horiz` and `coeff_km_horiz` are both `0.1`.
+These parameters are tunable, but early testing suggests that `0.1` provides a
+good balance for preserving isotropic and anisotropic turbulence behavior as
+resolution changes.
+
+A more exhaustive parameter study is still needed. At present, values much
+larger than `1.0` appear to reduce the model's effective resolution
+substantially and should generally be avoided.

--- a/components/eamxx/mkdocs.yml
+++ b/components/eamxx/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
   - 'Technical Guide':
     - 'Overview': 'technical/index.md'
     - 'Physics':
+      - 'SHOC-HOMME 3D turbulence coupling': 'technical/physics/shoc_3d_turbulence.md'
       - 'P3':
         - 'Autoconversion': 'technical/physics/p3/autoconversion.md'
         - 'Back to Cell Average': 'technical/physics/p3/back_to_cell_average.md'

--- a/components/eamxx/mkdocs.yml
+++ b/components/eamxx/mkdocs.yml
@@ -6,6 +6,7 @@ nav:
     - 'Overview': 'user/index.md'
     - 'EAMxx case basics': 'user/eamxx_cases.md'
     - 'Model Configuration': 'user/model_configuration.md'
+    - 'SHOC-HOMME 3D turbulence': 'user/shoc_homme_3d_turbulence.md'
     - 'Nudging': 'user/nudging.md'
     - 'Extra radiation calls': 'user/clean_clear_sky.md'
     - 'COSP': 'user/cosp.md'

--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -530,7 +530,8 @@ void AtmosphereDriver::setup_shoc_3d_turbulence_link ()
 
   if (m_atm_process_group->has_process("homme")) {
     auto homme_process = m_atm_process_group->get_process_nonconst("homme");
-    const bool do_3d_turbulence = homme_process->get_params().get("do_3d_turbulence", false);
+    const bool do_3d_turbulence =
+        homme_process->get_params().get<bool>("do_3d_turbulence_homme", false);
 
     auto shoc_process = m_atm_process_group->get_process_nonconst("shoc");
     shoc_process->get_params().set<bool>("do_3d_turbulence_shoc", do_3d_turbulence);

--- a/components/eamxx/src/dynamics/homme/eamxx_homme_fv_phys.cpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_fv_phys.cpp
@@ -247,8 +247,8 @@ void HommeDynamics::remap_fv_phys_to_dyn () const {
 
   const auto& params = c.get<Homme::SimulationParams>();
   if (params.do_3d_turbulence) {
-    const auto Km_phys = get_field_in("eddy_diff_mom",gn).get_view<const Real**>();
-    const auto Kh_phys = get_field_in("eddy_diff_heat",gn).get_view<const Real**>();
+    const auto Km_phys = get_field_in("eddy_diff_mom_horiz",gn).get_view<const Real**>();
+    const auto Kh_phys = get_field_in("eddy_diff_heat_horiz",gn).get_view<const Real**>();
     const auto Km = Homme::GllFvRemap::CPhys2T(Km_phys.data(), nelem, npg, nlev);
     const auto Kh = Homme::GllFvRemap::CPhys2T(Kh_phys.data(), nelem, npg, nlev);
     gfr.run_fv_phys_to_dyn(time_idx, T, uv, q, &Km, &Kh);

--- a/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp
@@ -581,8 +581,6 @@ void HommeDynamics::run_impl (const double dt)
     if (params.do_3d_turbulence){
       compute_horizontal_derivs_of_car_velocity();
       compute_local_strain_components3d();
-    } else if (params.do_3d_turbulence) {
-      m_helper_fields.at("shear_strain3d_components_dyn").deep_copy(0.0);
     }
 
     // Update nstep in the restart extra data, so it can be written to restart if needed.

--- a/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp
@@ -177,8 +177,8 @@ void HommeDynamics::create_requests ()
   add_field<Computed>("p_dry_mid",          pg_scalar3d_mid, Pa,    pgn,N);
   add_field<Computed>("omega",              pg_scalar3d_mid, Pa/s,  pgn,N);
   if (params.do_3d_turbulence) {
-    add_field<Required>("eddy_diff_heat",     pg_scalar3d_mid, m2/s,  pgn,N);
-    add_field<Required>("eddy_diff_mom",      pg_scalar3d_mid, m2/s,  pgn,N);
+    add_field<Required>("eddy_diff_heat_horiz", pg_scalar3d_mid, m2/s,  pgn,N);
+    add_field<Required>("eddy_diff_mom_horiz",  pg_scalar3d_mid, m2/s,  pgn,N);
     auto pg_shear_components_mid = m_phys_grid->get_3d_vector_layout(LEV,6);
     add_field<Computed>("tke_shear_strain3d_components", pg_shear_components_mid, 1/s, pgn,N);
   }
@@ -477,8 +477,8 @@ void HommeDynamics::initialize_impl (const RunType run_type)
 
     if (params.do_3d_turbulence) {
       // Remap SHOC eddy diffusivities from physics grid to dynamics grid.
-      m_p2d_remapper->register_field(get_field_in("eddy_diff_mom",pgn),m_helper_fields.at("Km_dyn"));
-      m_p2d_remapper->register_field(get_field_in("eddy_diff_heat",pgn),m_helper_fields.at("Kh_dyn"));
+      m_p2d_remapper->register_field(get_field_in("eddy_diff_mom_horiz",pgn),m_helper_fields.at("Km_dyn"));
+      m_p2d_remapper->register_field(get_field_in("eddy_diff_heat_horiz",pgn),m_helper_fields.at("Kh_dyn"));
 
       // Remap horizontal/local strain tensor components from dynamics to physics grid.
       m_d2p_remapper->register_field(m_helper_fields.at("shear_strain3d_components_dyn"), get_field_out("tke_shear_strain3d_components"));
@@ -917,6 +917,7 @@ void HommeDynamics::init_homme_views () {
   msg << "   nu_div: " << params.nu_div << "\n";
   msg << "   hypervis_order: " << params.hypervis_order << "\n";
   msg << "   hypervis_subcycle: " << params.hypervis_subcycle << "\n";
+  msg << "   horiz_turb_subcycle: " << params.horiz_turb_subcycle << "\n";
   msg << "   hypervis_subcycle_tom: " << params.hypervis_subcycle_tom << "\n";
   msg << "   hypervis_scaling: " << params.hypervis_scaling << "\n";
   msg << "   nu_ratio1: " << params.nu_ratio1 << "\n";

--- a/components/eamxx/src/physics/shoc/disp/shoc_tke_disp.cpp
+++ b/components/eamxx/src/physics/shoc/disp/shoc_tke_disp.cpp
@@ -60,7 +60,7 @@ void Functions<Real,DefaultDevice>
              lambda_low, lambda_high, lambda_slope, lambda_thresh,
              Ckh, Ckm, shoc_1p5tke, do_3d_turb,
              ekat::subview(wthv_sec, i),
-             ekat::subview(shear_strain3d_components, i),
+             shear_strain3d_components_s,
              ekat::subview(shear_strain3d, i),
              ekat::subview(shoc_mix, i),
              ekat::subview(dz_zi, i),

--- a/components/eamxx/src/physics/shoc/disp/shoc_tke_disp.cpp
+++ b/components/eamxx/src/physics/shoc/disp/shoc_tke_disp.cpp
@@ -60,7 +60,7 @@ void Functions<Real,DefaultDevice>
              lambda_low, lambda_high, lambda_slope, lambda_thresh,
              Ckh, Ckm, shoc_1p5tke, do_3d_turb,
              ekat::subview(wthv_sec, i),
-             shear_strain3d_components_s,
+             ekat::subview(shear_strain3d_components, i),
              ekat::subview(shear_strain3d, i),
              ekat::subview(shoc_mix, i),
              ekat::subview(dz_zi, i),

--- a/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
+++ b/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
@@ -588,6 +588,7 @@ void SHOCMacrophysics::run_impl (const double dt)
                  );
 
   if (runtime_options.do_3d_turb) {
+    // If doing 3d turbulence, then compute the horizontal eddy diffusivities to pass to HOMME.
     const auto tke       = get_field_out("tke").get_view<const Pack**>();
     const auto eddy_diff_heat_horiz = get_field_out("eddy_diff_heat_horiz").get_view<Pack**>();
     const auto eddy_diff_mom_horiz  = get_field_out("eddy_diff_mom_horiz").get_view<Pack**>();

--- a/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
+++ b/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
@@ -263,7 +263,6 @@ void SHOCMacrophysics::init_buffers(const ATMBufferManager &buffer_manager)
   const int n_wind_slots = ekat::npack<Pack>(2)*Pack::n;
   const int n_trac_slots = ekat::npack<Pack>(m_num_tracers+3)*Pack::n;
   const int wsm_size     = WSM::get_total_bytes_needed(nlevi_packs, 20+(2*n_wind_slots+n_trac_slots), policy)/sizeof(Pack);
-
   s_mem += wsm_size;
 
   size_t used_mem = (reinterpret_cast<Real*>(s_mem) - buffer_manager.get_memory())*sizeof(Real);

--- a/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
+++ b/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
@@ -80,6 +80,8 @@ void SHOCMacrophysics::create_requests()
     const auto vector3d_mid_6 = m_grid->get_3d_vector_layout(LEV,6);
     add_field<Required>("tke_shear_strain3d_components", vector3d_mid_6,nondim/s, grid_name, ps);
     add_field<Computed>("tke_shear_strain3d", scalar3d_mid,nondim/s2, grid_name, ps);
+    add_field<Computed>("eddy_diff_heat_horiz", scalar3d_mid, m2/s, grid_name, ps);
+    add_field<Computed>("eddy_diff_mom_horiz",  scalar3d_mid, m2/s, grid_name, ps);
   }
 
   // Input/Output variables
@@ -214,6 +216,8 @@ void SHOCMacrophysics::init_buffers(const ATMBufferManager &buffer_manager)
   const int num_tracer_packs = ekat::npack<Pack>(m_num_tracers);
   m_dummy_shear_strain3d = view_2d("dummy_shear_strain3d", m_num_cols, nlev_packs);
   Kokkos::deep_copy(m_dummy_shear_strain3d, 0);
+  m_dummy_shear_strain3d_components = view_3d("dummy_shear_strain3d_components", m_num_cols, 6, nlev_packs);
+  Kokkos::deep_copy(m_dummy_shear_strain3d_components, 0);
 
   m_buffer.pref_mid = decltype(m_buffer.pref_mid)(s_mem, nlev_packs);
   s_mem += m_buffer.pref_mid.size();
@@ -259,6 +263,7 @@ void SHOCMacrophysics::init_buffers(const ATMBufferManager &buffer_manager)
   const int n_wind_slots = ekat::npack<Pack>(2)*Pack::n;
   const int n_trac_slots = ekat::npack<Pack>(m_num_tracers+3)*Pack::n;
   const int wsm_size     = WSM::get_total_bytes_needed(nlevi_packs, 20+(2*n_wind_slots+n_trac_slots), policy)/sizeof(Pack);
+
   s_mem += wsm_size;
 
   size_t used_mem = (reinterpret_cast<Real*>(s_mem) - buffer_manager.get_memory())*sizeof(Real);
@@ -283,6 +288,8 @@ void SHOCMacrophysics::initialize_impl (const RunType run_type)
   runtime_options.c_diag_3rd_mom = m_params.get<double>("c_diag_3rd_mom");
   runtime_options.Ckh           = m_params.get<double>("coeff_kh");
   runtime_options.Ckm           = m_params.get<double>("coeff_km");
+  runtime_options.Ckh_horiz     = m_params.get<double>("coeff_kh_horiz",0.1);
+  runtime_options.Ckm_horiz     = m_params.get<double>("coeff_km_horiz",0.1);
   runtime_options.shoc_1p5tke   = m_params.get<bool>("shoc_1p5tke");
   runtime_options.do_3d_turb    = m_params.get<bool>("do_3d_turbulence_shoc", false);
   runtime_options.extra_diags   = m_params.get<bool>("extra_shoc_diags");
@@ -579,6 +586,26 @@ void SHOCMacrophysics::run_impl (const double dt)
                  , temporaries
 #endif
                  );
+
+  if (runtime_options.do_3d_turb) {
+    const auto tke       = get_field_out("tke").get_view<const Pack**>();
+    const auto eddy_diff_heat_horiz = get_field_out("eddy_diff_heat_horiz").get_view<Pack**>();
+    const auto eddy_diff_mom_horiz  = get_field_out("eddy_diff_mom_horiz").get_view<Pack**>();
+    const auto dx        = input.dx;
+    const auto dy        = input.dy;
+    const auto Ckh_horiz = runtime_options.Ckh_horiz;
+    const auto Ckm_horiz = runtime_options.Ckm_horiz;
+    const auto nlev      = m_num_levs;
+    Kokkos::parallel_for("horizontal_eddy_diffusivities", default_policy,
+                         KOKKOS_LAMBDA (const KT::MemberType& team) {
+      const int icol = team.league_rank();
+      SHF::horizontal_eddy_diffusivities(
+          team, nlev, Ckh_horiz, Ckm_horiz, dx(icol), dy(icol),
+          ekat::subview(tke,icol), ekat::subview(eddy_diff_heat_horiz,icol),
+          ekat::subview(eddy_diff_mom_horiz,icol));
+    });
+    Kokkos::fence();
+  }
 
   // Postprocessing of SHOC outputs
   Kokkos::parallel_for("shoc_postprocess",

--- a/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.hpp
+++ b/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.hpp
@@ -527,6 +527,7 @@ protected:
 #endif
 
   void initialize_impl (const RunType run_type);
+  void run_impl        (const double dt);
 
   // Update flux (if necessary)
   void check_flux_state_consistency(const double dt);
@@ -536,7 +537,6 @@ protected:
 
 protected:
 
-  void run_impl        (const double dt);
   void finalize_impl   ();
 
   // SHOC updates the 'tracers' group.
@@ -561,6 +561,7 @@ protected:
   // Struct which contains local variables
   Buffer m_buffer;
   view_2d m_dummy_shear_strain3d;
+  view_3d m_dummy_shear_strain3d_components;
 
   // Store the structures for each argument to shoc_main;
   SHF::SHOCInput input;

--- a/components/eamxx/src/physics/shoc/impl/shoc_eddy_diffusivities_impl.hpp
+++ b/components/eamxx/src/physics/shoc/impl/shoc_eddy_diffusivities_impl.hpp
@@ -3,6 +3,8 @@
 
 #include "shoc_functions.hpp" // for ETI only but harmless for GPU
 
+#include <cmath>
+
 namespace scream {
 namespace shoc {
 
@@ -52,6 +54,28 @@ void Functions<S,D>::eddy_diffusivities(
 
     tkh(k).set(!condition, Ckh*isotropy(k)*tke(k));
     tk(k).set(!condition,  Ckm*isotropy(k)*tke(k));
+  });
+}
+
+template<typename S, typename D>
+KOKKOS_FUNCTION
+void Functions<S,D>::horizontal_eddy_diffusivities(
+  const MemberType&            team,
+  const Int&                   nlev,
+  const Scalar&                Ckh_horiz,
+  const Scalar&                Ckm_horiz,
+  const Scalar&                grid_dx,
+  const Scalar&                grid_dy,
+  const uview_1d<const Pack>& tke,
+  const uview_1d<Pack>&       eddy_diff_heat_horiz,
+  const uview_1d<Pack>&       eddy_diff_mom_horiz)
+{
+  const Scalar horiz_length = std::sqrt(grid_dx*grid_dy);
+  const Int nlev_pack = ekat::npack<Pack>(nlev);
+  Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev_pack), [&] (const Int& k) {
+    const Pack velocity_scale = ekat::sqrt(tke(k));
+    eddy_diff_heat_horiz(k) = Ckh_horiz*horiz_length*velocity_scale;
+    eddy_diff_mom_horiz(k)  = Ckm_horiz*horiz_length*velocity_scale;
   });
 }
 

--- a/components/eamxx/src/physics/shoc/shoc_functions.hpp
+++ b/components/eamxx/src/physics/shoc/shoc_functions.hpp
@@ -78,6 +78,8 @@ template <typename ScalarT, typename DeviceT> struct Functions {
     Scalar c_diag_3rd_mom;
     Scalar Ckh;
     Scalar Ckm;
+    Scalar Ckh_horiz;
+    Scalar Ckm_horiz;
     bool shoc_1p5tke;
     bool extra_diags;
     bool do_3d_turb;
@@ -910,6 +912,13 @@ template <typename ScalarT, typename DeviceT> struct Functions {
                      const uview_1d<const Pack> &shoc_mix, const uview_1d<const Pack> &sterm_zt,
                      const uview_1d<const Pack> &isotropy, const uview_1d<const Pack> &tke,
                      const uview_1d<Pack> &tkh, const uview_1d<Pack> &tk);
+
+  KOKKOS_FUNCTION
+  static void horizontal_eddy_diffusivities(
+      const MemberType &team, const Int &nlev, const Scalar &Ckh_horiz,
+      const Scalar &Ckm_horiz, const Scalar &grid_dx, const Scalar &grid_dy,
+      const uview_1d<const Pack> &tke, const uview_1d<Pack> &eddy_diff_heat_horiz,
+      const uview_1d<Pack> &eddy_diff_mom_horiz);
 
   KOKKOS_FUNCTION
   static void shoc_tke(const MemberType &team, const Int &nlev, const Int &nlevi,

--- a/components/eamxx/tests/single-process/shoc/input.yaml
+++ b/components/eamxx/tests/single-process/shoc/input.yaml
@@ -33,6 +33,8 @@ eamxx:
     c_diag_3rd_mom: 7.0
     coeff_kh: 0.1
     coeff_km: 0.1
+    coeff_kh_horiz: 0.1
+    coeff_km_horiz: 0.1
     shoc_1p5tke: false
 
 grids_manager:

--- a/components/homme/src/share/control_mod.F90
+++ b/components/homme/src/share/control_mod.F90
@@ -171,10 +171,13 @@ module control_mod
   real (kind=real_kind), public :: tom_sponge_start=0         ! start of sponge layer, in hPa
 
   integer, public :: hypervis_subcycle=1                      ! number of subcycles for hyper viscsosity timestep
+  integer, public :: horiz_turb_subcycle=1                    ! number of subcycles for SGS horizontal diffusion
   integer, public :: hypervis_subcycle_tom=0                  ! number of subcycles for TOM diffusion
                                                               !   0   apply together with hyperviscosity
                                                               !   >1  apply timesplit from hyperviscosity
   integer, public :: hypervis_subcycle_q=1                    ! number of subcycles for hyper viscsosity timestep on TRACERS
+  integer, public :: horiz_turb_subcycle_q=1                  ! number of subcycles for SGS horizontal diffusion on TRACERS
+                                                              !   <0  use hypervis_subcycle_q
   integer, public :: hypervis_order=0                         ! laplace**hypervis_order.  0=not used  1=regular viscosity, 2=grad**4
 
   real (kind=real_kind), public :: hypervis_scaling=0         ! use tensor hyperviscosity

--- a/components/homme/src/share/cxx/ComposeTransportImpl.hpp
+++ b/components/homme/src/share/cxx/ComposeTransportImpl.hpp
@@ -78,7 +78,7 @@ struct ComposeTransportImpl {
   struct VelocityRecord;
 
   struct Data {
-    int nelemd, qsize, limiter_option, cdr_check, hv_q, hv_subcycle_q;
+    int nelemd, qsize, limiter_option, cdr_check, hv_q, hv_subcycle_q, hv_subcycle_q_sgs;
     int geometry_type; // 0: sphere, 1: plane
     int trajectory_nsubstep; // 0: original alg, >= 1: enhanced
     int trajectory_nvelocity;
@@ -107,7 +107,7 @@ struct ComposeTransportImpl {
 
     Data ()
       : nelemd(-1), qsize(-1), limiter_option(9), cdr_check(0), hv_q(0),
-        hv_subcycle_q(0), geometry_type(0), nu_q(0), hv_scaling(0), dp_tol(-1),
+        hv_subcycle_q(0), hv_subcycle_q_sgs(0), geometry_type(0), nu_q(0), hv_scaling(0), dp_tol(-1),
         independent_time_steps(false), do_3d_turbulence(false)
     {}
   };
@@ -126,7 +126,8 @@ struct ComposeTransportImpl {
   TeamUtils<ExecSpace> m_tu_ne, m_tu_ne_qsize, m_tu_ne_hv_q;
 
   std::shared_ptr<BoundaryExchange>
-    m_qdp_dss_be[Q_NUM_TIME_LEVELS], m_v_dss_be[2], m_hv_dss_be[2];
+    m_qdp_dss_be[Q_NUM_TIME_LEVELS], m_v_dss_be[2], m_hv_dss_be[2],
+    m_horiz_turb_dss_be[2];
 
   ComposeTransportImpl();
   ComposeTransportImpl(const int num_elems);

--- a/components/homme/src/share/cxx/ComposeTransportImplGeneral.cpp
+++ b/components/homme/src/share/cxx/ComposeTransportImplGeneral.cpp
@@ -11,7 +11,7 @@
 #include "compose_hommexx.hpp"
 
 extern "C" void
-sl_get_params(double* nu_q, double* hv_scaling, int* hv_q, int* hv_subcycle_q,
+sl_get_params(double* nu_q, double* hv_scaling, int* hv_q, int* hv_subcycle_q, int* hv_subcycle_q_sgs,
               int* limiter_option, int* cdr_check, int* geometry_type,
               int* trajectory_nsubstep, int* trajectory_nvelocity,
               int* diagnostics, bool* do_3d_turbulence);
@@ -57,7 +57,7 @@ void ComposeTransportImpl::reset (const SimulationParams& params) {
 
   const bool independent_time_steps = params.dt_tracer_factor > params.dt_remap_factor;
 
-  sl_get_params(&m_data.nu_q, &m_data.hv_scaling, &m_data.hv_q, &m_data.hv_subcycle_q,
+  sl_get_params(&m_data.nu_q, &m_data.hv_scaling, &m_data.hv_q, &m_data.hv_subcycle_q, &m_data.hv_subcycle_q_sgs,
                 &m_data.limiter_option, &m_data.cdr_check, &m_data.geometry_type,
                 &m_data.trajectory_nsubstep, &m_data.trajectory_nvelocity,
                 &m_data.diagnostics, &m_data.do_3d_turbulence);
@@ -109,6 +109,10 @@ void ComposeTransportImpl::reset (const SimulationParams& params) {
                         "semi_lagrange_hv_q should be in [0, qsize].");
   Errors::runtime_check(m_data.hv_subcycle_q >= 0,
                         "hypervis_subcycle_q should be >= 0.");
+  Errors::runtime_check(m_data.hv_subcycle_q_sgs >= 0,
+                        "horiz_turb_subcycle_q should be >= 0.");
+  Errors::runtime_check(!m_data.do_3d_turbulence || m_data.hv_subcycle_q_sgs > 0,
+                        "horiz_turb_subcycle_q should be > 0 when 3D turbulence is enabled.");
 
   m_tp_ne = Homme::get_default_team_policy<ExecSpace>(m_data.nelemd);
   m_tp_ne_qsize = Homme::get_default_team_policy<ExecSpace>(m_data.nelemd * m_data.qsize);
@@ -122,9 +126,9 @@ void ComposeTransportImpl::reset (const SimulationParams& params) {
   m_sphere_ops.allocate_buffers(m_tu_ne_qsize);
 
   if (Context::singleton().get<Connectivity>().get_comm().root())
-    printf("compose> nelemd %d qsize %d hv_q %d hv_subcycle_q %d lim %d "
+    printf("compose> nelemd %d qsize %d hv_q %d hv_subcycle_q %d hv_subcycle_q_sgs %d lim %d "
            "independent_time_steps %d\n",
-           m_data.nelemd, m_data.qsize, m_data.hv_q, m_data.hv_subcycle_q,
+           m_data.nelemd, m_data.qsize, m_data.hv_q, m_data.hv_subcycle_q, m_data.hv_subcycle_q_sgs,
            m_data.limiter_option, (int) m_data.independent_time_steps);
 }
 
@@ -207,6 +211,23 @@ void ComposeTransportImpl::init_boundary_exchanges () {
       be->registration_completed();
     }
   }
+
+  // For horizontal turbulent diffusion applied to all tracers.
+  if (m_data.do_3d_turbulence) {
+    for (int i = 0; i < 2; ++i) {
+      m_horiz_turb_dss_be[i] = std::make_shared<BoundaryExchange>();
+      auto be = m_horiz_turb_dss_be[i];
+      be->set_label(std::string("ComposeTransport-q-HorizTurb-" + std::to_string(i)));
+      be->set_diagnostics_level(sp.internal_diagnostics_level);
+      be->set_buffers_manager(bm_exchange);
+      be->set_num_fields(0, 0, m_data.qsize);
+      if (i == 0)
+        be->register_field(m_tracers.qtens_biharmonic, m_data.qsize, 0);
+      else
+        be->register_field(m_tracers.Q, m_data.qsize, 0);
+      be->registration_completed();
+    }
+  }
 }
 
 void ComposeTransportImpl::run (const TimeLevel& tl, const Real dt) {
@@ -227,14 +248,14 @@ void ComposeTransportImpl::run (const TimeLevel& tl, const Real dt) {
     advance_hypervis_scalar(dt);
     Kokkos::fence();
     GPTLstop("compose_hypervis_scalar");
+  }
 
-    // SGS horizontal turbulent diffusion for scalars
-    if (m_data.do_3d_turbulence){
-      GPTLstart("compose_horizturb_scalar");
-      advance_horizontal_turbulent_diffusion_scalar(dt);
-      Kokkos::fence();
-      GPTLstop("compose_horizturb_scalar");
-    }
+  // SGS horizontal turbulent diffusion for all tracers.
+  if (m_data.do_3d_turbulence) {
+    GPTLstart("compose_horizturb_scalar");
+    advance_horizontal_turbulent_diffusion_scalar(dt);
+    Kokkos::fence();
+    GPTLstop("compose_horizturb_scalar");
   }
 
   GPTLstart("compose_cedr_global");

--- a/components/homme/src/share/cxx/ComposeTransportImplHorizTurb.cpp
+++ b/components/homme/src/share/cxx/ComposeTransportImplHorizTurb.cpp
@@ -11,51 +11,117 @@
 
 namespace Homme {
 
+namespace {
+
+constexpr Real tracer_sgs_cfl_target = 1.00;
+
+KOKKOS_INLINE_FUNCTION
+constexpr Real get_lambda_vis_ct ()
+{
+  switch (NP) {
+  case 2: return 12.0;
+  case 3: return 30.0;
+  case 4: return 91.6742;
+  case 5: return 190.1176;
+  case 6: return 374.7788;
+  case 7: return 652.3015;
+  default: return 0.0;
+  }
+}
+
+KOKKOS_INLINE_FUNCTION
+Real get_local_laplace_metric_ct (const Real a, const Real b, const Real c, const Real d,
+                                  const Real lambda_vis, const Real scale_factor_inv)
+{
+  const Real s11 = a*a + c*c;
+  const Real s22 = b*b + d*d;
+  const Real s12 = a*b + c*d;
+  const Real disc = (s11 - s22)*(s11 - s22) + 4.0*s12*s12;
+  const Real max_eig = 0.5 * (s11 + s22 + std::sqrt(disc));
+  const Real norm_dinv = std::sqrt(max_eig);
+  return lambda_vis * (scale_factor_inv * norm_dinv) * (scale_factor_inv * norm_dinv);
+}
+
+} // namespace
+
 void ComposeTransportImpl::advance_horizontal_turbulent_diffusion_scalar (const Real dt_q) {
-  const auto dt = dt_q / m_data.hv_subcycle_q;
-  const auto hv_q = m_data.hv_q;
+  const auto dt = dt_q / m_data.hv_subcycle_q_sgs;
+  const auto qsize = m_data.qsize;
   const auto Qtens = m_tracers.qtens_biharmonic;
   const auto Q = m_tracers.Q;
   const auto Kh = m_derived.m_turb_diff_heat;
+  const auto dinv = m_geometry.m_dinv;
   const auto spheremp = m_geometry.m_spheremp;
-  const auto tu_ne_hv_q = m_tu_ne_hv_q;
+  const Real scale_factor_inv = 1.0 / m_geometry.m_scale_factor;
+  const Real lambda_vis = get_lambda_vis_ct();
+  const auto tu_ne_qsize = m_tu_ne_qsize;
   const auto sphere_ops = m_sphere_ops;
-  for (int it = 0; it < m_data.hv_subcycle_q; ++it) {
+
+  for (int it = 0; it < m_data.hv_subcycle_q_sgs; ++it) {
     { // Qtens = Q
       const auto f = KOKKOS_LAMBDA (const int idx) {
         int ie, q, i, j, lev;
-        idx_ie_q_ij_nlev<num_lev_pack>(hv_q, idx, ie, q, i, j, lev);
+        idx_ie_q_ij_nlev<num_lev_pack>(qsize, idx, ie, q, i, j, lev);
         Qtens(ie,q,i,j,lev) = Q(ie,q,i,j,lev);
       };
-      launch_ie_q_ij_nlev<num_lev_pack>(hv_q, f);
+      launch_ie_q_ij_nlev<num_lev_pack>(qsize, f);
     }
     // biharmonic_wk_scalar
     const auto laplace_simple_Qtens = [&] () {
       const auto f = KOKKOS_LAMBDA (const MT& team) {
-        KernelVariables kv(team, hv_q, tu_ne_hv_q);
+        KernelVariables kv(team, qsize, tu_ne_qsize);
         const auto Qtens_ie = Homme::subview(Qtens, kv.ie, kv.iq);
         sphere_ops.laplace_simple(kv, Qtens_ie, Qtens_ie);
       };
-      Kokkos::parallel_for(m_tp_ne_hv_q, f);
+      Kokkos::parallel_for(m_tp_ne_qsize, f);
     };
     laplace_simple_Qtens();
-    m_hv_dss_be[0]->exchange(m_geometry.m_rspheremp);
+    // Assemble the weak Laplacian tendency, but leave its mass weighting in
+    // place. The inverse mass matrix is applied once, after the tendency is
+    // added to Q below.
+    m_horiz_turb_dss_be[0]->exchange();
 
     Kokkos::fence();
 
-    { // Compute Q = Q spheremp - dt Kh Qtens. N.B. spheremp is already in
+    { // Compute Q = Q spheremp + dt Kh Qtens. N.B. spheremp is already in
       // Qtens from divergence_sphere_wk.
       const auto f = KOKKOS_LAMBDA (const int idx) {
         int ie, q, i, j, lev;
-        idx_ie_q_ij_nlev<num_lev_pack>(hv_q, idx, ie, q, i, j, lev);
-        Q(ie,q,i,j,lev) = (Q(ie,q,i,j,lev) * spheremp(ie,i,j)
-                           - dt * Kh(ie,i,j,lev) * Qtens(ie,q,i,j,lev));
+        idx_ie_q_ij_nlev<num_lev_pack>(qsize, idx, ie, q, i, j, lev);
+        auto kh_eff = Kh(ie,i,j,lev);
+
+        if (lambda_vis > 0) {
+          const Real a = dinv(ie,0,0,i,j);
+          const Real b = dinv(ie,0,1,i,j);
+          const Real c = dinv(ie,1,0,i,j);
+          const Real d = dinv(ie,1,1,i,j);
+          const Real laplace_metric = get_local_laplace_metric_ct(a, b, c, d,
+                                                                  lambda_vis, scale_factor_inv);
+          if (laplace_metric > 0) {
+            const Real max_diffusivity = 2.0 * tracer_sgs_cfl_target / (dt * laplace_metric);
+            for (int s = 0; s < VECTOR_SIZE; ++s) {
+              const int phys_lev = lev * VECTOR_SIZE + s;
+              if (phys_lev < NUM_PHYSICAL_LEV && kh_eff[s] > max_diffusivity) {
+                kh_eff[s] = max_diffusivity;
+              }
+            }
+          }
+        }
+        auto q_new = Q(ie,q,i,j,lev) * spheremp(ie,i,j);
+        for (int s = 0; s < VECTOR_SIZE; ++s) {
+          const int phys_lev = lev * VECTOR_SIZE + s;
+          if (phys_lev < NUM_PHYSICAL_LEV) {
+            q_new[s] = (Q(ie,q,i,j,lev)[s] * spheremp(ie,i,j)
+                        + dt * kh_eff[s] * Qtens(ie,q,i,j,lev)[s]);
+          }
+        }
+        Q(ie,q,i,j,lev) = q_new;
       };
-      launch_ie_q_ij_nlev<num_lev_pack>(hv_q, f);
+      launch_ie_q_ij_nlev<num_lev_pack>(qsize, f);
     }
     // Halo exchange Q and apply rspheremp.
     Kokkos::fence();
-    m_hv_dss_be[1]->exchange(m_geometry.m_rspheremp);
+    m_horiz_turb_dss_be[1]->exchange(m_geometry.m_rspheremp);
   }
 }
 

--- a/components/homme/src/share/cxx/ComposeTransportImplHorizTurb.cpp
+++ b/components/homme/src/share/cxx/ComposeTransportImplHorizTurb.cpp
@@ -18,6 +18,7 @@ constexpr Real tracer_sgs_cfl_target = 1.00;
 KOKKOS_INLINE_FUNCTION
 constexpr Real get_lambda_vis_ct ()
 {
+  // Element-order-dependent stability factor for the discrete Laplacian.
   switch (NP) {
   case 2: return 12.0;
   case 3: return 30.0;
@@ -33,6 +34,8 @@ KOKKOS_INLINE_FUNCTION
 Real get_local_laplace_metric_ct (const Real a, const Real b, const Real c, const Real d,
                                   const Real lambda_vis, const Real scale_factor_inv)
 {
+  // Estimate the largest mapped Laplacian eigenvalue at this GLL point so the
+  // local SGS diffusivity can be compared against a CFL limit.
   const Real s11 = a*a + c*c;
   const Real s22 = b*b + d*d;
   const Real s12 = a*b + c*d;
@@ -98,6 +101,8 @@ void ComposeTransportImpl::advance_horizontal_turbulent_diffusion_scalar (const 
           const Real laplace_metric = get_local_laplace_metric_ct(a, b, c, d,
                                                                   lambda_vis, scale_factor_inv);
           if (laplace_metric > 0) {
+            // Clip the tracer diffusivity so the local explicit SGS update
+            // stays within the target CFL bound on this element/GLL point.
             const Real max_diffusivity = 2.0 * tracer_sgs_cfl_target / (dt * laplace_metric);
             for (int s = 0; s < VECTOR_SIZE; ++s) {
               const int phys_lev = lev * VECTOR_SIZE + s;

--- a/components/homme/src/share/cxx/SimulationParams.hpp
+++ b/components/homme/src/share/cxx/SimulationParams.hpp
@@ -55,6 +55,7 @@ struct SimulationParams
   double    nu_div;
   int       hypervis_order;
   int       hypervis_subcycle;
+  int       horiz_turb_subcycle;
   int       hypervis_subcycle_tom;
   double    hypervis_scaling;
   double    nu_ratio1, nu_ratio2; // control balance between div and vort components in vector laplace
@@ -100,6 +101,7 @@ inline void SimulationParams::print (std::ostream& out) {
   out << "   nu_div: " << nu_div << "\n";
   out << "   hypervis_order: " << hypervis_order << "\n";
   out << "   hypervis_subcycle: " << hypervis_subcycle << "\n";
+  out << "   horiz_turb_subcycle: " << horiz_turb_subcycle << "\n";
   out << "   hypervis_subcycle_tom: " << hypervis_subcycle_tom << "\n";
   out << "   hypervis_scaling: " << hypervis_scaling << "\n";
   out << "   nu_ratio1: " << nu_ratio1 << "\n";

--- a/components/homme/src/share/cxx/SimulationParams.hpp
+++ b/components/homme/src/share/cxx/SimulationParams.hpp
@@ -55,7 +55,7 @@ struct SimulationParams
   double    nu_div;
   int       hypervis_order;
   int       hypervis_subcycle;
-  int       horiz_turb_subcycle;
+  int       horiz_turb_subcycle = 1;
   int       hypervis_subcycle_tom;
   double    hypervis_scaling;
   double    nu_ratio1, nu_ratio2; // control balance between div and vort components in vector laplace

--- a/components/homme/src/share/cxx/SimulationParams.hpp
+++ b/components/homme/src/share/cxx/SimulationParams.hpp
@@ -55,7 +55,7 @@ struct SimulationParams
   double    nu_div;
   int       hypervis_order;
   int       hypervis_subcycle;
-  int       horiz_turb_subcycle;
+  int       horiz_turb_subcycle = 1;
   int       hypervis_subcycle_tom;
   double    hypervis_scaling;
   // Scaling exponent for the sponge-layer (nu_top) tensor viscosity, mirroring

--- a/components/homme/src/share/cxx/SimulationParams.hpp
+++ b/components/homme/src/share/cxx/SimulationParams.hpp
@@ -55,6 +55,7 @@ struct SimulationParams
   double    nu_div;
   int       hypervis_order;
   int       hypervis_subcycle;
+  int       horiz_turb_subcycle;
   int       hypervis_subcycle_tom;
   double    hypervis_scaling;
   // Scaling exponent for the sponge-layer (nu_top) tensor viscosity, mirroring
@@ -105,6 +106,7 @@ inline void SimulationParams::print (std::ostream& out) {
   out << "   nu_div: " << nu_div << "\n";
   out << "   hypervis_order: " << hypervis_order << "\n";
   out << "   hypervis_subcycle: " << hypervis_subcycle << "\n";
+  out << "   horiz_turb_subcycle: " << horiz_turb_subcycle << "\n";
   out << "   hypervis_subcycle_tom: " << hypervis_subcycle_tom << "\n";
   out << "   hypervis_scaling: " << hypervis_scaling << "\n";
   out << "   laplace_scaling: " << laplace_scaling << "\n";

--- a/components/homme/src/share/namelist_mod.F90
+++ b/components/homme/src/share/namelist_mod.F90
@@ -80,8 +80,10 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
     disable_diagnostics, & ! use to disable diagnostics for timing reasons
     hypervis_order,       &
     hypervis_subcycle,    &
+    horiz_turb_subcycle,&
     hypervis_subcycle_tom,&
     hypervis_subcycle_q,  &
+    horiz_turb_subcycle_q, &
     smooth_phis_numcycle, &
     smooth_phis_p2filt, &
     smooth_phis_nudt,     &
@@ -314,8 +316,10 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
       dcmip16_pbl_type,&
       hypervis_order,    &
       hypervis_subcycle, &
+      horiz_turb_subcycle, &
       hypervis_subcycle_tom, &
       hypervis_subcycle_q, &
+      horiz_turb_subcycle_q, &
       hypervis_scaling, &
       laplace_scaling, &
       smooth_phis_numcycle, &
@@ -819,8 +823,10 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
     call MPI_bcast(hypervis_scaling,1,MPIreal_t   ,par%root,par%comm,ierr)
     call MPI_bcast(laplace_scaling,1,MPIreal_t   ,par%root,par%comm,ierr)
     call MPI_bcast(hypervis_subcycle,1,MPIinteger_t   ,par%root,par%comm,ierr)
+    call MPI_bcast(horiz_turb_subcycle,1,MPIinteger_t   ,par%root,par%comm,ierr)
     call MPI_bcast(hypervis_subcycle_tom,1,MPIinteger_t   ,par%root,par%comm,ierr)
     call MPI_bcast(hypervis_subcycle_q,1,MPIinteger_t   ,par%root,par%comm,ierr)
+    call MPI_bcast(horiz_turb_subcycle_q,1,MPIinteger_t   ,par%root,par%comm,ierr)
     call MPI_bcast(smooth_phis_numcycle,1,MPIinteger_t   ,par%root,par%comm,ierr)
     call MPI_bcast(smooth_phis_p2filt,1,MPIinteger_t   ,par%root,par%comm,ierr)
     call MPI_bcast(smooth_phis_nudt,1,MPIreal_t   ,par%root,par%comm,ierr)
@@ -964,6 +970,8 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
           call abortmp('hypervis_subcycle auto determine only supported for nv==4 and topology==cube')
        endif
     endif
+    if (horiz_turb_subcycle == -1) horiz_turb_subcycle = hypervis_subcycle
+    if (horiz_turb_subcycle_q < 0) horiz_turb_subcycle_q = hypervis_subcycle_q
 #endif
     ! set defautl for dynamics remap
     if (vert_remap_u_alg == -2) vert_remap_u_alg = vert_remap_q_alg
@@ -1237,8 +1245,10 @@ end if
        endif
 
        write(iulog,*)"hypervis_subcycle     = ",hypervis_subcycle
+       write(iulog,*)"horiz_turb_subcycle = ",horiz_turb_subcycle
        write(iulog,*)"hypervis_subcycle_tom = ",hypervis_subcycle_tom
        write(iulog,*)"hypervis_subcycle_q   = ",hypervis_subcycle_q
+       write(iulog,*)"horiz_turb_subcycle_q = ",horiz_turb_subcycle_q
        write(iulog,'(a,2e9.2)')"viscosity:  nu (vor/div) = ",nu,nu_div
        write(iulog,'(a,2e9.2)')"viscosity:  nu_s      = ",nu_s
        write(iulog,'(a,2e9.2)')"viscosity:  nu_q      = ",nu_q

--- a/components/homme/src/share/namelist_mod.F90
+++ b/components/homme/src/share/namelist_mod.F90
@@ -79,8 +79,10 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
     disable_diagnostics, & ! use to disable diagnostics for timing reasons
     hypervis_order,       &
     hypervis_subcycle,    &
+    horiz_turb_subcycle,&
     hypervis_subcycle_tom,&
     hypervis_subcycle_q,  &
+    horiz_turb_subcycle_q, &
     smooth_phis_numcycle, &
     smooth_phis_p2filt, &
     smooth_phis_nudt,     &
@@ -313,8 +315,10 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
       dcmip16_pbl_type,&
       hypervis_order,    &
       hypervis_subcycle, &
+      horiz_turb_subcycle, &
       hypervis_subcycle_tom, &
       hypervis_subcycle_q, &
+      horiz_turb_subcycle_q, &
       hypervis_scaling, &
       smooth_phis_numcycle, &
       smooth_phis_p2filt, &
@@ -816,8 +820,10 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
     call MPI_bcast(hypervis_order,1,MPIinteger_t   ,par%root,par%comm,ierr)
     call MPI_bcast(hypervis_scaling,1,MPIreal_t   ,par%root,par%comm,ierr)
     call MPI_bcast(hypervis_subcycle,1,MPIinteger_t   ,par%root,par%comm,ierr)
+    call MPI_bcast(horiz_turb_subcycle,1,MPIinteger_t   ,par%root,par%comm,ierr)
     call MPI_bcast(hypervis_subcycle_tom,1,MPIinteger_t   ,par%root,par%comm,ierr)
     call MPI_bcast(hypervis_subcycle_q,1,MPIinteger_t   ,par%root,par%comm,ierr)
+    call MPI_bcast(horiz_turb_subcycle_q,1,MPIinteger_t   ,par%root,par%comm,ierr)
     call MPI_bcast(smooth_phis_numcycle,1,MPIinteger_t   ,par%root,par%comm,ierr)
     call MPI_bcast(smooth_phis_p2filt,1,MPIinteger_t   ,par%root,par%comm,ierr)
     call MPI_bcast(smooth_phis_nudt,1,MPIreal_t   ,par%root,par%comm,ierr)
@@ -961,6 +967,8 @@ use physical_constants, only : Sx, Sy, Lx, Ly, dx, dy, dx_ref, dy_ref
           call abortmp('hypervis_subcycle auto determine only supported for nv==4 and topology==cube')
        endif
     endif
+    if (horiz_turb_subcycle == -1) horiz_turb_subcycle = hypervis_subcycle
+    if (horiz_turb_subcycle_q < 0) horiz_turb_subcycle_q = hypervis_subcycle_q
 #endif
     ! set defautl for dynamics remap
     if (vert_remap_u_alg == -2) vert_remap_u_alg = vert_remap_q_alg
@@ -1229,8 +1237,10 @@ end if
        endif
 
        write(iulog,*)"hypervis_subcycle     = ",hypervis_subcycle
+       write(iulog,*)"horiz_turb_subcycle = ",horiz_turb_subcycle
        write(iulog,*)"hypervis_subcycle_tom = ",hypervis_subcycle_tom
        write(iulog,*)"hypervis_subcycle_q   = ",hypervis_subcycle_q
+       write(iulog,*)"horiz_turb_subcycle_q = ",horiz_turb_subcycle_q
        write(iulog,'(a,2e9.2)')"viscosity:  nu (vor/div) = ",nu,nu_div
        write(iulog,'(a,2e9.2)')"viscosity:  nu_s      = ",nu_s
        write(iulog,'(a,2e9.2)')"viscosity:  nu_q      = ",nu_q

--- a/components/homme/src/share/sl_advection.F90
+++ b/components/homme/src/share/sl_advection.F90
@@ -193,16 +193,16 @@ contains
 #endif
   end subroutine sl_init1
 
-  subroutine sl_get_params(nu_q_out, hv_scaling, hv_q, hv_subcycle_q, limiter_option_out, &
+  subroutine sl_get_params(nu_q_out, hv_scaling, hv_q, hv_subcycle_q, hv_subcycle_q_sgs, limiter_option_out, &
        cdr_check, geometry_type, trajectory_nsubstep, trajectory_nvelocity, diagnostics, &
        do_3d_turbulence_out) bind(c)
-    use control_mod, only: semi_lagrange_hv_q, hypervis_subcycle_q, semi_lagrange_cdr_check, &
+    use control_mod, only: semi_lagrange_hv_q, hypervis_subcycle_q, horiz_turb_subcycle_q, semi_lagrange_cdr_check, &
          nu_q, hypervis_scaling, limiter_option, geometry, semi_lagrange_trajectory_nsubstep, &
          semi_lagrange_trajectory_nvelocity, semi_lagrange_diagnostics, do_3d_turbulence
     use iso_c_binding, only: c_int, c_double, c_bool
 
     real(c_double), intent(out) :: nu_q_out, hv_scaling
-    integer(c_int), intent(out) :: hv_q, hv_subcycle_q, limiter_option_out, cdr_check, &
+    integer(c_int), intent(out) :: hv_q, hv_subcycle_q, hv_subcycle_q_sgs, limiter_option_out, cdr_check, &
          geometry_type, trajectory_nsubstep, trajectory_nvelocity, diagnostics
     logical(c_bool), intent(out) :: do_3d_turbulence_out
 
@@ -210,6 +210,7 @@ contains
     hv_scaling = hypervis_scaling
     hv_q = semi_lagrange_hv_q
     hv_subcycle_q = hypervis_subcycle_q
+    hv_subcycle_q_sgs = horiz_turb_subcycle_q
     limiter_option_out = limiter_option
     cdr_check = 0
     if (semi_lagrange_cdr_check) cdr_check = 1

--- a/components/homme/src/theta-l_kokkos/cxx/HyperviscosityFunctorImpl.cpp
+++ b/components/homme/src/theta-l_kokkos/cxx/HyperviscosityFunctorImpl.cpp
@@ -27,6 +27,7 @@ constexpr Real sgs_clip_cfl_target = 1.00;
 
 constexpr Real get_lambda_vis ()
 {
+  // Element-order-dependent stability factor for the discrete Laplacian.
   switch (NP) {
   case 2: return 12.0;
   case 3: return 30.0;
@@ -42,6 +43,8 @@ KOKKOS_INLINE_FUNCTION
 Real get_local_laplace_metric (const Real a, const Real b, const Real c, const Real d,
                                const Real lambda_vis, const Real scale_factor_inv)
 {
+  // Estimate the largest mapped Laplacian eigenvalue at this GLL point so the
+  // local SGS diffusivity can be compared against a CFL limit.
   const Real s11 = a*a + c*c;
   const Real s22 = b*b + d*d;
   const Real s12 = a*b + c*d;
@@ -689,6 +692,8 @@ void HyperviscosityFunctorImpl::operator() (const TagSGSTurbLaplace&, const Team
         const Real d = dinv(kv.ie,1,1,igp,jgp);
         const Real laplace_metric = get_local_laplace_metric(a, b, c, d, lambda_vis, scale_factor_inv);
         if (laplace_metric > 0) {
+          // Convert the local Laplacian metric into the largest midpoint
+          // diffusivity allowed by the explicit SGS CFL target.
           max_diffusivity = 2.0 * sgs_clip_cfl_target / (m_data.dt_hvs_sgs * laplace_metric);
         }
       }
@@ -699,6 +704,8 @@ void HyperviscosityFunctorImpl::operator() (const TagSGSTurbLaplace&, const Team
           auto km = Km(k);
           auto kh = Kh(k);
           if (m_data.horiz_turb_subcycle > 0) {
+            // Clip momentum and heat diffusivities before applying the SGS
+            // Laplacian tendency at this element/GLL point.
             for (int s = 0; s < VECTOR_SIZE; ++s) {
               if (km[s] > max_diffusivity) km[s] = max_diffusivity;
               if (kh[s] > max_diffusivity) kh[s] = max_diffusivity;

--- a/components/homme/src/theta-l_kokkos/cxx/HyperviscosityFunctorImpl.cpp
+++ b/components/homme/src/theta-l_kokkos/cxx/HyperviscosityFunctorImpl.cpp
@@ -27,6 +27,7 @@ constexpr Real sgs_clip_cfl_target = 1.00;
 
 constexpr Real get_lambda_vis ()
 {
+  // Element-order-dependent stability factor for the discrete Laplacian.
   switch (NP) {
   case 2: return 12.0;
   case 3: return 30.0;
@@ -42,6 +43,8 @@ KOKKOS_INLINE_FUNCTION
 Real get_local_laplace_metric (const Real a, const Real b, const Real c, const Real d,
                                const Real lambda_vis, const Real scale_factor_inv)
 {
+  // Estimate the largest mapped Laplacian eigenvalue at this GLL point so the
+  // local SGS diffusivity can be compared against a CFL limit.
   const Real s11 = a*a + c*c;
   const Real s22 = b*b + d*d;
   const Real s12 = a*b + c*d;
@@ -775,6 +778,8 @@ void HyperviscosityFunctorImpl::operator() (const TagSGSTurbLaplace&, const Team
         const Real d = dinv(kv.ie,1,1,igp,jgp);
         const Real laplace_metric = get_local_laplace_metric(a, b, c, d, lambda_vis, scale_factor_inv);
         if (laplace_metric > 0) {
+          // Convert the local Laplacian metric into the largest midpoint
+          // diffusivity allowed by the explicit SGS CFL target.
           max_diffusivity = 2.0 * sgs_clip_cfl_target / (m_data.dt_hvs_sgs * laplace_metric);
         }
       }
@@ -785,6 +790,8 @@ void HyperviscosityFunctorImpl::operator() (const TagSGSTurbLaplace&, const Team
           auto km = Km(k);
           auto kh = Kh(k);
           if (m_data.horiz_turb_subcycle > 0) {
+            // Clip momentum and heat diffusivities before applying the SGS
+            // Laplacian tendency at this element/GLL point.
             for (int s = 0; s < VECTOR_SIZE; ++s) {
               if (km[s] > max_diffusivity) km[s] = max_diffusivity;
               if (kh[s] > max_diffusivity) kh[s] = max_diffusivity;

--- a/components/homme/src/theta-l_kokkos/cxx/HyperviscosityFunctorImpl.cpp
+++ b/components/homme/src/theta-l_kokkos/cxx/HyperviscosityFunctorImpl.cpp
@@ -800,7 +800,6 @@ void HyperviscosityFunctorImpl::operator() (const TagSGSTurbLaplace&, const Team
           Km_clip(k) = km;
           Kh_clip(k) = kh;
         });
-      kv.team_barrier();
 
       if (m_process_nh_vars) {
         wtens   = Homme::subview(m_buffers.wtens,kv.ie,igp,jgp);

--- a/components/homme/src/theta-l_kokkos/cxx/HyperviscosityFunctorImpl.cpp
+++ b/components/homme/src/theta-l_kokkos/cxx/HyperviscosityFunctorImpl.cpp
@@ -714,7 +714,6 @@ void HyperviscosityFunctorImpl::operator() (const TagSGSTurbLaplace&, const Team
           Km_clip(k) = km;
           Kh_clip(k) = kh;
         });
-      kv.team_barrier();
 
       if (m_process_nh_vars) {
         wtens   = Homme::subview(m_buffers.wtens,kv.ie,igp,jgp);

--- a/components/homme/src/theta-l_kokkos/cxx/HyperviscosityFunctorImpl.cpp
+++ b/components/homme/src/theta-l_kokkos/cxx/HyperviscosityFunctorImpl.cpp
@@ -15,8 +15,43 @@
 #include "mpi/MpiBuffersManager.hpp"
 #include "mpi/Connectivity.hpp"
 
+#include <cmath>
+#include <limits>
+
 namespace Homme
 {
+
+namespace {
+
+constexpr Real sgs_clip_cfl_target = 1.00;
+
+constexpr Real get_lambda_vis ()
+{
+  switch (NP) {
+  case 2: return 12.0;
+  case 3: return 30.0;
+  case 4: return 91.6742;
+  case 5: return 190.1176;
+  case 6: return 374.7788;
+  case 7: return 652.3015;
+  default: return 0.0;
+  }
+}
+
+KOKKOS_INLINE_FUNCTION
+Real get_local_laplace_metric (const Real a, const Real b, const Real c, const Real d,
+                               const Real lambda_vis, const Real scale_factor_inv)
+{
+  const Real s11 = a*a + c*c;
+  const Real s22 = b*b + d*d;
+  const Real s12 = a*b + c*d;
+  const Real disc = (s11 - s22)*(s11 - s22) + 4.0*s12*s12;
+  const Real max_eig = 0.5 * (s11 + s22 + std::sqrt(disc));
+  const Real norm_dinv = std::sqrt(max_eig);
+  return lambda_vis * (scale_factor_inv * norm_dinv) * (scale_factor_inv * norm_dinv);
+}
+
+} // anonymous namespace
 
 HyperviscosityFunctorImpl::
 HyperviscosityFunctorImpl (const SimulationParams&     params,
@@ -24,7 +59,8 @@ HyperviscosityFunctorImpl (const SimulationParams&     params,
                            const ElementsState&        state,
                            const ElementsDerivedState& derived)
  : m_num_elems(state.num_elems())
- , m_data (params.hypervis_subcycle,params.hypervis_subcycle_tom,
+ , m_data (params.hypervis_subcycle,params.horiz_turb_subcycle,
+           params.hypervis_subcycle_tom,
            params.nu_ratio1,params.nu_ratio2,params.nu_top,params.nu,
            params.nu_p,params.nu_s,params.hypervis_scaling,
            params.do_3d_turbulence, params.tom_sponge_start, params.laplace_scaling)
@@ -50,7 +86,8 @@ HyperviscosityFunctorImpl (const SimulationParams&     params,
 HyperviscosityFunctorImpl::
 HyperviscosityFunctorImpl (const int num_elems, const SimulationParams &params)
   : m_num_elems(num_elems)
-  , m_data (params.hypervis_subcycle,params.hypervis_subcycle_tom,
+  , m_data (params.hypervis_subcycle,params.horiz_turb_subcycle,
+            params.hypervis_subcycle_tom,
             params.nu_ratio1,params.nu_ratio2,params.nu_top,params.nu,
             params.nu_p,params.nu_s,params.hypervis_scaling,
             params.do_3d_turbulence, params.tom_sponge_start, params.laplace_scaling)
@@ -70,6 +107,8 @@ void HyperviscosityFunctorImpl::init_params(const SimulationParams& params)
 {
   // Sanity check
   assert(params.params_set);
+  assert(!m_data.do_3d_turbulence || m_data.horiz_turb_subcycle > 0);
+
   // tom_sponge_start is now stored in m_data
   //NOTE: we are missing the part of the block that computes m_nu_scale_top using tom_sponge_start.
   // As of 04/29/2026 we decided not to move this missing computation from
@@ -172,7 +211,7 @@ int HyperviscosityFunctorImpl::requested_buffer_size () const {
 
   // Number of scalar/vector int/mid buffers needed, with size nelems
   const int mid_vectors_nelems = 1;
-  const int int_scalars_nelems = 0 + (m_process_nh_vars ? 2 : 0);
+  const int int_scalars_nelems = 0 + (m_process_nh_vars ? 1 : 0);
   const int mid_scalars_nelems = 2 + (m_process_nh_vars ? 2 : 0);
 
   const int size = m_num_elems*(mid_scalars_nelems*size_mid_scalar +
@@ -206,9 +245,6 @@ void HyperviscosityFunctorImpl::init_buffers (const FunctorsBuffersManager& fbm)
 
     m_buffers.phitens = decltype(m_buffers.phitens)(mem,nelems);
     mem += size_mid_scalar*nelems;
-
-    m_buffers.turb_diff_heat_i = decltype(m_buffers.turb_diff_heat_i)(mem,nelems);
-    mem += size_int_scalar*nelems;
 
     m_buffers.turb_diff_mom_i = decltype(m_buffers.turb_diff_mom_i)(mem,nelems);
     mem += size_int_scalar*nelems;
@@ -246,16 +282,17 @@ void HyperviscosityFunctorImpl::init_boundary_exchanges () {
     be->set_diagnostics_level(sp.internal_diagnostics_level);
     const auto nlev = nlevs[i];
     be->set_buffers_manager(bm_exchange);
+    const bool is_sgs = i == 2;
     if (m_process_nh_vars) {
-      be->set_num_fields(0, 0, 6);
+      be->set_num_fields(0, 0, is_sgs ? 4 : 6);
     } else {
-      be->set_num_fields(0, 0, 4);
+      be->set_num_fields(0, 0, is_sgs ? 3 : 4);
     }
-    be->register_field(m_buffers.dptens, nlev);
+    if (!is_sgs) be->register_field(m_buffers.dptens, nlev);
     be->register_field(m_buffers.ttens, nlev);
     if (m_process_nh_vars) {
       be->register_field(m_buffers.wtens, nlev);
-      be->register_field(m_buffers.phitens, nlev);
+      if (!is_sgs) be->register_field(m_buffers.phitens, nlev);
     }
     be->register_field(m_buffers.vtens, 2, 0, nlev);
     be->registration_completed();
@@ -267,18 +304,16 @@ void HyperviscosityFunctorImpl::run (const int np1, const Real dt, const Real et
   m_data.np1 = np1;
 
   m_data.dt = dt;
-  if (m_data.hypervis_subcycle > 0) { 
-    m_data.dt_hvs = dt/m_data.hypervis_subcycle;
-  }else{
-    //won't be used
-    m_data.dt_hvs = -1.0;
-  }
+  m_data.dt_hvs = dt/m_data.hypervis_subcycle;
   if (m_data.hypervis_subcycle_tom > 0) { 
     m_data.dt_hvs_tom = dt/m_data.hypervis_subcycle_tom;
   }else{
     //won't be used
     m_data.dt_hvs_tom = -1.0;
   }
+  m_data.dt_hvs_sgs = m_data.do_3d_turbulence
+                    ? dt/m_data.horiz_turb_subcycle
+                    : -1.0;
   m_data.eta_ave_w = eta_ave_w;
 
   // Convert vtheta_dp -> theta
@@ -324,12 +359,12 @@ void HyperviscosityFunctorImpl::run (const int np1, const Real dt, const Real et
 
   // SGS Horizontal turbulent diffusion
   if (m_data.do_3d_turbulence > 0) {
-    for (int icycle = 0; icycle < m_data.hypervis_subcycle; ++icycle) {
+    for (int icycle = 0; icycle < m_data.horiz_turb_subcycle; ++icycle) {
       // laplace(fields) --> ttens, etc.
       Kokkos::parallel_for(m_policy_sgsturb_laplace, *this);
       Kokkos::fence();
 
-      // exchange is done on ttens, dptens, vtens, etc.
+      // Exchange the velocity, temperature, and vertical-velocity tendencies.
       assert (m_be_sgs->is_registration_completed());
       GPTLstart("sgsturb-bexch");
       m_be_sgs->exchange();
@@ -657,6 +692,8 @@ void HyperviscosityFunctorImpl::operator() (const TagSGSTurbLaplace&, const Team
 
   using MidColumn = decltype(Homme::subview(m_buffers.wtens,0,0,0));
   using IntColumn = decltype(Homme::subview(m_state.m_w_i,0,0,0,0));
+  const Real lambda_vis = get_lambda_vis();
+  const Real scale_factor_inv = 1.0 / m_geometry.m_scale_factor;
 
   Kokkos::parallel_for(Kokkos::TeamThreadRange(kv.team,NP*NP),
                        [&](const int idx) {
@@ -664,51 +701,16 @@ void HyperviscosityFunctorImpl::operator() (const TagSGSTurbLaplace&, const Team
     const int jgp = idx % NP;
 
     auto vtheta = Homme::subview(m_state.m_vtheta_dp,kv.ie,m_data.np1,igp,jgp);
-    auto dp = Homme::subview(m_state.m_dp3d,kv.ie,m_data.np1,igp,jgp);
     auto theta_ref = Homme::subview(m_state.m_ref_states.theta_ref,kv.ie,igp,jgp);
-    auto dp_ref = Homme::subview(m_state.m_ref_states.dp_ref,kv.ie,igp,jgp);
 
     Kokkos::parallel_for(Kokkos::ThreadVectorRange(kv.team,NUM_LEV),
                          [&](const int ilev) {
       vtheta(ilev) -= theta_ref(ilev);
-      dp(ilev) -= dp_ref(ilev);
     });
   });
 
   kv.team_barrier();
 
-  if (m_process_nh_vars) {
-    // Diffuse only the perturbational geopotential, not the terrain-following
-    // reference profile tied to phis.
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(kv.team,NP*NP),
-                         [&](const int idx) {
-      const int igp = idx / NP;
-      const int jgp = idx % NP;
-
-      auto phi_i = Homme::subview(m_state.m_phinh_i,kv.ie,m_data.np1,igp,jgp);
-      auto phi_i_ref = Homme::subview(m_state.m_ref_states.phi_i_ref,kv.ie,igp,jgp);
-
-      Kokkos::parallel_for(Kokkos::ThreadVectorRange(kv.team,NUM_LEV),
-                           [&](const int ilev) {
-        phi_i(ilev) -= phi_i_ref(ilev);
-      });
-
-#ifndef XX_NONBFB_COMING
-      if (NUM_LEV!=NUM_LEV_P) {
-        Kokkos::single(Kokkos::PerThread(kv.team),[&](){
-          phi_i(NUM_LEV_P-1) -= phi_i_ref(NUM_LEV_P-1);
-        });
-      }
-#endif
-    });
-
-    kv.team_barrier();
-  }
-
-  // Laplacian of layer thickness
-  m_sphere_ops.laplace_simple(kv,
-                              Homme::subview(m_state.m_dp3d,kv.ie,m_data.np1),
-                              Homme::subview(m_buffers.dptens,kv.ie));
   // Laplacian of theta
   m_sphere_ops.laplace_simple(kv,
                               Homme::subview(m_state.m_vtheta_dp,kv.ie,m_data.np1),
@@ -718,10 +720,6 @@ void HyperviscosityFunctorImpl::operator() (const TagSGSTurbLaplace&, const Team
     m_sphere_ops.laplace_simple<NUM_LEV,NUM_LEV_P>(kv,
                                                    Homme::subview(m_state.m_w_i,kv.ie,m_data.np1),
                                                    Homme::subview(m_buffers.wtens,kv.ie));
-    // Laplacian of geopotential
-    m_sphere_ops.laplace_simple<NUM_LEV,NUM_LEV_P>(kv,
-                                                   Homme::subview(m_state.m_phinh_i,kv.ie,m_data.np1),
-                                                   Homme::subview(m_buffers.phitens,kv.ie));
   }
 
   // Laplacian of velocity
@@ -732,46 +730,17 @@ void HyperviscosityFunctorImpl::operator() (const TagSGSTurbLaplace&, const Team
 
   kv.team_barrier();
 
-  if (m_process_nh_vars) {
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(kv.team,NP*NP),
-                         [&](const int idx) {
-      const int igp = idx / NP;
-      const int jgp = idx % NP;
-
-      auto phi_i = Homme::subview(m_state.m_phinh_i,kv.ie,m_data.np1,igp,jgp);
-      auto phi_i_ref = Homme::subview(m_state.m_ref_states.phi_i_ref,kv.ie,igp,jgp);
-
-      Kokkos::parallel_for(Kokkos::ThreadVectorRange(kv.team,NUM_LEV),
-                           [&](const int ilev) {
-        phi_i(ilev) += phi_i_ref(ilev);
-      });
-
-#ifndef XX_NONBFB_COMING
-      if (NUM_LEV!=NUM_LEV_P) {
-        Kokkos::single(Kokkos::PerThread(kv.team),[&](){
-          phi_i(NUM_LEV_P-1) += phi_i_ref(NUM_LEV_P-1);
-        });
-      }
-#endif
-    });
-
-    kv.team_barrier();
-  }
-
   Kokkos::parallel_for(Kokkos::TeamThreadRange(kv.team,NP*NP),
                        [&](const int idx) {
     const int igp = idx / NP;
     const int jgp = idx % NP;
 
     auto vtheta = Homme::subview(m_state.m_vtheta_dp,kv.ie,m_data.np1,igp,jgp);
-    auto dp = Homme::subview(m_state.m_dp3d,kv.ie,m_data.np1,igp,jgp);
     auto theta_ref = Homme::subview(m_state.m_ref_states.theta_ref,kv.ie,igp,jgp);
-    auto dp_ref = Homme::subview(m_state.m_ref_states.dp_ref,kv.ie,igp,jgp);
 
     Kokkos::parallel_for(Kokkos::ThreadVectorRange(kv.team,NUM_LEV),
                          [&](const int ilev) {
       vtheta(ilev) += theta_ref(ilev);
-      dp(ilev) += dp_ref(ilev);
     });
   });
 
@@ -786,43 +755,69 @@ void HyperviscosityFunctorImpl::operator() (const TagSGSTurbLaplace&, const Team
       const auto utens  = Homme::subview(m_buffers.vtens,kv.ie,0,igp,jgp);
       const auto vtens  = Homme::subview(m_buffers.vtens,kv.ie,1,igp,jgp);
       const auto ttens  = Homme::subview(m_buffers.ttens,kv.ie,igp,jgp);
-      const auto dptens = Homme::subview(m_buffers.dptens,kv.ie,igp,jgp);
 
-      auto Km = Homme::subview(m_derived.m_turb_diff_mom,kv.ie,igp,jgp);
-      auto Kh = Homme::subview(m_derived.m_turb_diff_heat,kv.ie,igp,jgp);
+      const auto Km = Homme::subview(m_derived.m_turb_diff_mom,kv.ie,igp,jgp);
+      const auto Kh = Homme::subview(m_derived.m_turb_diff_heat,kv.ie,igp,jgp);
+      Scalar km_clip_buf[NUM_LEV];
+      Scalar kh_clip_buf[NUM_LEV];
+      MidColumn Km_clip(km_clip_buf);
+      MidColumn Kh_clip(kh_clip_buf);
 
-      MidColumn wtens, phitens;
-      IntColumn Km_i, Kh_i;
+      MidColumn wtens;
+      IntColumn Km_i;
+
+      Real max_diffusivity = std::numeric_limits<Real>::max();
+      if (m_data.horiz_turb_subcycle > 0 && lambda_vis > 0 && m_data.dt_hvs_sgs > 0) {
+        const auto& dinv = m_geometry.m_dinv;
+        const Real a = dinv(kv.ie,0,0,igp,jgp);
+        const Real b = dinv(kv.ie,0,1,igp,jgp);
+        const Real c = dinv(kv.ie,1,0,igp,jgp);
+        const Real d = dinv(kv.ie,1,1,igp,jgp);
+        const Real laplace_metric = get_local_laplace_metric(a, b, c, d, lambda_vis, scale_factor_inv);
+        if (laplace_metric > 0) {
+          max_diffusivity = 2.0 * sgs_clip_cfl_target / (m_data.dt_hvs_sgs * laplace_metric);
+        }
+      }
+
+      Kokkos::parallel_for(
+        Kokkos::ThreadVectorRange(kv.team, NUM_LEV),
+        [&] (const int k) {
+          auto km = Km(k);
+          auto kh = Kh(k);
+          if (m_data.horiz_turb_subcycle > 0) {
+            for (int s = 0; s < VECTOR_SIZE; ++s) {
+              if (km[s] > max_diffusivity) km[s] = max_diffusivity;
+              if (kh[s] > max_diffusivity) kh[s] = max_diffusivity;
+            }
+          }
+          Km_clip(k) = km;
+          Kh_clip(k) = kh;
+        });
+      kv.team_barrier();
+
       if (m_process_nh_vars) {
         wtens   = Homme::subview(m_buffers.wtens,kv.ie,igp,jgp);
-        phitens = Homme::subview(m_buffers.phitens,kv.ie,igp,jgp);
 
         // Diffusivities on the interface grid
         Km_i = Homme::subview(m_buffers.turb_diff_mom_i,kv.ie,igp,jgp);
-        Kh_i = Homme::subview(m_buffers.turb_diff_heat_i,kv.ie,igp,jgp);
 
-        // Get diffusivities on the interface vertical grid from those
-        //  on the mid-point grid that were passed from physics
-        ColumnOps::compute_interface_values(kv, Km, Km_i);
-        ColumnOps::compute_interface_values(kv, Kh, Kh_i);
+        // Get interface diffusivities from the locally clipped midpoint values.
+        ColumnOps::compute_interface_values(kv, Km_clip, Km_i);
       }
 
       Kokkos::parallel_for(
         Kokkos::ThreadVectorRange(kv.team, NUM_LEV),
         [&] (const int k) {
 
-          const auto xf_m = m_data.dt_hvs * Km(k); // Momentum diffusivity
-          const auto xf_h = m_data.dt_hvs * Kh(k); // Heat diffusivity
+          const auto xf_m = m_data.dt_hvs_sgs * Km_clip(k); // Momentum diffusivity
+          const auto xf_h = m_data.dt_hvs_sgs * Kh_clip(k); // Heat diffusivity
           utens(k)  *= xf_m;
           vtens(k)  *= xf_m;
           ttens(k)  *= xf_h;
-          dptens(k) *= xf_h;
 
           if (m_process_nh_vars) {
-            const auto xf_mi = m_data.dt_hvs * Km_i(k); // Momentum diffusivity on interface
-            const auto xf_hi = m_data.dt_hvs * Kh_i(k); // Heat diffusivity on interface
+            const auto xf_mi = m_data.dt_hvs_sgs * Km_i(k); // Momentum diffusivity on interface
             wtens(k)   *= xf_mi;
-            phitens(k) *= xf_hi;
           }
 
         }); // threadvectorrange
@@ -846,22 +841,18 @@ void HyperviscosityFunctorImpl::operator() (const TagSGSTurbUpdateStates&, const
     auto u = Homme::subview(m_state.m_v,kv.ie,m_data.np1,0,igp,jgp);
     auto v = Homme::subview(m_state.m_v,kv.ie,m_data.np1,1,igp,jgp);
     auto vtheta = Homme::subview(m_state.m_vtheta_dp,kv.ie,m_data.np1,igp,jgp);
-    auto dp     = Homme::subview(m_state.m_dp3d,kv.ie,m_data.np1,igp,jgp);
 
     auto utens   = Homme::subview(m_buffers.vtens,kv.ie,0,igp,jgp);
     auto vtens   = Homme::subview(m_buffers.vtens,kv.ie,1,igp,jgp);
     auto ttens   = Homme::subview(m_buffers.ttens,kv.ie,igp,jgp);
-    auto dptens  = Homme::subview(m_buffers.dptens,kv.ie,igp,jgp);
     const auto& rspheremp = m_geometry.m_rspheremp(kv.ie,igp,jgp);
 
-    MidColumn wtens, phitens;
-    IntColumn w, phi_i;
+    MidColumn wtens;
+    IntColumn w;
 
     if (m_process_nh_vars) {
       wtens   = Homme::subview(m_buffers.wtens,kv.ie,igp,jgp);
-      phitens = Homme::subview(m_buffers.phitens,kv.ie,igp,jgp);
       w       = Homme::subview(m_state.m_w_i,kv.ie,m_data.np1,igp,jgp);
-      phi_i   = Homme::subview(m_state.m_phinh_i,kv.ie,m_data.np1,igp,jgp);
     }
 
     Kokkos::parallel_for(Kokkos::ThreadVectorRange(kv.team, NUM_LEV),
@@ -869,17 +860,13 @@ void HyperviscosityFunctorImpl::operator() (const TagSGSTurbUpdateStates&, const
       utens(k)   *= rspheremp;
       vtens(k)   *= rspheremp;
       ttens(k)   *= rspheremp;
-      dptens(k)  *= rspheremp;
       u(k)      += utens(k);
       v(k)      += vtens(k);
       vtheta(k) += ttens(k);
-      dp(k)     += dptens(k);
 
       if (m_process_nh_vars) {
         wtens(k)   *= rspheremp;
-        phitens(k) *= rspheremp;
         w(k)     += wtens(k);
-        phi_i(k) += phitens(k);
       }
 
     }); // threadvectorrange

--- a/components/homme/src/theta-l_kokkos/cxx/HyperviscosityFunctorImpl.cpp
+++ b/components/homme/src/theta-l_kokkos/cxx/HyperviscosityFunctorImpl.cpp
@@ -15,8 +15,43 @@
 #include "mpi/MpiBuffersManager.hpp"
 #include "mpi/Connectivity.hpp"
 
+#include <cmath>
+#include <limits>
+
 namespace Homme
 {
+
+namespace {
+
+constexpr Real sgs_clip_cfl_target = 1.00;
+
+constexpr Real get_lambda_vis ()
+{
+  switch (NP) {
+  case 2: return 12.0;
+  case 3: return 30.0;
+  case 4: return 91.6742;
+  case 5: return 190.1176;
+  case 6: return 374.7788;
+  case 7: return 652.3015;
+  default: return 0.0;
+  }
+}
+
+KOKKOS_INLINE_FUNCTION
+Real get_local_laplace_metric (const Real a, const Real b, const Real c, const Real d,
+                               const Real lambda_vis, const Real scale_factor_inv)
+{
+  const Real s11 = a*a + c*c;
+  const Real s22 = b*b + d*d;
+  const Real s12 = a*b + c*d;
+  const Real disc = (s11 - s22)*(s11 - s22) + 4.0*s12*s12;
+  const Real max_eig = 0.5 * (s11 + s22 + std::sqrt(disc));
+  const Real norm_dinv = std::sqrt(max_eig);
+  return lambda_vis * (scale_factor_inv * norm_dinv) * (scale_factor_inv * norm_dinv);
+}
+
+} // anonymous namespace
 
 HyperviscosityFunctorImpl::
 HyperviscosityFunctorImpl (const SimulationParams&     params,
@@ -24,7 +59,8 @@ HyperviscosityFunctorImpl (const SimulationParams&     params,
                            const ElementsState&        state,
                            const ElementsDerivedState& derived)
  : m_num_elems(state.num_elems())
- , m_data (params.hypervis_subcycle,params.hypervis_subcycle_tom,
+ , m_data (params.hypervis_subcycle,params.horiz_turb_subcycle,
+           params.hypervis_subcycle_tom,
            params.nu_ratio1,params.nu_ratio2,params.nu_top,params.nu,
            params.nu_p,params.nu_s,params.hypervis_scaling,
            params.do_3d_turbulence, params.tom_sponge_start)
@@ -51,7 +87,8 @@ HyperviscosityFunctorImpl (const SimulationParams&     params,
 HyperviscosityFunctorImpl::
 HyperviscosityFunctorImpl (const int num_elems, const SimulationParams &params)
   : m_num_elems(num_elems)
-  , m_data (params.hypervis_subcycle,params.hypervis_subcycle_tom,
+  , m_data (params.hypervis_subcycle,params.horiz_turb_subcycle,
+            params.hypervis_subcycle_tom,
             params.nu_ratio1,params.nu_ratio2,params.nu_top,params.nu,
             params.nu_p,params.nu_s,params.hypervis_scaling,
             params.do_3d_turbulence, params.tom_sponge_start)
@@ -72,6 +109,8 @@ void HyperviscosityFunctorImpl::init_params(const SimulationParams& params)
 {
   // Sanity check
   assert(params.params_set);
+  assert(!m_data.do_3d_turbulence || m_data.horiz_turb_subcycle > 0);
+
   // tom_sponge_start is now stored in m_data
   //NOTE: we are missing the part of the block that computes m_nu_scale_top using tom_sponge_start.
   // As of 04/29/2026 we decided not to move this missing computation from
@@ -174,7 +213,7 @@ int HyperviscosityFunctorImpl::requested_buffer_size () const {
 
   // Number of scalar/vector int/mid buffers needed, with size nelems
   const int mid_vectors_nelems = 1;
-  const int int_scalars_nelems = 0 + (m_process_nh_vars ? 2 : 0);
+  const int int_scalars_nelems = 0 + (m_process_nh_vars ? 1 : 0);
   const int mid_scalars_nelems = 2 + (m_process_nh_vars ? 2 : 0);
 
   const int size = m_num_elems*(mid_scalars_nelems*size_mid_scalar +
@@ -208,9 +247,6 @@ void HyperviscosityFunctorImpl::init_buffers (const FunctorsBuffersManager& fbm)
 
     m_buffers.phitens = decltype(m_buffers.phitens)(mem,nelems);
     mem += size_mid_scalar*nelems;
-
-    m_buffers.turb_diff_heat_i = decltype(m_buffers.turb_diff_heat_i)(mem,nelems);
-    mem += size_int_scalar*nelems;
 
     m_buffers.turb_diff_mom_i = decltype(m_buffers.turb_diff_mom_i)(mem,nelems);
     mem += size_int_scalar*nelems;
@@ -248,16 +284,17 @@ void HyperviscosityFunctorImpl::init_boundary_exchanges () {
     be->set_diagnostics_level(sp.internal_diagnostics_level);
     const auto nlev = nlevs[i];
     be->set_buffers_manager(bm_exchange);
+    const bool is_sgs = i == 2;
     if (m_process_nh_vars) {
-      be->set_num_fields(0, 0, 6);
+      be->set_num_fields(0, 0, is_sgs ? 4 : 6);
     } else {
-      be->set_num_fields(0, 0, 4);
+      be->set_num_fields(0, 0, is_sgs ? 3 : 4);
     }
-    be->register_field(m_buffers.dptens, nlev);
+    if (!is_sgs) be->register_field(m_buffers.dptens, nlev);
     be->register_field(m_buffers.ttens, nlev);
     if (m_process_nh_vars) {
       be->register_field(m_buffers.wtens, nlev);
-      be->register_field(m_buffers.phitens, nlev);
+      if (!is_sgs) be->register_field(m_buffers.phitens, nlev);
     }
     be->register_field(m_buffers.vtens, 2, 0, nlev);
     be->registration_completed();
@@ -269,18 +306,16 @@ void HyperviscosityFunctorImpl::run (const int np1, const Real dt, const Real et
   m_data.np1 = np1;
 
   m_data.dt = dt;
-  if (m_data.hypervis_subcycle > 0) { 
-    m_data.dt_hvs = dt/m_data.hypervis_subcycle;
-  }else{
-    //won't be used
-    m_data.dt_hvs = -1.0;
-  }
+  m_data.dt_hvs = dt/m_data.hypervis_subcycle;
   if (m_data.hypervis_subcycle_tom > 0) { 
     m_data.dt_hvs_tom = dt/m_data.hypervis_subcycle_tom;
   }else{
     //won't be used
     m_data.dt_hvs_tom = -1.0;
   }
+  m_data.dt_hvs_sgs = m_data.do_3d_turbulence
+                    ? dt/m_data.horiz_turb_subcycle
+                    : -1.0;
   m_data.eta_ave_w = eta_ave_w;
 
   // Convert vtheta_dp -> theta
@@ -326,12 +361,12 @@ void HyperviscosityFunctorImpl::run (const int np1, const Real dt, const Real et
 
   // SGS Horizontal turbulent diffusion
   if (m_data.do_3d_turbulence > 0) {
-    for (int icycle = 0; icycle < m_data.hypervis_subcycle; ++icycle) {
+    for (int icycle = 0; icycle < m_data.horiz_turb_subcycle; ++icycle) {
       // laplace(fields) --> ttens, etc.
       Kokkos::parallel_for(m_policy_sgsturb_laplace, *this);
       Kokkos::fence();
 
-      // exchange is done on ttens, dptens, vtens, etc.
+      // Exchange the velocity, temperature, and vertical-velocity tendencies.
       assert (m_be_sgs->is_registration_completed());
       GPTLstart("sgsturb-bexch");
       m_be_sgs->exchange();
@@ -571,6 +606,8 @@ void HyperviscosityFunctorImpl::operator() (const TagSGSTurbLaplace&, const Team
 
   using MidColumn = decltype(Homme::subview(m_buffers.wtens,0,0,0));
   using IntColumn = decltype(Homme::subview(m_state.m_w_i,0,0,0,0));
+  const Real lambda_vis = get_lambda_vis();
+  const Real scale_factor_inv = 1.0 / m_geometry.m_scale_factor;
 
   Kokkos::parallel_for(Kokkos::TeamThreadRange(kv.team,NP*NP),
                        [&](const int idx) {
@@ -578,51 +615,16 @@ void HyperviscosityFunctorImpl::operator() (const TagSGSTurbLaplace&, const Team
     const int jgp = idx % NP;
 
     auto vtheta = Homme::subview(m_state.m_vtheta_dp,kv.ie,m_data.np1,igp,jgp);
-    auto dp = Homme::subview(m_state.m_dp3d,kv.ie,m_data.np1,igp,jgp);
     auto theta_ref = Homme::subview(m_state.m_ref_states.theta_ref,kv.ie,igp,jgp);
-    auto dp_ref = Homme::subview(m_state.m_ref_states.dp_ref,kv.ie,igp,jgp);
 
     Kokkos::parallel_for(Kokkos::ThreadVectorRange(kv.team,NUM_LEV),
                          [&](const int ilev) {
       vtheta(ilev) -= theta_ref(ilev);
-      dp(ilev) -= dp_ref(ilev);
     });
   });
 
   kv.team_barrier();
 
-  if (m_process_nh_vars) {
-    // Diffuse only the perturbational geopotential, not the terrain-following
-    // reference profile tied to phis.
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(kv.team,NP*NP),
-                         [&](const int idx) {
-      const int igp = idx / NP;
-      const int jgp = idx % NP;
-
-      auto phi_i = Homme::subview(m_state.m_phinh_i,kv.ie,m_data.np1,igp,jgp);
-      auto phi_i_ref = Homme::subview(m_state.m_ref_states.phi_i_ref,kv.ie,igp,jgp);
-
-      Kokkos::parallel_for(Kokkos::ThreadVectorRange(kv.team,NUM_LEV),
-                           [&](const int ilev) {
-        phi_i(ilev) -= phi_i_ref(ilev);
-      });
-
-#ifndef XX_NONBFB_COMING
-      if (NUM_LEV!=NUM_LEV_P) {
-        Kokkos::single(Kokkos::PerThread(kv.team),[&](){
-          phi_i(NUM_LEV_P-1) -= phi_i_ref(NUM_LEV_P-1);
-        });
-      }
-#endif
-    });
-
-    kv.team_barrier();
-  }
-
-  // Laplacian of layer thickness
-  m_sphere_ops.laplace_simple(kv,
-                              Homme::subview(m_state.m_dp3d,kv.ie,m_data.np1),
-                              Homme::subview(m_buffers.dptens,kv.ie));
   // Laplacian of theta
   m_sphere_ops.laplace_simple(kv,
                               Homme::subview(m_state.m_vtheta_dp,kv.ie,m_data.np1),
@@ -632,10 +634,6 @@ void HyperviscosityFunctorImpl::operator() (const TagSGSTurbLaplace&, const Team
     m_sphere_ops.laplace_simple<NUM_LEV,NUM_LEV_P>(kv,
                                                    Homme::subview(m_state.m_w_i,kv.ie,m_data.np1),
                                                    Homme::subview(m_buffers.wtens,kv.ie));
-    // Laplacian of geopotential
-    m_sphere_ops.laplace_simple<NUM_LEV,NUM_LEV_P>(kv,
-                                                   Homme::subview(m_state.m_phinh_i,kv.ie,m_data.np1),
-                                                   Homme::subview(m_buffers.phitens,kv.ie));
   }
 
   // Laplacian of velocity
@@ -646,46 +644,17 @@ void HyperviscosityFunctorImpl::operator() (const TagSGSTurbLaplace&, const Team
 
   kv.team_barrier();
 
-  if (m_process_nh_vars) {
-    Kokkos::parallel_for(Kokkos::TeamThreadRange(kv.team,NP*NP),
-                         [&](const int idx) {
-      const int igp = idx / NP;
-      const int jgp = idx % NP;
-
-      auto phi_i = Homme::subview(m_state.m_phinh_i,kv.ie,m_data.np1,igp,jgp);
-      auto phi_i_ref = Homme::subview(m_state.m_ref_states.phi_i_ref,kv.ie,igp,jgp);
-
-      Kokkos::parallel_for(Kokkos::ThreadVectorRange(kv.team,NUM_LEV),
-                           [&](const int ilev) {
-        phi_i(ilev) += phi_i_ref(ilev);
-      });
-
-#ifndef XX_NONBFB_COMING
-      if (NUM_LEV!=NUM_LEV_P) {
-        Kokkos::single(Kokkos::PerThread(kv.team),[&](){
-          phi_i(NUM_LEV_P-1) += phi_i_ref(NUM_LEV_P-1);
-        });
-      }
-#endif
-    });
-
-    kv.team_barrier();
-  }
-
   Kokkos::parallel_for(Kokkos::TeamThreadRange(kv.team,NP*NP),
                        [&](const int idx) {
     const int igp = idx / NP;
     const int jgp = idx % NP;
 
     auto vtheta = Homme::subview(m_state.m_vtheta_dp,kv.ie,m_data.np1,igp,jgp);
-    auto dp = Homme::subview(m_state.m_dp3d,kv.ie,m_data.np1,igp,jgp);
     auto theta_ref = Homme::subview(m_state.m_ref_states.theta_ref,kv.ie,igp,jgp);
-    auto dp_ref = Homme::subview(m_state.m_ref_states.dp_ref,kv.ie,igp,jgp);
 
     Kokkos::parallel_for(Kokkos::ThreadVectorRange(kv.team,NUM_LEV),
                          [&](const int ilev) {
       vtheta(ilev) += theta_ref(ilev);
-      dp(ilev) += dp_ref(ilev);
     });
   });
 
@@ -700,43 +669,69 @@ void HyperviscosityFunctorImpl::operator() (const TagSGSTurbLaplace&, const Team
       const auto utens  = Homme::subview(m_buffers.vtens,kv.ie,0,igp,jgp);
       const auto vtens  = Homme::subview(m_buffers.vtens,kv.ie,1,igp,jgp);
       const auto ttens  = Homme::subview(m_buffers.ttens,kv.ie,igp,jgp);
-      const auto dptens = Homme::subview(m_buffers.dptens,kv.ie,igp,jgp);
 
-      auto Km = Homme::subview(m_derived.m_turb_diff_mom,kv.ie,igp,jgp);
-      auto Kh = Homme::subview(m_derived.m_turb_diff_heat,kv.ie,igp,jgp);
+      const auto Km = Homme::subview(m_derived.m_turb_diff_mom,kv.ie,igp,jgp);
+      const auto Kh = Homme::subview(m_derived.m_turb_diff_heat,kv.ie,igp,jgp);
+      Scalar km_clip_buf[NUM_LEV];
+      Scalar kh_clip_buf[NUM_LEV];
+      MidColumn Km_clip(km_clip_buf);
+      MidColumn Kh_clip(kh_clip_buf);
 
-      MidColumn wtens, phitens;
-      IntColumn Km_i, Kh_i;
+      MidColumn wtens;
+      IntColumn Km_i;
+
+      Real max_diffusivity = std::numeric_limits<Real>::max();
+      if (m_data.horiz_turb_subcycle > 0 && lambda_vis > 0 && m_data.dt_hvs_sgs > 0) {
+        const auto& dinv = m_geometry.m_dinv;
+        const Real a = dinv(kv.ie,0,0,igp,jgp);
+        const Real b = dinv(kv.ie,0,1,igp,jgp);
+        const Real c = dinv(kv.ie,1,0,igp,jgp);
+        const Real d = dinv(kv.ie,1,1,igp,jgp);
+        const Real laplace_metric = get_local_laplace_metric(a, b, c, d, lambda_vis, scale_factor_inv);
+        if (laplace_metric > 0) {
+          max_diffusivity = 2.0 * sgs_clip_cfl_target / (m_data.dt_hvs_sgs * laplace_metric);
+        }
+      }
+
+      Kokkos::parallel_for(
+        Kokkos::ThreadVectorRange(kv.team, NUM_LEV),
+        [&] (const int k) {
+          auto km = Km(k);
+          auto kh = Kh(k);
+          if (m_data.horiz_turb_subcycle > 0) {
+            for (int s = 0; s < VECTOR_SIZE; ++s) {
+              if (km[s] > max_diffusivity) km[s] = max_diffusivity;
+              if (kh[s] > max_diffusivity) kh[s] = max_diffusivity;
+            }
+          }
+          Km_clip(k) = km;
+          Kh_clip(k) = kh;
+        });
+      kv.team_barrier();
+
       if (m_process_nh_vars) {
         wtens   = Homme::subview(m_buffers.wtens,kv.ie,igp,jgp);
-        phitens = Homme::subview(m_buffers.phitens,kv.ie,igp,jgp);
 
         // Diffusivities on the interface grid
         Km_i = Homme::subview(m_buffers.turb_diff_mom_i,kv.ie,igp,jgp);
-        Kh_i = Homme::subview(m_buffers.turb_diff_heat_i,kv.ie,igp,jgp);
 
-        // Get diffusivities on the interface vertical grid from those
-        //  on the mid-point grid that were passed from physics
-        ColumnOps::compute_interface_values(kv, Km, Km_i);
-        ColumnOps::compute_interface_values(kv, Kh, Kh_i);
+        // Get interface diffusivities from the locally clipped midpoint values.
+        ColumnOps::compute_interface_values(kv, Km_clip, Km_i);
       }
 
       Kokkos::parallel_for(
         Kokkos::ThreadVectorRange(kv.team, NUM_LEV),
         [&] (const int k) {
 
-          const auto xf_m = m_data.dt_hvs * Km(k); // Momentum diffusivity
-          const auto xf_h = m_data.dt_hvs * Kh(k); // Heat diffusivity
+          const auto xf_m = m_data.dt_hvs_sgs * Km_clip(k); // Momentum diffusivity
+          const auto xf_h = m_data.dt_hvs_sgs * Kh_clip(k); // Heat diffusivity
           utens(k)  *= xf_m;
           vtens(k)  *= xf_m;
           ttens(k)  *= xf_h;
-          dptens(k) *= xf_h;
 
           if (m_process_nh_vars) {
-            const auto xf_mi = m_data.dt_hvs * Km_i(k); // Momentum diffusivity on interface
-            const auto xf_hi = m_data.dt_hvs * Kh_i(k); // Heat diffusivity on interface
+            const auto xf_mi = m_data.dt_hvs_sgs * Km_i(k); // Momentum diffusivity on interface
             wtens(k)   *= xf_mi;
-            phitens(k) *= xf_hi;
           }
 
         }); // threadvectorrange
@@ -760,22 +755,18 @@ void HyperviscosityFunctorImpl::operator() (const TagSGSTurbUpdateStates&, const
     auto u = Homme::subview(m_state.m_v,kv.ie,m_data.np1,0,igp,jgp);
     auto v = Homme::subview(m_state.m_v,kv.ie,m_data.np1,1,igp,jgp);
     auto vtheta = Homme::subview(m_state.m_vtheta_dp,kv.ie,m_data.np1,igp,jgp);
-    auto dp     = Homme::subview(m_state.m_dp3d,kv.ie,m_data.np1,igp,jgp);
 
     auto utens   = Homme::subview(m_buffers.vtens,kv.ie,0,igp,jgp);
     auto vtens   = Homme::subview(m_buffers.vtens,kv.ie,1,igp,jgp);
     auto ttens   = Homme::subview(m_buffers.ttens,kv.ie,igp,jgp);
-    auto dptens  = Homme::subview(m_buffers.dptens,kv.ie,igp,jgp);
     const auto& rspheremp = m_geometry.m_rspheremp(kv.ie,igp,jgp);
 
-    MidColumn wtens, phitens;
-    IntColumn w, phi_i;
+    MidColumn wtens;
+    IntColumn w;
 
     if (m_process_nh_vars) {
       wtens   = Homme::subview(m_buffers.wtens,kv.ie,igp,jgp);
-      phitens = Homme::subview(m_buffers.phitens,kv.ie,igp,jgp);
       w       = Homme::subview(m_state.m_w_i,kv.ie,m_data.np1,igp,jgp);
-      phi_i   = Homme::subview(m_state.m_phinh_i,kv.ie,m_data.np1,igp,jgp);
     }
 
     Kokkos::parallel_for(Kokkos::ThreadVectorRange(kv.team, NUM_LEV),
@@ -783,17 +774,13 @@ void HyperviscosityFunctorImpl::operator() (const TagSGSTurbUpdateStates&, const
       utens(k)   *= rspheremp;
       vtens(k)   *= rspheremp;
       ttens(k)   *= rspheremp;
-      dptens(k)  *= rspheremp;
       u(k)      += utens(k);
       v(k)      += vtens(k);
       vtheta(k) += ttens(k);
-      dp(k)     += dptens(k);
 
       if (m_process_nh_vars) {
         wtens(k)   *= rspheremp;
-        phitens(k) *= rspheremp;
         w(k)     += wtens(k);
-        phi_i(k) += phitens(k);
       }
 
     }); // threadvectorrange

--- a/components/homme/src/theta-l_kokkos/cxx/HyperviscosityFunctorImpl.cpp
+++ b/components/homme/src/theta-l_kokkos/cxx/HyperviscosityFunctorImpl.cpp
@@ -25,6 +25,7 @@ namespace {
 
 constexpr Real sgs_clip_cfl_target = 1.00;
 
+KOKKOS_INLINE_FUNCTION
 constexpr Real get_lambda_vis ()
 {
   // Element-order-dependent stability factor for the discrete Laplacian.

--- a/components/homme/src/theta-l_kokkos/cxx/HyperviscosityFunctorImpl.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/HyperviscosityFunctorImpl.hpp
@@ -20,6 +20,7 @@
 
 #include "utilities/VectorUtils.hpp"
 
+#include <cmath>
 #include <memory>
 
 #include "profiling.hpp"
@@ -37,20 +38,24 @@ class HyperviscosityFunctorImpl
 public:
   struct HyperviscosityData {
     HyperviscosityData(const int hypervis_subcycle_in, 
+                       const int horiz_turb_subcycle_in,
                        const int hypervis_subcycle_tom_in, 
                        const Real nu_ratio1_in, const Real nu_ratio2_in, const Real nu_top_in,
                        const Real nu_in, const Real nu_p_in, const Real nu_s_in,
                        const Real hypervis_scaling_in, bool do_3d_turbulence_in,
                        const double tom_sponge_start_in)
                       : hypervis_subcycle(hypervis_subcycle_in) 
+                      , horiz_turb_subcycle(horiz_turb_subcycle_in)
                       , hypervis_subcycle_tom(hypervis_subcycle_tom_in)
                       , nu_ratio1(nu_ratio1_in), nu_ratio2(nu_ratio2_in)
                       , nu_top(nu_top_in), nu(nu_in), nu_p(nu_p_in), nu_s(nu_s_in)
+                      , dt_hvs(-1.0), dt_hvs_sgs(-1.0), dt_hvs_tom(-1.0)
                       , consthv(hypervis_scaling_in == 0)
                       , do_3d_turbulence(do_3d_turbulence_in)
                       , tom_sponge_start(tom_sponge_start_in) {}
 
     const int   hypervis_subcycle;
+    const int   horiz_turb_subcycle;
     const int   hypervis_subcycle_tom;
 
     bool do_3d_turbulence;
@@ -66,6 +71,7 @@ public:
     int         np1; // The time-level on which to apply hv
     Real        dt;
     Real        dt_hvs;
+    Real        dt_hvs_sgs;
     Real        dt_hvs_tom;
 
     Real        eta_ave_w;
@@ -82,7 +88,6 @@ public:
     ExecViewManaged<Scalar * [NP][NP][NUM_LEV]>    wtens;
     ExecViewManaged<Scalar * [NP][NP][NUM_LEV]>    phitens;
     ExecViewManaged<Scalar * [2][NP][NP][NUM_LEV]> vtens;
-    ExecViewManaged<Scalar * [NP][NP][NUM_LEV_P]>  turb_diff_heat_i;
     ExecViewManaged<Scalar * [NP][NP][NUM_LEV_P]>  turb_diff_mom_i;
   };//buffers
 

--- a/components/homme/src/theta-l_kokkos/cxx/HyperviscosityFunctorImpl.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/HyperviscosityFunctorImpl.hpp
@@ -20,6 +20,7 @@
 
 #include "utilities/VectorUtils.hpp"
 
+#include <cmath>
 #include <memory>
 
 #include "profiling.hpp"
@@ -37,21 +38,25 @@ class HyperviscosityFunctorImpl
 public:
   struct HyperviscosityData {
     HyperviscosityData(const int hypervis_subcycle_in, 
+                       const int horiz_turb_subcycle_in,
                        const int hypervis_subcycle_tom_in, 
                        const Real nu_ratio1_in, const Real nu_ratio2_in, const Real nu_top_in,
                        const Real nu_in, const Real nu_p_in, const Real nu_s_in,
                        const Real hypervis_scaling_in, bool do_3d_turbulence_in,
                        const double tom_sponge_start_in, const Real laplace_scaling_in = 0.0)
                       : hypervis_subcycle(hypervis_subcycle_in) 
+                      , horiz_turb_subcycle(horiz_turb_subcycle_in)
                       , hypervis_subcycle_tom(hypervis_subcycle_tom_in)
                       , nu_ratio1(nu_ratio1_in), nu_ratio2(nu_ratio2_in)
                       , nu_top(nu_top_in), nu(nu_in), nu_p(nu_p_in), nu_s(nu_s_in)
+                      , dt_hvs(-1.0), dt_hvs_sgs(-1.0), dt_hvs_tom(-1.0)
                       , consthv(hypervis_scaling_in == 0)
                       , constsponge(laplace_scaling_in == 0)
                       , do_3d_turbulence(do_3d_turbulence_in)
                       , tom_sponge_start(tom_sponge_start_in) {}
 
     const int   hypervis_subcycle;
+    const int   horiz_turb_subcycle;
     const int   hypervis_subcycle_tom;
 
     bool do_3d_turbulence;
@@ -67,6 +72,7 @@ public:
     int         np1; // The time-level on which to apply hv
     Real        dt;
     Real        dt_hvs;
+    Real        dt_hvs_sgs;
     Real        dt_hvs_tom;
 
     Real        eta_ave_w;
@@ -84,7 +90,6 @@ public:
     ExecViewManaged<Scalar * [NP][NP][NUM_LEV]>    wtens;
     ExecViewManaged<Scalar * [NP][NP][NUM_LEV]>    phitens;
     ExecViewManaged<Scalar * [2][NP][NP][NUM_LEV]> vtens;
-    ExecViewManaged<Scalar * [NP][NP][NUM_LEV_P]>  turb_diff_heat_i;
     ExecViewManaged<Scalar * [NP][NP][NUM_LEV_P]>  turb_diff_mom_i;
   };//buffers
 

--- a/components/homme/src/theta-l_kokkos/cxx/cxx_f90_interface_theta.cpp
+++ b/components/homme/src/theta-l_kokkos/cxx/cxx_f90_interface_theta.cpp
@@ -41,8 +41,8 @@ extern "C"
 void init_simulation_params_c (const int& remap_alg, const int& limiter_option, const int& rsplit, const int& qsplit,
                                const int& time_step_type, const int& qsize, const int& state_frequency,
                                const Real& nu, const Real& nu_p, const Real& nu_q, const Real& nu_s, const Real& nu_div, const Real& nu_top,
-                               const int& hypervis_order, const int& hypervis_subcycle, const int& hypervis_subcycle_tom,
-                               const double& hypervis_scaling, const double& laplace_scaling, const double& dcmip16_mu,
+                               const int& hypervis_order, const int& hypervis_subcycle, const int& horiz_turb_subcycle,
+                               const int& hypervis_subcycle_tom, const double& hypervis_scaling, const double& laplace_scaling, const double& dcmip16_mu,
                                const int& ftype, const int& theta_adv_form, const int& prescribed_wind, const int& use_moisture, const int& disable_diagnostics,
                                const int& use_cpstar, const int& transport_alg, const int& theta_hydrostatic_mode, const char** test_case,
                                const int& dt_remap_factor, const int& dt_tracer_factor,
@@ -56,6 +56,8 @@ void init_simulation_params_c (const int& remap_alg, const int& limiter_option, 
   // options in the C++ build, we will remove some checks
   Errors::check_option("init_simulation_params_c","vert_remap_q_alg",remap_alg,{1,3,10});
   Errors::check_option("init_simulation_params_c","hypervis_order",hypervis_order,{2});
+  Errors::check_option("init_simulation_params_c","hypervis_subcycle",hypervis_subcycle,0,Errors::ComparisonOp::GT);
+  Errors::check_option("init_simulation_params_c","horiz_turb_subcycle",horiz_turb_subcycle,0,Errors::ComparisonOp::GT);
   Errors::check_option("init_simulation_params_c","transport_alg",transport_alg,{0,12});
   Errors::check_option("init_simulation_params_c","time_step_type",time_step_type,{1,4,5,6,7,9,10});
   Errors::check_option("init_simulation_params_c","qsize",qsize,0,Errors::ComparisonOp::GE);
@@ -113,6 +115,7 @@ void init_simulation_params_c (const int& remap_alg, const int& limiter_option, 
   params.nu_top                        = nu_top;
   params.hypervis_order                = hypervis_order;
   params.hypervis_subcycle             = hypervis_subcycle;
+  params.horiz_turb_subcycle           = horiz_turb_subcycle;
   params.hypervis_subcycle_tom         = hypervis_subcycle_tom;
   params.hypervis_scaling              = hypervis_scaling;
   params.laplace_scaling               = laplace_scaling;

--- a/components/homme/src/theta-l_kokkos/cxx/cxx_f90_interface_theta.cpp
+++ b/components/homme/src/theta-l_kokkos/cxx/cxx_f90_interface_theta.cpp
@@ -41,7 +41,8 @@ extern "C"
 void init_simulation_params_c (const int& remap_alg, const int& limiter_option, const int& rsplit, const int& qsplit,
                                const int& time_step_type, const int& qsize, const int& state_frequency,
                                const Real& nu, const Real& nu_p, const Real& nu_q, const Real& nu_s, const Real& nu_div, const Real& nu_top,
-                               const int& hypervis_order, const int& hypervis_subcycle, const int& hypervis_subcycle_tom,
+                               const int& hypervis_order, const int& hypervis_subcycle, const int& horiz_turb_subcycle,
+                               const int& hypervis_subcycle_tom,
                                const double& hypervis_scaling, const double& dcmip16_mu,
                                const int& ftype, const int& theta_adv_form, const int& prescribed_wind, const int& use_moisture, const int& disable_diagnostics,
                                const int& use_cpstar, const int& transport_alg, const int& theta_hydrostatic_mode, const char** test_case,
@@ -56,6 +57,8 @@ void init_simulation_params_c (const int& remap_alg, const int& limiter_option, 
   // options in the C++ build, we will remove some checks
   Errors::check_option("init_simulation_params_c","vert_remap_q_alg",remap_alg,{1,3,10});
   Errors::check_option("init_simulation_params_c","hypervis_order",hypervis_order,{2});
+  Errors::check_option("init_simulation_params_c","hypervis_subcycle",hypervis_subcycle,0,Errors::ComparisonOp::GT);
+  Errors::check_option("init_simulation_params_c","horiz_turb_subcycle",horiz_turb_subcycle,0,Errors::ComparisonOp::GT);
   Errors::check_option("init_simulation_params_c","transport_alg",transport_alg,{0,12});
   Errors::check_option("init_simulation_params_c","time_step_type",time_step_type,{1,4,5,6,7,9,10});
   Errors::check_option("init_simulation_params_c","qsize",qsize,0,Errors::ComparisonOp::GE);
@@ -113,6 +116,7 @@ void init_simulation_params_c (const int& remap_alg, const int& limiter_option, 
   params.nu_top                        = nu_top;
   params.hypervis_order                = hypervis_order;
   params.hypervis_subcycle             = hypervis_subcycle;
+  params.horiz_turb_subcycle           = horiz_turb_subcycle;
   params.hypervis_subcycle_tom         = hypervis_subcycle_tom;
   params.hypervis_scaling              = hypervis_scaling;
   params.disable_diagnostics           = (bool)disable_diagnostics;

--- a/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
+++ b/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
@@ -85,7 +85,8 @@ contains
     use hybvcoord_mod, only : hvcoord_t
     use control_mod,   only : limiter_option, rsplit, qsplit, tstep_type, statefreq,   &
                               nu, nu_p, nu_q, nu_s, nu_div, nu_top, vert_remap_q_alg,  &
-                              hypervis_order, hypervis_subcycle, hypervis_subcycle_tom,&
+                              hypervis_order, hypervis_subcycle, horiz_turb_subcycle,&
+                              hypervis_subcycle_tom,                                    &
                               hypervis_scaling,                                        &
                               ftype, prescribed_wind, use_moisture, disable_diagnostics,   &
                               use_cpstar, transport_alg, theta_hydrostatic_mode,       &
@@ -128,7 +129,8 @@ contains
 
     call init_simulation_params_c (vert_remap_q_alg, limiter_option, rsplit, qsplit, tstep_type,  &
                                    qsize, statefreq, nu, nu_p, nu_q, nu_s, nu_div, nu_top,        &
-                                   hypervis_order, hypervis_subcycle, hypervis_subcycle_tom,      &
+                                   hypervis_order, hypervis_subcycle, horiz_turb_subcycle,      &
+                                   hypervis_subcycle_tom,                                          &
                                    hypervis_scaling,                                              &
                                    dcmip16_mu, ftype, theta_advect_form,                          &
                                    prescribed_wind,                                               &

--- a/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
+++ b/components/homme/src/theta-l_kokkos/prim_driver_mod.F90
@@ -92,8 +92,8 @@ contains
     use hybvcoord_mod, only : hvcoord_t
     use control_mod,   only : limiter_option, rsplit, qsplit, tstep_type, statefreq,   &
                               nu, nu_p, nu_q, nu_s, nu_div, nu_top, vert_remap_q_alg,  &
-                              hypervis_order, hypervis_subcycle, hypervis_subcycle_tom,&
-                              hypervis_scaling, laplace_scaling,                       &
+                              hypervis_order, hypervis_subcycle, horiz_turb_subcycle, &
+                              hypervis_subcycle_tom, hypervis_scaling, laplace_scaling, &
                               ftype, prescribed_wind, use_moisture, disable_diagnostics,   &
                               use_cpstar, transport_alg, theta_hydrostatic_mode,       &
                               dcmip16_mu, theta_advect_form, test_case,                &
@@ -135,8 +135,8 @@ contains
 
     call init_simulation_params_c (vert_remap_q_alg, limiter_option, rsplit, qsplit, tstep_type,  &
                                    qsize, statefreq, nu, nu_p, nu_q, nu_s, nu_div, nu_top,        &
-                                   hypervis_order, hypervis_subcycle, hypervis_subcycle_tom,      &
-                                   hypervis_scaling, laplace_scaling,                             &
+                                   hypervis_order, hypervis_subcycle, horiz_turb_subcycle,        &
+                                   hypervis_subcycle_tom, hypervis_scaling, laplace_scaling,      &
                                    dcmip16_mu, ftype, theta_advect_form,                          &
                                    prescribed_wind,                                               &
                                    use_moisture_int,                                              &

--- a/components/homme/src/theta-l_kokkos/theta_f2c_mod.F90
+++ b/components/homme/src/theta-l_kokkos/theta_f2c_mod.F90
@@ -9,8 +9,8 @@ interface
   ! Copies simulation parameters to C++ structures
   subroutine init_simulation_params_c (remap_alg, limiter_option, rsplit, qsplit, time_step_type,    &
                                        qsize, state_frequency, nu, nu_p, nu_q, nu_s, nu_div, nu_top, &
-                                       hypervis_order, hypervis_subcycle, hypervis_subcycle_tom,     &
-                                       hypervis_scaling, laplace_scaling,                            &
+                                       hypervis_order, hypervis_subcycle, horiz_turb_subcycle,       &
+                                       hypervis_subcycle_tom, hypervis_scaling, laplace_scaling,     &
                                        dcmip16_mu, ftype, theta_adv_form, prescribed_wind, use_moisture, &
                                        disable_diagnostics, use_cpstar, transport_alg,               &
                                        theta_hydrostatic_mode, test_case_name, dt_remap_factor,      &
@@ -27,7 +27,7 @@ interface
     integer(kind=c_int),  intent(in) :: state_frequency, qsize, internal_diagnostics_level
     real(kind=c_double),  intent(in) :: nu, nu_p, nu_q, nu_s, nu_div, nu_top, hypervis_scaling, laplace_scaling, dcmip16_mu, &
                       scale_factor, laplacian_rigid_factor, dp3d_thresh, vtheta_thresh
-    integer(kind=c_int),  intent(in) :: hypervis_order, hypervis_subcycle, hypervis_subcycle_tom
+    integer(kind=c_int),  intent(in) :: hypervis_order, hypervis_subcycle, horiz_turb_subcycle, hypervis_subcycle_tom
     integer(kind=c_int),  intent(in) :: ftype, theta_adv_form
     integer(kind=c_int),  intent(in) :: prescribed_wind, use_moisture, disable_diagnostics, use_cpstar
     integer(kind=c_int),  intent(in) :: theta_hydrostatic_mode, pgrad_correction, do_3d_turbulence

--- a/components/homme/src/theta-l_kokkos/theta_f2c_mod.F90
+++ b/components/homme/src/theta-l_kokkos/theta_f2c_mod.F90
@@ -9,7 +9,8 @@ interface
   ! Copies simulation parameters to C++ structures
   subroutine init_simulation_params_c (remap_alg, limiter_option, rsplit, qsplit, time_step_type,    &
                                        qsize, state_frequency, nu, nu_p, nu_q, nu_s, nu_div, nu_top, &
-                                       hypervis_order, hypervis_subcycle, hypervis_subcycle_tom,     &
+                                       hypervis_order, hypervis_subcycle, horiz_turb_subcycle,     &
+                                       hypervis_subcycle_tom,                                         &
                                        hypervis_scaling,                                             &
                                        dcmip16_mu, ftype, theta_adv_form, prescribed_wind, use_moisture, &
                                        disable_diagnostics, use_cpstar, transport_alg,               &
@@ -26,8 +27,8 @@ interface
     integer(kind=c_int),  intent(in) :: dt_remap_factor, dt_tracer_factor, transport_alg
     integer(kind=c_int),  intent(in) :: state_frequency, qsize, internal_diagnostics_level
     real(kind=c_double),  intent(in) :: nu, nu_p, nu_q, nu_s, nu_div, nu_top, hypervis_scaling, dcmip16_mu, &
-                      scale_factor, laplacian_rigid_factor, dp3d_thresh, vtheta_thresh
-    integer(kind=c_int),  intent(in) :: hypervis_order, hypervis_subcycle, hypervis_subcycle_tom
+                                        scale_factor, laplacian_rigid_factor, dp3d_thresh, vtheta_thresh
+    integer(kind=c_int),  intent(in) :: hypervis_order, hypervis_subcycle, horiz_turb_subcycle, hypervis_subcycle_tom
     integer(kind=c_int),  intent(in) :: ftype, theta_adv_form
     integer(kind=c_int),  intent(in) :: prescribed_wind, use_moisture, disable_diagnostics, use_cpstar
     integer(kind=c_int),  intent(in) :: theta_hydrostatic_mode, pgrad_correction, do_3d_turbulence


### PR DESCRIPTION
This PR puts the finishing touches on the implementation of 3D turbulence and addresses several issues identified during rigorous scientific validation and numerical stress testing. These changes include bug fixes, corrections to the implementation, new namelist controls, and several improvements to the numerical and scientific formulation.
Specific changes include:

1. **Adds independent namelist controls for horizontal turbulence subcycling** and removes its dependence on the dynamical-core hyperviscosity subcycling. This allows the numerical stability and computational cost of SGS horizontal diffusion to be controlled independently of hyperviscosity.
2. **Fixes an issue where tracer SGS horizontal diffusion was applied only to water vapor.** Horizontal SGS diffusion is now applied consistently to all tracers.
3. **Fixes two major bugs in the SGS tracer diffusion implementation** that caused model crashes at high horizontal resolution.  This includes an egregious sign issue when applying laplacian tendencies and avoiding applying mass matrix each subcycle.
4. **Adds CFL-based clipping of the horizontal eddy diffusivities for numerical stability.** Testing indicates that this clipping is triggered only rarely when using the default horizontal eddy-diffusivity parameters and therefore has negligible impact on the intended SGS turbulence formulation under normal conditions.
5. **Introduces a separate formulation for the horizontal eddy diffusivities rather than using the vertical eddy diffusivities.** This is more consistent with other 3D turbulence formulations and is more physically appropriate, particularly at kilometer and gray-zone resolutions where SGS turbulence can be strongly anisotropic. At these resolutions, the characteristic horizontal and vertical mixing scales can differ substantially, so using the same diffusivity formulation in both directions can produce unrealistically strong horizontal mixing.
6. **Fixes an issue where the do_3d_turbulence flag was not being linked correctly to SHOC.** Also add checks to ensure the flags to HOMME and SHOC are set consistently.
7. **Prevents layer thickness and geopotential from being horizontally diffused by the SGS turbulence scheme.**  Unlike tracers and thermodynamic quantities, layer thickness and geopotential are components of the model's dynamical state and are governed by the resolved equations of motion and mass continuity. Applying an additional SGS horizontal diffusion operator to these fields is not physically analogous to turbulent mixing of tracers and can introduce unintended modifications to the model's mass distribution and pressure/geopotential structure. Horizontal SGS turbulence is therefore restricted to quantities for which turbulent transport has a clear physical interpretation.
8. **Adds documentation for the 3D turbulence scheme.**

Since 3D turbulence is a stealth feature, it is expected this PR will be B4B.