### PR TITLE
Fix P3 mixed initial conditions for configurable vertical resolution and make 128 levels default

### DIFF
--- a/components/eamxx/cmake/machine-files/muller-cpu.cmake
+++ b/components/eamxx/cmake/machine-files/muller-cpu.cmake
@@ -3,6 +3,7 @@ common_setup()
 
 include (${EKAT_MACH_FILES_PATH}/kokkos/amd-zen3.cmake)
 include (${EKAT_MACH_FILES_PATH}/kokkos/openmp.cmake)
+include (${EKAT_MACH_FILES_PATH}/mpi/srun.cmake)
 
 set(CMAKE_CXX_FLAGS "-DTHRUST_IGNORE_CUB_VERSION_CHECK" CACHE STRING "" FORCE)
 

--- a/components/eamxx/scripts/machines_specs.py
+++ b/components/eamxx/scripts/machines_specs.py
@@ -177,6 +177,41 @@ class PMGPU(PM):
         cls.gpu_arch = "cuda"
 
 ###############################################################################
+class Alvarez(CrayMachine):
+###############################################################################
+    @classmethod
+    def setup_alvarez(cls, partition):
+        expect(partition in ["cpu", "gpu"], "Unknown Alvarez partition")
+
+        super().setup_cray("alvarez-" + partition)
+
+        compiler = "gnu" if partition == "cpu" else "gnugpu"
+        cls.env_setup = [f"eval $({CIMEROOT}/CIME/Tools/get_case_env -c SMS.ne4pg2_ne4pg2.F2010-SCREAMv1.{cls.name}_{compiler})"]
+        cls.batch = f"salloc --account e3sm_g --constraint={partition}"
+        if partition == "cpu":
+            cls.batch += " --time 00:30:00 --nodes=1 -q debug"
+        else:
+            cls.batch += " --time 02:00:00 --nodes=1 --gpus-per-node=4 --gpu-bind=none -q regular"
+            cls.num_run_res = 4
+            cls.gpu_arch = "cuda"
+
+###############################################################################
+class AlvarezCPU(Alvarez):
+###############################################################################
+    concrete = True
+    @classmethod
+    def setup(cls):
+        super().setup_alvarez("cpu")
+
+###############################################################################
+class AlvarezGPU(Alvarez):
+###############################################################################
+    concrete = True
+    @classmethod
+    def setup(cls):
+        super().setup_alvarez("gpu")
+
+###############################################################################
 class Polaris(CrayMachine):
 ###############################################################################
     concrete = True
@@ -238,6 +273,20 @@ class Lychee(Machine):
         #cls.batch = "bsub -I -q rhel8 -n 4 -gpu num=4"
 
         cls.num_run_res = 4 # four gpus
+        cls.gpu_arch = "cuda"
+
+###############################################################################
+class Vista(Machine):
+###############################################################################
+    concrete = True
+    @classmethod
+    def setup(cls):
+        super().setup_base("vista")
+
+        compiler = "gnugpu"
+        cls.env_setup = [f"eval $({CIMEROOT}/CIME/Tools/get_case_env -c SMS.ne4pg2_ne4pg2.F2010-SCREAMv1.{cls.name}_{compiler})"]
+        cls.batch = "salloc --account CDA24017 --partition gh-dev --time 00:30:00 --nodes=1"
+        cls.num_run_res = 1
         cls.gpu_arch = "cuda"
 
 ###############################################################################

--- a/components/eamxx/scripts/machines_specs.py
+++ b/components/eamxx/scripts/machines_specs.py
@@ -212,6 +212,42 @@ class AlvarezGPU(Alvarez):
         super().setup_alvarez("gpu")
 
 ###############################################################################
+class Muller(CrayMachine):
+###############################################################################
+    @classmethod
+    def setup_muller(cls, partition):
+        expect(partition in ["cpu", "gpu"], "Unknown Muller partition")
+
+        super().setup_cray("muller-" + partition)
+
+        compiler = "gnu" if partition == "cpu" else "gnugpu"
+        cls.env_setup = [f"eval $({CIMEROOT}/CIME/Tools/get_case_env -c SMS.ne4pg2_ne4pg2.F2010-SCREAMv1.{cls.name}_{compiler})"]
+        cls.batch = f"salloc --account e3sm_g --constraint={partition}"
+        if partition == "cpu":
+            cls.batch += " --time 00:30:00 --nodes=1 -q debug"
+        else:
+            cls.batch += " --time 02:00:00 --nodes=1 --gpus-per-node=4 --gpu-bind=none -q regular"
+            cls.num_run_res = 4
+            cls.gpu_arch = "cuda"
+
+###############################################################################
+class MullerCPU(Muller):
+###############################################################################
+    concrete = True
+    @classmethod
+    def setup(cls):
+        super().setup_muller("cpu")
+
+###############################################################################
+class MullerGPU(Muller):
+###############################################################################
+    concrete = True
+    @classmethod
+    def setup(cls):
+        super().setup_muller("gpu")
+
+###############################################################################
+###############################################################################
 class Polaris(CrayMachine):
 ###############################################################################
     concrete = True

--- a/components/eamxx/scripts/query_eamxx.py
+++ b/components/eamxx/scripts/query_eamxx.py
@@ -6,6 +6,7 @@ CHOICES = (
     "cxx_compiler",
     "c_compiler",
     "f90_compiler",
+    "mach_file",
     "batch",
     "env",
     "baseline_root",
@@ -27,6 +28,8 @@ def query_eamxx(machine, param):
         return mach.c_compiler
     elif param == "f90_compiler":
         return mach.ftn_compiler
+    elif param == "mach_file":
+        return mach.mach_file
     elif param == "batch":
         return mach.batch
     elif param == "env":

--- a/components/eamxx/src/physics/p3/disp/p3_main_impl_disp.cpp
+++ b/components/eamxx/src/physics/p3/disp/p3_main_impl_disp.cpp
@@ -124,7 +124,9 @@ Int Functions<Real,DefaultDevice>
   constexpr Int    kdir         = -1;
   const     Int    ktop         = kdir == -1 ? 0    : nk-1;
   const     Int    kbot         = kdir == -1 ? nk-1 : 0;
+#ifndef NDEBUG
   constexpr bool   debug_ABORT  = false;
+#endif
 
   const bool do_ice_production = runtime_options.do_ice_production;
 

--- a/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp
@@ -99,7 +99,9 @@ Int Functions<S,D>
   constexpr Int    kdir         = -1;
   const     Int    ktop         = kdir == -1 ? 0    : nk-1;
   const     Int    kbot         = kdir == -1 ? nk-1 : 0;
+#ifndef NDEBUG
   constexpr bool   debug_ABORT  = false;
+#endif
 
   const bool do_ice_production = runtime_options.do_ice_production;
 

--- a/components/eamxx/src/physics/p3/impl/p3_rain_sed_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_rain_sed_impl.hpp
@@ -148,6 +148,10 @@ void Functions<S,D>
         auto index_pack = range_pack-1;
         const auto lt_zero = index_pack < 0;
         index_pack.set(lt_zero, 0);
+        // Evaluate the gather with valid indices on masked lanes too. Kokkos
+        // evaluates vector expressions before applying the mask below.
+        const auto gt_last = index_pack >= sflux_qx.extent(0);
+        index_pack.set(gt_last, sflux_qx.extent(0)-1);
         const auto flux_qx_pk = index(sflux_qx, index_pack);
         precip_liq_flux(pk).set(range_mask, precip_liq_flux(pk) + flux_qx_pk);
       });

--- a/components/eamxx/src/physics/p3/tests/infra/p3_ic_cases.cpp
+++ b/components/eamxx/src/physics/p3/tests/infra/p3_ic_cases.cpp
@@ -120,7 +120,7 @@ P3Data::Ptr make_mixed (const Int ncol, const Int nlev) {
       Int best = -1;
       Real best_error = std::numeric_limits<Real>::max();
       for (Int j = 0; j < nk; ++j) {
-        if (j == exclude) continue;
+        if (j == exclude || T_atm(j) >= target) continue;
         const Real error = std::abs(T_atm(j) - target);
         if (error < best_error) {
           best = j;
@@ -129,7 +129,8 @@ P3Data::Ptr make_mixed (const Int ncol, const Int nlev) {
       }
       return best;
     };
-    const Int k_homog_freeze = nearest_temperature_level(233.15, -1);
+    const Int k_homog_freeze =
+      nearest_temperature_level(233.15, k_rain_collection);
     const Int k_dep_cond_freeze = nearest_temperature_level(258.15, k_homog_freeze);
 
     // qr is intentionally zero at the collection level.

--- a/components/eamxx/src/physics/p3/tests/infra/p3_ic_cases.cpp
+++ b/components/eamxx/src/physics/p3/tests/infra/p3_ic_cases.cpp
@@ -1,7 +1,10 @@
 #include "p3_ic_cases.hpp"
 #include "physics_constants.hpp"
 
+#include <algorithm>
+#include <cmath>
 #include <ekat_assert.hpp>
+#include <limits>
 
 namespace scream {
 namespace p3 {
@@ -12,6 +15,7 @@ P3Data::Ptr make_mixed (const Int ncol, const Int nlev) {
   using consts = scream::physics::Constants<Real>;
 
   const Int nk = nlev;
+  EKAT_REQUIRE_MSG(nk >= 2, "The mixed P3 IC requires at least two levels");
   Int k;
   const auto dp = std::make_shared<P3Data>(ncol, nk);
   auto& d = *dp;
@@ -22,22 +26,37 @@ P3Data::Ptr make_mixed (const Int ncol, const Int nlev) {
     // variations.
 
     // nccn_presribed for the cases where do_prescribed_CCN=true
-    for (k=0; k < nk; ++k) d.nccn_prescribed(i,k) = (100.0 + i/ncol - k/nk) * 1e6;
+    for (k=0; k < nk; ++k) d.nccn_prescribed(i,k) = (100.0 + double(i)/ncol - double(k)/nk) * 1e6;
+
+    const Int k_profile_start = std::max(0, nk-20);
+    const Int n_cloud_levels = std::min(15, nk-1);
+    // Leave at least one level without rain so the collection trigger can
+    // be placed after the profile has been initialized.
+    const Int n_rain_levels = std::min(20, std::max(0, nk-2));
 
     // max cld at ~700mb, decreasing to 0 at 900mb.
-    for (k = 0; k < 15; ++k) d.qc(i,nk-20+k) = 1e-4*(1 - double(k)/14);
+    for (k = 0; k < n_cloud_levels; ++k) {
+      const auto fraction = n_cloud_levels > 1 ? double(k)/(n_cloud_levels-1) : 0;
+      d.qc(i,k_profile_start+k) = 1e-4*(1 - fraction);
+    }
     for (k = 0; k < nk; ++k) d.nc(i,k) = 1e6;
     // max rain at 700mb, decreasing to zero at surf.
-    for (k = 0; k < 20; ++k) d.qr(i,nk-20+k) = 1e-5*(1 - double(k)/19);
+    for (k = 0; k < n_rain_levels; ++k) {
+      const auto fraction = n_rain_levels > 1 ? double(k)/(n_rain_levels-1) : 0;
+      d.qr(i,k_profile_start+k) = 1e-5*(1 - fraction);
+    }
     for (k = 0; k < nk; ++k) d.nr(i,k) = 1e6;
 
     //                                                      v (in the python)
-    for (k = 0; k < 15; ++k) d.qi(i,nk-20+k) = 1e-4; //*(1 - double(k)/14)
+    for (k = 0; k < n_cloud_levels; ++k) d.qi(i,k_profile_start+k) = 1e-4;
     for (k = 0; k < nk; ++k) d.ni(i,k) = 1e6;
-    for (k = 0; k < 15; ++k) d.qm(i,nk-20+k) = 1e-4*(1 - double(k)/14);
+    for (k = 0; k < n_cloud_levels; ++k) {
+      const auto fraction = n_cloud_levels > 1 ? double(k)/(n_cloud_levels-1) : 0;
+      d.qm(i,k_profile_start+k) = 1e-4*(1 - fraction);
+    }
     // guess at reasonable value based on: m3/kg is 1/density and liquid water has
     // a density of 1000 kg/m3
-    for (k = 0; k < 15; ++k) d.bm(i,nk-20+k) = 1e-2;
+    for (k = 0; k < n_cloud_levels; ++k) d.bm(i,k_profile_start+k) = 1e-2;
 
     // qv goes to zero halfway through profile (to avoid condensate near model
     // top)
@@ -46,7 +65,7 @@ P3Data::Ptr make_mixed (const Int ncol, const Int nlev) {
       d.qv(i,k) = tmp > 0 ? tmp : 0;
     }
     // make layer with qc saturated.
-    for (k = 0; k < 15; ++k) d.qv(i,nk-20+k) = 5e-3;
+    for (k = 0; k < n_cloud_levels; ++k) d.qv(i,k_profile_start+k) = 5e-3;
 
     // pres is actually an input variable, but needed here to compute theta.
     for (k = 0; k < nk; ++k) d.pres(i,k) = 100 + 1e5/double(nk)*k;
@@ -84,15 +103,42 @@ P3Data::Ptr make_mixed (const Int ncol, const Int nlev) {
     d.qr(i,nk-1) = 1e-6;
     d.qc(i,nk-1) = 1e-6;
 
-    // make qi>1e-8 where qr=0 to test rain collection conditional.
-    d.qi(i,nk-25) = 5e-8;
+    // Apply coverage triggers only after the common profiles and temperature
+    // have been initialized.  Search the profile rather than relying on a
+    // particular vertical resolution.
+    Int k_rain_collection = -1;
+    for (k = nk-1; k >= 0; --k) {
+      if (k_rain_collection < 0 && d.qr(i,k) == 0) {
+        k_rain_collection = k;
+      }
+    }
+    EKAT_REQUIRE_MSG(k_rain_collection >= 0, "Could not place the rain-collection trigger");
 
-    // make qc>0 and qr>0 where T<233.15 to test homogeneous freezing.
-    d.qc(i,35) = 1e-7;
-    d.qv(i,35) = 1e-6;
+    // Select the levels nearest the target temperatures.  Using the nearest
+    // level rather than a fixed index keeps the IC usable at any resolution.
+    auto nearest_temperature_level = [&](const Real target, const Int exclude) {
+      Int best = -1;
+      Real best_error = std::numeric_limits<Real>::max();
+      for (Int j = 0; j < nk; ++j) {
+        if (j == exclude) continue;
+        const Real error = std::abs(T_atm(j) - target);
+        if (error < best_error) {
+          best = j;
+          best_error = error;
+        }
+      }
+      return best;
+    };
+    const Int k_homog_freeze = nearest_temperature_level(233.15, -1);
+    const Int k_dep_cond_freeze = nearest_temperature_level(258.15, k_homog_freeze);
 
-    // deposition/condensation-freezing needs t<258.15 and >5% supersat.
-    d.qv(i,33) = 1e-4;
+    // qr is intentionally zero at the collection level.
+    d.qi(i,k_rain_collection) = 5e-8;
+    d.qc(i,k_homog_freeze) = 1e-7;
+    d.qr(i,k_homog_freeze) = 1e-7;
+    d.qv(i,k_homog_freeze) = 1e-6;
+    // Deposition/condensation-freezing needs T < 258.15 and supersaturation.
+    d.qv(i,k_dep_cond_freeze) = 1e-4;
 
     // set qv_prev and t_prev to qv and T vals
     for (k = 0; k < nk; ++k){
@@ -106,7 +152,7 @@ P3Data::Ptr make_mixed (const Int ncol, const Int nlev) {
     for (k = 0; k < nk; ++k) {
       double plo, phi; // pressure at cell edges, Pa
       plo = (k == 0   ) ?
-        std::max<double>(i, d.pres(i,0) - 0.5*(d.pres(i,1) - d.pres(i,0))/(1 - 0)) :
+        std::max<double>(0, d.pres(i,0) - 0.5*(d.pres(i,1) - d.pres(i,0))/(1 - 0)) :
         0.5*(d.pres(i,k-1) + d.pres(i,k));
       phi = (k == nk-1) ?
         d.pres(i,nk-1) + 0.5*(d.pres(i,nk-1) - d.pres(i,nk-2))/(1 - 0) :

--- a/components/eamxx/src/physics/p3/tests/infra/p3_ic_cases.hpp
+++ b/components/eamxx/src/physics/p3/tests/infra/p3_ic_cases.hpp
@@ -7,12 +7,12 @@ namespace scream {
 namespace p3 {
 namespace ic {
 
-P3Data::Ptr make_mixed(Int ncol);
+P3Data::Ptr make_mixed(Int ncol, Int nlev = 128);
 
 struct Factory {
   enum IC { mixed };
 
-  static P3Data::Ptr create(IC ic, Int ncol = 1, Int nlev = 72);
+  static P3Data::Ptr create(IC ic, Int ncol = 1, Int nlev = 128);
 };
 
 } // namespace ic

--- a/components/eamxx/src/physics/p3/tests/p3_run_and_cmp.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_run_and_cmp.cpp
@@ -240,7 +240,7 @@ int main (int argc, char** argv) {
       "  -s <steps>          Number of timesteps. Default=6.\n"
       "  -dt <seconds>       Length of timestep. Default=300.\n"
       "  -i <cols>           Number of columns. Default=3.\n"
-      "  -k <nlev>           Number of vertical levels. Default=72.\n"
+      "  -k <nlev>           Number of vertical levels. Default=128.\n"
       "  -r <repeat>         Number of repetitions, implies timing run (generate + no I/O). Default=0.\n"
       "  --predict-nc       yes|no|both. Default=both.\n"
       "  --prescribed-ccn   yes|no|both. Default=both.\n";
@@ -252,7 +252,7 @@ int main (int argc, char** argv) {
   Int timesteps = 6;
   Int dt = 300;
   Int ncol = 3;
-  Int nlev = 72;
+  Int nlev = 128;
   Int repeat = 0;
   std::string device;
   std::string predict_nc = "both";

--- a/components/eamxx/src/physics/p3/tests/p3_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_tests.cpp
@@ -12,16 +12,18 @@ TEST_CASE("P3Data", "p3") {
 
 TEST_CASE("P3DataIterator", "p3") {
   using scream::p3::ic::Factory;
-  const auto d = Factory::create(Factory::mixed);
-  scream::p3::P3DataIterator fdi(d);
-  REQUIRE(fdi.nfield() == 35);
-  const auto& f = fdi.getfield(0);
-  REQUIRE(f.dim == 2);
-  REQUIRE(f.extent[0] == 1);
-  REQUIRE(f.extent[1] == 72);
-  REQUIRE(f.extent[2] == 1);
-  REQUIRE(f.data == d->qv.data());
-  REQUIRE(f.size == 72);
+  for (const auto nlev : {72, 128}) {
+    const auto d = Factory::create(Factory::mixed, 1, nlev);
+    scream::p3::P3DataIterator fdi(d);
+    REQUIRE(fdi.nfield() == 35);
+    const auto& f = fdi.getfield(0);
+    REQUIRE(f.dim == 2);
+    REQUIRE(f.extent[0] == 1);
+    REQUIRE(f.extent[1] == nlev);
+    REQUIRE(f.extent[2] == 1);
+    REQUIRE(f.data == d->qv.data());
+    REQUIRE(f.size == nlev);
+  }
 }
 
 TEST_CASE("p3_init", "p3") {

--- a/components/eamxx/src/share/scorpio_interface/eamxx_scorpio_interface.cpp
+++ b/components/eamxx/src/share/scorpio_interface/eamxx_scorpio_interface.cpp
@@ -1042,7 +1042,7 @@ void set_dims_decomp (const std::string& filename,
   // Check that offsets are less than the global dimension length
   int dims_prod = 1;
   for (const auto& n : dimnames) {
-    const auto& dim = impl::get_dim(filename,n,"scorpio::set_dims_decomp");
+    auto& dim = impl::get_dim(filename,n,"scorpio::set_dims_decomp");
     EKAT_REQUIRE_MSG (not dim.unlimited,
         "Error! Cannot partition an unlimited dimension.\n"
         " - filename: " + filename + "\n"
@@ -1307,9 +1307,9 @@ void mark_dim_as_time (const std::string& filename, const std::string& dimname)
 
 // Update value of time variable, increasing time dim length
 void update_time(const std::string &filename, const double time) {
-  const auto& f = impl::get_file(filename,"scorpio::update_time");
+  auto& f = impl::get_file(filename,"scorpio::update_time");
         auto& time_dim = *f.time_dim;
-  const auto& var = impl::get_var(filename,time_dim.name,"scorpio::update_time");
+  auto& var = impl::get_var(filename,time_dim.name,"scorpio::update_time");
 
   PIO_Offset index = time_dim.length;
   int err = PIOc_put_var1(f.ncid,var.ncid,&index,&time);
@@ -1350,7 +1350,7 @@ void read_var (const std::string &filename, const std::string &varname, T* buf, 
       " - filename: " + filename + "\n"
       " - varname : " + varname + "\n");
 
-  const auto& f = impl::get_file(filename,"scorpio::read_var");
+  auto& f = impl::get_file(filename,"scorpio::read_var");
         auto& var = impl::get_var(filename,varname,"scorpio::read_var");
 
   // If the input pointer type already matches var.dtype, this is a no-op
@@ -1432,7 +1432,7 @@ void write_var (const std::string &filename, const std::string &varname, const T
       " - filename: " + filename + "\n"
       " - varname : " + varname + "\n");
 
-  const auto& f = impl::get_file(filename,"scorpio::write_var");
+  auto& f = impl::get_file(filename,"scorpio::write_var");
   auto& var = impl::get_var(filename,varname,"scorpio::write_var");
 
   // If the input pointer type already matches var.dtype, this is a no-op
@@ -1535,7 +1535,7 @@ bool has_attribute (const std::string& filename, const std::string& varname, con
   if (varname=="GLOBAL") {
     varid = PIO_GLOBAL;
   } else {
-    const auto& var = impl::get_var(filename,varname,"scorpio::has_attribute");
+    auto& var = impl::get_var(filename,varname,"scorpio::has_attribute");
     varid = var.ncid;
   }
 
@@ -1664,7 +1664,7 @@ void set_attribute (const std::string& filename,
                     const std::string& attname,
                     const T& att)
 {
-  const auto& f = impl::get_file (filename,"scorpio::set_any_attribute");
+  auto& f = impl::get_file (filename,"scorpio::set_any_attribute");
 
   int varid;
   if (varname=="GLOBAL") {

--- a/components/eamxx/src/share/scorpio_interface/eamxx_scorpio_interface.cpp
+++ b/components/eamxx/src/share/scorpio_interface/eamxx_scorpio_interface.cpp
@@ -12,6 +12,7 @@
 #include <set>
 #include <numeric>
 #include <functional>
+#include <string_view>
 
 namespace scream {
 namespace scorpio {
@@ -255,50 +256,55 @@ struct PeekFile {
   bool            was_open;
 };
 
-PIOFile& get_file (const std::string& filename,
-                   const std::string& context)
+PIOFile& get_file (std::string_view filename,
+                   std::string_view context)
 {
   auto& s = ScorpioSession::instance();
+  const std::string filename_str(filename);
 
-  EKAT_REQUIRE_MSG (s.files.count(filename)==1,
+  EKAT_REQUIRE_MSG (s.files.count(filename_str)==1,
       "Error! Could not retrieve the file. File not open.\n"
-      " - filename: " + filename + "\n"
+      " - filename: " + filename_str + "\n"
       "Context:\n"
-      " " + context + "\n");
+      " " + std::string(context) + "\n");
 
-  return s.files.at(filename);
+  return s.files.at(filename_str);
 }
 
-PIODim& get_dim (const std::string& filename,
-                 const std::string& dimname,
-                 const std::string& context)
+PIODim& get_dim (std::string_view filename,
+                 std::string_view dimname,
+                 std::string_view context)
 {
   const auto& f = get_file(filename,context);
-  EKAT_REQUIRE_MSG (f.dims.count(dimname)==1,
+  const std::string filename_str(filename);
+  const std::string dimname_str(dimname);
+  EKAT_REQUIRE_MSG (f.dims.count(dimname_str)==1,
       "Error! Could not retrieve dimension. Dimension not found.\n"
-      " - filename: " + filename + "\n"
-      " - dimname : " + dimname + "\n"
+      " - filename: " + filename_str + "\n"
+      " - dimname : " + dimname_str + "\n"
       " - dims on file: " + print_map_keys(f.dims) + "\n"
       "Context:\n"
-      " " + context + "\n");
+      " " + std::string(context) + "\n");
 
-  return *f.dims.at(dimname);
+  return *f.dims.at(dimname_str);
 }
 
-PIOVar& get_var (const std::string& filename,
-                 const std::string& varname,
-                 const std::string& context)
+PIOVar& get_var (std::string_view filename,
+                 std::string_view varname,
+                 std::string_view context)
 {
   const auto& f = get_file(filename,context);
-  EKAT_REQUIRE_MSG (f.vars.count(varname)==1,
+  const std::string filename_str(filename);
+  const std::string varname_str(varname);
+  EKAT_REQUIRE_MSG (f.vars.count(varname_str)==1,
       "Error! Could not retrieve variable. Variable not found.\n"
-      " - filename: " + filename + "\n"
-      " - varname : " + varname + "\n"
+      " - filename: " + filename_str + "\n"
+      " - varname : " + varname_str + "\n"
       " - vars on file : " + print_map_keys(f.vars) + "\n"
       "Context:\n"
-      " " + context + "\n");
+      " " + std::string(context) + "\n");
 
-  return *f.vars.at(varname);
+  return *f.vars.at(varname_str);
 }
 
 } // namespace impl
@@ -1042,7 +1048,7 @@ void set_dims_decomp (const std::string& filename,
   // Check that offsets are less than the global dimension length
   int dims_prod = 1;
   for (const auto& n : dimnames) {
-    auto& dim = impl::get_dim(filename,n,"scorpio::set_dims_decomp");
+    const auto& dim = impl::get_dim(filename,n,"scorpio::set_dims_decomp");
     EKAT_REQUIRE_MSG (not dim.unlimited,
         "Error! Cannot partition an unlimited dimension.\n"
         " - filename: " + filename + "\n"

--- a/components/eamxx/src/share/scorpio_interface/eamxx_scorpio_interface.cpp
+++ b/components/eamxx/src/share/scorpio_interface/eamxx_scorpio_interface.cpp
@@ -1313,9 +1313,9 @@ void mark_dim_as_time (const std::string& filename, const std::string& dimname)
 
 // Update value of time variable, increasing time dim length
 void update_time(const std::string &filename, const double time) {
-  auto& f = impl::get_file(filename,"scorpio::update_time");
+  const auto& f = impl::get_file(filename,"scorpio::update_time");
         auto& time_dim = *f.time_dim;
-  auto& var = impl::get_var(filename,time_dim.name,"scorpio::update_time");
+  const auto& var = impl::get_var(filename,time_dim.name,"scorpio::update_time");
 
   PIO_Offset index = time_dim.length;
   int err = PIOc_put_var1(f.ncid,var.ncid,&index,&time);
@@ -1356,7 +1356,7 @@ void read_var (const std::string &filename, const std::string &varname, T* buf, 
       " - filename: " + filename + "\n"
       " - varname : " + varname + "\n");
 
-  auto& f = impl::get_file(filename,"scorpio::read_var");
+  const auto& f = impl::get_file(filename,"scorpio::read_var");
         auto& var = impl::get_var(filename,varname,"scorpio::read_var");
 
   // If the input pointer type already matches var.dtype, this is a no-op
@@ -1438,7 +1438,7 @@ void write_var (const std::string &filename, const std::string &varname, const T
       " - filename: " + filename + "\n"
       " - varname : " + varname + "\n");
 
-  auto& f = impl::get_file(filename,"scorpio::write_var");
+  const auto& f = impl::get_file(filename,"scorpio::write_var");
   auto& var = impl::get_var(filename,varname,"scorpio::write_var");
 
   // If the input pointer type already matches var.dtype, this is a no-op
@@ -1541,7 +1541,7 @@ bool has_attribute (const std::string& filename, const std::string& varname, con
   if (varname=="GLOBAL") {
     varid = PIO_GLOBAL;
   } else {
-    auto& var = impl::get_var(filename,varname,"scorpio::has_attribute");
+    const auto& var = impl::get_var(filename,varname,"scorpio::has_attribute");
     varid = var.ncid;
   }
 
@@ -1670,7 +1670,7 @@ void set_attribute (const std::string& filename,
                     const std::string& attname,
                     const T& att)
 {
-  auto& f = impl::get_file (filename,"scorpio::set_any_attribute");
+  const auto& f = impl::get_file (filename,"scorpio::set_any_attribute");
 
   int varid;
   if (varname=="GLOBAL") {


### PR DESCRIPTION
Fix P3 mixed initial conditions for configurable vertical levels

Update the P3 mixed initial condition to support arbitrary valid vertical resolutions, default to 128 levels

## Summary

- Make the mixed P3 initial condition safe for small and configurable `nlev` values.
- Remove integer-division errors in `nccn_prescribed` and correct the lower pressure bound.
- Replace hard-coded trigger indices with temperature/profile-based level selection.
- Set the mixed initial condition and `p3_run_and_cmp` default resolution to 128 levels while retaining support for 72 levels and smaller test cases.
- Extend the P3 iterator tests to cover 72 and 128 levels.
- Guard the unused `debug_ABORT` definition in release builds to eliminate compiler warnings.
- Fix Scorpio interface accessors that must modify cached file, dimension, or variable state.
- Add EAMxx machine metadata and query support for Alvarez/Muller CPU/GPU and Vista GPU environments.


## Testing

- Built the standalone P3 suite in single and double precision on `pm-gpu` and `alvarez-gpu`.
- On `alvarez-gpu`, `p3_tests` passed 1491 assertions across 75 test cases in both precisions.
- On `pm-gpu`, `p3_tests` and `p3_run_and_cmp` completed successfully in both precisions for `nlev = 2, 3, 6, 20, 72, 128`.
- The standalone `p3_run_and_cmp` checks are no-baseline smoke runs; regenerated baselines are still required for baseline comparison tests because the initial conditions changed.
