### PR TITLE
Fix race condition in gcam buildnml

### DIFF
--- a/components/gcam/cime_config/buildnml
+++ b/components/gcam/cime_config/buildnml
@@ -290,8 +290,8 @@ def buildnml(case, caseroot, compname):
 
     # === Symlinks formerly created by the run script ===
 
-    # Note, this this is touching files outside the case, there's a potential
-    # for races here if other gcam cases are running concurrently which is why
+    # Note: since this touches files outside the case, there's potential
+    # for races if other GCAM cases are running concurrently, which is why
     # we need distributed_dir_lock
     case_parent = os.path.dirname(caseroot)
     with distributed_dir_lock(case_parent, timeout=600):

--- a/components/gcam/cime_config/buildnml
+++ b/components/gcam/cime_config/buildnml
@@ -15,7 +15,7 @@ sys.path.append(os.path.join(_CIMEROOT, "scripts", "Tools"))
 
 from standard_script_setup import *
 from CIME.case import Case
-from CIME.utils import expect, run_cmd_no_fail, safe_copy
+from CIME.utils import expect, run_cmd_no_fail, safe_copy, distributed_dir_lock
 from CIME.buildnml import create_namelist_infile, parse_input
 
 _GCAM_LINK_OVERWRITE = False
@@ -79,11 +79,11 @@ def buildnml(case, caseroot, compname):
     # So for now make a simple one that just sets hgrid in config_cache.xml
     # - remove the creation of config_cache.xml from build-namelist
     #--------------------------------------------------------------------
-    
+
     sysmod = os.path.join(srcroot, "components/gcam/bld/configure")
     sysmod += " -hgrid {}".format(iac_grid)
     sysmod += " -usr_src {}".format(caseroot)
-    run_cmd_no_fail(sysmod, from_dir=iacconf_dir)    
+    run_cmd_no_fail(sysmod, from_dir=iacconf_dir)
 
     #--------------------------------------------------------------------
     # Invoke gcam build-namelist - output will go in $CASEBUILD/gcamconf
@@ -155,7 +155,7 @@ def buildnml(case, caseroot, compname):
         sysmod += ' -namelist " &gcamexp {} /" '.format(gcam_namelist_opts)
         sysmod += " -use_case {}".format(usecase)
         sysmod += ' -inst_string "{}" {}'.format(inst_string, gcam_bldnml_opts)
-        
+
         run_cmd_no_fail(sysmod, from_dir=iacconf_dir)
 
         # -----------------------------------------------------
@@ -289,9 +289,15 @@ def buildnml(case, caseroot, compname):
     # expect(os.path.isdir(gcam_rdir), "GCAM restart dir missing: {}".format(gcam_rdir))
 
     # === Symlinks formerly created by the run script ===
-    # this one is used by the regular GCAM configuration files
-    _ensure_symlink(os.path.join(gcam_idir, "input"),
-                    os.path.join(os.path.dirname(caseroot), "input"))
+
+    # Note, this this is touching files outside the case, there's a potential
+    # for races here if other gcam cases are running concurrently which is why
+    # we need distributed_dir_lock
+    case_parent = os.path.dirname(caseroot)
+    with distributed_dir_lock(case_parent, timeout=600):
+        # This one is used by the regular GCAM configuration files
+        _ensure_symlink(os.path.join(gcam_idir, "input"), os.path.join(case_parent, "input"))
+
     # this one is used by SMS/ERS tests
     _ensure_symlink(os.path.join(gcam_idir, "input"),
                     os.path.join(os.path.dirname(rundir), "input"))
@@ -334,7 +340,7 @@ def buildnml(case, caseroot, compname):
                  os.path.join(rundir, "iESM_Init_CropPast.nc"))
     _ensure_copy(os.path.join(ldir, "surfdata_360x720_mcrop2015_c07082020.nc"),
                  os.path.join(rundir, "surfdata_360x720_mcrop_init.nc"))
-    
+
     # Dynamic source: absolute path or relative to glm2iacdir - use copies for these files
     dyn_src_path = None
     if iesm_dyn_source:
@@ -414,7 +420,7 @@ def buildnml(case, caseroot, compname):
     ]
     if iesm_dyn_source:
         dyn_files_to_check.append(("surfdata_iESM_dyn.nc", dyn_src_in_rundir))
-    
+
     # Check if this is a fresh start (no existing dynamic files) or if we should create missing ones
     for dyn_name, src_file in dyn_files_to_check:
         dyn_path = os.path.join(rundir, dyn_name)
@@ -423,7 +429,7 @@ def buildnml(case, caseroot, compname):
             _ensure_copy(src_file, dyn_path)
         else:
             logger.info("Dynamic file already exists, preserving: %s", dyn_name)
-    
+
     # Special case: ensure surfdata_iESM_dyn.nc exists for non-startup runs if we have surfdata_iESM.nc
     if not (run_type == "startup" and str(run_refdate).startswith("2015")):
         if iesm_dyn_source and os.path.exists(os.path.join(rundir, "surfdata_iESM.nc")):


### PR DESCRIPTION
Use new CIME util to lock the shared directory.

As a side note, are we sure that this line:
`_ensure_symlink(os.path.join(gcam_idir, "input"), os.path.join(case_parent, "input"))`

... is the desired behavior? I know nothing about GCAM, but `$caseroot/input` makes more sense than `$caseroot/../input` which, for most machines would put it in `$scratch/input`.

I also cleaned up some trailing whitespace.

[BFB]