### PR TITLE
EAMxx: Add the capability in SPC to read a list of gas species (GHG and oxidants)

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -569,6 +569,8 @@ be lost if SCREAM_HACK_XML is not enabled.
       <spc_data_file hgrid="ne.*np4.pg2">${DIN_LOC_ROOT}/atm/scream/init/spc_from_v3LRamip_2010_clim_ne30pg2_c20260206.nc</spc_data_file>
       <spc_data_file hgrid="ne4np4.pg2">${DIN_LOC_ROOT}/atm/scream/init/spc_from_v3LRamip_2010_clim_ne4pg2_c20260211.nc</spc_data_file>
 
+      <gas_species type="array(string)" doc="List of gas species to read in and prescribe">o3</gas_species>
+
       <time_interpolation_method type="string" doc="Method for interpolating SPC data in time">yearly_periodic</time_interpolation_method>
     </spc>
 

--- a/components/eamxx/src/physics/spc/eamxx_spc_process_interface.cpp
+++ b/components/eamxx/src/physics/spc/eamxx_spc_process_interface.cpp
@@ -6,6 +6,7 @@
 
 #include <ekat_assert.hpp>
 #include <ekat_units.hpp>
+#include <ekat_string_utils.hpp>
 
 namespace scream
 {
@@ -15,6 +16,12 @@ SPC::SPC (const ekat::Comm& comm, const ekat::ParameterList& params)
 {
   EKAT_REQUIRE_MSG(m_params.isParameter("spc_data_file"),
       "ERROR: spc_data_file is missing from SPC parameter list.");
+  EKAT_REQUIRE_MSG(m_params.isParameter("gas_species"),
+      "ERROR: gas_species is missing from SPC parameter list.");
+
+  m_gas_species = m_params.get<std::vector<std::string>>("gas_species");
+  EKAT_REQUIRE_MSG(m_gas_species.size()>0,
+      "ERROR: gas_species list in SPC parameter list is empty.");
 }
 
 // =========================================================================================
@@ -35,7 +42,9 @@ void SPC::create_requests()
   add_field<Required>("p_mid"      , scalar3d_mid, Pa,     grid_name, ps);
 
   // Set of fields used strictly as output
-  add_field<Computed>("o3_volume_mix_ratio", scalar3d_mid,    mol/mol,   grid_name, ps);
+  for (const auto& species : m_gas_species) {
+    add_field<Computed>(species + "_volume_mix_ratio", scalar3d_mid, mol/mol, grid_name, ps);
+  }
 }
 
 // =========================================================================================
@@ -45,9 +54,11 @@ void SPC::initialize_impl (const RunType /* run_type */)
 
   // NOTE: SPC does not have an internal persistent state, so run_type is irrelevant
 
-  std::vector<Field> spc_fields = {
-      get_field_out("o3_volume_mix_ratio").alias("O3")
-  };
+  std::vector<Field> spc_fields;
+  spc_fields.reserve(m_gas_species.size());
+  for (const auto& species : m_gas_species) {
+    spc_fields.push_back(get_field_out(species + "_volume_mix_ratio").alias(ekat::upper_case(species)));
+  }
   auto spc_data_file = m_params.get<std::string>("spc_data_file");
   auto spc_map_file  = m_params.get<std::string>("spc_remap_file","");
   auto time_interpolation_method = m_params.get<std::string>("time_interpolation_method","yearly_periodic");
@@ -89,7 +100,9 @@ void SPC::initialize_impl (const RunType /* run_type */)
   // Set property checks for fields in this process
   using FWI = FieldWithinIntervalCheck;
 
-  add_postcondition_check<FWI>(get_field_out("o3_volume_mix_ratio"),m_model_grid,1e-36,1e-2,true);
+  for (const auto& species : m_gas_species) {
+    add_postcondition_check<FWI>(get_field_out(species + "_volume_mix_ratio"),m_model_grid,1e-36,1e-2,true);
+  }
 }
 
 // =========================================================================================

--- a/components/eamxx/src/physics/spc/eamxx_spc_process_interface.hpp
+++ b/components/eamxx/src/physics/spc/eamxx_spc_process_interface.hpp
@@ -37,6 +37,9 @@ protected:
   std::shared_ptr<const AbstractGrid>   m_model_grid;
 
   std::shared_ptr<DataInterpolation>    m_data_interpolation;
+
+  // Names of the gas species to be read in and prescribed
+  std::vector<std::string> m_gas_species;
 }; // class SPC
 
 } // namespace scream


### PR DESCRIPTION
Previous SPC can only read O3.

To including other GHG gases (CO2, CH4, N2O, CFCs) and oxidants (O3, CO, OH, etc), the PR adds the capability to read a list of gas species (in namelist).

This PR should be BFB for current EAMxx and EAMxx+SPC.

Future code cleaning in rrtmgp and specifying new SPC input files are needed to finally switch to SPC. 