### PR TITLE
Fix eamxx-L72 testmod accidentally affecting all its users

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -764,7 +764,7 @@ _TESTS = {
             "ERS_Ln22.ne30_ne30.F2010-SCREAMv1.eamxx-internal_diagnostics_level--eamxx-output-preset-3",
             "PEM_Ln90.ne30pg2_ne30pg2.F2010-SCREAMv1.eamxx-spa_remap",
             "ERS_Ln90.ne30pg2_ne30pg2.F2010-SCREAMv1.eamxx-small_kernels--eamxx-output-preset-5",
-            "ERP_Ln22.conusx4v1pg2_r05_oECv3.F2010-SCREAMv1-noAero.eamxx-bfbhash--eamxx-L72",
+            "ERP_Ln22.conusx4v1pg2_r05_oECv3.F2010-SCREAMv1-noAero.eamxx-bfbhash--eamxx-L72-rrm",
             "ERS_Ln22.ne30pg2_ne30pg2.F2010-SCREAMv1.eamxx-L128--eamxx-output-preset-4",
             "REP_Ld5.ne30pg2_ne30pg2.F2010-SCREAMv1.eamxx-L128--eamxx-output-preset-6",
             "SMS.ne30pg2_EC30to60E2r2.WCYCLXX2010",

--- a/components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/L72/rrm/shell_commands
+++ b/components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/L72/rrm/shell_commands
@@ -1,0 +1,7 @@
+./xmlchange SCREAM_CMAKE_OPTIONS="`./xmlquery -value SCREAM_CMAKE_OPTIONS | sed 's/SCREAM_NUM_VERTICAL_LEV [0-9][0-9]*/SCREAM_NUM_VERTICAL_LEV 72/'`"
+
+# Enable the tensor-viscosity sponge layer at the model top.
+$CIMEROOT/../components/eamxx/scripts/atmchange tom_sponge_start=2 -b
+$CIMEROOT/../components/eamxx/scripts/atmchange laplace_scaling=1 -b
+$CIMEROOT/../components/eamxx/scripts/atmchange nu_top=5e-7 -b
+$CIMEROOT/../components/eamxx/scripts/atmchange hypervis_subcycle=2 -b

--- a/components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/L72/shell_commands
+++ b/components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/L72/shell_commands
@@ -1,7 +1,1 @@
 ./xmlchange SCREAM_CMAKE_OPTIONS="`./xmlquery -value SCREAM_CMAKE_OPTIONS | sed 's/SCREAM_NUM_VERTICAL_LEV [0-9][0-9]*/SCREAM_NUM_VERTICAL_LEV 72/'`"
-
-# Enable the tensor-viscosity sponge layer at the model top.
-$CIMEROOT/../components/eamxx/scripts/atmchange tom_sponge_start=2 -b
-$CIMEROOT/../components/eamxx/scripts/atmchange laplace_scaling=1 -b
-$CIMEROOT/../components/eamxx/scripts/atmchange nu_top=5e-7 -b
-$CIMEROOT/../components/eamxx/scripts/atmchange hypervis_subcycle=2 -b


### PR DESCRIPTION
Fix a regression from PR #8646 where the shared eamxx-L72 testmod was accidentally modified to enable the sponge layer for all its users instead of just the intended RRM conus test.

## Description

PR #8646 added sponge-layer atmchange commands directly to `testmods_dirs/eamxx/L72/shell_commands`, intending to enable tensor-viscosity sponge-layer testing only for the `conusx4v1pg2` RRM bfbhash test. However, `eamxx-L72` is a widely shared testmod used by many other tests (e.g. the mam4xx REP/ERS/SMS_D test families in `cime_config/tests.py`), so this change inadvertently altered those tests as well.

This PR:
- Reverts `testmods_dirs/eamxx/L72/shell_commands` back to its original content (just the vertical-level change).
- Adds a new nested testmod, `testmods_dirs/eamxx/L72/rrm` (test name `eamxx-L72-rrm`), containing the L72 vertical-level change plus the sponge-layer atmchange commands.
- Updates the `conusx4v1pg2` RRM bfbhash test entry in `cime_config/tests.py` to use `eamxx-L72-rrm` instead of `eamxx-L72`, restoring the other `eamxx-L72` users to their original behavior.