### PR TITLE
Allow inheriting environment on PBS

### DIFF
--- a/cime_config/machines/config_batch.xml
+++ b/cime_config/machines/config_batch.xml
@@ -202,6 +202,7 @@
       <directive> -N {{ job_id }}</directive>
       <directive default="n"> -r {{ rerunnable }} </directive>
       <directive> -j oe </directive>
+      <directive> -V </directive>
     </directives>
   </batch_system>
 


### PR DESCRIPTION
Allow inheriting environment on PBS. This adds the `-V` directive to CIME when submitting on systems using pbspro. This option allows the batch job to inherit the environment from the calling script. Other batch systems seem to do this by default, so only seems to trigger on systems like Aurora using pbs. This eliminates the need to rely on user-changes in shell profiles to load the correct python in the batch job (still need to make sure a correct python is loaded before issuing any CIME commands). This change should only affect machines using pbspro.

[BFB]