### PR TITLE
Workflows: make test-all-eamxx upload also the ctest XML files

### DIFF
--- a/.github/actions/test-all-eamxx/action.yml
+++ b/.github/actions/test-all-eamxx/action.yml
@@ -118,6 +118,6 @@ runs:
       with:
         name: log-files-${{ inputs.build_type }}-${{ inputs.machine }}
         path: |
-          components/eamxx/ctest-build/**/Testing/Temporary/Last*.log
           components/eamxx/ctest-build/**/ctest_resource_file.json
           components/eamxx/ctest-build/**/CMakeCache.txt
+          components/eamxx/ctest-build/**/Testing/**


### PR DESCRIPTION
Allows to better debug some ctest issues

[BFB]

---

This mimics what we did in the EKAT workflow, which allowed us to identify the strings in the oneapi compiler output that tripped CTest into thinking there was a test failure. We later added exceptions for those strings, and got the oneapi CI to stop reporting false negatives. Hopefully, we can do the same here.

Edit: upon further consideration, I decided to upload the WHOLE `Testing` folder. It's not much more than what we were hand-picking, and this makes the workflow file easier.