### PR TITLE
Fix uninitialized tc_curr causing FIDEAL debug crash

### DIFF
--- a/components/eam/src/physics/cam/physpkg.F90
+++ b/components/eam/src/physics/cam/physpkg.F90
@@ -840,6 +840,12 @@ subroutine phys_init( phys_state, phys_tend, pbuf2d, cam_out )
 
     call check_energy_init(phys_state)
 
+    ! Initialize energy diagnostic state fields (tc_curr, tc_init, etc.)
+    ! so they aren't left at the Infinity sentinel value for ideal/adiabatic
+    ! physics configurations (e.g. FIDEAL), which return before the call
+    ! further below.
+    call co2_diags_init(phys_state)
+
     call tracers_init()
 
     ! age of air tracers
@@ -913,7 +919,6 @@ subroutine phys_init( phys_state, phys_tend, pbuf2d, cam_out )
     if (co2_transport()) then
        call co2_init()
     end if
-    call co2_diags_init(phys_state)
 
     ! CAM3 prescribed ozone
     if (cam3_ozone_data_on) call cam3_ozone_data_init(phys_state)


### PR DESCRIPTION
Fix a crash in FIDEAL debug builds caused by an uninitialized energy diagnostic state field.

Fixes https://github.com/E3SM-Project/E3SM/issues/5294

## Description

The energy diagnostic state fields (`tc_curr`, `tc_init`, `tc_mnst`, `tc_prev`) are allocated with `tc_curr` set to an `Infinity` sentinel value, and are normally zeroed out by `co2_diags_init()`. However, `phys_init()` returns early for adiabatic/ideal physics configurations (e.g. the `FIDEAL` compset) before reaching the `co2_diags_init()` call, leaving `tc_curr` at `Infinity` for the entire run.

In debug builds, this trips the `shr_assert_in_domain` check on `state%tc_curr` and crashes the run with a segmentation fault during `cime_init`.

This PR moves the `co2_diags_init()` call to before the `adiabatic`/`ideal_phys` early return in `phys_init()` so these fields are always initialized, and removes the now-redundant duplicate call further down.

## Testing

Tested on Chrysalis (LCRC) with `ERP_D_Ld3.ne4pg2_ne4pg2.FIDEAL.chrysalis_gnu.allactive-pioroot1` and `ERP_D_Ld3.ne4pg2_ne4pg2.FIDEAL.chrysalis_intel.allactive-pioroot1` (both now PASS; previously failed with a segfault at RUN). Also verified `ERP_Ld3.ne4pg2_ne4pg2.FIDEAL.chrysalis_intel.allactive-pioroot1 -c -b master` passes and matches the `master` baseline bit-for-bit, confirming no change in non-debug model behavior.