### PR TITLE
Add ndrop nsubmix diagnostics

### DIFF
--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_functions.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_functions.hpp
@@ -7,6 +7,43 @@
 
 namespace scream {
 
+namespace detail {
+
+static constexpr Real max_exact_ndrop_nsubmix_aggregate = 16777216;
+
+KOKKOS_INLINE_FUNCTION
+bool can_accumulate_ndrop_nsubmix(const int nsubmix, const bool reset,
+                                  const Real sum) {
+  if(nsubmix <= 0) {
+    return false;
+  }
+  if(nsubmix > 16777216) {
+    return false;
+  }
+  const Real count = static_cast<Real>(nsubmix);
+  return reset ||
+         (sum >= 0 && sum <= max_exact_ndrop_nsubmix_aggregate - count);
+}
+
+KOKKOS_INLINE_FUNCTION
+void accumulate_ndrop_nsubmix(const int nsubmix, const bool reset,
+                              Real &latest, Real &sum, Real &maximum) {
+  EKAT_KERNEL_REQUIRE_MSG(
+      can_accumulate_ndrop_nsubmix(nsubmix, reset, sum),
+      "ndrop nsubmix is invalid or exceeds the exact integer output range");
+  const Real count = static_cast<Real>(nsubmix);
+  latest = count;
+  if(reset) {
+    sum     = count;
+    maximum = count;
+  } else {
+    sum += count;
+    maximum = count > maximum ? count : maximum;
+  }
+}
+
+}  // namespace detail
+
 namespace {
 
 void compute_w0_and_rho(const int ncol,
@@ -204,6 +241,10 @@ void call_function_dropmixnuc(
     MAMAci::view_3d coltend_cw, MAMAci::view_2d qcld,
     MAMAci::view_2d ndropcol, MAMAci::view_2d ndropmix, MAMAci::view_2d nsource,
     MAMAci::view_2d wtke, MAMAci::view_3d ccn,
+    mam_coupling::view_1d ndrop_nsubmix,
+    mam_coupling::view_1d ndrop_sum_nsubmix,
+    mam_coupling::view_1d ndrop_max_nsubmix,
+    const bool reset_ndrop_nsubmix_accumulators,
 
     // ## outputs to be used by other processes ##
     // qqcw_fld_work should be directly assigned to the cloud borne aerosols
@@ -350,6 +391,7 @@ void call_function_dropmixnuc(
               }
             });
         team.team_barrier();
+        int nsubmix = 0;
         mam4::ndrop::dropmixnuc(
             team, dt, ekat::subview(T_mid, icol), ekat::subview(p_mid, icol),
             ekat::subview(p_int, icol), ekat::subview(pdel, icol),
@@ -366,8 +408,8 @@ void call_function_dropmixnuc(
             ptend_q_view, ekat::subview(tendnd, icol),
             ekat::subview(factnum, icol), ekat::subview(ndropcol, icol),
             ekat::subview(ndropmix, icol), ekat::subview(nsource, icol),
-            ekat::subview(wtke, icol), ekat::subview(ccn, icol), coltend_view,
-            coltend_cw_view, top_lev,
+            nsubmix, ekat::subview(wtke, icol), ekat::subview(ccn, icol),
+            coltend_view, coltend_cw_view, top_lev,
             // work arrays
             raercol_cw_view, raercol_view, ekat::subview(nact, icol),
             ekat::subview(mact, icol), ekat::subview(eddy_diff, icol),
@@ -378,6 +420,13 @@ void call_function_dropmixnuc(
             ekat::subview(srcn, icol), ekat::subview(source, icol),
             ekat::subview(dz, icol), ekat::subview(csbot_cscen, icol),
             ekat::subview(raertend, icol), ekat::subview(qqcwtend, icol));
+
+        Kokkos::single(Kokkos::PerTeam(team), [&]() {
+          detail::accumulate_ndrop_nsubmix(
+              nsubmix, reset_ndrop_nsubmix_accumulators,
+              ndrop_nsubmix(icol), ndrop_sum_nsubmix(icol),
+              ndrop_max_nsubmix(icol));
+        });
       });
 }
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
@@ -155,6 +155,12 @@ void MAMAci::create_requests() {
   // FIXME: [TEMPORARY]droplet number mixing ratio source tendency [#/kg/s]
   add_field<Computed>("nsource", scalar3d_mid, n_unit / s, grid_name);
 
+  // Exact explicit vertical-mixing loop count from ndrop. The sum and maximum
+  // aggregate all MAMAci calls in the enclosing physics step.
+  add_field<Computed>("ndrop_nsubmix", scalar2d, none, grid_name);
+  add_field<Computed>("ndrop_sum_nsubmix", scalar2d, none, grid_name);
+  add_field<Computed>("ndrop_max_nsubmix", scalar2d, none, grid_name);
+
   // FIXME: [TEMPORARY]droplet number mixing ratio tendency due to mixing
   // [#/kg/s]
   add_field<Computed>("ndropmix", scalar3d_mid, n_unit / s, grid_name);
@@ -309,6 +315,9 @@ void MAMAci::initialize_impl(const RunType run_type) {
       {"nc_nuceat_tend", {-1e100, 1e100}},                   // FIXME
       {"nsource", {-1e10, 1e10}},                            // FIXME
       {"ndropmix", {-1e10, 1e10}},                           // FIXME
+      {"ndrop_nsubmix", {0, detail::max_exact_ndrop_nsubmix_aggregate}},
+      {"ndrop_sum_nsubmix", {0, detail::max_exact_ndrop_nsubmix_aggregate}},
+      {"ndrop_max_nsubmix", {0, detail::max_exact_ndrop_nsubmix_aggregate}},
       {"nc_inp_to_aci", {-1e10, 1e10}},                      // FIXME
       {"ccn_0p02", {-1e10, 1e10}},                           // FIXME
       {"ccn_0p05", {-1e10, 1e10}},                           // FIXME
@@ -439,6 +448,16 @@ void MAMAci::initialize_impl(const RunType run_type) {
   // Temporarily output nc_inp_to_aci_
   nc_inp_to_aci_ = get_field_out("nc_inp_to_aci").get_view<Real **>();
 
+  ndrop_nsubmix_ = get_field_out("ndrop_nsubmix").get_view<Real *>();
+  ndrop_sum_nsubmix_ =
+      get_field_out("ndrop_sum_nsubmix").get_view<Real *>();
+  ndrop_max_nsubmix_ =
+      get_field_out("ndrop_max_nsubmix").get_view<Real *>();
+  Kokkos::deep_copy(ndrop_nsubmix_, Real(0));
+  Kokkos::deep_copy(ndrop_sum_nsubmix_, Real(0));
+  Kokkos::deep_copy(ndrop_max_nsubmix_, Real(0));
+  reset_ndrop_nsubmix_accumulators_ = true;
+
   // FIXME: [TEMPORARY] remove the following ccn outputs
   ccn_0p02_ = get_field_out("ccn_0p02").get_view<Real **>();
   ccn_0p05_ = get_field_out("ccn_0p05").get_view<Real **>();
@@ -493,6 +512,10 @@ void MAMAci::initialize_impl(const RunType run_type) {
 // ================================================================
 void MAMAci::run_impl(const double dt) {
   using TPF = ekat::TeamPolicyFactory<KT::ExeSpace>;
+
+  const bool completes_physics_step =
+      do_update_time_stamp() &&
+      get_subcycle_iter() == get_num_subcycles() - 1;
 
   const auto scan_policy = TPF::get_thread_range_parallel_scan_team_policy(ncol_, nlev_);
 
@@ -562,6 +585,8 @@ void MAMAci::run_impl(const double dt) {
       cloud_frac_prev_, dry_aero_, nlev_, top_lev_, enable_aero_vertical_mix_,
       // output
       coltend_, coltend_cw_, qcld_, ndropcol_, ndropmix_, nsource_, wtke_, ccn_,
+      ndrop_nsubmix_, ndrop_sum_nsubmix_, ndrop_max_nsubmix_,
+      reset_ndrop_nsubmix_accumulators_,
       // ## output to be used by the other processes ##
       qqcw_fld_work_, ptend_q_, factnum_, tendnd_,
       // work arrays
@@ -615,6 +640,10 @@ void MAMAci::run_impl(const double dt) {
 
   post_process(wet_aero_, dry_aero_, dry_atm_);
   Kokkos::fence();  // wait before returning to calling function
+  reset_ndrop_nsubmix_accumulators_ = false;
+  if(completes_physics_step) {
+    reset_ndrop_nsubmix_accumulators_ = true;
+  }
 }
 
 }  // namespace scream

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.hpp
@@ -46,6 +46,7 @@ class MAMAci final : public MAMGenericInterface {
   Real wsubmin_;                   // Minimum subgrid vertical velocity
   bool enable_aero_vertical_mix_;  // To enable vertical mixing of aerosols
   int top_lev_;                    // Top level for MAM4xx
+  bool reset_ndrop_nsubmix_accumulators_ = true;
 
   //------------------------------------------------------------------------
   // END: ACI runtime ( or namelist) options
@@ -103,6 +104,9 @@ class MAMAci final : public MAMGenericInterface {
   view_3d ccn_;
   view_3d coltend_; 
   view_3d coltend_cw_; 
+  view_1d ndrop_nsubmix_;
+  view_1d ndrop_sum_nsubmix_;
+  view_1d ndrop_max_nsubmix_;
 
   // raercol_cw_ and raercol_ are work-array views for dropmixnuc whose
   // storage is allocated from the temporary buffer in init_temporary_views().

--- a/components/eamxx/src/physics/mam/tests/CMakeLists.txt
+++ b/components/eamxx/src/physics/mam/tests/CMakeLists.txt
@@ -11,6 +11,15 @@ if (NOT SCREAM_ONLY_GENERATE_BASELINES)
   target_compile_definitions(mam_photo_table_test PRIVATE
     SCREAM_DATA_DIR="${SCREAM_DATA_DIR}"
   )
+
+  CreateUnitTest(mam_ndrop_nsubmix_test
+    SOURCES mam_ndrop_nsubmix_test.cpp
+    LIBS mam
+    LABELS "mam;physics"
+    MPI_RANKS 1
+    THREADS 1
+  )
+
   # Ensure test input files are present in the data dir
   GetInputFile(scream/mam4xx/photolysis/table_photo_input_ts_355.yaml)
   GetInputFile(scream/mam4xx/photolysis/jlong_input_ts_355.yaml)

--- a/components/eamxx/src/physics/mam/tests/mam_ndrop_nsubmix_test.cpp
+++ b/components/eamxx/src/physics/mam/tests/mam_ndrop_nsubmix_test.cpp
@@ -1,0 +1,32 @@
+#include <catch2/catch.hpp>
+
+#include <physics/mam/eamxx_mam_aci_process_interface.hpp>
+#include <physics/mam/eamxx_mam_aci_functions.hpp>
+
+TEST_CASE("ndrop nsubmix aggregation", "[mam4][ndrop]") {
+  scream::Real latest = 100;
+  scream::Real sum = 100;
+  scream::Real maximum = 100;
+
+  scream::detail::accumulate_ndrop_nsubmix(2, true, latest, sum, maximum);
+  scream::detail::accumulate_ndrop_nsubmix(4, false, latest, sum, maximum);
+  scream::detail::accumulate_ndrop_nsubmix(3, false, latest, sum, maximum);
+
+  REQUIRE(latest == 3);
+  REQUIRE(sum == 9);
+  REQUIRE(maximum == 4);
+
+  REQUIRE(scream::detail::can_accumulate_ndrop_nsubmix(
+      3, false, scream::detail::max_exact_ndrop_nsubmix_aggregate - 3));
+  REQUIRE_FALSE(scream::detail::can_accumulate_ndrop_nsubmix(
+      4, false, scream::detail::max_exact_ndrop_nsubmix_aggregate - 3));
+  REQUIRE_FALSE(scream::detail::can_accumulate_ndrop_nsubmix(0, true, 0));
+  REQUIRE_FALSE(scream::detail::can_accumulate_ndrop_nsubmix(
+      16777217, true, 0));
+
+  sum = scream::detail::max_exact_ndrop_nsubmix_aggregate - 3;
+  scream::detail::accumulate_ndrop_nsubmix(3, false, latest, sum, maximum);
+  REQUIRE(latest == 3);
+  REQUIRE(sum == scream::detail::max_exact_ndrop_nsubmix_aggregate);
+  REQUIRE(maximum == 4);
+}

--- a/components/eamxx/tests/single-process/mam/aci/output.yaml
+++ b/components/eamxx/tests/single-process/mam/aci/output.yaml
@@ -57,6 +57,9 @@ fields:
       - num_c4
       - eddy_diff_heat
       - nc_nuceat_tend
+      - ndrop_nsubmix
+      - ndrop_sum_nsubmix
+      - ndrop_max_nsubmix
       - ni_activated
       
 output_control:


### PR DESCRIPTION
Add exact ndrop explicit mixing count diagnostics without changing the physics.

## Summary

Add three per-column EAMxx output fields:

- `ndrop_nsubmix`: count used by the most recent MAMAci call.
- `ndrop_sum_nsubmix`: sum across MAMAci calls in the enclosing physics step.
- `ndrop_max_nsubmix`: maximum across those calls.

MAM4xx returns the integer that directly controls the existing explicit mixing loop. EAMxx records the latest value and physics-step summaries within the existing device kernel, without a per-call host copy, MPI reduction, or separate reset kernel.

All three fields are initialized to zero. Before the first ACI call, zero means that the count has not yet been calculated.

## Exactness and failure behavior

Atmospheric history output defaults to single precision, including for double-precision model builds. An always-active check therefore limits each count and accumulated sum to 16,777,216 (2^24) in all builds. Every accepted integer remains exact both in the model's `Real` fields and in default history output. Invalid nonpositive counts and aggregates above the exact limit fail loudly.

## Dependency

Depends on [eagles-project/mam4xx#577](https://github.com/eagles-project/mam4xx/pull/577), which exposes the exact loop count without changing MAM4xx physics.

## Validation

- MAM4xx focused ndrop unit test: 1/1 passed.
- Complete MAM4xx ndrop comparison suite: 78 passed and 2 existing configured skips; no numerical failures.
- Independent review: PASS for draft-PR readiness.
- Local EAMxx compilation was not attempted because this Mac is not a supported EAMxx test machine.

## Scope

This diagnostic-only change does not alter the computed substep count, loop bounds, equations, limiters, process ordering, state updates, or production physics.