### PR TITLE
For pm-gpu, reapply a LD_LIBRARY_PATH work-around to avoid cuda runtime error

### DIFF
--- a/cime_config/machines/config_machines.xml
+++ b/cime_config/machines/config_machines.xml
@@ -515,9 +515,7 @@
       <env name="MPICH_COLL_SYNC">MPI_Bcast</env>
       <env name="NETCDF_PATH">$ENV{CRAY_NETCDF_HDF5PARALLEL_PREFIX}</env>
       <env name="PNETCDF_PATH">$ENV{CRAY_PARALLEL_NETCDF_PREFIX}</env>
-    </environment_variables>
-    <environment_variables DEBUG="TRUE">
-      <env name="LD_LIBRARY_PATH">$ENV{CRAY_LD_LIBRARY_PATH}:$ENV{LD_LIBRARY_PATH}</env> <!-- https://github.com/E3SM-Project/E3SM/issues/7117 -->
+      <env name="LD_LIBRARY_PATH">$ENV{CRAY_LD_LIBRARY_PATH}:$ENV{LD_LIBRARY_PATH}</env> <!-- https://github.com/E3SM-Project/E3SM/issues/8650 -->
     </environment_variables>
     <environment_variables BUILD_THREADED="TRUE">
       <env name="OMP_STACKSIZE">128M</env>


### PR DESCRIPTION
Place `CRAY_LD_LIBRARY_PATH` before `LD_LIBRARY_PATH` for non-DEBUG cases on pm-gpu.
Restores the Cray MPI/HDF5/NetCDF libraries and ensures they win over conflicting libraries introduced by the new CPE/CUDA modules.  CRAY_LD_LIBRARY_PATH supplies libraries that are otherwise absent.

Fixes https://github.com/E3SM-Project/E3SM/issues/8650

[bfb]


