### PR TITLE
EAMxx: set compiler flags before parsing EKAT

### DIFF
--- a/components/eamxx/CMakeLists.txt
+++ b/components/eamxx/CMakeLists.txt
@@ -457,6 +457,12 @@ endif()
 #               Configure all tpls and subfolders                  #
 ####################################################################
 
+# Set compiler-specific flags. Do it BEFORE ekat, so ekat gets the flags too
+include(EkatSetCompilerFlags)
+ResetFlags()
+SetCommonFlags()
+SetProfilingFlags(PROFILER ${EKAT_PROFILING_TOOL} COVERAGE ${EKAT_ENABLE_COVERAGE})
+
 # We will use the sharedlib one in CIME builds
 if (NOT SCREAM_CIME_BUILD)
   set (EKAT_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../../externals/ekat)
@@ -494,12 +500,6 @@ if (NOT SCREAM_CIME_BUILD)
 
   add_subdirectory(${EKAT_SOURCE_DIR} ${CMAKE_BINARY_DIR}/externals/ekat)
 endif()
-
-# Set compiler-specific flags
-include(EkatSetCompilerFlags)
-ResetFlags()
-SetCommonFlags()
-SetProfilingFlags(PROFILER ${EKAT_PROFILING_TOOL} COVERAGE ${EKAT_ENABLE_COVERAGE})
 
 include(EkatMpiUtils)
 # We should avoid cxx bindings in mpi; they are already deprecated,


### PR DESCRIPTION
If in standalone mode, this ensures EKAT is built with the same flags as EAMxx.

[non-BFB] for standalone builds

---

With this fix, I am able to make the eamxx-sa / oneapi-openmp tests pass when ekat is built (like in our nightlies). The reason the nightlies failed is b/c the flag `-fp-model precise` was NOT in added to the ekat libs (and tests), which resulted in a couple of tests failing due to fp round errors.

This change should affect all standalone builds and executables, but the odds that the missing flags were affecting ekat code that was built as a library is tiny. Most of the issues would likely show in templated code, which by the time is compiled in EAMxx would be compiled with the correct flags anyways. The only issue was when building EKAT executables for tests.

On a separate note, I think we should start testing what happens if we completely remove the lines

```cmake
include(EkatSetCompilerFlags)
ResetFlags()
SetCommonFlags()
SetProfilingFlags(PROFILER ${EKAT_PROFILING_TOOL} COVERAGE ${EKAT_ENABLE_COVERAGE})
```
in CIME builds (i.e., use whatever flags CIME is telling us to use).