### PR TITLE
EAMxx: attempt to fix intermittent fail of oneapi CI runs

### DIFF
--- a/components/eamxx/cmake/CTestCustom.cmake
+++ b/components/eamxx/cmake/CTestCustom.cmake
@@ -1,0 +1,7 @@
+# Exception rules for ctest automatic error detection
+# These are strings in the build output that ctest mistakenly
+# interprets as errors
+list(APPEND CTEST_CUSTOM_ERROR_EXCEPTION
+  ".*error_handler.*"
+  ".*spdlog/fmt/bundled/format.h.*"
+)

--- a/components/eamxx/cmake/ctest_script.cmake
+++ b/components/eamxx/cmake/ctest_script.cmake
@@ -17,13 +17,8 @@ set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
 
 ctest_start(${dashboard_model} TRACK ${dashboard_track})
 
-# Add some exception rules for ctest automatic error detection
-# These are strings in the build output that ctest mistakenly
-# interprets as errors
-list(APPEND CTEST_CUSTOM_ERROR_EXCEPTION
-  ".*error_handler.*"
-  ".*spdlog/fmt/bundled/format.h.*"
-)
+# Read CTestCustom.cmake from this folder
+ctest_read_custom_files("${CMAKE_CURRENT_LIST_DIR}")
 
 if (USE_NINJA)
   set (CTEST_CMAKE_GENERATOR Ninja)

--- a/components/eamxx/cmake/ctest_script.cmake
+++ b/components/eamxx/cmake/ctest_script.cmake
@@ -24,6 +24,17 @@ if (USE_NINJA)
   set (CTEST_CMAKE_GENERATOR Ninja)
 endif()
 
+# Decide what build flags to use
+set (BUILD_FLAGS)
+if (NOT USE_NINJA)
+  string (APPEND BUILD_FLAGS " --output-sync=target")
+endif()
+if (DEFINED ENV{SCREAM_BUILD_PARALLEL_LEVEL})
+  string (APPEND BUILD_FLAGS " -j$ENV{SCREAM_BUILD_PARALLEL_LEVEL}")
+else()
+  string (APPEND BUILD_FLAGS " -j4")
+endif()
+
 separate_arguments(OPTIONS_LIST UNIX_COMMAND "${CMAKE_COMMAND}")
 ctest_configure(OPTIONS "${OPTIONS_LIST}" RETURN_VALUE CONFIG_ERROR_CODE)
 
@@ -31,11 +42,7 @@ if (CONFIG_ERROR_CODE)
   set (TEST_FAILS TRUE)
 else ()
   if (NOT CONFIG_ONLY)
-    if (DEFINED ENV{SCREAM_BUILD_PARALLEL_LEVEL})
-      ctest_build(FLAGS "-j$ENV{SCREAM_BUILD_PARALLEL_LEVEL}" RETURN_VALUE BUILD_ERROR_CODE)
-    else()
-      ctest_build(FLAGS "-j4" RETURN_VALUE BUILD_ERROR_CODE)
-    endif()
+    ctest_build(FLAGS "${BUILD_FLAGS}" RETURN_VALUE BUILD_ERROR_CODE)
 
     # Need this code so that build errors don't get buried
     if (BUILD_ERROR_CODE)


### PR DESCRIPTION
Two modifications:

- add flag to buffer make output to reduce odds of scrambling when building with large -j N values
- move the ctest exceptions to a file stored in the repo (rather than created on the fly).

[BFB]

---