### PR TITLE
EAMxx: enable maximum internal diags in ZMxx CIME test

### DIFF
--- a/cime_config/tests.py
+++ b/cime_config/tests.py
@@ -244,6 +244,7 @@ _TESTS = {
             "ERP_Ld3.ne4pg2_ne4pg2.FIDEAL.allactive-pioroot1",
             "ERS_Ld5.ne4pg2_oQU480.F2010.eam-sathist_F2010",
             "ERS_Ld5.ne4pg2_oQU480.F2010xx-ZM",
+            "ERS_Ld5.ne4pg2_oQU480.F2010xx-ZM.eamxx-zm_debug",
             )
         },
 

--- a/components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/zm_debug/shell_commands
+++ b/components/eamxx/cime_config/testdefs/testmods_dirs/eamxx/zm_debug/shell_commands
@@ -1,0 +1,1 @@
+$CIMEROOT/../components/eamxx/scripts/atmchange ANY::internal_diagnostics_level=2 eamxx::internal_diagnostics_level=0 -b


### PR DESCRIPTION
This PR is meant to be merged in next only. It will be used to get better diagnostics the next time the ZM xx test fails, since we cannot reproduce the fail manually.

I will revert on next when we're done debugging (or we can reset next to master if it's a good time).