### PR TITLE
Modifies mksurfdat to add wetland fraction to lakes

### DIFF
--- a/components/elm/tools/mksurfdata_map/src/mksurfdat.F90
+++ b/components/elm/tools/mksurfdata_map/src/mksurfdat.F90
@@ -843,6 +843,10 @@ program mksurfdat
        pctwet(n) = float(nint(pctwet(n)))
        pctgla(n) = float(nint(pctgla(n)))
        
+       ! ELM does not include physics for wetlands, so we add it to the lake fraction.
+       pctlak(n) = pctlak(n) + pctwet(n)
+       pctwet(n) = 0._r8
+
        ! Make sure sum of land cover types does not exceed 100. If it does,
        ! subtract excess from most dominant land cover.
        


### PR DESCRIPTION
ELM has no wetland-specific physics implemented. So, PCT_WETLAND is converted
to PCT_LAKE. The most significant impact of this PR is that new surface dataset generated
will have Black Sea and Caspian Sea treated as lakes instead of wetlands in ELM.

[BFB] for code.  Does change generated surface data.
