### PR TITLE
Add missing EAMxx init-time diagnostics

### DIFF
--- a/components/eamxx/src/dynamics/homme/interface/homme_driver_mod.F90
+++ b/components/eamxx/src/dynamics/homme/interface/homme_driver_mod.F90
@@ -187,8 +187,8 @@ contains
                                  prim_init_tensorvisc2
     use prim_state_mod,    only: prim_printstate
     use model_init_mod,    only: model_init2
-    use global_norms_mod,  only: dss_hvtensor, print_cfl
-    use control_mod,       only: disable_diagnostics
+    use global_norms_mod,  only: dss_hvtensor, print_cfl, print_mesh_stats
+    use control_mod,       only: disable_diagnostics, topology
     use dimensions_mod,    only: nelemd
     use homme_context_mod, only: is_model_inited, is_data_structures_inited, &
                                  elem, hybrid, hvcoord, deriv, tl
@@ -220,7 +220,14 @@ contains
     ! coefficient), which dss_hvtensor also updates.
     call prim_init_tensorvisc2 (elem)
 
-    ! Print advective and viscious CFL estimates
+    ! Print mesh statistics (element area, norm(Dinv), distortion, etc.),
+    ! same diagnostics printed by EAM's prim_init2 (prim_driver_base.F90).
+    if (topology == "cube" .OR. topology == "plane") then
+       call print_mesh_stats(elem, hybrid, 1, nelemd)
+    end if
+
+    ! Print advective and viscious CFL estimates, plus dt_dyn/dt_tracer/
+    ! dt_remap timestep-size diagnostics (all printed inside print_cfl)
     call print_cfl(elem,hybrid,1,nelemd)
 
     ! Initialize reference states before functors so that setup() can read

--- a/components/eamxx/src/dynamics/homme/interface/homme_driver_mod.F90
+++ b/components/eamxx/src/dynamics/homme/interface/homme_driver_mod.F90
@@ -226,7 +226,7 @@ contains
        call print_mesh_stats(elem, hybrid, 1, nelemd)
     end if
 
-    ! Print advective and viscious CFL estimates, plus dt_dyn/dt_tracer/
+    ! Print advective and viscous CFL estimates, plus dt_dyn/dt_tracer/
     ! dt_remap timestep-size diagnostics (all printed inside print_cfl)
     call print_cfl(elem,hybrid,1,nelemd)
 

--- a/components/eamxx/src/dynamics/homme/interface/homme_driver_mod.F90
+++ b/components/eamxx/src/dynamics/homme/interface/homme_driver_mod.F90
@@ -186,8 +186,8 @@ contains
                                  prim_init_state_views, prim_init_tensorvisc
     use prim_state_mod,    only: prim_printstate
     use model_init_mod,    only: model_init2
-    use global_norms_mod,  only: dss_hvtensor, print_cfl
-    use control_mod,       only: disable_diagnostics
+    use global_norms_mod,  only: dss_hvtensor, print_cfl, print_mesh_stats
+    use control_mod,       only: disable_diagnostics, topology
     use dimensions_mod,    only: nelemd
     use homme_context_mod, only: is_model_inited, is_data_structures_inited, &
                                  elem, hybrid, hvcoord, deriv, tl
@@ -215,7 +215,14 @@ contains
     ! prim_complete_init1_phase_f90 -> prim_init_grid_views).
     call prim_init_tensorvisc (elem)
 
-    ! Print advective and viscious CFL estimates
+    ! Print mesh statistics (element area, norm(Dinv), distortion, etc.),
+    ! same diagnostics printed by EAM's prim_init2 (prim_driver_base.F90).
+    if (topology == "cube" .OR. topology == "plane") then
+       call print_mesh_stats(elem, hybrid, 1, nelemd)
+    end if
+
+    ! Print advective and viscious CFL estimates, plus dt_dyn/dt_tracer/
+    ! dt_remap timestep-size diagnostics (all printed inside print_cfl)
     call print_cfl(elem,hybrid,1,nelemd)
 
     ! Initialize reference states before functors so that setup() can read

--- a/components/eamxx/src/dynamics/homme/interface/homme_driver_mod.F90
+++ b/components/eamxx/src/dynamics/homme/interface/homme_driver_mod.F90
@@ -221,7 +221,7 @@ contains
        call print_mesh_stats(elem, hybrid, 1, nelemd)
     end if
 
-    ! Print advective and viscious CFL estimates, plus dt_dyn/dt_tracer/
+    ! Print advective and viscous CFL estimates, plus dt_dyn/dt_tracer/
     ! dt_remap timestep-size diagnostics (all printed inside print_cfl)
     call print_cfl(elem,hybrid,1,nelemd)
 

--- a/components/homme/src/share/global_norms_mod.F90
+++ b/components/homme/src/share/global_norms_mod.F90
@@ -21,7 +21,7 @@ module global_norms_mod
 
   public :: print_cfl
   public :: dss_hvtensor
-  public :: test_global_integral
+  public :: print_mesh_stats
   public :: global_integral
   public :: wrap_repro_sum
 
@@ -97,14 +97,14 @@ contains
   end function global_integral
 
   ! ================================
-  ! test_global_integral:
+  ! print_mesh_stats:
   !
   ! test that the global integral of 
   ! the area of the sphere is 1.
   !
   ! ================================
 
-  subroutine test_global_integral(elem,hybrid,nets,nete,mindxout)
+  subroutine print_mesh_stats(elem,hybrid,nets,nete,mindxout)
     use kinds,       only : real_kind
     use hybrid_mod,  only : hybrid_t
     use element_mod, only : element_t
@@ -225,7 +225,7 @@ contains
         mindxout=1000_real_kind*min_len
     end if
 
-  end subroutine test_global_integral
+  end subroutine print_mesh_stats
 
 
 !------------------------------------------------------------------------------------
@@ -249,7 +249,7 @@ contains
 #ifdef MODEL_THETA_L
     use element_state, only : nu_scale_top
 #endif
-    use dimensions_mod, only : np
+    use dimensions_mod, only : np, qsize
     use quadrature_mod, only : gausslobatto, quadrature_t
 
     use reduction_mod, only : ParallelMin,ParallelMax
@@ -257,6 +257,9 @@ contains
     use control_mod, only : nu, nu_q, nu_div, hypervis_order, nu_top,  &
                             hypervis_scaling, laplace_scaling, dcmip16_mu,dcmip16_mu_s
     use control_mod, only : tstep_type
+    use control_mod, only : dt_remap_factor, dt_tracer_factor, transport_alg, &
+                            hypervis_subcycle, hypervis_subcycle_q, hypervis_subcycle_tom
+    use time_mod,    only : tstep
 
     type(element_t)      , intent(inout) :: elem(:)
     integer              , intent(in) :: nets,nete
@@ -267,6 +270,8 @@ contains
     real (kind=real_kind) :: max_normDinv  ! used for CFL
     real (kind=real_kind) :: normDinv_hypervis, normDinv_laplace
     real (kind=real_kind) :: lambda_max, lambda_vis, min_gw, lambda, nu_div_actual, nu_top_actual
+    real (kind=real_kind) :: dt_dyn_vis     ! viscosity timestep used in dynamics
+    real (kind=real_kind) :: dt_tracer_vis  ! viscosity timestep used in tracers
     integer :: ie
     type (quadrature_t)    :: gp
 
@@ -400,6 +405,40 @@ contains
            1.0d0/(dcmip16_mu_s*((scale_factor_inv*max_normDinv)**2)*lambda_vis),'s'
 
       write(iulog,*) 'tstep_type = ',tstep_type
+
+       ! compute timestep seen by viscosity operator:
+       dt_dyn_vis = tstep
+       if (dt_tracer_factor>1 .and. tstep_type == 1) then
+          ! tstep_type==1: RK2 followed by LF.  internal LF stages apply viscosity at 2*dt
+          dt_dyn_vis = 2*tstep
+       endif
+       dt_tracer_vis=tstep*dt_tracer_factor
+
+       ! compute actual viscosity timesteps with subcycling
+       dt_tracer_vis = dt_tracer_vis/hypervis_subcycle_q
+       dt_dyn_vis = dt_dyn_vis/hypervis_subcycle
+
+       ! print out the timestep sizes actually used by the model
+       write(iulog,'(a,2f9.2)')        "dt_remap: (0=disabled)   ",tstep*dt_remap_factor
+       if (transport_alg > 0) then
+          if (qsize>0) then
+              write(iulog,'(a,2f9.2)') "dt_tracer (SL):          ",tstep*dt_tracer_factor
+          endif
+       elseif (transport_alg == 0) then
+          if (qsize>0) then
+             write(iulog,'(a,2f9.2)')  "dt_tracer (EUL), per RK stage: ", &
+                 tstep*dt_tracer_factor,(tstep*dt_tracer_factor)/2
+          end if
+       endif
+       write(iulog,'(a,2f9.2)')        "dt_dyn:                  ",tstep
+       write(iulog,'(a,2f9.2)')        "dt_dyn (viscosity):      ",dt_dyn_vis
+       write(iulog,'(a,2f9.2)')        "dt_tracer (viscosity):   ",dt_tracer_vis
+       if (hypervis_subcycle_tom==0) then
+          ! applied with hyperviscosity
+          write(iulog,'(a,2f9.2)') "dt_vis_TOM:  ",dt_dyn_vis
+       else
+          write(iulog,'(a,2f9.2)') "dt_vis_TOM:  ",tstep/hypervis_subcycle_tom
+       endif
     end if
 
   end subroutine print_cfl

--- a/components/homme/src/share/global_norms_mod.F90
+++ b/components/homme/src/share/global_norms_mod.F90
@@ -99,9 +99,9 @@ contains
   ! ================================
   ! print_mesh_stats:
   !
-  ! test that the global integral of 
-  ! the area of the sphere is 1.
-  !
+  ! Print mesh statistics (area, dx spacing, norm(Dinv), distortion) and
+  ! report the global integral of 1 over the domain (area should be ~1 on
+  ! the unit sphere, or Lx*Ly on plane).
   ! ================================
 
   subroutine print_mesh_stats(elem,hybrid,nets,nete,mindxout)

--- a/components/homme/src/share/global_norms_mod.F90
+++ b/components/homme/src/share/global_norms_mod.F90
@@ -21,7 +21,7 @@ module global_norms_mod
 
   public :: print_cfl
   public :: dss_hvtensor
-  public :: test_global_integral
+  public :: print_mesh_stats
   public :: global_integral
   public :: wrap_repro_sum
 
@@ -97,14 +97,14 @@ contains
   end function global_integral
 
   ! ================================
-  ! test_global_integral:
+  ! print_mesh_stats:
   !
   ! test that the global integral of 
   ! the area of the sphere is 1.
   !
   ! ================================
 
-  subroutine test_global_integral(elem,hybrid,nets,nete,mindxout)
+  subroutine print_mesh_stats(elem,hybrid,nets,nete,mindxout)
     use kinds,       only : real_kind
     use hybrid_mod,  only : hybrid_t
     use element_mod, only : element_t
@@ -225,7 +225,7 @@ contains
         mindxout=1000_real_kind*min_len
     end if
 
-  end subroutine test_global_integral
+  end subroutine print_mesh_stats
 
 
 !------------------------------------------------------------------------------------
@@ -249,7 +249,7 @@ contains
 #ifdef MODEL_THETA_L
     use element_state, only : nu_scale_top
 #endif
-    use dimensions_mod, only : np
+    use dimensions_mod, only : np, qsize
     use quadrature_mod, only : gausslobatto, quadrature_t
 
     use reduction_mod, only : ParallelMin,ParallelMax
@@ -257,6 +257,9 @@ contains
     use control_mod, only : nu, nu_q, nu_div, hypervis_order, nu_top,  &
                             hypervis_scaling, dcmip16_mu,dcmip16_mu_s
     use control_mod, only : tstep_type
+    use control_mod, only : dt_remap_factor, dt_tracer_factor, transport_alg, &
+                            hypervis_subcycle, hypervis_subcycle_q, hypervis_subcycle_tom
+    use time_mod,    only : tstep
 
     type(element_t)      , intent(inout) :: elem(:)
     integer              , intent(in) :: nets,nete
@@ -267,6 +270,8 @@ contains
     real (kind=real_kind) :: max_normDinv  ! used for CFL
     real (kind=real_kind) :: normDinv_hypervis
     real (kind=real_kind) :: lambda_max, lambda_vis, min_gw, lambda, nu_div_actual, nu_top_actual
+    real (kind=real_kind) :: dt_dyn_vis     ! viscosity timestep used in dynamics
+    real (kind=real_kind) :: dt_tracer_vis  ! viscosity timestep used in tracers
     integer :: ie
     type (quadrature_t)    :: gp
 
@@ -390,6 +395,40 @@ contains
            1.0d0/(dcmip16_mu_s*((scale_factor_inv*max_normDinv)**2)*lambda_vis),'s'
 
       write(iulog,*) 'tstep_type = ',tstep_type
+
+       ! compute timestep seen by viscosity operator:
+       dt_dyn_vis = tstep
+       if (dt_tracer_factor>1 .and. tstep_type == 1) then
+          ! tstep_type==1: RK2 followed by LF.  internal LF stages apply viscosity at 2*dt
+          dt_dyn_vis = 2*tstep
+       endif
+       dt_tracer_vis=tstep*dt_tracer_factor
+
+       ! compute actual viscosity timesteps with subcycling
+       dt_tracer_vis = dt_tracer_vis/hypervis_subcycle_q
+       dt_dyn_vis = dt_dyn_vis/hypervis_subcycle
+
+       ! print out the timestep sizes actually used by the model
+       write(iulog,'(a,2f9.2)')        "dt_remap: (0=disabled)   ",tstep*dt_remap_factor
+       if (transport_alg > 0) then
+          if (qsize>0) then
+              write(iulog,'(a,2f9.2)') "dt_tracer (SL):          ",tstep*dt_tracer_factor
+          endif
+       elseif (transport_alg == 0) then
+          if (qsize>0) then
+             write(iulog,'(a,2f9.2)')  "dt_tracer (EUL), per RK stage: ", &
+                 tstep*dt_tracer_factor,(tstep*dt_tracer_factor)/2
+          end if
+       endif
+       write(iulog,'(a,2f9.2)')        "dt_dyn:                  ",tstep
+       write(iulog,'(a,2f9.2)')        "dt_dyn (viscosity):      ",dt_dyn_vis
+       write(iulog,'(a,2f9.2)')        "dt_tracer (viscosity):   ",dt_tracer_vis
+       if (hypervis_subcycle_tom==0) then
+          ! applied with hyperviscosity
+          write(iulog,'(a,2f9.2)') "dt_vis_TOM:  ",dt_dyn_vis
+       else
+          write(iulog,'(a,2f9.2)') "dt_vis_TOM:  ",tstep/hypervis_subcycle_tom
+       endif
     end if
 
   end subroutine print_cfl

--- a/components/homme/src/share/prim_driver_base.F90
+++ b/components/homme/src/share/prim_driver_base.F90
@@ -946,7 +946,7 @@ contains
     ! apply dss and bilinear projection to tensor coefficients
     call dss_hvtensor(elem,hybrid,nets,nete)
 
-    ! advective and viscious CFL estimates, plus dt_dyn/dt_tracer/dt_remap
+    ! advective and viscous CFL estimates, plus dt_dyn/dt_tracer/dt_remap
     ! timestep-size diagnostics (printed inside print_cfl)
     call print_cfl(elem,hybrid,nets,nete)
 

--- a/components/homme/src/share/prim_driver_base.F90
+++ b/components/homme/src/share/prim_driver_base.F90
@@ -733,10 +733,8 @@ contains
   subroutine prim_init2(elem, hybrid, nets, nete, tl, hvcoord)
 
     use control_mod,          only: runtype, topology, dt_remap_factor, dt_tracer_factor,&
-                                    tstep_type, hypervis_subcycle, &
-                                    hypervis_subcycle_q, hypervis_subcycle_tom, &
                                     transport_alg, prim_step_type
-    use global_norms_mod,     only: test_global_integral, print_cfl, dss_hvtensor
+    use global_norms_mod,     only: print_mesh_stats, print_cfl, dss_hvtensor
     use hybvcoord_mod,        only: hvcoord_t
     use parallel_mod,         only: parallel_t, haltmp, syncmp, abortmp
     use prim_state_mod,       only: prim_printstate, prim_diag_scalars
@@ -762,10 +760,6 @@ contains
     ! ==================================
     ! Local variables
     ! ==================================
-
-    ! variables used to calculate CFL
-    real (kind=real_kind) :: dt_dyn_vis         ! viscosity timestep used in dynamics
-    real (kind=real_kind) :: dt_tracer_vis      ! viscosity timestep used in tracers
 
 #ifdef CAM
     integer :: k
@@ -811,21 +805,9 @@ contains
 #endif
 
     if (topology == "cube" .OR. topology=='plane') then
-       call test_global_integral(elem, hybrid,nets,nete)
+       call print_mesh_stats(elem, hybrid,nets,nete)
     end if
 
-
-    ! compute timestep seen by viscosity operator:
-    dt_dyn_vis = tstep
-    if (dt_tracer_factor>1 .and. tstep_type == 1) then
-       ! tstep_type==1: RK2 followed by LF.  internal LF stages apply viscosity at 2*dt
-       dt_dyn_vis = 2*tstep
-    endif
-    dt_tracer_vis=tstep*dt_tracer_factor
-
-    ! compute actual viscosity timesteps with subcycling
-    dt_tracer_vis = dt_tracer_vis/hypervis_subcycle_q
-    dt_dyn_vis = dt_dyn_vis/hypervis_subcycle
 
 #ifdef TRILINOS
 
@@ -964,7 +946,8 @@ contains
     ! apply dss and bilinear projection to tensor coefficients
     call dss_hvtensor(elem,hybrid,nets,nete)
 
-    ! advective and viscious CFL estimates
+    ! advective and viscious CFL estimates, plus dt_dyn/dt_tracer/dt_remap
+    ! timestep-size diagnostics (printed inside print_cfl)
     call print_cfl(elem,hybrid,nets,nete)
 
     ! Use the flexible time stepper if dt_remap_factor == 0 (vertically Eulerian
@@ -976,29 +959,6 @@ contains
     endif
 
     if (hybrid%masterthread) then
-       ! CAM has set tstep based on dtime before calling prim_init2(),
-       ! so only now does HOMME learn the timstep.  print them out:
-       write(iulog,'(a,2f9.2)')        "dt_remap: (0=disabled)   ",tstep*dt_remap_factor
-       if (transport_alg > 0) then
-          if (qsize>0) then
-              write(iulog,'(a,2f9.2)') "dt_tracer (SL):          ",tstep*dt_tracer_factor
-          endif
-       elseif(transport_alg == 0) then
-          if (qsize>0) then
-             write(iulog,'(a,2f9.2)')  "dt_tracer (EUL), per RK stage: ", &
-                 tstep*dt_tracer_factor,(tstep*dt_tracer_factor)/2
-          end if
-       endif
-       write(iulog,'(a,2f9.2)')        "dt_dyn:                  ",tstep
-       write(iulog,'(a,2f9.2)')        "dt_dyn (viscosity):      ",dt_dyn_vis
-       write(iulog,'(a,2f9.2)')        "dt_tracer (viscosity):   ",dt_tracer_vis
-       if (hypervis_subcycle_tom==0) then                                                     
-          ! applied with hyperviscosity                                                       
-          write(iulog,'(a,2f9.2)') "dt_vis_TOM:  ",dt_dyn_vis                                 
-       else                                                                                   
-          write(iulog,'(a,2f9.2)') "dt_vis_TOM:  ",tstep/hypervis_subcycle_tom               
-       endif                                                                 
-
        if (prim_step_type == 2) then
           write(iulog,*) "Running with prim_step_flexible"
        elseif(prim_step_type == 1) then

--- a/components/homme/src/sweqx/sweq_mod.F90
+++ b/components/homme/src/sweqx/sweq_mod.F90
@@ -33,7 +33,7 @@ contains
     use shal_movie_mod, only : shal_movie_init, shal_movie_output, shal_movie_finish
 #endif
     !-----------------
-    use global_norms_mod, only : test_global_integral, print_cfl, dss_hvtensor
+    use global_norms_mod, only : print_mesh_stats, print_cfl, dss_hvtensor
     !-----------------
     use quadrature_mod, only : quadrature_t, gausslobatto
     !-----------------
@@ -190,7 +190,7 @@ contains
     call t_startf('sweq')
     hybrid = hybrid_create(par,ithr,hthreads)
     simday=0
-       call test_global_integral(elem,hybrid,nets,nete)
+       call print_mesh_stats(elem,hybrid,nets,nete)
        call dss_hvtensor(elem,hybrid,nets,nete)
        call print_cfl(elem,hybrid,nets,nete)
 
@@ -845,7 +845,7 @@ contains
 
 #endif
     !-----------------
-    use global_norms_mod, only : test_global_integral, print_cfl, dss_hvtensor
+    use global_norms_mod, only : print_mesh_stats, print_cfl, dss_hvtensor
     !-----------------
     use quadrature_mod, only : quadrature_t, gausslobatto
     !-----------------
@@ -928,7 +928,7 @@ contains
 
     hybrid = hybrid_create(par,ithr,hthreads)
 
-       call test_global_integral(elem,hybrid,nets,nete,mindx)
+       call print_mesh_stats(elem,hybrid,nets,nete,mindx)
        call dss_hvtensor(elem,hybrid,nets,nete)
        call print_cfl(elem,hybrid,nets,nete)
 


### PR DESCRIPTION
Restore mesh-statistics and timestep-size diagnostics that were printed for EAM but missing for EAMxx during initialization.  These are useful for debugging crashes, especially CFL issues like the  current consusx4 failures.

## Summary
Rename `test_global_integral` to `print_mesh_stats` in `global_norms_mod.F90` for clarity, and call it from EAMxx's `prim_init_model_f90` (before `print_cfl`), matching where EAM's `prim_init2` calls it. This restores the mesh-statistics diagnostics (element area, norm(Dinv), distortion, dx spacing) that previously only printed for EAM, not EAMxx.

Also fold the `dt_remap`/`dt_tracer`/`dt_dyn`/`dt_vis_TOM` timestep-size diagnostics (previously printed inline at the end of `prim_init2` in `prim_driver_base.F90`) directly into `print_cfl`. Since EAMxx already calls `print_cfl`, this makes those diagnostics print for EAMxx too, with no new call needed on the EAMxx side.

## Changes
- `components/homme/src/share/global_norms_mod.F90`: renamed `test_global_integral` → `print_mesh_stats`; moved the `dt_remap`/`dt_tracer`/`dt_dyn`/`dt_vis_TOM` timestep diagnostics from `prim_driver_base.F90` into `print_cfl`.
- `components/homme/src/share/prim_driver_base.F90`: updated `prim_init2` to call the renamed `print_mesh_stats`; removed the now-redundant inline timestep diagnostics (moved into `print_cfl`).
- `components/eamxx/src/dynamics/homme/interface/homme_driver_mod.F90`: added a call to `print_mesh_stats` in `prim_init_model_f90` before `print_cfl`, matching EAM's `prim_init2` ordering.
- `components/homme/src/sweqx/sweq_mod.F90`: updated call sites for the renamed `print_mesh_stats`.

[BFB]
