### PR TITLE
Add F90 cld_base_mass_flux limiter to fix EAMxx unit Tests

### DIFF
--- a/components/eam/src/physics/cam/zm/zm_conv.F90
+++ b/components/eam/src/physics/cam/zm/zm_conv.F90
@@ -585,6 +585,8 @@ subroutine zm_conv_main(pcols, ncol, pver, pverp, is_first_step, time_step, &
       end if
       if (zm_param%clos_dyn_adj) then
          cld_base_mass_flux(i) = max(cld_base_mass_flux(i) - omega_g(i,pbl_top_g(i))*0.01_r8, 0._r8)
+         ! reapply limiter from above to protect against instability caused by large omega values
+         if (mflx_up_max(i) > 0._r8)  cld_base_mass_flux(i) = min(cld_base_mass_flux(i),1._r8/(time_step*mflx_up_max(i)))
       end if
    end do
 


### PR DESCRIPTION
The real reason for this change is to fix EAMxx unit tests... but it's also just a good change to make in general, and it's not expected to have any real impact on the climate of v3. The second limiter was added in PR #8421 for stability in EAMxx, but it did not cause test failures until later, and not adding it on the EAM side was somewhat an oversight, but also perhaps intentional to not create non-BFB diffs.

The fact that this was not caught by unit tests until now is strange... the current unit test failures only happen when running on the GPU, but they are actually reproducible on the CPU for certain baseline seeds. In fact the test results can change somewhat randomly when the seed is changed. This issue was uncovered by using `./zm_tests --rng-seed 23568 --args -g -b ${BASELINE_DIR}` to generate the baselines for CPU tests.

[non-BFB] for EAM