### PR TITLE
EAMxx: IOP create_horiz_remappers to DataInterpolation Class 

### DIFF
--- a/components/eamxx/src/physics/spa/eamxx_spa_process_interface.cpp
+++ b/components/eamxx/src/physics/spa/eamxx_spa_process_interface.cpp
@@ -97,20 +97,7 @@ void SPA::initialize_impl (const RunType /* run_type */)
                    ". Valid options are: yearly_periodic, linear.\n");
   }
 
-  if (m_iop_data_manager!=nullptr) {
-    // IOP cases cannot have a remap file. We will create a IOPRemapper as the horiz remapper
-    EKAT_REQUIRE_MSG(spa_map_file == "" or spa_map_file=="none",
-      "Error! Cannot define spa_remap_file for cases with an Intensive Observation Period defined. "
-      "The IOP class defines it's own remap from file data -> model data.\n");
-
-    // TODO: expose tgt lat/lon in IOPDataManager, to avoid injecting knowledge
-    // of its param list structure in other places
-    Real iop_lat = m_iop_data_manager->get_params().get<Real>("target_latitude");
-    Real iop_lon = m_iop_data_manager->get_params().get<Real>("target_longitude");
-    m_data_interpolation->create_horiz_remappers (iop_lat,iop_lon);
-  } else {
-    m_data_interpolation->create_horiz_remappers (spa_map_file=="none" ? "" : spa_map_file);
-  }
+  m_data_interpolation->create_horiz_remappers(spa_map_file, m_iop_data_manager);
   DataInterpolation::VertRemapData vremap_data;
   vremap_data.vr_type = DataInterpolation::Dynamic3DRef;
   vremap_data.pname = "PS";

--- a/components/eamxx/src/physics/spc/eamxx_spc_process_interface.cpp
+++ b/components/eamxx/src/physics/spc/eamxx_spc_process_interface.cpp
@@ -65,20 +65,7 @@ void SPC::initialize_impl (const RunType /* run_type */)
                    ". Valid options are: yearly_periodic, linear.\n");
   }
 
-  if (m_iop_data_manager!=nullptr) {
-    // IOP cases cannot have a remap file. We will create a IOPRemapper as the horiz remapper
-    EKAT_REQUIRE_MSG(spc_map_file == "" or spc_map_file=="none",
-      "Error! Cannot define spc_remap_file for cases with an Intensive Observation Period defined. "
-      "The IOP class defines it's own remap from file data -> model data.\n");
-
-    // TODO: expose tgt lat/lon in IOPDataManager, to avoid injecting knowledge
-    // of its param list structure in other places
-    Real iop_lat = m_iop_data_manager->get_params().get<Real>("target_latitude");
-    Real iop_lon = m_iop_data_manager->get_params().get<Real>("target_longitude");
-    m_data_interpolation->create_horiz_remappers (iop_lat,iop_lon);
-  } else {
-    m_data_interpolation->create_horiz_remappers (spc_map_file=="none" ? "" : spc_map_file);
-  }
+  m_data_interpolation->create_horiz_remappers(spc_map_file, m_iop_data_manager);
   DataInterpolation::VertRemapData vremap_data;
   vremap_data.vr_type = DataInterpolation::Dynamic3DRef;
   vremap_data.pname = "PS";

--- a/components/eamxx/src/share/algorithm/eamxx_data_interpolation.cpp
+++ b/components/eamxx/src/share/algorithm/eamxx_data_interpolation.cpp
@@ -642,43 +642,6 @@ create_horiz_remappers (const std::string& map_file)
 }
 
 void DataInterpolation::
-create_horiz_remappers (const Real iop_lat, const Real iop_lon)
-{
-  using namespace ShortFieldTagsNames;
-
-  EKAT_REQUIRE_MSG (m_horiz_remapper_beg==nullptr,
-      "[DataInterpolation] Error! Horizontal remappers were already setup.\n");
-
-  EKAT_REQUIRE_MSG (not std::isnan(iop_lat) and not std::isnan(iop_lon),
-      "[DataInterpolation] Error! At least one between iop_lat and iop_lon appears to be invalid.\n"
-      "  - iop_lat: " << iop_lat << "\n"
-      "  - iop_lon: " << iop_lon << "\n");
-
-  int ncols_model = m_model_grid->get_num_global_dofs();
-  int nlevs_model = m_model_grid->get_num_vertical_levels();
-
-  // Create hremap tgt grid
-  int nlevs_data = m_fields_have_lev_dim ? get_input_files_dimlen (m_input_files_dimnames[e2str(LEV)]) : nlevs_model;
-  int ncols_data = m_fields_have_col_dim ? get_input_files_dimlen (m_input_files_dimnames[e2str(COL)]) : ncols_model;
-
-  // Create grid for IO and load lat/lon field in IO grid from any data file
-  m_data_grid = create_point_grid(m_name+"_data",ncols_data,nlevs_data,m_model_grid->get_comm());
-  auto lat  = m_data_grid->create_geometry_data("lat",m_data_grid->get_2d_scalar_layout());
-  auto lon  = m_data_grid->create_geometry_data("lon",m_data_grid->get_2d_scalar_layout());
-  auto gids = m_data_grid->get_partitioned_dim_gids();
-  auto comm = m_data_grid->get_comm();
-  read_fields(m_time_database.files.front(),{lat,lon},gids,comm);
-
-  // Create iop remap tgt grid
-  m_grid_after_hremap = m_model_grid->clone(m_name+"_post_hremap",true);
-  m_grid_after_hremap->reset_vertical_configuration(nlevs_data, AbstractGrid::VKind::Model);
-  m_horiz_remapper_beg = std::make_shared<IOPRemapper>(m_data_grid,m_grid_after_hremap,iop_lat,iop_lon);
-  if (m_time_dependent) {
-    m_horiz_remapper_end = std::make_shared<IOPRemapper>(m_data_grid,m_grid_after_hremap,iop_lat,iop_lon);
-  }
-}
-
-void DataInterpolation::
 create_horiz_remappers (const std::string& map_file,
                         const std::shared_ptr<IOPDataManager>& iop_data_manager)
 {
@@ -692,7 +655,39 @@ create_horiz_remappers (const std::string& map_file,
     // of its parameter list structure in other places
     Real iop_lat = iop_data_manager->get_params().get<Real>("target_latitude");
     Real iop_lon = iop_data_manager->get_params().get<Real>("target_longitude");
-    create_horiz_remappers(iop_lat, iop_lon);
+
+    using namespace ShortFieldTagsNames;
+
+    EKAT_REQUIRE_MSG (m_horiz_remapper_beg==nullptr,
+        "[DataInterpolation] Error! Horizontal remappers were already setup.\n");
+
+    EKAT_REQUIRE_MSG (not std::isnan(iop_lat) and not std::isnan(iop_lon),
+        "[DataInterpolation] Error! At least one between iop_lat and iop_lon appears to be invalid.\n"
+        "  - iop_lat: " << iop_lat << "\n"
+        "  - iop_lon: " << iop_lon << "\n");
+
+    int ncols_model = m_model_grid->get_num_global_dofs();
+    int nlevs_model = m_model_grid->get_num_vertical_levels();
+
+    // Create hremap tgt grid
+    int nlevs_data = m_fields_have_lev_dim ? get_input_files_dimlen (m_input_files_dimnames[e2str(LEV)]) : nlevs_model;
+    int ncols_data = m_fields_have_col_dim ? get_input_files_dimlen (m_input_files_dimnames[e2str(COL)]) : ncols_model;
+
+    // Create grid for IO and load lat/lon field in IO grid from any data file
+    m_data_grid = create_point_grid(m_name+"_data",ncols_data,nlevs_data,m_model_grid->get_comm());
+    auto lat  = m_data_grid->create_geometry_data("lat",m_data_grid->get_2d_scalar_layout());
+    auto lon  = m_data_grid->create_geometry_data("lon",m_data_grid->get_2d_scalar_layout());
+    auto gids = m_data_grid->get_partitioned_dim_gids();
+    auto comm = m_data_grid->get_comm();
+    read_fields(m_time_database.files.front(),{lat,lon},gids,comm);
+
+    // Create iop remap tgt grid
+    m_grid_after_hremap = m_model_grid->clone(m_name+"_post_hremap",true);
+    m_grid_after_hremap->reset_vertical_configuration(nlevs_data, AbstractGrid::VKind::Model);
+    m_horiz_remapper_beg = std::make_shared<IOPRemapper>(m_data_grid,m_grid_after_hremap,iop_lat,iop_lon);
+    if (m_time_dependent) {
+      m_horiz_remapper_end = std::make_shared<IOPRemapper>(m_data_grid,m_grid_after_hremap,iop_lat,iop_lon);
+    }
   } else {
     create_horiz_remappers(map_file=="none" ? "" : map_file);
   }

--- a/components/eamxx/src/share/algorithm/eamxx_data_interpolation.cpp
+++ b/components/eamxx/src/share/algorithm/eamxx_data_interpolation.cpp
@@ -5,6 +5,7 @@
 #include "share/remap/horizontal_remapper.hpp"
 #include "share/remap/iop_remapper.hpp"
 #include "share/grid/point_grid.hpp"
+#include "share/data_managers/IOPDataManager.hpp"
 #include "share/scorpio_interface/eamxx_scorpio_interface.hpp"
 #include "share/field/field_reader.hpp"
 #include "share/util/eamxx_universal_constants.hpp"
@@ -674,6 +675,26 @@ create_horiz_remappers (const Real iop_lat, const Real iop_lon)
   m_horiz_remapper_beg = std::make_shared<IOPRemapper>(m_data_grid,m_grid_after_hremap,iop_lat,iop_lon);
   if (m_time_dependent) {
     m_horiz_remapper_end = std::make_shared<IOPRemapper>(m_data_grid,m_grid_after_hremap,iop_lat,iop_lon);
+  }
+}
+
+void DataInterpolation::
+create_horiz_remappers (const std::string& map_file,
+                        const std::shared_ptr<IOPDataManager>& iop_data_manager)
+{
+  // IOP cases cannot have a remap file. We will create a IOPRemapper as the horiz remapper
+  if (iop_data_manager!=nullptr) {
+    EKAT_REQUIRE_MSG(map_file == "" || map_file=="none",
+      "[DataInterpolation] Error! Cannot define map_file for cases with an Intensive Observation Period defined. "
+      "The IOP class defines its own remap from file data to model data.\n");
+
+    // TODO: expose tgt lat/lon in IOPDataManager, to avoid injecting knowledge
+    // of its parameter list structure in other places
+    Real iop_lat = iop_data_manager->get_params().get<Real>("target_latitude");
+    Real iop_lon = iop_data_manager->get_params().get<Real>("target_longitude");
+    create_horiz_remappers(iop_lat, iop_lon);
+  } else {
+    create_horiz_remappers(map_file=="none" ? "" : map_file);
   }
 }
 

--- a/components/eamxx/src/share/algorithm/eamxx_data_interpolation.hpp
+++ b/components/eamxx/src/share/algorithm/eamxx_data_interpolation.hpp
@@ -77,7 +77,6 @@ public:
                               int time_index = -1);
 
   void create_horiz_remappers (const std::string& map_file = "");
-  void create_horiz_remappers (const Real iop_lat, const Real iop_lon);
   void create_horiz_remappers (const std::string& map_file,
                                const std::shared_ptr<IOPDataManager>& iop_data_manager);
   void create_vert_remapper ();

--- a/components/eamxx/src/share/algorithm/eamxx_data_interpolation.hpp
+++ b/components/eamxx/src/share/algorithm/eamxx_data_interpolation.hpp
@@ -12,6 +12,9 @@
 namespace scream
 {
 
+// Forward declaration
+class IOPDataManager;
+
 class DataInterpolation
 {
 public:
@@ -75,6 +78,8 @@ public:
 
   void create_horiz_remappers (const std::string& map_file = "");
   void create_horiz_remappers (const Real iop_lat, const Real iop_lon);
+  void create_horiz_remappers (const std::string& map_file,
+                               const std::shared_ptr<IOPDataManager>& iop_data_manager);
   void create_vert_remapper ();
   void create_vert_remapper (const VertRemapData& data);
 


### PR DESCRIPTION
This PR refactors the IOP logic out of the atmosphere process and into the DataInterpolation class. Since DataInterpolation is instantiated and reused in multiple locations within eamxx-mam4xx, centralizing this logic avoids code duplication.

I will update the eamxx-mam4xx call to `create_horiz_remappers(spa_map_file, m_iop_data_manager)` in PR https://github.com/E3SM-Project/E3SM/pull/8615

Once PR https://github.com/E3SM-Project/E3SM/pull/8615, PR https://github.com/E3SM-Project/E3SM/pull/8430, and this PR are merged into master, we will be able to run MAM4xx+DPxx.

I will also close PR https://github.com/E3SM-Project/E3SM/pull/8517.