### PR TITLE
EAMxx: connect dexpr to diags

### DIFF
--- a/components/eamxx/CMakeLists.txt
+++ b/components/eamxx/CMakeLists.txt
@@ -537,6 +537,15 @@ endif()
 # scripts work correctly. We are not really interested in building/testing SCREAM.
 if (NOT DEFINED ENV{SCREAM_FAKE_ONLY})
 
+  if (NOT TARGET dexpr)
+    set (DEXPR_ENABLE_TESTS OFF CACHE BOOL "" FORCE)
+    set (DEXPR_ENABLE_TOOL  OFF CACHE BOOL "" FORCE)
+    set (DEXPR_WERROR       OFF CACHE BOOL "" FORCE)
+    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../../share/dexpr
+                     ${CMAKE_BINARY_DIR}/externals/dexpr)
+    set_target_properties(dexpr PROPERTIES POSITION_INDEPENDENT_CODE ON)
+  endif()
+
   add_subdirectory(tpls)
   add_subdirectory(src)
 

--- a/components/eamxx/docs/user/diags/builtin_aliases.md
+++ b/components/eamxx/docs/user/diags/builtin_aliases.md
@@ -35,6 +35,10 @@ which in turn chains:
 
 - Built-in aliases are checked before all other pattern rules (including suffix
   operators and binary ops), so they always take precedence.
+- `X_atm_backtend` ends in a `FieldOverDtDiag`, so it inherits that
+  diagnostic's restriction: it cannot be written to an `instant` output stream,
+  where `dt` is zero at `t0`. Use an averaged stream. See
+  [Field divided by timestep](field_over_dt.md).
 - The match is greedy on the field-name part, so `T_mid_at_500hPa_atm_backtend`
   expands to `T_mid_at_500hPa_minus_T_mid_at_500hPa_prev_over_dt`.
 - Additional built-in aliases may be added in `eamxx_io_utils.cpp` in the

--- a/components/eamxx/docs/user/diags/conditional_sampling.md
+++ b/components/eamxx/docs/user/diags/conditional_sampling.md
@@ -71,6 +71,18 @@ To count the percentage of earth where the surface pressure is > 1e5Pa:
 
 - `mask_where_ps_gt_100000_horiz_avg`
 
+**A mask cannot currently be written to file.** The mask diagnostic's output has
+`int` data type, and IO cannot write it: listing a `mask_where_..` name in
+`field_names` aborts the run with a narrowing-conversion error. Reducing it does
+not help: `mask_where_ps_gt_100000_horiz_avg` is still an `int`. The workaround
+is to promote it to `Real` by multiplying by 1, which is easiest to write as an
+[expression](expressions.md):
+
+```yaml
+field_names:
+  - wet_frac := mask.where(ps>100000)*1.0
+```
+
 ## Caveats
 
 - For now, we only support 1D, 2D, and 3D fields.

--- a/components/eamxx/docs/user/diags/conditional_sampling.md
+++ b/components/eamxx/docs/user/diags/conditional_sampling.md
@@ -55,8 +55,10 @@ Use the special condition field name `lev`.
 ## Mask-only calculation
 
 Compute a mask stating where the condition is met.
-Use the special input field name `mask`. The output will be `1`
-where the condition is satisfied and `0` elsewhere.
+Put `mask` where the sampled field name goes. It is a placeholder, not a field:
+nothing named `mask` exists in the field manager, and it is recognized only in
+that one position, so it cannot be requested or operated on by itself. The
+output will be `1` where the condition is satisfied and `0` elsewhere.
 This is particularly useful when combined with horizontal or vertical
 reductions to count occurrences of specific conditions.
 

--- a/components/eamxx/docs/user/diags/expressions.md
+++ b/components/eamxx/docs/user/diags/expressions.md
@@ -1,6 +1,6 @@
 # Diagnostic expressions
 
-Alongside the underscore names described in the rest of this section, EAMxx can
+As the underscore-based system is being deprecated, EAMxx can now
 build diagnostics from **expressions**:
 
 ```yaml
@@ -44,6 +44,7 @@ diagnostics use but that are not written), need no name of their own.
 | Operator | Meaning |
 | -------- | ------- |
 | `a + b`, `a - b`, `a * b`, `a / b` | element-wise arithmetic |
+| `-a` | negation, shorthand for `(-1)*a` |
 | `>`, `>=`, `<`, `<=`, `==`, `!=` | comparison, **only** inside `where(..)` |
 | `( )` | grouping |
 
@@ -55,11 +56,14 @@ field_names:
   - p_hPa      := p_mid/100
   - T_scaled   := T_mid*0.5
   - dry_air    := p_mid - qv*p_mid
+  - p_ratio    := p_mid / P0
 ```
 
 Precedence is the usual one, so `qc+qv*p_mid` is `qc+(qv*p_mid)`. Note this
 differs from the underscore spelling `qc_plus_qv_times_p_mid`, which means
-`(qc+qv)*p_mid`. When in doubt, parenthesize.
+`(qc+qv)*p_mid`. When in doubt, parenthesize. (That pair only illustrates
+grouping: `qc+(qv*p_mid)` adds a mixing ratio to a pressure, and is rejected at
+run time for incompatible units, while `(qc+qv)*p_mid` is fine.)
 
 ## Functions
 
@@ -79,7 +83,7 @@ is an honest analogue.
 | `X.sum('lev')` | `X_vert_sum` |
 | `X.mean('lev', weights='dp')` | `X_vert_avg_dp_weighted` |
 | `X.where(qv>0.01)` | `X_where_qv_gt_0.01` |
-| `X.differentiate('p_mid')` | `X_pvert_derivative` |
+| `X.derivative('p_mid')` | `X_pvert_derivative` |
 | `X.histogram(bins=[0,1,2])` | `X_histogram_0_1_2` |
 | `X.zonal_mean(bins=20)` | `X_zonal_avg_20_bins` |
 | `X.shift(time=1)` | `X_prev` |
@@ -104,8 +108,20 @@ Notes:
   `weights` for `'lev'` is `'dp'` or `'dz'`.
 - `where` takes a single comparison. `and`/`or` are not supported; chain
   `where(..)` calls instead. The special operand names `mask` and `lev` work as
-  they do in the underscore syntax, so `mask.where(lev>5)` is valid.
-- `X.tend()` is shorthand for `(X - X.shift(time=1)).over_dt()`.
+  they do in the underscore syntax, so `mask.where(lev>5)` parses.
+- **`over_dt` and `tend` cannot go in an `instant` stream.** An instant stream
+  takes a snapshot at `t0`, before any step has run, and `dt` is zero there, so
+  the diagnostic aborts with "dt must be positive". Write them to an averaged
+  stream (`averaging_type: average`, `max`, `min`) instead. This is a property
+  of the diagnostic, not of the syntax: the underscore spellings `X_over_dt` and
+  `X_atm_backtend` behave the same way.
+- **A `mask` operand cannot currently be written to file.** The diagnostic is
+  built, but its output has `int` data type, which IO cannot handle: writing
+  `mask.where(..)` (or the underscore `mask_where_..`) fails with a narrowing
+  conversion error, and reducing it first does not help. Multiply by 1 to
+  promote it to `Real` -- `mask.where(ps>100000)*1.0` writes fine.
+- `X.tend()` is shorthand for `(X - X.shift(time=1)).over_dt()`, and inherits
+  the `over_dt` restriction above.
 - Histogram bin edges must be non-negative, and must be writable without an
   exponent: the diagnostic joins them with `_` and splits them back apart, so
   `1e3` is fine (it is written `1000.0`) but `1e30` is not.
@@ -126,9 +142,12 @@ xarray, on the same arguments. The rest have no xarray spelling we could adopt:
 | `over_dt`, `tend` | no xarray equivalent |
 | `mean('lev', weights=..)` | xarray would be `weighted(dp).mean('lev')`, again a chain |
 
+`X.mean('lev', weights='dp')` is `(X*dp).sum('lev')/dp.sum('lev')`, but computed
+in one sweep rather than as three diagnostics.
+
 Two operand names are special, inherited from the underscore syntax rather than
 from xarray: `mask` stands for the 0/1 indicator of the condition itself, so
-`mask.where(..)` gives where the condition holds rather than sampling a field;
+`mask.where(...)` is 1 where the condition `(...)` holds;
 and `lev` on the left of a comparison means the level index.
 
 ## Errors
@@ -185,3 +204,11 @@ fails fast rather than at the moment a user first writes it.
 So adding a function means: register it with an example, translate it, and both
 checks come along for free. The `dexpr` command line tool does the same for the
 generic vocabulary -- `dexpr check "<expr>"` and `dexpr check-registry`.
+
+Those two checks stop at "a diagnostic was built". Every expression on this page
+is also run end to end -- computed and written to NetCDF -- by the standalone
+test in
+`components/eamxx/tests/multi-process/dynamics_physics/homme_shoc_cld_p3_rrtmgp_pg2`,
+which carries two extra output streams for the purpose: `output_diags_ins.yaml`
+and, for the ones an instant stream cannot hold, `output_diags_avg.yaml`. Keep
+them in step with this page: an example added here belongs in one of those.

--- a/components/eamxx/docs/user/diags/expressions.md
+++ b/components/eamxx/docs/user/diags/expressions.md
@@ -1,0 +1,187 @@
+# Diagnostic expressions
+
+Alongside the underscore names described in the rest of this section, EAMxx can
+build diagnostics from **expressions**:
+
+```yaml
+field_names:
+  - q_flux := (qc+qv)*p_mid
+  - cold_T  := T_mid.where(T_mid<273.15).mean('lev')
+```
+
+Expressions are parsed by [`dexpr`](https://github.com/E3SM-Project/E3SM/tree/master/share/dexpr),
+the expression parser shared across E3SM components. They exist because the
+underscore syntax cannot express grouping: `qc_plus_qv_times_p_mid` is grouped
+by regex greediness, not by operator precedence (see
+[Binary arithmetics](binary_ops.md) and [Parsing precedence](parsing_precedence.md)).
+Written as an expression, it means what it looks like.
+
+Both syntaxes work, and they are resolved independently: a name is matched
+against the underscore patterns first, and only names that match none of them
+are read as an expression. Nothing you write today changes meaning.
+
+## Expressions must be given a name
+
+An expression is not a usable NetCDF variable name, and `field_names` entries
+are written to file verbatim. So any expression you want written must be given
+a name with `:=`:
+
+```yaml
+field_names:
+  - q_flux := (qc+qv)*p_mid    # good
+  - (qc+qv)*p_mid              # error: "An expression must be given an output name"
+```
+
+The expression itself is recorded in the variable's `alias_of` attribute, so
+the provenance stays in the file.
+
+This applies only to what is *written*. Expressions nested inside other
+expressions, and expressions in the `aliases:` section (intermediates that other
+diagnostics use but that are not written), need no name of their own.
+
+## Operators
+
+| Operator | Meaning |
+| -------- | ------- |
+| `a + b`, `a - b`, `a * b`, `a / b` | element-wise arithmetic |
+| `>`, `>=`, `<`, `<=`, `==`, `!=` | comparison, **only** inside `where(..)` |
+| `( )` | grouping |
+
+Operands may be fields, other expressions, named physical constants (`Rgas`,
+`P0`, ...), or numeric literals:
+
+```yaml
+field_names:
+  - p_hPa      := p_mid/100
+  - T_scaled   := T_mid*0.5
+  - dry_air    := p_mid - qv*p_mid
+```
+
+Precedence is the usual one, so `qc+qv*p_mid` is `qc+(qv*p_mid)`. Note this
+differs from the underscore spelling `qc_plus_qv_times_p_mid`, which means
+`(qc+qv)*p_mid`. When in doubt, parenthesize.
+
+## Functions
+
+Functions are written as methods on the field they act on, `X.f(..)`, and are
+named after their [xarray](https://docs.xarray.dev) counterparts wherever there
+is an honest analogue.
+
+| Expression | Equivalent underscore name |
+| ---------- | -------------------------- |
+| `X.isel(lev=10)` | `X_at_lev_10` |
+| `X.isel(lev=0)` | `X_at_model_top` |
+| `X.isel(lev=-1)` | `X_at_model_bot` |
+| `X.interp(p_mid=500, units='hPa')` | `X_at_500hPa` |
+| `X.interp(z_mid=10, reference='surface')` | `X_at_10m_above_surface` |
+| `X.mean('col')` | `X_horiz_avg` |
+| `X.mean('lev')` | `X_vert_avg` |
+| `X.sum('lev')` | `X_vert_sum` |
+| `X.mean('lev', weights='dp')` | `X_vert_avg_dp_weighted` |
+| `X.where(qv>0.01)` | `X_where_qv_gt_0.01` |
+| `X.differentiate('p_mid')` | `X_pvert_derivative` |
+| `X.histogram(bins=[0,1,2])` | `X_histogram_0_1_2` |
+| `X.zonal_mean(bins=20)` | `X_zonal_avg_20_bins` |
+| `X.shift(time=1)` | `X_prev` |
+| `X.over_dt()` | `X_over_dt` |
+| `X.tend()` | `X_atm_backtend` |
+
+Notes:
+
+- `isel` indexes levels the way xarray does: `lev=0` is the model top and
+  `lev=-1` the bottom. Other negative indices are rejected, since they cannot
+  be resolved without knowing the level count.
+- `interp` takes exactly one of `p_mid` or `z_mid`, named after the coordinate
+  as in xarray. `units` defaults to `Pa` and `m` respectively; `reference`
+  (`'surface'` or `'sealevel'`, default `'sealevel'`) applies to `z_mid` only.
+- **`shift` looks BACK in time**, following xarray's sign convention: a positive
+  shift moves data forward, so `shift(time=1)` is the value from the *previous*
+  step. `shift(time=-1)` would be the value from a step *ahead*, which a running
+  model cannot know, and is rejected -- do not read it as "one step back" by
+  analogy with `isel(lev=-1)`. Only `time=1` is available, since only one step
+  of history is kept.
+- `mean('col')` is always area weighted, so `weights` does not apply to it.
+  `weights` for `'lev'` is `'dp'` or `'dz'`.
+- `where` takes a single comparison. `and`/`or` are not supported; chain
+  `where(..)` calls instead. The special operand names `mask` and `lev` work as
+  they do in the underscore syntax, so `mask.where(lev>5)` is valid.
+- `X.tend()` is shorthand for `(X - X.shift(time=1)).over_dt()`.
+- Histogram bin edges must be non-negative, and must be writable without an
+  exponent: the diagnostic joins them with `_` and splits them back apart, so
+  `1e3` is fine (it is written `1000.0`) but `1e30` is not.
+
+Named quantities are not operations, and stay plain names in an expression:
+`LiqWaterPath`, `RelativeHumidity`, `z_mid`, `dz`, `precip_liq_surf_mass_flux`,
+and so on.
+
+### Where this departs from xarray
+
+`isel`, `interp`, `mean`, `sum`, `where` and `shift` mean what they mean in
+xarray, on the same arguments. The rest have no xarray spelling we could adopt:
+
+| | |
+| --- | --- |
+| `histogram` | not in xarray; the keyword follows [xhistogram](https://xhistogram.readthedocs.io) |
+| `zonal_mean` | xarray would be `groupby_bins('lat', 20).mean()`, a call chain we cannot represent |
+| `over_dt`, `tend` | no xarray equivalent |
+| `mean('lev', weights=..)` | xarray would be `weighted(dp).mean('lev')`, again a chain |
+
+Two operand names are special, inherited from the underscore syntax rather than
+from xarray: `mask` stands for the 0/1 indicator of the condition itself, so
+`mask.where(..)` gives where the condition holds rather than sampling a field;
+and `lev` on the left of a comparison means the level index.
+
+## Errors
+
+An expression that does not parse, calls a function that does not exist, or
+uses an operator no diagnostic implements is rejected with a message pointing
+at the offending part. Unknown function names come back with the list of
+available ones.
+
+```text
+Error! Unsupported expression: no diagnostic implements the operator '**'.
+ - subexpression: (T_mid**2)
+```
+
+## Worked example
+
+```yaml
+fields:
+  physics_pg2:
+    aliases:
+      # An intermediate: used below, but not written to file. No name needed
+      # for the expression itself beyond the alias.
+      - warm_T := T_mid.where(T_mid>273.15)
+
+    field_names:
+      # Column-mean temperature, but only where it is above freezing
+      - warm_T_colavg := warm_T.mean('lev')
+      # Surface temperature where the air is moist
+      - sfc_moist_T   := T_mid.where(qv>0.0).isel(lev=-1)
+      # Moisture flux
+      - q_flux        := (qc+qv)*p_mid
+```
+
+## Adding a function
+
+The set of callable functions is registered by EAMxx, in
+`components/eamxx/src/share/io/eamxx_dexpr_diags.cpp`, not by `dexpr` itself.
+Adding one means adding a `FunctionSpec` to the registry there and a case to the
+translator that maps it onto a diagnostic; nothing under `share/dexpr` changes.
+
+Each `FunctionSpec` carries an `example` of how the call is written. That is not
+just documentation: two checks use it, so a function that does not hang together
+fails fast rather than at the moment a user first writes it.
+
+- `dexpr::validate_registry`, called where the registry is built, proves the
+  example parses, matches the spec that declared it (arity, keyword names,
+  required keywords), and really calls that function. Declare `mean` as taking
+  no positional arguments while writing `T_mid.mean('lev')` and this catches it.
+- The `dexpr_every_registered_function_is_buildable` case in
+  `src/share/io/tests/create_diag.cpp` runs every example through
+  `create_diagnostic`, so a function registered without a translator case is
+  caught too.
+
+So adding a function means: register it with an example, translate it, and both
+checks come along for free. The `dexpr` command line tool does the same for the
+generic vocabulary -- `dexpr check "<expr>"` and `dexpr check-registry`.

--- a/components/eamxx/docs/user/diags/expressions.md
+++ b/components/eamxx/docs/user/diags/expressions.md
@@ -107,19 +107,32 @@ Notes:
 - `mean('col')` is always area weighted, so `weights` does not apply to it.
   `weights` for `'lev'` is `'dp'` or `'dz'`.
 - `where` takes a single comparison. `and`/`or` are not supported; chain
-  `where(..)` calls instead. The special operand names `mask` and `lev` work as
-  they do in the underscore syntax, so `mask.where(lev>5)` parses.
+  `where(..)` calls instead.
+- **`mask` and `lev` are placeholders, not fields.** Neither exists in the field
+  manager, and neither means anything on its own. `mask` is only legal as the
+  receiver of `.where(..)`: `mask.where(cond)` is the 0/1 indicator of `cond`
+  itself, rather than some field sampled by it. `lev` is only legal as the left
+  operand of the comparison inside `where(..)`, where it means the level index.
+  So `mask.where(lev>5)` is a request, while `mask`, `mask*1.0`,
+  `mask.mean('lev')` and `lev>5` are not: each of those leaves `mask` or `lev`
+  as an operand to be resolved on its own, and the run aborts with
+  `The key 'mask' is not associated to any registered product`, since it is
+  neither a field nor a diagnostic. Both names are inherited from the underscore
+  syntax (`mask_where_lev_gt_5`), not from xarray.
 - **`over_dt` and `tend` cannot go in an `instant` stream.** An instant stream
   takes a snapshot at `t0`, before any step has run, and `dt` is zero there, so
   the diagnostic aborts with "dt must be positive". Write them to an averaged
   stream (`averaging_type: average`, `max`, `min`) instead. This is a property
   of the diagnostic, not of the syntax: the underscore spellings `X_over_dt` and
   `X_atm_backtend` behave the same way.
-- **A `mask` operand cannot currently be written to file.** The diagnostic is
-  built, but its output has `int` data type, which IO cannot handle: writing
-  `mask.where(..)` (or the underscore `mask_where_..`) fails with a narrowing
-  conversion error, and reducing it first does not help. Multiply by 1 to
-  promote it to `Real` -- `mask.where(ps>100000)*1.0` writes fine.
+- **A `mask.where(..)` result cannot currently be written to file as is.** The
+  diagnostic is built, but its output has `int` data type, which IO cannot
+  handle: listing `mask.where(..)` (or the underscore `mask_where_..`) in
+  `field_names` fails with a narrowing conversion error, and reducing it first
+  does not help. Multiplying by 1 promotes it to `Real`, and
+  `mask.where(ps>100000)*1.0` writes fine. Note the `*1.0` applies to the field
+  that `where` produced, which is a perfectly ordinary field; it is not an
+  operation on `mask`, which per the bullet above cannot be multiplied.
 - `X.tend()` is shorthand for `(X - X.shift(time=1)).over_dt()`, and inherits
   the `over_dt` restriction above.
 - Histogram bin edges must be non-negative, and must be writable without an
@@ -145,10 +158,10 @@ xarray, on the same arguments. The rest have no xarray spelling we could adopt:
 `X.mean('lev', weights='dp')` is `(X*dp).sum('lev')/dp.sum('lev')`, but computed
 in one sweep rather than as three diagnostics.
 
-Two operand names are special, inherited from the underscore syntax rather than
-from xarray: `mask` stands for the 0/1 indicator of the condition itself, so
-`mask.where(...)` is 1 where the condition `(...)` holds;
-and `lev` on the left of a comparison means the level index.
+Two operand names have no xarray analogue at all, because they are not fields:
+`mask` and `lev`, both inherited from the underscore syntax and both legal only
+inside `where(..)`. See the note above for what they mean and where they may
+appear.
 
 ## Errors
 

--- a/components/eamxx/docs/user/diags/field_over_dt.md
+++ b/components/eamxx/docs/user/diags/field_over_dt.md
@@ -21,8 +21,11 @@ The output field has the same layout and grid as `X`, with units `[X_units / s]`
 - At evaluation time (`compute_diagnostic`), `dt` is computed as the difference
   between the field's current timestamp and the saved start timestamp (in seconds).
 - The output is `X / dt` element-wise.
-- On the very first evaluation — before `init_timestep` has been called — the
-  output is filled with the standard EAMxx fill value (`constants::fill_value<Real>`).
+- Before `init_timestep` has ever been called, the output is filled with the
+  standard EAMxx fill value (`constants::fill_value<Real>`). Note this does NOT
+  cover the case where `init_timestep` HAS been called but no time has elapsed
+  since: there `dt` is zero, which is an error rather than a fill value (see
+  the caveats below).
 
 ## Example: atmospheric backward tendency
 
@@ -43,6 +46,11 @@ built-in alias system (see [Built-in aliases](builtin_aliases.md)).
 ## Caveats
 
 - `dt` must be strictly positive; a zero or negative timestep triggers a runtime error.
+- **This diagnostic cannot be written to an `instant` output stream.** An instant
+  stream takes a snapshot at `t0`, before the first step has run, so `dt` is zero
+  and the run aborts with "dt must be positive". Use an averaged stream
+  (`averaging_type: average`, `max`, `min`) instead. The same applies to
+  everything built on top of it, including `X_atm_backtend`.
 - Only fields with `Real` data type are supported.
 - The suffix `_over_dt` is matched *before* binary-op patterns, so
   `A_minus_B_over_dt` parses as `FieldOverDtDiag(A_minus_B)`, not

--- a/components/eamxx/docs/user/diags/index.md
+++ b/components/eamxx/docs/user/diags/index.md
@@ -13,6 +13,7 @@ are designed generically and composably, and are requestable by users.
 - [Previous-timestep field](field_prev.md)
 - [Field divided by timestep](field_over_dt.md)
 - [Built-in aliases](builtin_aliases.md)
+- [Diagnostic expressions](expressions.md)
 - [Parsing precedence](parsing_precedence.md)
 
 More details to follow.

--- a/components/eamxx/docs/user/diags/parsing_precedence.md
+++ b/components/eamxx/docs/user/diags/parsing_precedence.md
@@ -41,14 +41,18 @@ control — how composite names are parsed.
 
 8. **Histograms** — `X_histogram_<bin_config>`.
 
-9. **Expressions** — a name none of the patterns above claimed is parsed as a
-   [diagnostic expression](expressions.md), e.g. `(qc+qv)*p_mid` or
-   `T_mid.mean('lev')`. Being last is what keeps every name above working
-   unchanged; it is not a statement about which syntax to prefer. Expressions
-   are the intended replacement for items 3–8, which will eventually go away.
+9. **Plain diagnostic name** — a name none of the patterns above claimed, and
+   that is a bare identifier, is looked up directly in the atmosphere-diagnostic
+   factory.
 
-10. **Plain diagnostic name** — a bare identifier is not an expression, so it is
-    looked up directly in the atmosphere-diagnostic factory.
+10. **Expressions** — anything left is parsed as a
+    [diagnostic expression](expressions.md), e.g. `(qc+qv)*p_mid` or
+    `T_mid.mean('lev')`. This is the last resort: there is nothing after it, so
+    an expression that does not parse, or that no diagnostic implements, is an
+    error rather than a fall-through. Being last is what keeps every name above
+    working unchanged; it is not a statement about which syntax to prefer.
+    Expressions are the intended replacement for items 3–8, which will
+    eventually go away.
 
 ## Key rules
 

--- a/components/eamxx/docs/user/diags/parsing_precedence.md
+++ b/components/eamxx/docs/user/diags/parsing_precedence.md
@@ -41,8 +41,14 @@ control — how composite names are parsed.
 
 8. **Histograms** — `X_histogram_<bin_config>`.
 
-9. **Plain diagnostic name** — the string is looked up directly in the
-   atmosphere-diagnostic factory.
+9. **Expressions** — a name none of the patterns above claimed is parsed as a
+   [diagnostic expression](expressions.md), e.g. `(qc+qv)*p_mid` or
+   `T_mid.mean('lev')`. Being last is what keeps every name above working
+   unchanged; it is not a statement about which syntax to prefer. Expressions
+   are the intended replacement for items 3–8, which will eventually go away.
+
+10. **Plain diagnostic name** — a bare identifier is not an expression, so it is
+    looked up directly in the atmosphere-diagnostic factory.
 
 ## Key rules
 
@@ -106,3 +112,14 @@ Use `:=` in both sections to give a convenient name to a complex expression.
 
 Use `:=` aliases to break complex expressions into named sub-expressions.
 This is always clearer than relying on implicit precedence.
+
+Better still, write the thing as an expression, where the grouping is explicit
+and the two rules above do not apply at all:
+
+```none
+A_minus_B_over_C     →  (A-B)/C   by rule 1 above
+(A-B)/C              →  (A-B)/C   because you said so
+A-(B/C)              →  A-(B/C)   which rule 1 gives you no way to ask for
+```
+
+See [Diagnostic expressions](expressions.md).

--- a/components/eamxx/mkdocs.yml
+++ b/components/eamxx/mkdocs.yml
@@ -21,6 +21,7 @@ nav:
       - 'Conditional sampling': 'user/diags/conditional_sampling.md'
       - 'Binary arithmetics': 'user/diags/binary_ops.md'
       - 'Vertical derivative': 'user/diags/vert_derivative.md'
+      - 'Diagnostic expressions': 'user/diags/expressions.md'
     - 'Presentations': 'user/presentations.md'
     - 'IO Aliases': 'user/io_aliases.md'
   - 'Developer Guide':

--- a/components/eamxx/src/share/diagnostics/abstract_diagnostic.cpp
+++ b/components/eamxx/src/share/diagnostics/abstract_diagnostic.cpp
@@ -19,6 +19,20 @@ AbstractDiagnostic (const ekat::Comm& comm,
 void AbstractDiagnostic::initialize ()
 {
   initialize_impl();
+
+  // A diag names its output field from its params, e.g. BinaryOp builds
+  // "<arg1>_<op>_<arg2>". That is not always what the customer asked for, and
+  // customers look the field up by name: 'X_atm_backtend' is an alias for
+  // 'X_minus_X_prev_over_dt'. So honor an explicit name when given one.
+  // NOTE: an alias shares tracking, alloc props and extra data, so masks,
+  //       timestamps and avg-cnt bookkeeping carry over.
+  if (m_params.isParameter("output_field_name")) {
+    const auto& name = m_params.get<std::string>("output_field_name");
+    if (name!=m_diagnostic_output.name()) {
+      m_diagnostic_output = m_diagnostic_output.alias(name);
+    }
+  }
+
   m_is_initialized = true;
 }
 

--- a/components/eamxx/src/share/diagnostics/binary_op.cpp
+++ b/components/eamxx/src/share/diagnostics/binary_op.cpp
@@ -2,6 +2,9 @@
 
 #include "share/physics/physics_constants.hpp"
 
+#include <cmath>
+#include <cstdlib>
+
 namespace {
   constexpr int OP_PLUS = 0;
   constexpr int OP_MINUS = 1;
@@ -10,6 +13,44 @@ namespace {
 }
 
 namespace scream {
+
+namespace {
+// A non-field operand is a named physical constant (Rgas, P0, ...) or a numeric
+// literal. Only expressions can write a literal -- (qc+qv)*2 -- but accept both.
+// NOTE: strtod because from_chars for floating point is missing on some
+//       compilers we support (e.g. compy).
+bool str2real (const std::string& s, Real& value) {
+  if (s.empty()) return false;
+
+  char* endptr;
+  const char* startptr = s.c_str();
+  const double d = std::strtod(startptr,&endptr);
+
+  if (endptr==startptr or *endptr!='\0') return false;
+  // strtod also takes "nan"/"inf"; those are field names to us, not numbers.
+  if (not std::isfinite(d)) return false;
+
+  value = static_cast<Real>(d);
+  return true;
+}
+
+bool is_scalar (const std::string& s) {
+  Real dummy;
+  return physics::Constants<Real>::dictionary().count(s)>0 or str2real(s,dummy);
+}
+
+Real scalar_value (const std::string& s) {
+  Real value;
+  if (str2real(s,value)) return value;
+  return physics::Constants<Real>::dictionary().at(s).value;
+}
+
+ekat::units::Units scalar_units (const std::string& s) {
+  Real dummy;
+  if (str2real(s,dummy)) return ekat::units::Units::nondimensional();
+  return physics::Constants<Real>::dictionary().at(s).units;
+}
+} // anonymous namespace
 
 // parse string to get the operator code
 int get_binary_operator_code(const std::string& op) {
@@ -184,9 +225,8 @@ BinaryOp(const ekat::Comm &comm,
                    "Error! Invalid binary operator: '" + m_binary_op_str + "'\n"
                    "Valid operators are: plus, minus, times, over\n");
 
-  const auto& pc_dict = physics::Constants<Real>::dictionary();
-  m_arg1_is_field = pc_dict.count(m_arg1_name)==0;
-  m_arg2_is_field = pc_dict.count(m_arg2_name)==0;
+  m_arg1_is_field = not is_scalar(m_arg1_name);
+  m_arg2_is_field = not is_scalar(m_arg2_name);
   if (m_arg1_is_field)
     m_field_in_names.push_back(m_arg1_name);
   if (m_arg2_is_field)
@@ -195,8 +235,6 @@ BinaryOp(const ekat::Comm &comm,
 
 void BinaryOp::initialize_impl()
 {
-  const auto& dict = physics::Constants<Real>::dictionary();
-
   if (m_arg1_is_field and m_arg2_is_field) {
     const auto& fid1   = m_fields_in.at(m_arg1_name).get_header().get_identifier();
     const auto& fid2   = m_fields_in.at(m_arg2_name).get_header().get_identifier();
@@ -226,10 +264,10 @@ void BinaryOp::initialize_impl()
   auto dl = m_arg1_is_field ? m_fields_in.at(m_arg1_name).get_header().get_identifier().get_layout()
                             : (m_arg2_is_field ? m_fields_in.at(m_arg2_name).get_header().get_identifier().get_layout()
                                                : FieldLayout({},{}));
-  const auto& u1 = m_arg1_is_field ? m_fields_in.at(m_arg1_name).get_header().get_identifier().get_units()
-                                   : dict.at(m_arg1_name).units;
-  const auto& u2 = m_arg2_is_field ? m_fields_in.at(m_arg2_name).get_header().get_identifier().get_units()
-                                   : dict.at(m_arg2_name).units;
+  const auto u1 = m_arg1_is_field ? m_fields_in.at(m_arg1_name).get_header().get_identifier().get_units()
+                                  : scalar_units(m_arg1_name);
+  const auto u2 = m_arg2_is_field ? m_fields_in.at(m_arg2_name).get_header().get_identifier().get_units()
+                                  : scalar_units(m_arg2_name);
   auto diag_units = apply_binary_op(u1, u2, m_binary_op_code);
   auto gn = m_params.get<std::string>("grid_name");
   auto diag_name = m_arg1_name + "_" + m_binary_op_str + "_" + m_arg2_name;
@@ -238,8 +276,8 @@ void BinaryOp::initialize_impl()
 
   if (not m_arg1_is_field and not m_arg2_is_field) {
     // We can pre-compute the diag now
-    const auto  c1 = dict.at(m_arg1_name).value;
-    const auto  c2 = dict.at(m_arg2_name).value;
+    const auto  c1 = scalar_value(m_arg1_name);
+    const auto  c2 = scalar_value(m_arg2_name);
     apply_binary_op(m_diagnostic_output, c1, c2, m_binary_op_code);
   } else {
     m_arg1_has_mask = m_arg1_is_field and m_fields_in.at(m_arg1_name).has_valid_mask();
@@ -263,18 +301,17 @@ void BinaryOp::compute_impl()
   }
 
   // Note the case where m_arg1_is_field=m_arg2_is_field=false was handled in the initialize method
-  const auto& dict = physics::Constants<Real>::dictionary();
   if (m_arg1_is_field and m_arg2_is_field) {
     const auto& f1 = m_fields_in.at(m_arg1_name);
     const auto& f2 = m_fields_in.at(m_arg2_name);
     apply_binary_op(m_diagnostic_output, f1, f2, m_binary_op_code);
   } else if (m_arg1_is_field) {
     const auto& f1 = m_fields_in.at(m_arg1_name);
-    const auto  c2 = dict.at(m_arg2_name).value;
+    const auto  c2 = scalar_value(m_arg2_name);
     apply_binary_op(m_diagnostic_output, f1, c2, m_binary_op_code);
   } else if (m_arg2_is_field) {
     // We can do scale/scale_inv for * and /, but for + and - we must deep copy arg2 first
-    const auto  c1 = physics::Constants<Real>::dictionary().at(m_arg1_name).value;
+    const auto  c1 = scalar_value(m_arg1_name);
     const auto& f2 = m_fields_in.at(m_arg2_name);
     apply_binary_op(m_diagnostic_output, c1, f2, m_binary_op_code);
   }

--- a/components/eamxx/src/share/diagnostics/binary_op.cpp
+++ b/components/eamxx/src/share/diagnostics/binary_op.cpp
@@ -34,21 +34,23 @@ bool str2real (const std::string& s, Real& value) {
   return true;
 }
 
-bool is_scalar (const std::string& s) {
-  Real dummy;
-  return physics::Constants<Real>::dictionary().count(s)>0 or str2real(s,dummy);
-}
-
-Real scalar_value (const std::string& s) {
-  Real value;
-  if (str2real(s,value)) return value;
-  return physics::Constants<Real>::dictionary().at(s).value;
-}
-
-ekat::units::Units scalar_units (const std::string& s) {
-  Real dummy;
-  if (str2real(s,dummy)) return ekat::units::Units::nondimensional();
-  return physics::Constants<Real>::dictionary().at(s).units;
+// Resolves 's' as a scalar operand, if it is one. The dictionary is checked
+// first: a lookup is cheaper than a strtod, and named constants are the common
+// case. Called once per operand, from the constructor; initialize_impl and
+// compute_impl use the cached values.
+bool scalar_operand (const std::string& s, Real& value, ekat::units::Units& units) {
+  const auto& dict = physics::Constants<Real>::dictionary();
+  auto it = dict.find(s);
+  if (it!=dict.end()) {
+    value = it->second.value;
+    units = it->second.units;
+    return true;
+  }
+  if (str2real(s,value)) {
+    units = ekat::units::Units::nondimensional();
+    return true;
+  }
+  return false;
 }
 } // anonymous namespace
 
@@ -225,8 +227,10 @@ BinaryOp(const ekat::Comm &comm,
                    "Error! Invalid binary operator: '" + m_binary_op_str + "'\n"
                    "Valid operators are: plus, minus, times, over\n");
 
-  m_arg1_is_field = not is_scalar(m_arg1_name);
-  m_arg2_is_field = not is_scalar(m_arg2_name);
+  // A non-field operand's value/units never change, so resolve them here rather
+  // than on every compute_impl call.
+  m_arg1_is_field = not scalar_operand(m_arg1_name,m_arg1_value,m_arg1_units);
+  m_arg2_is_field = not scalar_operand(m_arg2_name,m_arg2_value,m_arg2_units);
   if (m_arg1_is_field)
     m_field_in_names.push_back(m_arg1_name);
   if (m_arg2_is_field)
@@ -265,9 +269,9 @@ void BinaryOp::initialize_impl()
                             : (m_arg2_is_field ? m_fields_in.at(m_arg2_name).get_header().get_identifier().get_layout()
                                                : FieldLayout({},{}));
   const auto u1 = m_arg1_is_field ? m_fields_in.at(m_arg1_name).get_header().get_identifier().get_units()
-                                  : scalar_units(m_arg1_name);
+                                  : m_arg1_units;
   const auto u2 = m_arg2_is_field ? m_fields_in.at(m_arg2_name).get_header().get_identifier().get_units()
-                                  : scalar_units(m_arg2_name);
+                                  : m_arg2_units;
   auto diag_units = apply_binary_op(u1, u2, m_binary_op_code);
   auto gn = m_params.get<std::string>("grid_name");
   auto diag_name = m_arg1_name + "_" + m_binary_op_str + "_" + m_arg2_name;
@@ -276,9 +280,7 @@ void BinaryOp::initialize_impl()
 
   if (not m_arg1_is_field and not m_arg2_is_field) {
     // We can pre-compute the diag now
-    const auto  c1 = scalar_value(m_arg1_name);
-    const auto  c2 = scalar_value(m_arg2_name);
-    apply_binary_op(m_diagnostic_output, c1, c2, m_binary_op_code);
+    apply_binary_op(m_diagnostic_output, m_arg1_value, m_arg2_value, m_binary_op_code);
   } else {
     m_arg1_has_mask = m_arg1_is_field and m_fields_in.at(m_arg1_name).has_valid_mask();
     m_arg2_has_mask = m_arg2_is_field and m_fields_in.at(m_arg2_name).has_valid_mask();
@@ -307,13 +309,11 @@ void BinaryOp::compute_impl()
     apply_binary_op(m_diagnostic_output, f1, f2, m_binary_op_code);
   } else if (m_arg1_is_field) {
     const auto& f1 = m_fields_in.at(m_arg1_name);
-    const auto  c2 = scalar_value(m_arg2_name);
-    apply_binary_op(m_diagnostic_output, f1, c2, m_binary_op_code);
+    apply_binary_op(m_diagnostic_output, f1, m_arg2_value, m_binary_op_code);
   } else if (m_arg2_is_field) {
     // We can do scale/scale_inv for * and /, but for + and - we must deep copy arg2 first
-    const auto  c1 = scalar_value(m_arg1_name);
     const auto& f2 = m_fields_in.at(m_arg2_name);
-    apply_binary_op(m_diagnostic_output, c1, f2, m_binary_op_code);
+    apply_binary_op(m_diagnostic_output, m_arg1_value, f2, m_binary_op_code);
   }
 
   // Until IO is ready to fully rely on valid_mask fields, we must set diag=fill_value where invalid

--- a/components/eamxx/src/share/diagnostics/binary_op.hpp
+++ b/components/eamxx/src/share/diagnostics/binary_op.hpp
@@ -3,6 +3,8 @@
 
 #include "share/diagnostics/abstract_diagnostic.hpp"
 
+#include <limits>
+
 namespace scream {
 
 /*
@@ -37,6 +39,13 @@ class BinaryOp : public AbstractDiagnostic {
 
   bool m_arg1_is_field;
   bool m_arg2_is_field;
+
+  // Value/units of a non-field operand, resolved once in the constructor.
+  // Meaningless (and NaN) when the corresponding operand IS a field.
+  Real m_arg1_value = std::numeric_limits<Real>::quiet_NaN();
+  Real m_arg2_value = std::numeric_limits<Real>::quiet_NaN();
+  ekat::units::Units m_arg1_units = ekat::units::Units::invalid();
+  ekat::units::Units m_arg2_units = ekat::units::Units::invalid();
 
   bool m_arg1_has_mask = false;
   bool m_arg2_has_mask = false;

--- a/components/eamxx/src/share/io/CMakeLists.txt
+++ b/components/eamxx/src/share/io/CMakeLists.txt
@@ -10,12 +10,15 @@ add_library(eamxx_io
   eamxx_output_manager.cpp
   scorpio_output.cpp
   eamxx_io_utils.cpp
+  eamxx_dexpr_diags.cpp
 )
 
 target_link_libraries(eamxx_io PUBLIC
   eamxx_data_managers
   eamxx_scorpio_interface
   eamxx_diagnostics)
+
+target_link_libraries(eamxx_io PRIVATE dexpr)
 
 if (NOT SCREAM_LIB_ONLY)
   add_subdirectory(tests)

--- a/components/eamxx/src/share/io/eamxx_dexpr_diags.cpp
+++ b/components/eamxx/src/share/io/eamxx_dexpr_diags.cpp
@@ -173,6 +173,7 @@ std::string binary_op_to_diag_op (TokenTypes op)
 
 // Unary minus, as '-X' or the '-f2' in '-f2*f3'. No diagnostic negates a
 // field, but BinaryOp multiplies one by a scalar literal, so '-X' is '(-1)*X'.
+// TODO: implement translation for other unary operators asap
 void translate_unary (const ast::UnaryExpression& e, const ast::Expression& self,
                       std::string& diag_name, ekat::ParameterList& params)
 {
@@ -191,19 +192,29 @@ void translate_unary (const ast::UnaryExpression& e, const ast::Expression& self
 void translate_binary (const ast::BinaryExpression& e, const ast::Expression& self,
                        std::string& diag_name, ekat::ParameterList& params)
 {
-  // dexpr has a single BinaryExpression node for EVERY infix operator, not just
-  // the arithmetic ones: comparisons, 'and'/'or', '**', and even '.' all parse
-  // to it. So a node that casts to BinaryExpression may still be a comparison
-  // ('T_mid<273' at the top level) or a bare attribute access ('T_mid.mean',
-  // with no call). Only the four arithmetic ops map to a diagnostic; the rest
-  // get an error that says what they actually are.
+  // Called on the ROOT of a whole field_names entry, and dexpr roots an
+  // expression at its LOWEST-precedence operator -- which need not be an
+  // arithmetic one, since EVERY infix operator builds a BinaryExpression:
+  // comparisons, 'and'/'or', '**' and '.' included. So arriving here means
+  // "the request is an infix expression", not "the request is arithmetic",
+  // and e.op still has to be checked.
+  //
+  // Concretely, the two non-arithmetic ops handled below are reached by
+  //   field_names: [T_mid<273]      -> root is BinaryExpression{LessThan}
+  //   field_names: [T_mid.mean]     -> root is BinaryExpression{Dot}
+  // Both parse; neither names something we can compute. Note a comparison
+  // written where it belongs, inside where(..), is consumed by translate_call
+  // and never reaches this function -- which is why the error below can safely
+  // say the comparison is in the wrong place.
   const auto op = binary_op_to_diag_op(e.op);
   if (op=="") {
     if (comparison_to_cmp(e.op)!="") {
-      unsupported("a comparison is only meaningful inside where(..)",self);
+      unsupported("a comparison is only meaningful inside where(..), "
+                  "as in 'T_mid.where(T_mid<273)'",self);
     }
     if (e.op==TokenTypes::Dot) {
-      unsupported("attribute access with no call",self);
+      unsupported("attribute access with no call; EAMxx has no attributes, "
+                  "only methods, so this needs '(..)'",self);
     }
     unsupported("no diagnostic implements the operator '" +
                 dexpr::binary_op_to_string(e.op) + "'",self);
@@ -216,15 +227,15 @@ void translate_binary (const ast::BinaryExpression& e, const ast::Expression& se
 }
 
 // ---------------------------------------------------------------------------
-// The EAMxx vocabulary
+// The EAMxx vocabulary -- TODO: REDO!
 // ---------------------------------------------------------------------------
 // Named after xarray where there is an honest analogue. Lives here, not in
 // share/dexpr: dexpr owns the grammar, we own the vocabulary.
 //
 // Sits above translate_call() because the two are a pair -- every entry here
-// needs a case there. Nothing enforces that in the type system, so two checks
-// do: validate_registry() below, and the create_diag case that builds every
-// example.
+// needs a case there. Nothing enforces that, so an entry added without its case
+// is caught only when a user first writes that function, as the "registered but
+// not translated" error at the end of translate_call().
 //
 // Each entry is a dexpr::FunctionSpec, whose fields are:
 //   name            the method name, as written in 'X.name(..)'
@@ -235,9 +246,10 @@ void translate_binary (const ast::BinaryExpression& e, const ast::Expression& se
 //                   pairs. 'true' means the call is invalid without it;
 //                   'false' means optional. A keyword not listed here is
 //                   rejected, so this doubles as the spell-checker.
-//   example         a call that must parse, match this spec, and translate.
-//                   validate_registry() and the create_diag test both run it,
-//                   so it cannot drift from the code below.
+//   example         a call that must parse and match this spec.
+//                   validate_registry() runs it, so a spec cannot lie about
+//                   its own arity or keywords.
+// TODO: Let's rethink how a vocab shall be introduced and maintained ... below is fugly
 const dexpr::FunctionRegistry& eamxx_registry ()
 {
   static const dexpr::FunctionRegistry reg = [] {
@@ -458,6 +470,7 @@ void translate_call (const Call& call, const ast::Expression& self,
     // the value from a step ahead, which a running model cannot know -- worth
     // saying out loud, since isel(lev=-1) makes -1 look like "one back".
     const auto n = int_arg(*keyword(call,"time"),"'time'");
+    // TODO: support recursive shift (i.e., shift(time=2) would look back two steps)
     EKAT_REQUIRE_MSG (n==1,
         "Error! Only shift(time=1) is available.\n"
         " - expression: " + ast::to_string(self) + "\n"
@@ -470,6 +483,7 @@ void translate_call (const Call& call, const ast::Expression& self,
   }
 
   if (call.name=="over_dt") {
+    // TODO: support dt as a constant, so T_mid/dt can work out of the box like p_mid/P0
     diag_name = "FieldOverDt";
     return;
   }
@@ -504,14 +518,13 @@ dexpr_create_diagnostic (const std::string& expr,
     dexpr::parser::Parser parser {dexpr::Lexer{expr}};
     root = parser.parse();
   } catch (const dexpr::parser::ParserError& e) {
-    // Matched no legacy pattern and is not a legal identifier, so it can only
-    // have been meant as an expression. Say where it went wrong.
     EKAT_ERROR_MSG (
-        "Error! '" + expr + "' is neither a registered diagnostic nor a valid expression.\n" +
+        "Error! '" + expr + "' is not a valid expression.\n" +
         std::string(e.what()));
   }
 
-  // A bare identifier is a diag class name or a typo; the caller's to resolve.
+  // A bare identifier is a diag class name or a typo;
+  // in that case, return nullptr to let the caller handle it.
   if (as<ast::Identifier>(*root)) {
     return nullptr;
   }
@@ -531,9 +544,6 @@ dexpr_create_diagnostic (const std::string& expr,
   } else if (as<ast::FuncExpression>(*root)) {
     unsupported("EAMxx functions are written as methods, X.f(..), not f(X)",*root);
   } else {
-    // Everything left is a leaf that is not a name: a bare literal, a string,
-    // a list. There is nothing to compute, and nothing for the factory to look
-    // up either, so this is the end of the road for the whole precedence chain.
     unsupported("this is neither a diagnostic name nor an operation on a field",*root);
   }
 
@@ -544,15 +554,6 @@ dexpr_create_diagnostic (const std::string& expr,
   params.set<bool>("from_expression",true);
 
   return DiagnosticFactory::instance().create(diag_name,grid->get_comm(),params,grid);
-}
-
-std::vector<std::string> dexpr_diagnostic_examples ()
-{
-  std::vector<std::string> out;
-  for (const auto& entry : eamxx_registry()) {
-    out.push_back(entry.second.example);
-  }
-  return out;
 }
 
 } // namespace scream

--- a/components/eamxx/src/share/io/eamxx_dexpr_diags.cpp
+++ b/components/eamxx/src/share/io/eamxx_dexpr_diags.cpp
@@ -171,9 +171,32 @@ std::string binary_op_to_diag_op (TokenTypes op)
   }
 }
 
+// Unary minus, as '-X' or the '-f2' in '-f2*f3'. No diagnostic negates a
+// field, but BinaryOp multiplies one by a scalar literal, so '-X' is '(-1)*X'.
+void translate_unary (const ast::UnaryExpression& e, const ast::Expression& self,
+                      std::string& diag_name, ekat::ParameterList& params)
+{
+  // dexpr's only other prefix operator is '!', which has no diagnostic.
+  if (e.op!=TokenTypes::Minus) {
+    unsupported("no diagnostic implements the unary operator '" +
+                dexpr::unary_op_to_string(e.op) + "'",self);
+  }
+
+  diag_name = "BinaryOp";
+  params.set<std::string>("arg1","-1");
+  params.set<std::string>("arg2",name_of(*e.right));
+  params.set<std::string>("binary_op","times");
+}
+
 void translate_binary (const ast::BinaryExpression& e, const ast::Expression& self,
                        std::string& diag_name, ekat::ParameterList& params)
 {
+  // dexpr has a single BinaryExpression node for EVERY infix operator, not just
+  // the arithmetic ones: comparisons, 'and'/'or', '**', and even '.' all parse
+  // to it. So a node that casts to BinaryExpression may still be a comparison
+  // ('T_mid<273' at the top level) or a bare attribute access ('T_mid.mean',
+  // with no call). Only the four arithmetic ops map to a diagnostic; the rest
+  // get an error that says what they actually are.
   const auto op = binary_op_to_diag_op(e.op);
   if (op=="") {
     if (comparison_to_cmp(e.op)!="") {
@@ -202,6 +225,19 @@ void translate_binary (const ast::BinaryExpression& e, const ast::Expression& se
 // needs a case there. Nothing enforces that in the type system, so two checks
 // do: validate_registry() below, and the create_diag case that builds every
 // example.
+//
+// Each entry is a dexpr::FunctionSpec, whose fields are:
+//   name            the method name, as written in 'X.name(..)'
+//   desc            one line, shown in error messages and by the dexpr tool
+//   min/max_positional  how many POSITIONAL args the call takes. The receiver
+//                   X is not one of them, so 'X.mean("lev")' has one.
+//   keywords        the accepted 'kw=value' arguments, as {name,required}
+//                   pairs. 'true' means the call is invalid without it;
+//                   'false' means optional. A keyword not listed here is
+//                   rejected, so this doubles as the spell-checker.
+//   example         a call that must parse, match this spec, and translate.
+//                   validate_registry() and the create_diag test both run it,
+//                   so it cannot drift from the code below.
 const dexpr::FunctionRegistry& eamxx_registry ()
 {
   static const dexpr::FunctionRegistry reg = [] {
@@ -232,11 +268,11 @@ const dexpr::FunctionRegistry& eamxx_registry ()
            .min_positional = 1, .max_positional = 1,
            .keywords = {},
            .example = "T_mid.where(qv>0.01)"});
-    r.add({.name = "differentiate",
+    r.add({.name = "derivative",
            .desc = "vertical derivative w.r.t. 'p_mid' or 'z_mid'",
            .min_positional = 1, .max_positional = 1,
            .keywords = {},
-           .example = "T_mid.differentiate('p_mid')"});
+           .example = "T_mid.derivative('p_mid')"});
     r.add({.name = "histogram",
            .desc = "counts per bin, given the bin edges",
            .min_positional = 0, .max_positional = 0,
@@ -373,10 +409,10 @@ void translate_call (const Call& call, const ast::Expression& self,
     return;
   }
 
-  if (call.name=="differentiate") {
+  if (call.name=="derivative") {
     const auto wrt = string_arg(*call.positional[0],"the coordinate");
     EKAT_REQUIRE_MSG (wrt=="p_mid" or wrt=="z_mid",
-        "Error! Unknown coordinate in differentiate().\n"
+        "Error! Unknown coordinate in derivative().\n"
         " - expression: " + ast::to_string(self) + "\n"
         " - input: '" + wrt + "'\n"
         " - valid coordinates: 'p_mid', 'z_mid'\n");
@@ -491,12 +527,14 @@ dexpr_create_diagnostic (const std::string& expr,
   } else if (const auto* bin = as<ast::BinaryExpression>(*root)) {
     translate_binary(*bin,*root,diag_name,params);
   } else if (const auto* un = as<ast::UnaryExpression>(*root)) {
-    unsupported("no diagnostic implements the unary operator '" +
-                dexpr::unary_op_to_string(un->op) + "'",*root);
+    translate_unary(*un,*root,diag_name,params);
   } else if (as<ast::FuncExpression>(*root)) {
     unsupported("EAMxx functions are written as methods, X.f(..), not f(X)",*root);
   } else {
-    unsupported("an expression must produce a field",*root);
+    // Everything left is a leaf that is not a name: a bare literal, a string,
+    // a list. There is nothing to compute, and nothing for the factory to look
+    // up either, so this is the end of the road for the whole precedence chain.
+    unsupported("this is neither a diagnostic name nor an operation on a field",*root);
   }
 
   // Name the field after the request, so customers find what they asked for.

--- a/components/eamxx/src/share/io/eamxx_dexpr_diags.cpp
+++ b/components/eamxx/src/share/io/eamxx_dexpr_diags.cpp
@@ -1,0 +1,520 @@
+#include "share/io/eamxx_dexpr_diags.hpp"
+
+#include <dexpr/ast.hpp>
+#include <dexpr/lexer.hpp>
+#include <dexpr/parser.hpp>
+#include <dexpr/supported_functions.hpp>
+#include <dexpr/tokens.hpp>
+
+#include <ekat_assert.hpp>
+
+#include <map>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+namespace scream {
+
+namespace {
+
+using dexpr::TokenTypes;
+namespace ast = dexpr::ast;
+
+// ---------------------------------------------------------------------------
+// Small helpers over the AST
+// ---------------------------------------------------------------------------
+
+template<typename Node>
+const Node* as (const ast::Expression& e) {
+  return e.visit([](const auto& node) -> const Node* {
+    if constexpr (std::is_same_v<std::decay_t<decltype(node)>,Node>) {
+      return &node;
+    } else {
+      return nullptr;
+    }
+  });
+}
+
+[[noreturn]] void unsupported (const std::string& what, const ast::Expression& e)
+{
+  EKAT_ERROR_MSG (
+      "Error! Unsupported expression: " + what + ".\n"
+      " - subexpression: " + ast::to_string(e) + "\n"
+      " - for the diagnostics EAMxx can build from an expression, see\n"
+      "   components/eamxx/docs/user/diags/expressions.md\n");
+  throw std::logic_error("unreachable"); // EKAT_ERROR_MSG already threw
+}
+
+// A method call parses as a FuncExpression whose 'function' is a Dot binary
+// expression, so the receiver and method name have to be dug back out.
+struct Call {
+  const ast::Expression* receiver = nullptr;
+  std::string name;
+  std::vector<const ast::Expression*> positional;
+  std::map<std::string,const ast::Expression*> keywords;
+};
+
+// Returns false if 'e' is not a method call at all.
+bool as_method_call (const ast::Expression& e, Call& call)
+{
+  const auto* fn = as<ast::FuncExpression>(e);
+  if (fn==nullptr) {
+    return false;
+  }
+  const auto* dot = as<ast::BinaryExpression>(*fn->function);
+  if (dot==nullptr or dot->op!=TokenTypes::Dot) {
+    return false;
+  }
+  const auto* name = as<ast::Identifier>(*dot->right);
+  if (name==nullptr) {
+    return false;
+  }
+
+  call.receiver = dot->left.get();
+  call.name     = name->value;
+  for (const auto& arg : fn->args) {
+    // A keyword argument is an Assign whose lhs is a name. Anything else is
+    // positional, including 'f(1=2)', which validate_calls() rejects on arity.
+    const auto* assign = as<ast::BinaryExpression>(*arg);
+    const auto* kw = assign!=nullptr && assign->op==TokenTypes::Assign
+                   ? as<ast::Identifier>(*assign->left)
+                   : nullptr;
+    if (kw!=nullptr) {
+      call.keywords[kw->value] = assign->right.get();
+    } else {
+      call.positional.push_back(arg.get());
+    }
+  }
+  return true;
+}
+
+// The name a subexpression is known by. Anything but a plain field name comes
+// back parenthesized, e.g. "(qc+qv)" -- the name create_diagnostic() resolves
+// later, and the resulting field's name. dexpr renders it, so it round-trips.
+std::string name_of (const ast::Expression& e) {
+  return ast::to_string(e);
+}
+
+// dexpr renders literals: a FloatLiteral keeps a double, not its lexeme, and
+// dexpr prints the shortest form that reads back.
+std::string literal_str (const ast::Expression& e)
+{
+  if (as<ast::IntegerLiteral>(e) or as<ast::FloatLiteral>(e)) {
+    return ast::to_string(e);
+  }
+  if (const auto* s = as<ast::StringLiteral>(e)) {
+    return s->value;
+  }
+  unsupported("expected a literal",e);
+}
+
+int int_arg (const ast::Expression& e, const std::string& ctx)
+{
+  const auto* i = as<ast::IntegerLiteral>(e);
+  if (i==nullptr) {
+    // A negative index parses as unary minus; the only place we accept one,
+    // since no diagnostic negates a field.
+    const auto* u = as<ast::UnaryExpression>(e);
+    if (u!=nullptr and u->op==TokenTypes::Minus) {
+      const auto* inner = as<ast::IntegerLiteral>(*u->right);
+      if (inner!=nullptr) {
+        return -inner->value;
+      }
+    }
+    unsupported(ctx + " must be an integer",e);
+  }
+  return i->value;
+}
+
+std::string string_arg (const ast::Expression& e, const std::string& ctx)
+{
+  const auto* s = as<ast::StringLiteral>(e);
+  if (s==nullptr) {
+    unsupported(ctx + " must be a quoted string",e);
+  }
+  return s->value;
+}
+
+const ast::Expression* keyword (const Call& call, const std::string& name)
+{
+  auto it = call.keywords.find(name);
+  return it==call.keywords.end() ? nullptr : it->second;
+}
+
+// ---------------------------------------------------------------------------
+// Translation: one AST node -> one diagnostic
+// ---------------------------------------------------------------------------
+// Only the root is translated. Operands go down by name, and the customer
+// resolving dependencies brings them back here one at a time.
+
+std::string comparison_to_cmp (TokenTypes op)
+{
+  switch (op) {
+    case TokenTypes::GreaterThan:  return "gt";
+    case TokenTypes::GreaterEqual: return "ge";
+    case TokenTypes::LessThan:     return "lt";
+    case TokenTypes::LessEq:       return "le";
+    case TokenTypes::Equal:        return "eq";
+    case TokenTypes::NotEqual:     return "ne";
+    default:                       return "";
+  }
+}
+
+std::string binary_op_to_diag_op (TokenTypes op)
+{
+  switch (op) {
+    case TokenTypes::Plus:     return "plus";
+    case TokenTypes::Minus:    return "minus";
+    case TokenTypes::Asterisk: return "times";
+    case TokenTypes::Slash:    return "over";
+    default:                   return "";
+  }
+}
+
+void translate_binary (const ast::BinaryExpression& e, const ast::Expression& self,
+                       std::string& diag_name, ekat::ParameterList& params)
+{
+  const auto op = binary_op_to_diag_op(e.op);
+  if (op=="") {
+    if (comparison_to_cmp(e.op)!="") {
+      unsupported("a comparison is only meaningful inside where(..)",self);
+    }
+    if (e.op==TokenTypes::Dot) {
+      unsupported("attribute access with no call",self);
+    }
+    unsupported("no diagnostic implements the operator '" +
+                dexpr::binary_op_to_string(e.op) + "'",self);
+  }
+
+  diag_name = "BinaryOp";
+  params.set<std::string>("arg1",name_of(*e.left));
+  params.set<std::string>("arg2",name_of(*e.right));
+  params.set<std::string>("binary_op",op);
+}
+
+// ---------------------------------------------------------------------------
+// The EAMxx vocabulary
+// ---------------------------------------------------------------------------
+// Named after xarray where there is an honest analogue. Lives here, not in
+// share/dexpr: dexpr owns the grammar, we own the vocabulary.
+//
+// Sits above translate_call() because the two are a pair -- every entry here
+// needs a case there. Nothing enforces that in the type system, so two checks
+// do: validate_registry() below, and the create_diag case that builds every
+// example.
+const dexpr::FunctionRegistry& eamxx_registry ()
+{
+  static const dexpr::FunctionRegistry reg = [] {
+    dexpr::FunctionRegistry r;
+
+    r.add({.name = "isel",
+           .desc = "value at a vertical index; -1 is the bottom level",
+           .min_positional = 0, .max_positional = 0,
+           .keywords = {{"lev",true}},
+           .example = "T_mid.isel(lev=10)"});
+    r.add({.name = "interp",
+           .desc = "value interpolated to a pressure or height coordinate",
+           .min_positional = 0, .max_positional = 0,
+           .keywords = {{"p_mid",false},{"z_mid",false},{"units",false},{"reference",false}},
+           .example = "T_mid.interp(p_mid=500,units='hPa')"});
+    r.add({.name = "mean",
+           .desc = "average over a dimension ('col' or 'lev')",
+           .min_positional = 1, .max_positional = 1,
+           .keywords = {{"weights",false}},
+           .example = "T_mid.mean('lev',weights='dp')"});
+    r.add({.name = "sum",
+           .desc = "sum over a dimension ('lev')",
+           .min_positional = 1, .max_positional = 1,
+           .keywords = {{"weights",false}},
+           .example = "T_mid.sum('lev',weights='dz')"});
+    r.add({.name = "where",
+           .desc = "keep values where a condition holds",
+           .min_positional = 1, .max_positional = 1,
+           .keywords = {},
+           .example = "T_mid.where(qv>0.01)"});
+    r.add({.name = "differentiate",
+           .desc = "vertical derivative w.r.t. 'p_mid' or 'z_mid'",
+           .min_positional = 1, .max_positional = 1,
+           .keywords = {},
+           .example = "T_mid.differentiate('p_mid')"});
+    r.add({.name = "histogram",
+           .desc = "counts per bin, given the bin edges",
+           .min_positional = 0, .max_positional = 0,
+           .keywords = {{"bins",true}},
+           .example = "T_mid.histogram(bins=[0,1,2])"});
+    r.add({.name = "zonal_mean",
+           .desc = "average within latitude bands",
+           .min_positional = 0, .max_positional = 0,
+           .keywords = {{"bins",true}},
+           .example = "T_mid.zonal_mean(bins=20)"});
+    r.add({.name = "shift",
+           .desc = "value at a previous time step; only time=1 is available",
+           .min_positional = 0, .max_positional = 0,
+           .keywords = {{"time",true}},
+           .example = "T_mid.shift(time=1)"});
+    r.add({.name = "over_dt",
+           .desc = "value divided by the time step",
+           .min_positional = 0, .max_positional = 0,
+           .keywords = {},
+           .example = "T_mid.over_dt()"});
+    r.add({.name = "tend",
+           .desc = "tendency over the time step, i.e. (X-X.shift(time=1)).over_dt()",
+           .min_positional = 0, .max_positional = 0,
+           .keywords = {},
+           .example = "T_mid.tend()"});
+
+    // Each example must parse, match the spec that declared it, and call it.
+    // A wrong arity or keyword fails here, not when a user first writes it.
+    dexpr::validate_registry(r);
+    return r;
+  }();
+  return reg;
+}
+
+void translate_call (const Call& call, const ast::Expression& self,
+                     std::string& diag_name, ekat::ParameterList& params)
+{
+  const auto operand = name_of(*call.receiver);
+  params.set<std::string>("field_name",operand);
+
+  if (call.name=="isel") {
+    // xarray indexing: negative counts from the end. Only -1 resolves without
+    // knowing the level count. lev=0 is the model top.
+    const auto idx = int_arg(*keyword(call,"lev"),"the 'lev' index");
+    std::string location;
+    if (idx==-1) {
+      location = "model_bot";
+    } else {
+      EKAT_REQUIRE_MSG (idx>=0,
+          "Error! Invalid vertical index in isel().\n"
+          " - expression: " + ast::to_string(self) + "\n"
+          " - input: " + std::to_string(idx) + "\n"
+          " - only -1 (the bottom level) is supported as a negative index,\n"
+          "   since the others cannot be resolved without the level count.\n");
+      location = "lev_" + std::to_string(idx);
+    }
+    diag_name = "FieldAtLevel";
+    params.set<std::string>("vertical_location",location);
+    return;
+  }
+
+  if (call.name=="interp") {
+    const auto* plev = keyword(call,"p_mid");
+    const auto* z    = keyword(call,"z_mid");
+    EKAT_REQUIRE_MSG ((plev!=nullptr) != (z!=nullptr),
+        "Error! interp() takes exactly one of 'p_mid' or 'z_mid'.\n"
+        " - expression: " + ast::to_string(self) + "\n");
+
+    if (plev!=nullptr) {
+      const auto* units = keyword(call,"units");
+      EKAT_REQUIRE_MSG (keyword(call,"reference")==nullptr,
+          "Error! 'reference' applies to interp(z_mid=..), not interp(p_mid=..).\n"
+          " - expression: " + ast::to_string(self) + "\n");
+      diag_name = "FieldAtPressureLevel";
+      params.set<std::string>("pressure_value",literal_str(*plev));
+      params.set<std::string>("pressure_units",
+          units==nullptr ? std::string("Pa") : string_arg(*units,"'units'"));
+    } else {
+      const auto* units = keyword(call,"units");
+      const auto* ref   = keyword(call,"reference");
+      diag_name = "FieldAtHeight";
+      params.set<std::string>("height_value",literal_str(*z));
+      params.set<std::string>("height_units",
+          units==nullptr ? std::string("m") : string_arg(*units,"'units'"));
+      params.set<std::string>("surface_reference",
+          ref==nullptr ? std::string("sealevel") : string_arg(*ref,"'reference'"));
+    }
+    return;
+  }
+
+  if (call.name=="mean" or call.name=="sum") {
+    const auto dim = string_arg(*call.positional[0],"the dimension");
+    const auto* weights = keyword(call,"weights");
+
+    if (dim=="col") {
+      EKAT_REQUIRE_MSG (call.name=="mean",
+          "Error! Only an average is available over 'col'.\n"
+          " - expression: " + ast::to_string(self) + "\n");
+      EKAT_REQUIRE_MSG (weights==nullptr,
+          "Error! Averaging over 'col' is always area weighted; 'weights' does not apply.\n"
+          " - expression: " + ast::to_string(self) + "\n");
+      diag_name = "HorizAvg";
+      return;
+    }
+
+    EKAT_REQUIRE_MSG (dim=="lev",
+        "Error! Unknown dimension in " + call.name + "().\n"
+        " - expression: " + ast::to_string(self) + "\n"
+        " - input: '" + dim + "'\n"
+        " - valid dimensions: 'col', 'lev'\n");
+
+    diag_name = "VertContract";
+    params.set<std::string>("contract_method",call.name=="mean" ? "avg" : "sum");
+    if (weights!=nullptr) {
+      params.set<std::string>("weighting_method",string_arg(*weights,"'weights'"));
+    }
+    return;
+  }
+
+  if (call.name=="where") {
+    const auto& cond = *call.positional[0];
+    const auto* cmp = as<ast::BinaryExpression>(cond);
+    EKAT_REQUIRE_MSG (cmp!=nullptr and comparison_to_cmp(cmp->op)!="",
+        "Error! where() takes a single comparison.\n"
+        " - expression: " + ast::to_string(self) + "\n"
+        " - condition: " + ast::to_string(cond) + "\n"
+        " - valid comparisons: >, >=, <, <=, ==, !=\n"
+        " - note: 'and'/'or' are not supported; chain where(..) calls instead.\n");
+
+    diag_name = "ConditionalSampling";
+    params.set<std::string>("condition_lhs",name_of(*cmp->left));
+    params.set<std::string>("condition_cmp",comparison_to_cmp(cmp->op));
+    params.set<std::string>("condition_rhs",name_of(*cmp->right));
+    return;
+  }
+
+  if (call.name=="differentiate") {
+    const auto wrt = string_arg(*call.positional[0],"the coordinate");
+    EKAT_REQUIRE_MSG (wrt=="p_mid" or wrt=="z_mid",
+        "Error! Unknown coordinate in differentiate().\n"
+        " - expression: " + ast::to_string(self) + "\n"
+        " - input: '" + wrt + "'\n"
+        " - valid coordinates: 'p_mid', 'z_mid'\n");
+    diag_name = "VertDerivative";
+    params.set<std::string>("derivative_method",wrt=="p_mid" ? "p" : "z");
+    return;
+  }
+
+  if (call.name=="histogram") {
+    const auto* bins = as<ast::ArrayExpression>(*keyword(call,"bins"));
+    EKAT_REQUIRE_MSG (bins!=nullptr and bins->elements.size()>=2,
+        "Error! histogram() takes 'bins', an array of at least two edges.\n"
+        " - expression: " + ast::to_string(self) + "\n");
+    // The diag re-splits on '_', so edges must survive: no exponents or signs.
+    std::string config;
+    for (size_t i=0; i<bins->elements.size(); ++i) {
+      const auto edge = literal_str(*bins->elements[i]);
+      EKAT_REQUIRE_MSG (edge.find_first_not_of("0123456789.")==std::string::npos,
+          "Error! Histogram bin edges must be non-negative decimals.\n"
+          " - expression: " + ast::to_string(self) + "\n"
+          " - edge: " + edge + "\n");
+      config += (i==0 ? "" : "_") + edge;
+    }
+    diag_name = "Histogram";
+    params.set<std::string>("bin_configuration",config);
+    return;
+  }
+
+  if (call.name=="zonal_mean") {
+    const auto bins = int_arg(*keyword(call,"bins"),"'bins'");
+    EKAT_REQUIRE_MSG (bins>0,
+        "Error! zonal_mean() needs a positive number of bins.\n"
+        " - expression: " + ast::to_string(self) + "\n"
+        " - bins: " + std::to_string(bins) + "\n");
+    diag_name = "ZonalAvg";
+    params.set<std::string>("number_of_zonal_bins",std::to_string(bins));
+    return;
+  }
+
+  if (call.name=="shift") {
+    // xarray's sign convention: a positive shift moves data forward, so
+    // shift(time=1) is the value from one step BACK. A negative shift would be
+    // the value from a step ahead, which a running model cannot know -- worth
+    // saying out loud, since isel(lev=-1) makes -1 look like "one back".
+    const auto n = int_arg(*keyword(call,"time"),"'time'");
+    EKAT_REQUIRE_MSG (n==1,
+        "Error! Only shift(time=1) is available.\n"
+        " - expression: " + ast::to_string(self) + "\n"
+        " - input: " + std::to_string(n) + "\n"
+        " - a positive shift looks BACK in time, as in xarray, so time=1 is the\n"
+        "   previous step. Negative would look ahead, which we cannot do, and\n"
+        "   only one step of history is kept.\n");
+    diag_name = "FieldPrev";
+    return;
+  }
+
+  if (call.name=="over_dt") {
+    diag_name = "FieldOverDt";
+    return;
+  }
+
+  if (call.name=="tend") {
+    // Shorthand expanded here, not in the grammar. The operand is the
+    // difference expression, which comes back through create_diagnostic().
+    // NOTE: the inner parens around 'time=1' are how dexpr renders a keyword
+    //       argument, so this matches what name_of() gives for the same
+    //       expression written out by hand, and the two share one diag.
+    diag_name = "FieldOverDt";
+    params.set<std::string>("field_name",
+        "(" + operand + "-" + operand + ".shift((time=1)))");
+    return;
+  }
+
+  // validate_calls() rejects unknown names, so this means the registry and the
+  // cases above have drifted apart.
+  EKAT_ERROR_MSG (
+      "Error! Internal error: '" + call.name + "' is registered but not translated.\n"
+      " - expression: " + ast::to_string(self) + "\n");
+}
+
+} // anonymous namespace
+
+std::shared_ptr<AbstractDiagnostic>
+dexpr_create_diagnostic (const std::string& expr,
+                         const std::shared_ptr<const AbstractGrid>& grid)
+{
+  ast::ExprPtr root;
+  try {
+    dexpr::parser::Parser parser {dexpr::Lexer{expr}};
+    root = parser.parse();
+  } catch (const dexpr::parser::ParserError& e) {
+    // Matched no legacy pattern and is not a legal identifier, so it can only
+    // have been meant as an expression. Say where it went wrong.
+    EKAT_ERROR_MSG (
+        "Error! '" + expr + "' is neither a registered diagnostic nor a valid expression.\n" +
+        std::string(e.what()));
+  }
+
+  // A bare identifier is a diag class name or a typo; the caller's to resolve.
+  if (as<ast::Identifier>(*root)) {
+    return nullptr;
+  }
+
+  dexpr::validate_calls(*root,eamxx_registry());
+
+  std::string diag_name;
+  ekat::ParameterList params(expr);
+  params.set("grid_name",grid->name());
+
+  if (Call call; as_method_call(*root,call)) {
+    translate_call(call,*root,diag_name,params);
+  } else if (const auto* bin = as<ast::BinaryExpression>(*root)) {
+    translate_binary(*bin,*root,diag_name,params);
+  } else if (const auto* un = as<ast::UnaryExpression>(*root)) {
+    unsupported("no diagnostic implements the unary operator '" +
+                dexpr::unary_op_to_string(un->op) + "'",*root);
+  } else if (as<ast::FuncExpression>(*root)) {
+    unsupported("EAMxx functions are written as methods, X.f(..), not f(X)",*root);
+  } else {
+    unsupported("an expression must produce a field",*root);
+  }
+
+  // Name the field after the request, so customers find what they asked for.
+  params.set<std::string>("output_field_name",expr);
+  // Mark how it resolved: an expression is not a usable NetCDF variable name,
+  // so whoever writes it must require an output name.
+  params.set<bool>("from_expression",true);
+
+  return DiagnosticFactory::instance().create(diag_name,grid->get_comm(),params,grid);
+}
+
+std::vector<std::string> dexpr_diagnostic_examples ()
+{
+  std::vector<std::string> out;
+  for (const auto& entry : eamxx_registry()) {
+    out.push_back(entry.second.example);
+  }
+  return out;
+}
+
+} // namespace scream

--- a/components/eamxx/src/share/io/eamxx_dexpr_diags.hpp
+++ b/components/eamxx/src/share/io/eamxx_dexpr_diags.hpp
@@ -1,0 +1,53 @@
+#ifndef SCREAM_EAMXX_DEXPR_DIAGS_HPP
+#define SCREAM_EAMXX_DEXPR_DIAGS_HPP
+
+#include "share/diagnostics/abstract_diagnostic.hpp"
+#include "share/grid/abstract_grid.hpp"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace scream {
+
+/*
+ * The expression front end for diagnostics.
+ *
+ * An alternative to the regex patterns in create_diagnostic(), not a layer on
+ * top: it parses with share/dexpr and drives the diagnostic factory from the
+ * AST. It neither produces nor consumes legacy underscore names, so the two
+ * front ends evolve independently.
+ *
+ * Composition is by field name, as always. A diag declares its operands by
+ * their canonical expression string, and the customer resolving dependencies
+ * feeds those back through create_diagnostic(): '(qc+qv)*p_mid' gives
+ * BinaryOp{arg1="(qc+qv)", arg2="p_mid"}, and '(qc+qv)' comes back here. Those
+ * names carry parentheses and quotes, which no legacy pattern matches, so they
+ * cannot be intercepted by a regex on the way back in.
+ *
+ * Diags built here carry two extra params:
+ *   - 'output_field_name': the expression, so the output field is named after
+ *     the request rather than the diag's own param concatenation.
+ *   - 'from_expression': marks a name as resolved by this front end. An
+ *     expression is not a usable NetCDF variable name, so a customer writing
+ *     one to file must require 'name := expr'.
+ *
+ * NOTE: exposes no dexpr types, keeping dexpr (and its C++20 requirement)
+ *       private to eamxx_io.
+ */
+
+// Returns nullptr if 'expr' is a plain identifier: that is a diag class name
+// (or a typo) for the caller to resolve as before. Throws if 'expr' is an
+// expression we cannot parse, validate, or translate.
+std::shared_ptr<AbstractDiagnostic>
+dexpr_create_diagnostic (const std::string& expr,
+                         const std::shared_ptr<const AbstractGrid>& grid);
+
+// One example call per supported function, e.g. "T_mid.isel(lev=10)". Exposed
+// so a test can prove every registered function is buildable; a function with
+// no case in the translator is otherwise caught only when someone writes it.
+std::vector<std::string> dexpr_diagnostic_examples ();
+
+} // namespace scream
+
+#endif // SCREAM_EAMXX_DEXPR_DIAGS_HPP

--- a/components/eamxx/src/share/io/eamxx_dexpr_diags.hpp
+++ b/components/eamxx/src/share/io/eamxx_dexpr_diags.hpp
@@ -32,8 +32,7 @@ namespace scream {
  *     expression is not a usable NetCDF variable name, so a customer writing
  *     one to file must require 'name := expr'.
  *
- * NOTE: exposes no dexpr types, keeping dexpr (and its C++20 requirement)
- *       private to eamxx_io.
+ * NOTE: exposes no dexpr types, keeping dexpr private to eamxx_io.
  */
 
 // Returns nullptr if 'expr' is a plain identifier: that is a diag class name
@@ -42,11 +41,6 @@ namespace scream {
 std::shared_ptr<AbstractDiagnostic>
 dexpr_create_diagnostic (const std::string& expr,
                          const std::shared_ptr<const AbstractGrid>& grid);
-
-// One example call per supported function, e.g. "T_mid.isel(lev=10)". Exposed
-// so a test can prove every registered function is buildable; a function with
-// no case in the translator is otherwise caught only when someone writes it.
-std::vector<std::string> dexpr_diagnostic_examples ();
 
 } // namespace scream
 

--- a/components/eamxx/src/share/io/eamxx_io_utils.cpp
+++ b/components/eamxx/src/share/io/eamxx_io_utils.cpp
@@ -1,5 +1,7 @@
 #include "share/io/eamxx_io_utils.hpp"
 
+#include "share/io/eamxx_dexpr_diags.hpp"
+
 #include "share/scorpio_interface/eamxx_scorpio_interface.hpp"
 #include "share/util/eamxx_utils.hpp"
 #include "share/core/eamxx_config.hpp"
@@ -266,7 +268,12 @@ create_diagnostic (const std::string& diag_field_name,
   }
   else
   {
-    // No existing special regex matches, so we assume that the diag field name IS the diag name.
+    // No pattern claimed this name. Try reading it as an expression before
+    // assuming it IS a diag class name. A plain identifier comes back nullptr,
+    // so we fall through to the factory exactly as before.
+    if (auto diag = dexpr_create_diagnostic(diag_field_name,grid)) {
+      return diag;
+    }
     diag_name = diag_field_name;
   }
 

--- a/components/eamxx/src/share/io/eamxx_io_utils.cpp
+++ b/components/eamxx/src/share/io/eamxx_io_utils.cpp
@@ -120,7 +120,11 @@ create_diagnostic (const std::string& diag_field_name,
     std::regex bt (generic_field + "_atm_backtend$");
     if (std::regex_search(diag_field_name, alias_matches, bt)) {
       const auto f = alias_matches[1].str();
-      return create_diagnostic(f + "_minus_" + f + "_prev_over_dt", grid);
+      auto diag = create_diagnostic(f + "_minus_" + f + "_prev_over_dt", grid);
+      // The expansion names its field after the canonical form, but the
+      // customer asked for the alias, and looks it up by that.
+      diag->get_params().set<std::string>("output_field_name",diag_field_name);
+      return diag;
     }
     // More built-in aliases may be added here.
   }

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -1105,6 +1105,16 @@ process_requested_fields()
     EKAT_REQUIRE_MSG(tokens.size()==2 or tokens.size()==1,
         "Error! Invalid alias request. Should be 'alias:=original'.\n"
         " - request: " + name + "\n");
+    // Trimming can leave a token empty (' := expr', 'name :=', or an entry that
+    // is only whitespace). Catch it here: an empty name silently poisons
+    // m_fields_names/m_alias_to_orig, and only fails much later.
+    for (const auto& t : tokens) {
+      EKAT_REQUIRE_MSG(not t.empty(),
+          "Error! Empty field name in output request.\n"
+          " - stream name: " + m_stream_name + "\n"
+          " - request: '" + name + "'\n"
+          " - expected 'alias := original' with both sides non-empty.\n");
+    }
     if (tokens.size()==2) {
       EKAT_REQUIRE_MSG (m_alias_to_orig.count(tokens[0])==0,
           "Error! The same alias has been used multiple times.\n"

--- a/components/eamxx/src/share/io/scorpio_output.cpp
+++ b/components/eamxx/src/share/io/scorpio_output.cpp
@@ -1068,6 +1068,9 @@ process_requested_fields()
   std::set<std::string> intermediate_names;
   for (const auto& spec : m_intermediate_aliases) {
     auto tokens = ekat::split(spec, ":=");
+    for (auto& t : tokens) {
+      t = ekat::trim(t);
+    }
     EKAT_REQUIRE_MSG(tokens.size()==2 && !tokens[0].empty() && !tokens[1].empty(),
         "Error! Invalid entry in 'aliases' section. Should be 'alias:=original'.\n"
         " - entry: " + spec + "\n");
@@ -1092,8 +1095,13 @@ process_requested_fields()
   }
 
   // Next, find out which field names are just aliases (using ':=' syntax)
+  // NOTE: spaces around ':=' are allowed and stripped; expressions read
+  //       better with them.
   for (auto& name : m_fields_names) {
     auto tokens = ekat::split(name,":=");
+    for (auto& t : tokens) {
+      t = ekat::trim(t);
+    }
     EKAT_REQUIRE_MSG(tokens.size()==2 or tokens.size()==1,
         "Error! Invalid alias request. Should be 'alias:=original'.\n"
         " - request: " + name + "\n");
@@ -1104,8 +1112,8 @@ process_requested_fields()
           " - first alias: " + tokens[0] + ":=" + m_alias_to_orig[tokens[0]] + "\n"
           " - second alias: " + tokens[0] + ":=" + tokens[1] + "\n");
       m_alias_to_orig[tokens[0]] = tokens[1];
-      name = tokens[0];
     }
+    name = tokens[0];
   }
 
   // In case someone has an alias of an alias, we need to resolve the TRUE orig names.
@@ -1209,6 +1217,10 @@ process_requested_fields()
   // This ensures we can evaluate diags in order at runtime
   bool done = false;
   std::set<std::string> remaining(m_fields_names.begin(),m_fields_names.end());
+  // m_fields_names now holds exactly the variables that reach the nc file:
+  // alias targets live in m_alias_to_orig, 'aliases' entries are intermediates.
+  // Copy it, since 'remaining' shrinks below.
+  const std::set<std::string> written_names(remaining);
   for (const auto& it : m_alias_to_orig) {
     remaining.insert(it.second);
   }
@@ -1239,11 +1251,30 @@ process_requested_fields()
           remove_these.insert(name);
         }
       } else {
-        auto& diag = m_diag_repo[name];
-        if (not diag) {
-          // First time we run into this diag. Create it
-          diag = create_diagnostic(name,fm_model->get_grid());
-        }
+        // Reuse the diag if another stream built it, else create it.
+        // NOTE: cache it only after the check below, or a stream that fails to
+        //       build leaves it in the shared static repo for everyone else.
+        auto it = m_diag_repo.find(name);
+        auto diag = it==m_diag_repo.end()
+                  ? create_diagnostic(name,fm_model->get_grid())
+                  : it->second;
+
+        // Field names go into the nc file verbatim, and '(qc+qv)*p_mid' is
+        // not a usable variable name, so an expression we must WRITE needs one.
+        // As an alias target, an 'aliases' intermediate, or nested in a larger
+        // expression, it is fine and needs no name.
+        EKAT_REQUIRE_MSG (
+            not (written_names.count(name)==1 and
+                 diag->get_params().isParameter("from_expression")),
+            "Error! An expression must be given an output name.\n"
+            " - stream name: " + m_stream_name + "\n"
+            " - request: " + name + "\n"
+            " - instead of\n"
+            "     - " + name + "\n"
+            "   write\n"
+            "     - <name> := " + name + "\n");
+
+        m_diag_repo[name] = diag;
         // Add its deps to the list of fields to process (if not already in fm_model)
         bool deps_met = true;
         for (const auto& dep_name : diag->get_input_fields_names()) {

--- a/components/eamxx/src/share/io/tests/CMakeLists.txt
+++ b/components/eamxx/src/share/io/tests/CMakeLists.txt
@@ -27,6 +27,14 @@ if (NOT SCREAM_ONLY_GENERATE_BASELINES)
     LABELS io diagnostics
   )
 
+  ## Test output of diagnostics requested as expressions
+  CreateUnitTest(io_dexpr
+    SOURCES io_dexpr.cpp
+    LIBS eamxx_io eamxx_diagnostics
+    LABELS io diagnostics
+    MPI_RANKS 1 ${SCREAM_TEST_MAX_RANKS}
+  )
+
   ## Test conditional geo data output (io_output_if_dim_exists feature)
   CreateUnitTest(io_cond_geo
     SOURCES io_cond_geo.cpp

--- a/components/eamxx/src/share/io/tests/create_diag.cpp
+++ b/components/eamxx/src/share/io/tests/create_diag.cpp
@@ -452,18 +452,6 @@ TEST_CASE("create_diag")
     REQUIRE_FALSE (d2->get_params().isParameter("from_expression"));
   }
 
-  SECTION ("dexpr_every_registered_function_is_buildable") {
-    // validate_registry() already proved each example matches its spec; this
-    // proves the translator turns each one into a diagnostic. A function
-    // registered with no case is otherwise caught only when someone writes it.
-    const auto examples = dexpr_diagnostic_examples();
-    REQUIRE (examples.size()>0);
-    for (const auto& e : examples) {
-      INFO ("example: " + e);
-      REQUIRE (create_diagnostic(e,grid)!=nullptr);
-    }
-  }
-
   SECTION ("dexpr_marks_what_it_built") {
     // Customers must tell an expression from a plain name, since an
     // expression needs a ':=' output name.

--- a/components/eamxx/src/share/io/tests/create_diag.cpp
+++ b/components/eamxx/src/share/io/tests/create_diag.cpp
@@ -2,6 +2,7 @@
 
 #include "share/diagnostics/register_diagnostics.hpp"
 
+#include "share/io/eamxx_dexpr_diags.hpp"
 #include "share/io/eamxx_io_utils.hpp"
 #include "share/grid/point_grid.hpp"
 
@@ -17,6 +18,10 @@ TEST_CASE("create_diag")
   const int ncols = 3*comm.size();
   const int nlevs = 10;
   auto grid = create_point_grid("physics",ncols,nlevs,comm);
+
+  // Some diags look up geometry data as they are constructed
+  grid->create_geometry_data("area",grid->get_2d_scalar_layout()).deep_copy(1.0);
+  grid->create_geometry_data("lat", grid->get_2d_scalar_layout()).deep_copy(0.0);
 
   SECTION ("field_at") {
     // FieldAtLevel
@@ -166,6 +171,283 @@ TEST_CASE("create_diag")
     auto d7 = create_diagnostic("dz",grid);
     REQUIRE (std::dynamic_pointer_cast<VerticalLayer>(d7)!=nullptr);
     REQUIRE (d7->get_params().get<std::string>("vert_location")=="mid");
+  }
+
+  // ==========================================================================
+  //  Expression syntax
+  // ==========================================================================
+  // Names no pattern above claims go to the dexpr front end, which drives the
+  // same factory from the parsed expression. Operands go down by canonical
+  // expression string and come back through create_diagnostic one at a time.
+
+  SECTION ("dexpr_operators") {
+    auto d1 = create_diagnostic("(qc+qv)*p_mid",grid);
+    REQUIRE (std::dynamic_pointer_cast<BinaryOp>(d1)!=nullptr);
+    REQUIRE (d1->get_params().get<std::string>("arg1")=="(qc+qv)");
+    REQUIRE (d1->get_params().get<std::string>("arg2")=="p_mid");
+    REQUIRE (d1->get_params().get<std::string>("binary_op")=="times");
+    // The field is named after the request, not after "(qc+qv)_times_p_mid"
+    REQUIRE (d1->get_params().get<std::string>("output_field_name")=="(qc+qv)*p_mid");
+
+    // ...and the operand resolves on its own when it comes back around.
+    auto inner = create_diagnostic("(qc+qv)",grid);
+    REQUIRE (std::dynamic_pointer_cast<BinaryOp>(inner)!=nullptr);
+    REQUIRE (inner->get_params().get<std::string>("arg1")=="qc");
+    REQUIRE (inner->get_params().get<std::string>("arg2")=="qv");
+    REQUIRE (inner->get_params().get<std::string>("binary_op")=="plus");
+
+    auto d2 = create_diagnostic("T_mid-p_mid",grid);
+    REQUIRE (d2->get_params().get<std::string>("binary_op")=="minus");
+    auto d3 = create_diagnostic("T_mid/p_mid",grid);
+    REQUIRE (d3->get_params().get<std::string>("binary_op")=="over");
+  }
+
+  SECTION ("dexpr_operator_precedence") {
+    // 'qc_plus_qv_times_p_mid' groups by regex greediness: (qc+qv)*p_mid. As
+    // an expression, '*' binds tighter.
+    auto d1 = create_diagnostic("qc+qv*p_mid",grid);
+    REQUIRE (d1->get_params().get<std::string>("binary_op")=="plus");
+    REQUIRE (d1->get_params().get<std::string>("arg1")=="qc");
+    REQUIRE (d1->get_params().get<std::string>("arg2")=="(qv*p_mid)");
+
+    auto legacy = create_diagnostic("qc_plus_qv_times_p_mid",grid);
+    REQUIRE (legacy->get_params().get<std::string>("binary_op")=="times");
+    REQUIRE (legacy->get_params().get<std::string>("arg1")=="qc_plus_qv");
+  }
+
+  SECTION ("dexpr_numeric_literals") {
+    // The underscore syntax cannot write a literal, so BinaryOp only ever saw
+    // named constants. p_mid/100 must not look for a field called "100".
+    auto d1 = create_diagnostic("p_mid/100",grid);
+    REQUIRE (std::dynamic_pointer_cast<BinaryOp>(d1)!=nullptr);
+    REQUIRE (d1->get_params().get<std::string>("arg2")=="100");
+    // 100 is a scalar, so it is not requested as an input field
+    REQUIRE (d1->get_input_fields_names().size()==1);
+    REQUIRE (d1->get_input_fields_names().front()=="p_mid");
+
+    auto d2 = create_diagnostic("T_mid*0.5",grid);
+    REQUIRE (d2->get_params().get<std::string>("arg2")=="0.5");
+    REQUIRE (d2->get_input_fields_names().size()==1);
+  }
+
+  SECTION ("dexpr_composition_is_unambiguous") {
+    // 'qc.where(p_mid>100) + qv' has no unambiguous underscore spelling:
+    // 'qc_where_p_mid_gt_100_plus_qv' hits the conditional-sampling pattern
+    // first with a greedy field name, silently giving
+    // ConditionalSampling(qc, p_mid, gt, 100_plus_qv). Canonical expression
+    // strings cannot be mis-bound: no legacy pattern matches parentheses.
+    auto d1 = create_diagnostic("qc.where(p_mid>100) + qv",grid);
+    REQUIRE (std::dynamic_pointer_cast<BinaryOp>(d1)!=nullptr);
+    REQUIRE (d1->get_params().get<std::string>("arg1")=="qc.where((p_mid>100))");
+    REQUIRE (d1->get_params().get<std::string>("arg2")=="qv");
+
+    auto lhs = create_diagnostic("qc.where((p_mid>100))",grid);
+    REQUIRE (std::dynamic_pointer_cast<ConditionalSampling>(lhs)!=nullptr);
+    REQUIRE (lhs->get_params().get<std::string>("field_name")=="qc");
+    REQUIRE (lhs->get_params().get<std::string>("condition_lhs")=="p_mid");
+    REQUIRE (lhs->get_params().get<std::string>("condition_cmp")=="gt");
+    REQUIRE (lhs->get_params().get<std::string>("condition_rhs")=="100");
+
+    // Two levels of nesting
+    auto d2 = create_diagnostic("(qc.where(p_mid>100) + qv) * T_mid",grid);
+    REQUIRE (d2->get_params().get<std::string>("arg1")=="(qc.where((p_mid>100))+qv)");
+    REQUIRE (d2->get_params().get<std::string>("binary_op")=="times");
+  }
+
+  SECTION ("dexpr_isel") {
+    auto d1 = create_diagnostic("T_mid.isel(lev=3)",grid);
+    REQUIRE (std::dynamic_pointer_cast<FieldAtLevel>(d1)!=nullptr);
+    REQUIRE (d1->get_params().get<std::string>("field_name")=="T_mid");
+    REQUIRE (d1->get_params().get<std::string>("vertical_location")=="lev_3");
+
+    // xarray negative indexing; -1 is the one we can resolve without the
+    // level count.
+    auto d2 = create_diagnostic("T_mid.isel(lev=-1)",grid);
+    REQUIRE (d2->get_params().get<std::string>("vertical_location")=="model_bot");
+    REQUIRE_THROWS (create_diagnostic("T_mid.isel(lev=-2)",grid));
+
+    // lev=0 is the model top; there is no separate label for it
+    auto d3 = create_diagnostic("T_mid.isel(lev=0)",grid);
+    REQUIRE (d3->get_params().get<std::string>("vertical_location")=="lev_0");
+    REQUIRE_THROWS (create_diagnostic("T_mid.isel(lev='model_top')",grid));
+  }
+
+  SECTION ("dexpr_interp") {
+    auto d1 = create_diagnostic("T_mid.interp(p_mid=500,units='hPa')",grid);
+    REQUIRE (std::dynamic_pointer_cast<FieldAtPressureLevel>(d1)!=nullptr);
+    REQUIRE (d1->get_params().get<std::string>("pressure_value")=="500");
+    REQUIRE (d1->get_params().get<std::string>("pressure_units")=="hPa");
+
+    // Pa is the default, matching the units everything else in EAMxx uses
+    auto d2 = create_diagnostic("T_mid.interp(p_mid=50000)",grid);
+    REQUIRE (d2->get_params().get<std::string>("pressure_units")=="Pa");
+
+    auto d3 = create_diagnostic("T_mid.interp(z_mid=10,reference='surface')",grid);
+    REQUIRE (std::dynamic_pointer_cast<FieldAtHeight>(d3)!=nullptr);
+    REQUIRE (d3->get_params().get<std::string>("height_value")=="10");
+    REQUIRE (d3->get_params().get<std::string>("height_units")=="m");
+    REQUIRE (d3->get_params().get<std::string>("surface_reference")=="surface");
+
+    REQUIRE_THROWS (create_diagnostic("T_mid.interp(p_mid=500,z_mid=10)",grid));
+    REQUIRE_THROWS (create_diagnostic("T_mid.interp()",grid));
+    REQUIRE_THROWS (create_diagnostic("T_mid.interp(p_mid=500,reference='surface')",grid));
+  }
+
+  SECTION ("dexpr_reductions") {
+    auto d1 = create_diagnostic("T_mid.mean('col')",grid);
+    REQUIRE (std::dynamic_pointer_cast<HorizAvg>(d1)!=nullptr);
+    REQUIRE (d1->get_params().get<std::string>("field_name")=="T_mid");
+
+    auto d2 = create_diagnostic("T_mid.mean('lev')",grid);
+    REQUIRE (std::dynamic_pointer_cast<VertContract>(d2)!=nullptr);
+    REQUIRE (d2->get_params().get<std::string>("contract_method")=="avg");
+
+    auto d3 = create_diagnostic("T_mid.sum('lev')",grid);
+    REQUIRE (std::dynamic_pointer_cast<VertContract>(d3)!=nullptr);
+    REQUIRE (d3->get_params().get<std::string>("contract_method")=="sum");
+
+    auto d4 = create_diagnostic("T_mid.mean('lev',weights='dp')",grid);
+    REQUIRE (d4->get_params().get<std::string>("weighting_method")=="dp");
+    // ...same as the legacy spelling
+    auto legacy = create_diagnostic("T_mid_vert_avg_dp_weighted",grid);
+    REQUIRE (legacy->get_params().get<std::string>("weighting_method")=="dp");
+
+    REQUIRE_THROWS (create_diagnostic("T_mid.mean('time')",grid));
+    REQUIRE_THROWS (create_diagnostic("T_mid.sum('col')",grid));
+    REQUIRE_THROWS (create_diagnostic("T_mid.mean('col',weights='dp')",grid));
+  }
+
+  SECTION ("dexpr_where") {
+    auto d1 = create_diagnostic("T_mid.where(qv>0.01)",grid);
+    REQUIRE (std::dynamic_pointer_cast<ConditionalSampling>(d1)!=nullptr);
+    REQUIRE (d1->get_params().get<std::string>("condition_rhs")=="0.01");
+    REQUIRE (d1->get_params().get<std::string>("condition_cmp")=="gt");
+
+    // The special operand names carry over from the legacy spelling
+    auto d2 = create_diagnostic("mask.where(lev>5)",grid);
+    REQUIRE (d2->get_params().get<std::string>("field_name")=="mask");
+    REQUIRE (d2->get_params().get<std::string>("condition_lhs")=="lev");
+
+    auto d3 = create_diagnostic("T_mid.where(qv<=0.01)",grid);
+    REQUIRE (d3->get_params().get<std::string>("condition_cmp")=="le");
+    auto d4 = create_diagnostic("T_mid.where(qv!=0)",grid);
+    REQUIRE (d4->get_params().get<std::string>("condition_cmp")=="ne");
+
+    // ConditionalSampling takes exactly one comparison
+    REQUIRE_THROWS (create_diagnostic("T_mid.where(qv>0 and qc<1)",grid));
+    REQUIRE_THROWS (create_diagnostic("T_mid.where(qv)",grid));
+    // ...and a comparison is meaningless anywhere else
+    REQUIRE_THROWS (create_diagnostic("T_mid>0",grid));
+  }
+
+  SECTION ("dexpr_other_calls") {
+    auto d1 = create_diagnostic("T_mid.differentiate('p_mid')",grid);
+    REQUIRE (std::dynamic_pointer_cast<VertDerivative>(d1)!=nullptr);
+    REQUIRE (d1->get_params().get<std::string>("derivative_method")=="p");
+    REQUIRE_THROWS (create_diagnostic("T_mid.differentiate('t')",grid));
+    // the bare shorthands are gone; name the coordinate
+    REQUIRE_THROWS (create_diagnostic("T_mid.differentiate('p')",grid));
+
+    auto d2 = create_diagnostic("T_mid.histogram(bins=[0,1.5,2])",grid);
+    REQUIRE (std::dynamic_pointer_cast<Histogram>(d2)!=nullptr);
+    REQUIRE (d2->get_params().get<std::string>("bin_configuration")=="0_1.5_2");
+    // Edges render in the shortest form that reads back, so an exponent in
+    // the request need not survive into the configuration...
+    auto d2b = create_diagnostic("T_mid.histogram(bins=[0,1e3])",grid);
+    REQUIRE (d2b->get_params().get<std::string>("bin_configuration")=="0_1000.0");
+    // ...but one that cannot be written without an exponent must be rejected,
+    // since the diag re-splits the configuration on '_' and parses each piece.
+    REQUIRE_THROWS (create_diagnostic("T_mid.histogram(bins=[0,1e30])",grid));
+    REQUIRE_THROWS (create_diagnostic("T_mid.histogram(bins=[0])",grid));
+
+    auto d3 = create_diagnostic("T_mid.zonal_mean(bins=20)",grid);
+    REQUIRE (std::dynamic_pointer_cast<ZonalAvg>(d3)!=nullptr);
+    REQUIRE (d3->get_params().get<std::string>("number_of_zonal_bins")=="20");
+    REQUIRE_THROWS (create_diagnostic("T_mid.zonal_mean(bins=-1)",grid));
+    REQUIRE_THROWS (create_diagnostic("T_mid.zonal_mean(bins='many')",grid));
+
+    auto d4 = create_diagnostic("T_mid.shift(time=1)",grid);
+    REQUIRE (std::dynamic_pointer_cast<FieldPrev>(d4)!=nullptr);
+    REQUIRE (d4->get_params().get<std::string>("field_name")=="T_mid");
+    // A positive shift looks back, as in xarray. -1 would look ahead, which we
+    // cannot do, and is the mistake isel(lev=-1) invites.
+    REQUIRE_THROWS (create_diagnostic("T_mid.shift(time=-1)",grid));
+    REQUIRE_THROWS (create_diagnostic("T_mid.shift(time=0)",grid));
+    REQUIRE_THROWS (create_diagnostic("T_mid.shift(time=2)",grid));
+    REQUIRE_THROWS (create_diagnostic("T_mid.prev()",grid));
+
+    auto d5 = create_diagnostic("T_mid.over_dt()",grid);
+    REQUIRE (std::dynamic_pointer_cast<FieldOverDt>(d5)!=nullptr);
+  }
+
+  SECTION ("dexpr_tend") {
+    // Shorthand for (X-X.shift(time=1)).over_dt(): the _atm_backtend tree.
+    auto d1 = create_diagnostic("T_mid.tend()",grid);
+    REQUIRE (std::dynamic_pointer_cast<FieldOverDt>(d1)!=nullptr);
+    REQUIRE (d1->get_params().get<std::string>("field_name")=="(T_mid-T_mid.shift((time=1)))");
+
+    // The expansion is the canonical rendering, so writing it out by hand
+    // resolves to the same diag.
+    auto diff = create_diagnostic("(T_mid-T_mid.shift(time=1))",grid);
+    REQUIRE (std::dynamic_pointer_cast<BinaryOp>(diff)!=nullptr);
+    REQUIRE (diff->get_params().get<std::string>("binary_op")=="minus");
+    REQUIRE (diff->get_params().get<std::string>("arg2")=="T_mid.shift((time=1))");
+
+    auto prev = create_diagnostic("T_mid.shift(time=1)",grid);
+    REQUIRE (std::dynamic_pointer_cast<FieldPrev>(prev)!=nullptr);
+  }
+
+  SECTION ("dexpr_rejects") {
+    // Unknown function: the message names what IS available
+    REQUIRE_THROWS (create_diagnostic("T_mid.iselect(lev=1)",grid));
+    // Unknown keyword
+    REQUIRE_THROWS (create_diagnostic("T_mid.isel(levl=1)",grid));
+    // Free-standing spelling of a method
+    REQUIRE_THROWS (create_diagnostic("mean(T_mid,'lev')",grid));
+    // Operators with no diagnostic behind them
+    REQUIRE_THROWS (create_diagnostic("T_mid**2",grid));
+    REQUIRE_THROWS (create_diagnostic("-T_mid",grid));
+    // Attribute access with no call
+    REQUIRE_THROWS (create_diagnostic("T_mid.prev",grid));
+    // An expression must produce a field
+    REQUIRE_THROWS (create_diagnostic("[1,2]",grid));
+    // A non-name on the lhs of '=' is not a keyword argument, so it counts
+    // against the positional arity rather than dereferencing a null name
+    REQUIRE_THROWS (create_diagnostic("T_mid.isel(1=2)",grid));
+  }
+
+  SECTION ("dexpr_leaves_plain_names_alone") {
+    // A bare identifier is a diag class name or a typo; the factory decides.
+    auto d1 = create_diagnostic("AtmosphereDensity",grid);
+    REQUIRE (std::dynamic_pointer_cast<AtmDensity>(d1)!=nullptr);
+    REQUIRE_FALSE (d1->get_params().isParameter("from_expression"));
+
+    REQUIRE_THROWS (create_diagnostic("NotADiagnostic",grid));
+
+    // Legacy names matched a pattern long before the expression front end.
+    auto d2 = create_diagnostic("BlaH_123_where_qv_gt_0.01",grid);
+    REQUIRE (std::dynamic_pointer_cast<ConditionalSampling>(d2)!=nullptr);
+    REQUIRE_FALSE (d2->get_params().isParameter("from_expression"));
+  }
+
+  SECTION ("dexpr_every_registered_function_is_buildable") {
+    // validate_registry() already proved each example matches its spec; this
+    // proves the translator turns each one into a diagnostic. A function
+    // registered with no case is otherwise caught only when someone writes it.
+    const auto examples = dexpr_diagnostic_examples();
+    REQUIRE (examples.size()>0);
+    for (const auto& e : examples) {
+      INFO ("example: " + e);
+      REQUIRE (create_diagnostic(e,grid)!=nullptr);
+    }
+  }
+
+  SECTION ("dexpr_marks_what_it_built") {
+    // Customers must tell an expression from a plain name, since an
+    // expression needs a ':=' output name.
+    auto d1 = create_diagnostic("(qc+qv)*p_mid",grid);
+    REQUIRE (d1->get_params().isParameter("from_expression"));
+    REQUIRE (d1->get_params().get<bool>("from_expression"));
   }
 
 }

--- a/components/eamxx/src/share/io/tests/create_diag.cpp
+++ b/components/eamxx/src/share/io/tests/create_diag.cpp
@@ -202,6 +202,28 @@ TEST_CASE("create_diag")
     REQUIRE (d3->get_params().get<std::string>("binary_op")=="over");
   }
 
+  SECTION ("dexpr_unary_minus") {
+    // No diagnostic negates a field, so '-X' goes through BinaryOp as (-1)*X.
+    auto d1 = create_diagnostic("-T_mid",grid);
+    REQUIRE (std::dynamic_pointer_cast<BinaryOp>(d1)!=nullptr);
+    REQUIRE (d1->get_params().get<std::string>("arg1")=="-1");
+    REQUIRE (d1->get_params().get<std::string>("arg2")=="T_mid");
+    REQUIRE (d1->get_params().get<std::string>("binary_op")=="times");
+    // -1 is a scalar, so only T_mid is requested as an input field
+    REQUIRE (d1->get_input_fields_names().size()==1);
+    REQUIRE (d1->get_input_fields_names().front()=="T_mid");
+
+    // Prefix binds tighter than '*', so '-qc*qv' is '(-qc)*qv'...
+    auto d2 = create_diagnostic("-qc*qv",grid);
+    REQUIRE (d2->get_params().get<std::string>("binary_op")=="times");
+    REQUIRE (d2->get_params().get<std::string>("arg1")=="(-qc)");
+    REQUIRE (d2->get_params().get<std::string>("arg2")=="qv");
+    // ...and the negated operand resolves on its own when it comes back around
+    auto inner = create_diagnostic("(-qc)",grid);
+    REQUIRE (inner->get_params().get<std::string>("arg1")=="-1");
+    REQUIRE (inner->get_params().get<std::string>("arg2")=="qc");
+  }
+
   SECTION ("dexpr_operator_precedence") {
     // 'qc_plus_qv_times_p_mid' groups by regex greediness: (qc+qv)*p_mid. As
     // an expression, '*' binds tighter.
@@ -341,12 +363,12 @@ TEST_CASE("create_diag")
   }
 
   SECTION ("dexpr_other_calls") {
-    auto d1 = create_diagnostic("T_mid.differentiate('p_mid')",grid);
+    auto d1 = create_diagnostic("T_mid.derivative('p_mid')",grid);
     REQUIRE (std::dynamic_pointer_cast<VertDerivative>(d1)!=nullptr);
     REQUIRE (d1->get_params().get<std::string>("derivative_method")=="p");
-    REQUIRE_THROWS (create_diagnostic("T_mid.differentiate('t')",grid));
+    REQUIRE_THROWS (create_diagnostic("T_mid.derivative('t')",grid));
     // the bare shorthands are gone; name the coordinate
-    REQUIRE_THROWS (create_diagnostic("T_mid.differentiate('p')",grid));
+    REQUIRE_THROWS (create_diagnostic("T_mid.derivative('p')",grid));
 
     auto d2 = create_diagnostic("T_mid.histogram(bins=[0,1.5,2])",grid);
     REQUIRE (std::dynamic_pointer_cast<Histogram>(d2)!=nullptr);
@@ -406,7 +428,7 @@ TEST_CASE("create_diag")
     REQUIRE_THROWS (create_diagnostic("mean(T_mid,'lev')",grid));
     // Operators with no diagnostic behind them
     REQUIRE_THROWS (create_diagnostic("T_mid**2",grid));
-    REQUIRE_THROWS (create_diagnostic("-T_mid",grid));
+    REQUIRE_THROWS (create_diagnostic("!T_mid",grid));
     // Attribute access with no call
     REQUIRE_THROWS (create_diagnostic("T_mid.prev",grid));
     // An expression must produce a field

--- a/components/eamxx/src/share/io/tests/create_diag.cpp
+++ b/components/eamxx/src/share/io/tests/create_diag.cpp
@@ -114,6 +114,9 @@ TEST_CASE("create_diag")
     auto d1 = create_diagnostic("BlaH_123_atm_backtend",grid);
     REQUIRE (std::dynamic_pointer_cast<FieldOverDt>(d1)!=nullptr);
     REQUIRE (d1->get_params().get<std::string>("field_name")=="BlaH_123_minus_BlaH_123_prev");
+    // The diag would name its field after the expansion, but the customer
+    // asked for the alias. Without this, an output stream throws.
+    REQUIRE (d1->get_params().get<std::string>("output_field_name")=="BlaH_123_atm_backtend");
   }
 
   SECTION ("field_prev") {

--- a/components/eamxx/src/share/io/tests/io_dexpr.cpp
+++ b/components/eamxx/src/share/io/tests/io_dexpr.cpp
@@ -1,0 +1,275 @@
+#include <catch2/catch.hpp>
+
+#include "share/data_managers/field_manager.hpp"
+#include "share/data_managers/mesh_free_grids_manager.hpp"
+#include "share/diagnostics/register_diagnostics.hpp"
+#include "share/field/field.hpp"
+#include "share/field/field_reader.hpp"
+#include "share/io/eamxx_output_manager.hpp"
+#include "share/scorpio_interface/eamxx_scorpio_interface.hpp"
+#include "share/util/eamxx_time_stamp.hpp"
+
+#include <ekat_comm.hpp>
+#include <ekat_parameter_list.hpp>
+#include <ekat_units.hpp>
+
+#include <fstream>
+#include <string>
+#include <vector>
+
+/*
+ * End-to-end checks for names resolved by the expression front end.
+ *
+ * create_diag.cpp covers the translation. Only here can we check that the field
+ * survives an output stream, which looks fields up by the REQUESTED name while
+ * a diag derives its own from its params -- not the same thing for an
+ * expression, nor for the _atm_backtend alias.
+ */
+
+namespace scream {
+
+namespace {
+
+constexpr int ncols = 6;
+constexpr int nlevs = 4;
+
+// qv[i][k] = n + i*(k+1), T_mid[i][k] = n - i*(k+1): simple enough that
+// expected values can be written down by hand.
+void calc_fields (Field& qv, Field& T_mid, const int n)
+{
+  auto qv_h = qv.get_view<Real**,Host>();
+  auto T_h  = T_mid.get_view<Real**,Host>();
+  const int nl = qv.get_header().get_identifier().get_layout().dim(0);
+  for (int i=0; i<nl; ++i) {
+    for (int k=0; k<nlevs; ++k) {
+      qv_h(i,k) = n + i*(k+1);
+      T_h (i,k) = n - i*(k+1);
+    }
+  }
+  qv.sync_to_dev();
+  T_mid.sync_to_dev();
+}
+
+// NOTE: built on the grids manager, not the grid: the 'fields->$grid' output
+//       syntax needs a non-const grid.
+std::shared_ptr<FieldManager>
+create_test_fm (const std::shared_ptr<const GridsManager>& gm,
+                const std::shared_ptr<const AbstractGrid>& grid,
+                const util::TimeStamp& t0)
+{
+  using namespace ekat::units;
+  using namespace ShortFieldTagsNames;
+
+  const auto layout3d = grid->get_3d_scalar_layout(LEV);
+  auto fm = std::make_shared<FieldManager>(gm);
+
+  Field qv    (FieldIdentifier("qv",   layout3d, kg/kg, grid->name()));
+  Field T_mid (FieldIdentifier("T_mid",layout3d, K,     grid->name()));
+  qv.allocate_view();
+  T_mid.allocate_view();
+  qv.get_header().get_tracking().update_time_stamp(t0);
+  T_mid.get_header().get_tracking().update_time_stamp(t0);
+
+  fm->add_field(qv);
+  fm->add_field(T_mid);
+
+  calc_fields(qv,T_mid,0);
+
+  return fm;
+}
+
+// NOTE: the 'aliases' section only exists in the full fields->$grid syntax
+ekat::ParameterList output_params (const std::string& prefix,
+                                   const std::string& grid_name,
+                                   const std::vector<std::string>& field_names,
+                                   const std::vector<std::string>& aliases = {})
+{
+  ekat::ParameterList params;
+  params.set<std::string>("filename_prefix",prefix);
+  params.set<std::string>("averaging_type","INSTANT");
+  params.set<std::string>("floating_point_precision","real");
+
+  auto& f_pl = params.sublist("fields").sublist(grid_name);
+  f_pl.set("field_names",field_names);
+  if (not aliases.empty()) {
+    f_pl.set("aliases",aliases);
+  }
+
+  auto& ctrl_pl = params.sublist("output_control");
+  ctrl_pl.set<std::string>("frequency_units","nsteps");
+  ctrl_pl.set<int>("frequency",1);
+  ctrl_pl.set<bool>("save_grid_data",false);
+  // No snapshot at t0: a tendency has no meaning before the first step
+  ctrl_pl.set<bool>("skip_t0_output",true);
+
+  return params;
+}
+
+} // anonymous namespace
+
+TEST_CASE ("io_with_expressions")
+{
+  using namespace ShortFieldTagsNames;
+  using namespace ekat::units;
+
+  register_diagnostics();
+
+  ekat::Comm comm(MPI_COMM_WORLD);
+  scorpio::init_subsystem(comm);
+
+  auto gm = create_mesh_free_grids_manager(comm,0,0,nlevs,ncols);
+  gm->build_grids();
+  auto grid = gm->get_grid("point_grid");
+  const auto gname = grid->name();
+
+  util::TimeStamp t0({2023,1,1},{0,0,0});
+  auto fm = create_test_fm(gm,grid,t0);
+
+  const std::string prefix = "io_dexpr";
+  const int dt = 1;
+  const int nsteps = 3;
+
+  auto params = output_params(prefix,gname,
+      {
+        // An expression must be given a name, since field names go into the
+        // nc file verbatim
+        "prod := qv*T_mid",
+        // Grouping is explicit, unlike in the underscore spelling, where it
+        // falls out of regex greediness
+        "shifted := (qv+qv)*T_mid",
+        // Built on the intermediate below, by name
+        "half := qvT/2",
+        // A method call
+        "col_qv := qv.mean('lev')",
+        // Regression: expands to T_mid_minus_T_mid_prev_over_dt, so the diag
+        // names its field after the expansion. Without an explicit output
+        // name the stream throws during setup.
+        "T_mid_atm_backtend",
+      },
+      {
+        // An intermediate: resolved and usable by name, but not written
+        "qvT := qv*T_mid",
+      });
+
+  // NOTE: scoped, so the stream (and the diags it owns) are gone before Kokkos
+  //       is finalized
+  auto t = t0;
+  {
+  OutputManager om;
+  om.initialize(comm,params,t0,false);
+  om.setup(fm,gm->get_grid_names());
+
+  for (int n=1; n<=nsteps; ++n) {
+    om.init_timestep(t,dt);
+    t += dt;
+
+    auto qv    = fm->get_field("qv");
+    auto T_mid = fm->get_field("T_mid");
+    calc_fields(qv,T_mid,n);
+    qv.get_header().get_tracking().update_time_stamp(t);
+    T_mid.get_header().get_tracking().update_time_stamp(t);
+
+    om.run(t);
+  }
+  om.finalize();
+  }
+
+  // NOTE: the file is named after the FIRST snapshot in it, which is t0+dt
+  //       here, since we skip the t0 output
+  const auto filename = prefix + ".INSTANT.nsteps_x1.np" +
+                        std::to_string(comm.size()) + "." + (t0+dt).to_string() + ".nc";
+  std::ifstream file_check(filename);
+  REQUIRE (file_check.good());
+  file_check.close();
+
+  scorpio::register_file(filename,scorpio::Read);
+  REQUIRE (scorpio::has_var(filename,"prod"));
+  REQUIRE (scorpio::has_var(filename,"shifted"));
+  REQUIRE (scorpio::has_var(filename,"half"));
+  REQUIRE (scorpio::has_var(filename,"col_qv"));
+  // The one that used to throw during setup
+  REQUIRE (scorpio::has_var(filename,"T_mid_atm_backtend"));
+  // An 'aliases' entry is an intermediate: resolved, used, but not written
+  REQUIRE_FALSE (scorpio::has_var(filename,"qvT"));
+  // The file records where the numbers came from
+  REQUIRE (scorpio::get_attribute<std::string>(filename,"prod","alias_of")=="qv*T_mid");
+  REQUIRE (scorpio::get_attribute<std::string>(filename,"half","alias_of")=="qvT/2");
+  scorpio::release_file(filename);
+
+  // Values
+  // NOTE: scoped, so the fields are gone before Kokkos is finalized
+  {
+  const auto layout3d = grid->get_3d_scalar_layout(LEV);
+  const auto layout2d = grid->get_2d_scalar_layout();
+  Field prod    (FieldIdentifier("prod",   layout3d, kg/kg*K, gname));
+  Field shifted (FieldIdentifier("shifted",layout3d, kg/kg*K, gname));
+  Field half    (FieldIdentifier("half",   layout3d, kg/kg*K, gname));
+  Field col_qv  (FieldIdentifier("col_qv", layout2d, kg/kg,   gname));
+  Field backtend(FieldIdentifier("T_mid_atm_backtend",layout3d, K/s, gname));
+  for (auto* f : {&prod,&shifted,&half,&col_qv,&backtend}) {
+    f->allocate_view();
+    f->get_header().get_tracking().update_time_stamp(t0);
+  }
+
+  FieldReader reader;
+  reader.set_file_specs(filename);
+  reader.set_dim_decomp(grid->get_partitioned_dim_gids(),comm);
+  reader.set_fields({prod,shifted,half,col_qv,backtend});
+
+  const int nlocal = grid->get_num_local_dofs();
+  for (int n=1; n<=nsteps; ++n) {
+    reader.read(n-1);
+    prod.sync_to_host();
+    shifted.sync_to_host();
+    half.sync_to_host();
+    col_qv.sync_to_host();
+    backtend.sync_to_host();
+    auto prod_h     = prod.get_view<const Real**,Host>();
+    auto shifted_h  = shifted.get_view<const Real**,Host>();
+    auto half_h     = half.get_view<const Real**,Host>();
+    auto col_qv_h   = col_qv.get_view<const Real*,Host>();
+    auto backtend_h = backtend.get_view<const Real**,Host>();
+
+    for (int i=0; i<nlocal; ++i) {
+      Real qv_col_sum = 0;
+      for (int k=0; k<nlevs; ++k) {
+        const Real qv_v = n + i*(k+1);
+        const Real T_v  = n - i*(k+1);
+        qv_col_sum += qv_v;
+
+        REQUIRE (prod_h(i,k)==qv_v*T_v);
+        // (qv+qv)*T_mid, not qv+(qv*T_mid): '*' binds tighter than '+'
+        REQUIRE (shifted_h(i,k)==(qv_v+qv_v)*T_v);
+        REQUIRE (half_h(i,k)==qv_v*T_v/2);
+        // T_mid gains exactly -i*(k+1)+... i.e. 1 per step, over dt=1
+        REQUIRE (backtend_h(i,k)==1);
+      }
+      REQUIRE (col_qv_h(i)==qv_col_sum/nlevs);
+    }
+  }
+  reader.clean_up();
+  }
+
+  // An expression in field_names would become an nc variable of that name.
+  // It needs a name -- decided by how it RESOLVED, not by its characters.
+  {
+    auto bad = output_params("io_dexpr_unnamed",gname,{"qv*T_mid"});
+    OutputManager om_bad;
+    om_bad.initialize(comm,bad,t0,false);
+    REQUIRE_THROWS (om_bad.setup(fm,gm->get_grid_names()));
+  }
+
+  // ...so a legacy name with a '.' is still fine unaliased, which a
+  // character-based rule would have broken.
+  {
+    auto legacy = output_params("io_dexpr_legacy",gname,{"T_mid_where_qv_gt_0.01"});
+    OutputManager om_legacy;
+    om_legacy.initialize(comm,legacy,t0,false);
+    REQUIRE_NOTHROW (om_legacy.setup(fm,gm->get_grid_names()));
+    om_legacy.finalize();
+  }
+
+  scorpio::finalize_subsystem();
+}
+
+} // namespace scream

--- a/components/eamxx/tests/multi-process/dynamics_physics/homme_shoc_cld_p3_rrtmgp_pg2/CMakeLists.txt
+++ b/components/eamxx/tests/multi-process/dynamics_physics/homme_shoc_cld_p3_rrtmgp_pg2/CMakeLists.txt
@@ -29,6 +29,14 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input.yaml
                ${CMAKE_CURRENT_BINARY_DIR}/input.yaml)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/output.yaml
                ${CMAKE_CURRENT_BINARY_DIR}/output.yaml)
+# Two extra streams carrying the diagnostic expressions from
+# docs/user/diags/expressions.md, so every documented spelling is exercised
+# end-to-end. They are split because 'over_dt' and friends cannot go in an
+# INSTANT stream; see the comments in the yamls.
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/output_diags_ins.yaml
+               ${CMAKE_CURRENT_BINARY_DIR}/output_diags_ins.yaml)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/output_diags_avg.yaml
+               ${CMAKE_CURRENT_BINARY_DIR}/output_diags_avg.yaml)
 
 # Set homme's test options, so that we can configure the namelist correctly
 # Discretization/algorithm settings
@@ -82,6 +90,24 @@ CompareNCFilesFamilyMpi (
   FILE_META_NAME ${TEST_BASE_NAME}_output.INSTANT.nsteps_x${NUM_STEPS}.npMPIRANKS.${RUN_T0}.nc
   MPI_RANKS ${TEST_RANK_START} ${TEST_RANK_END}
   LABELS dynamics physics tms shoc cld p3 rrtmgp pg2
+  META_FIXTURES_REQUIRED ${FIXTURES_BASE_NAME}_npMPIRANKS_omp1
+)
+
+# The diagnostic-expression streams get the same treatment: a reduction like
+# mean('col') or zonal_mean() must not depend on the rank count.
+CompareNCFilesFamilyMpi (
+  TEST_BASE_NAME ${TEST_BASE_NAME}_diags_ins
+  FILE_META_NAME ${TEST_BASE_NAME}_diags_ins.INSTANT.nsteps_x${NUM_STEPS}.npMPIRANKS.${RUN_T0}.nc
+  MPI_RANKS ${TEST_RANK_START} ${TEST_RANK_END}
+  LABELS dynamics physics tms shoc cld p3 rrtmgp pg2 diagnostics
+  META_FIXTURES_REQUIRED ${FIXTURES_BASE_NAME}_npMPIRANKS_omp1
+)
+
+CompareNCFilesFamilyMpi (
+  TEST_BASE_NAME ${TEST_BASE_NAME}_diags_avg
+  FILE_META_NAME ${TEST_BASE_NAME}_diags_avg.AVERAGE.nsteps_x${NUM_STEPS}.npMPIRANKS.${RUN_T0}.nc
+  MPI_RANKS ${TEST_RANK_START} ${TEST_RANK_END}
+  LABELS dynamics physics tms shoc cld p3 rrtmgp pg2 diagnostics
   META_FIXTURES_REQUIRED ${FIXTURES_BASE_NAME}_npMPIRANKS_omp1
 )
 

--- a/components/eamxx/tests/multi-process/dynamics_physics/homme_shoc_cld_p3_rrtmgp_pg2/input.yaml
+++ b/components/eamxx/tests/multi-process/dynamics_physics/homme_shoc_cld_p3_rrtmgp_pg2/input.yaml
@@ -78,5 +78,5 @@ grids_manager:
 
 # The parameters for I/O control
 scorpio:
-  output_yaml_files: ["output.yaml"]
+  output_yaml_files: ["output.yaml", "output_diags_ins.yaml", "output_diags_avg.yaml"]
 ...

--- a/components/eamxx/tests/multi-process/dynamics_physics/homme_shoc_cld_p3_rrtmgp_pg2/output_diags_avg.yaml
+++ b/components/eamxx/tests/multi-process/dynamics_physics/homme_shoc_cld_p3_rrtmgp_pg2/output_diags_avg.yaml
@@ -1,0 +1,27 @@
+%YAML 1.1
+---
+# The documented expressions that an INSTANT stream cannot carry.
+#
+# 'over_dt' divides by the time elapsed since the start of the step. An INSTANT
+# stream writes a snapshot at t0, before any step has run, where that time is
+# zero and the diagnostic aborts with "dt must be positive" -- so these have to
+# go in an averaged stream. 'tend' is built on 'over_dt' and inherits the
+# restriction, as do the legacy underscore spellings of both.
+filename_prefix: homme_shoc_cld_p3_rrtmgp_pg2_diags_avg
+averaging_type: average
+fields:
+  physics_pg2:
+    field_names:
+      - T_rate        := T_mid.over_dt()
+      - T_tend        := T_mid.tend()
+      # The legacy spellings of the same two.
+      - T_rate_legacy := T_mid_over_dt
+      - T_tend_legacy := T_mid_atm_backtend
+      # A bare mask has int data type, which IO cannot write; multiplying by 1
+      # promotes it to Real. See docs/user/diags/conditional_sampling.md.
+      - wet_frac      := mask.where(ps>100000)*1.0
+
+output_control:
+  frequency: ${NUM_STEPS}
+  frequency_units: nsteps
+...

--- a/components/eamxx/tests/multi-process/dynamics_physics/homme_shoc_cld_p3_rrtmgp_pg2/output_diags_ins.yaml
+++ b/components/eamxx/tests/multi-process/dynamics_physics/homme_shoc_cld_p3_rrtmgp_pg2/output_diags_ins.yaml
@@ -1,0 +1,61 @@
+%YAML 1.1
+---
+# Every diagnostic expression documented in
+# components/eamxx/docs/user/diags/expressions.md that can be written to an
+# INSTANT stream. The point is not the numbers, it is that each documented
+# spelling parses, builds a diagnostic, and reaches the NetCDF file: a docs
+# example that stops working fails here rather than in a user's yaml.
+#
+# The dt-dependent ones live in output_diags_avg.yaml; see the note at the end.
+filename_prefix: homme_shoc_cld_p3_rrtmgp_pg2_diags_ins
+averaging_type: instant
+fields:
+  physics_pg2:
+    aliases:
+      # An intermediate: usable as an operand below, but never written.
+      - qt := qc+qv
+    field_names:
+      # --- Operators -------------------------------------------------------
+      # Grouping is what the underscore syntax cannot express.
+      - q_flux    := (qc+qv)*p_mid
+      # An operand may be a numeric literal...
+      - p_hPa     := p_mid/100
+      - T_scaled  := T_mid*0.5
+      # ...a named physical constant...
+      - p_ratio   := p_mid/P0
+      # ...or another expression.
+      - dry_air   := p_mid - qv*p_mid
+      # Negation: no diagnostic negates a field, so this goes through (-1)*X.
+      - neg_T     := -T_mid
+      # A ':=' alias declared in 'aliases' is usable as an operand.
+      - qt_flux   := qt*p_mid
+
+      # --- Functions (one per row of the docs' function table) --------------
+      - T_lev10   := T_mid.isel(lev=10)
+      - T_top     := T_mid.isel(lev=0)
+      - T_bot     := T_mid.isel(lev=-1)
+      - T_500hPa  := T_mid.interp(p_mid=500, units='hPa')
+      - T_10m     := T_mid.interp(z_mid=10, reference='surface')
+      - T_colavg  := T_mid.mean('col')
+      - T_vavg    := T_mid.mean('lev')
+      - T_vsum    := T_mid.sum('lev')
+      - T_dpavg   := T_mid.mean('lev', weights='dp')
+      - T_wet     := T_mid.where(qv>0.01)
+      - T_dpdz    := T_mid.derivative('p_mid')
+      - T_hist    := T_mid.histogram(bins=[200,250,300])
+      - T_zonal   := T_mid.zonal_mean(bins=20)
+      - T_prev    := T_mid.shift(time=1)
+
+      # --- Composition ------------------------------------------------------
+      # No unambiguous underscore spelling exists for this one.
+      - cold_T    := T_mid.where(T_mid<273.15).mean('lev')
+
+      # NOTE: 'over_dt' and 'tend' are NOT here on purpose. They divide by the
+      #       time elapsed since the start of the step, and an INSTANT stream
+      #       writes a snapshot at t0, before any step has run, where that time
+      #       is zero. See output_diags_avg.yaml.
+
+output_control:
+  frequency: ${NUM_STEPS}
+  frequency_units: nsteps
+...

--- a/share/dexpr/CMakeLists.txt
+++ b/share/dexpr/CMakeLists.txt
@@ -1,9 +1,11 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.14)
 
-project(dexpr
-  VERSION 0.1.0
-  DESCRIPTION "Lexer and parser for the diagnostics expression language"
-  LANGUAGES CXX)
+if (CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  project(dexpr
+    VERSION 0.1.0
+    DESCRIPTION "Lexer and parser for the diagnostics expression language"
+    LANGUAGES CXX)
+endif()
 
 # This library is deliberately standalone: it has no Kokkos, MPI, netCDF or
 # EKAT dependency, and is not wired into the CIME/csm_share build. That is
@@ -17,6 +19,7 @@ add_library(dexpr
   src/lexer.cpp
   src/parser.cpp
   src/precedences.cpp
+  src/supported_functions.cpp
   src/tokens.cpp
 )
 

--- a/share/dexpr/README.md
+++ b/share/dexpr/README.md
@@ -43,8 +43,10 @@ AST nodes are represented by a `std::variant`, visited through
 `Expression::visit`, which serves as a generic wrapper around `std::visit`.
 This design means the nodes should be stable and transformations acting on the AST can be easily added.
 
-The basic set of callable functions lives in one place, `supported_functions.hpp`.
-Nothing else in the library is diagnostics-specific.
+Callable functions are not baked in. `supported_functions.hpp` defines a
+`FunctionRegistry` a component fills in at init; see
+[Component-supplied functions](#component-supplied-functions) below. Nothing
+else in the library is diagnostics-specific.
 
 ### Parser terminology
 
@@ -78,11 +80,85 @@ Some terminology used throughout the implementation:
   It receives the expression to its left and parses the required expression(s) to its right.
   Example tokens include: aritmetic operators, logical operators, opening parenthesis, etc...
 
+## Component-supplied functions
+
+dexpr owns the grammar; a component owns the vocabulary. The parser accepts any
+call syntactically -- `foo(a, b=c)` parses the same whether or not `foo` exists
+-- and a component declares what it can actually evaluate by filling a
+`FunctionRegistry` and running `validate_calls` over the AST:
+
+```c++
+dexpr::FunctionRegistry reg;
+reg.add({.name = "mean",
+         .desc = "average over a dimension",
+         .min_positional = 1,           // a method call's receiver is not
+         .max_positional = 1,           // counted as a positional argument
+         .keywords = {{"weights", false}},
+         .example = "T_mid.mean('lev', weights='dp')"});
+
+dexpr::validate_registry(reg);          // the vocabulary describes itself
+
+parser::Parser parser{Lexer{input}};
+const auto expr = parser.parse();
+dexpr::validate_calls(*expr, reg);      // throws ValidationError
+```
+
+`validate_calls` checks that each callee is a plain name, that the name is
+registered, that positional arity fits, that every keyword argument names a
+declared parameter and appears once, and that required keywords are present. It
+collects every problem in the expression and throws once, so a user fixes them
+all in one pass rather than one build at a time. Unknown names come back with
+the registered set listed.
+
+Whether a call is written `f(x)` or `x.f()` is not dexpr's business: both parse,
+and the receiver of a method call is simply not counted as a positional
+argument. A component that implements only one spelling rejects the other.
+
+Keeping this out of the parser is deliberate: the same expression can be
+checked against different components' vocabularies, and adding a callable
+requires no edit to this library.
+
+### Checking a vocabulary
+
+Every spec carries an `example` of how the call is actually written, and
+`validate_registry` proves each one parses, passes `validate_calls` against the
+registry it belongs to, and really calls the function that declared it. So a
+vocabulary is checked against itself: declare `mean` as taking no positional
+arguments while writing `T_mid.mean('lev')`, and you hear about it the moment
+the registry is built rather than the first time a user writes that call. Run it
+from a unit test, or straight from the code that fills the registry -- EAMxx
+does the latter, in `eamxx_dexpr_diags.cpp`.
+
+The command line tool checks expressions and the builtin vocabulary directly:
+
+```shell
+dexpr functions          # list the builtins, with an example of each
+dexpr check "x.where(y>0) + 3*z"
+dexpr check-registry     # every builtin against its own example
+```
+
+`dexpr check` knows only the builtins, since a component's vocabulary lives in
+that component; a component checks against its own registry with the same two
+calls shown above.
+
+What this does NOT check is whether the component can actually evaluate the
+call -- that a registered name has a case in whatever turns the AST into work.
+A component covers that by running its own examples through its own builder, as
+EAMxx does in `src/share/io/tests/create_diag.cpp`.
+
+`builtin_functions()` holds the four generic callables (`where`, `sum`,
+`derivative`, `tend`) as an optional seed. Nothing consults it implicitly -- a
+component may seed from it or start empty.
+
+`FunctionRegistry::add` rejects a spec that cannot be satisfied at all -- no
+name, a positional arity with no valid count, a keyword argument that is
+nameless or repeated -- so those never reach `validate_registry`.
+
 ## Building
 
 `dexpr` is deliberately standalone. It has no Kokkos, MPI, netCDF or EKAT
 dependency, it is not part of the CIME or `csm_share` build, and it requires
-only CMake 3.20 and a C++20 compiler:
+only CMake 3.14 and a C++20 compiler:
 
 ```shell
 ./run_tests.sh
@@ -122,14 +198,6 @@ Release, on every pull request touching this directory.
 
 Not implemented here, recorded so it is not rediscovered:
 
-- **Component-supplied functions.** The callable set is fixed in
-  `supported_functions.hpp` and nothing consults it, so `nope(x)` parses and is
-  never rejected. The plan is a registry a component fills in at init -- each
-  function's name, its parameters in positional order, and whether the call is
-  written free (`where(...)`) or as a method (`T_mid.interp(...)`) -- plus a
-  pass over the AST that checks calls against it. That pass stays out of the
-  parser on purpose, so `foo(a, b=c)` parses the same whether or not `foo`
-  exists.
 - **Operator syntax is fixed.** A registry would let a component add functions
   but not operators. A new operator means editing the token enum, the lexer,
   the precedence table and the parser's dispatch tables.

--- a/share/dexpr/include/dexpr/supported_functions.hpp
+++ b/share/dexpr/include/dexpr/supported_functions.hpp
@@ -47,8 +47,10 @@ struct FunctionSpec {
   std::string to_string() const;
 };
 
+// No trailing newline: to_string() is already multi-line, and the caller
+// decides how entries are separated.
 inline std::ostream& operator<<(std::ostream& os, const FunctionSpec& function) {
-  return os << function.to_string() << '\n';
+  return os << function.to_string();
 }
 
 // Ordered, so listings and error messages are stable rather than hash-order.

--- a/share/dexpr/include/dexpr/supported_functions.hpp
+++ b/share/dexpr/include/dexpr/supported_functions.hpp
@@ -1,74 +1,94 @@
+/**
+ * @file supported_functions.hpp
+ * @brief The set of callables a component makes available to expressions.
+ *
+ * dexpr owns the grammar; a component owns the vocabulary. The parser accepts
+ * any call syntactically -- `foo(a, b=c)` parses whether or not `foo` exists --
+ * and a component says what it can evaluate by filling a FunctionRegistry and
+ * running validate_calls() over the AST. Keeping that out of the parser lets
+ * one expression be checked against several components' vocabularies.
+ */
 #ifndef DEXPR_SUPPORTED_FUNCTIONS_HPP
 #define DEXPR_SUPPORTED_FUNCTIONS_HPP
 
-#include <array>
+#include <dexpr/ast.hpp>
+
+#include <map>
 #include <ostream>
-#include <span>
+#include <stdexcept>
 #include <string>
 #include <string_view>
+#include <vector>
+
 namespace dexpr {
-struct SupportedFunction {
-  std::string_view name;
-  std::string_view desc;
-  std::span<const std::string_view> arguments;
 
-  std::string to_string() const {
-    std::string str_{name};
-    str_ += "(";
-    if (!arguments.empty()) {
-      for (auto val : arguments) {
-        str_ += std::string(val) + ",";
-      }
-      str_.pop_back(); // removes trailing comma
-    }
-    str_ += ")";
-    str_ += "\n--- " + std::string(desc);
-
-    return str_;
-  }
+// A keyword argument, e.g. the `dims` of `derivative(dx, dims=['col'])`.
+struct ParamSpec {
+  std::string name;
+  bool required = false;
 };
-inline std::ostream& operator<<(std::ostream& os,
-                                const SupportedFunction& function) {
+
+struct FunctionSpec {
+  std::string name;
+  std::string desc;
+
+  // Positional arity, not counting keyword arguments. For a method call `x.f()`
+  // the receiver is not positional, so `x.mean('lev')` has one.
+  int min_positional = 0;
+  int max_positional = 0;
+
+  std::vector<ParamSpec> keywords;
+
+  // How the call is written, e.g. "T_mid.mean('lev')". Documentation, and what
+  // validate_registry() checks the spec against.
+  std::string example;
+
+  // "name(arg, kw=..)\n--- desc\n--- e.g. example", the `dexpr` tool listing.
+  std::string to_string() const;
+};
+
+inline std::ostream& operator<<(std::ostream& os, const FunctionSpec& function) {
   return os << function.to_string() << '\n';
 }
 
-inline constexpr std::array where_args{
-    std::string_view{"<boolean expression>"},
+// Ordered, so listings and error messages are stable rather than hash-order.
+class FunctionRegistry {
+public:
+  // Throws std::invalid_argument if the spec is malformed (no name, impossible
+  // arity, a nameless or repeated keyword) or the name is already registered.
+  void add(FunctionSpec spec);
+
+  const FunctionSpec* find(std::string_view name) const;
+  bool contains(std::string_view name) const { return find(name) != nullptr; }
+
+  std::vector<std::string> names() const;
+
+  auto begin() const { return fns_.begin(); }
+  auto end() const { return fns_.end(); }
+
+private:
+  // std::less<> so lookups take a string_view without allocating.
+  std::map<std::string, FunctionSpec, std::less<>> fns_;
 };
 
-inline constexpr std::array sum_args{
-    std::string_view{"dims=[..]"},
+// Generic callables, offered as a seed. Nothing consults it implicitly.
+const FunctionRegistry& builtin_functions();
+
+class ValidationError : public std::runtime_error {
+public:
+  explicit ValidationError(const std::vector<std::string>& errors);
 };
 
-inline constexpr std::array derivative_args{
-    std::string_view{"dx"},
-    std::string_view{"dims=[..]"},
-};
+// Checks every call in the tree: callee is a plain name, name is registered,
+// positional arity fits, keywords are declared and present as required.
+// Collects every problem and throws once.
+void validate_calls(const ast::Expression& root, const FunctionRegistry& reg);
 
-inline constexpr std::array<std::string_view, 0> tend_args{};
+// Checks a vocabulary against itself: every spec's example must parse, pass
+// validate_calls() against `reg`, and call the function that declared it. Run
+// it after registering a function, from a test or from the registry itself.
+void validate_registry(const FunctionRegistry& reg);
 
-inline constexpr std::array supported{
-    SupportedFunction{
-        .name = "where",
-        .desc = "applies condition to operand",
-        .arguments = where_args,
-    },
-    SupportedFunction{
-        .name = "sum",
-        .desc = "sums operand over designated indices (int or name)",
-        .arguments = sum_args,
-    },
-    SupportedFunction{
-        .name = "derivative",
-        .desc = "takes derivative w.r.t. `dx` over designated dimension",
-        .arguments = derivative_args,
-    },
-    SupportedFunction{
-        .name = "tend",
-        .desc = "calculates the tendency of a variable over time",
-        .arguments = tend_args,
-    },
-};
 } // namespace dexpr
 
 #endif

--- a/share/dexpr/src/supported_functions.cpp
+++ b/share/dexpr/src/supported_functions.cpp
@@ -1,0 +1,415 @@
+#include <dexpr/supported_functions.hpp>
+
+#include <dexpr/lexer.hpp>
+#include <dexpr/parser.hpp>
+#include <dexpr/tokens.hpp>
+
+#include <algorithm>
+#include <set>
+#include <type_traits>
+#include <utility>
+
+/**
+ * @file supported_functions.cpp
+ * @brief FunctionRegistry, the builtin seed, and the call-validation visitor.
+ */
+namespace dexpr {
+
+std::string FunctionSpec::to_string() const {
+  std::string str_{name};
+  str_ += "(";
+
+  bool first = true;
+  for (int i = 0; i < min_positional; ++i) {
+    if (!first) {
+      str_ += ", ";
+    }
+    first = false;
+    str_ += "<arg>";
+  }
+  for (int i = min_positional; i < max_positional; ++i) {
+    if (!first) {
+      str_ += ", ";
+    }
+    first = false;
+    str_ += "[<arg>]";
+  }
+  for (const auto& kw : keywords) {
+    if (!first) {
+      str_ += ", ";
+    }
+    first = false;
+    str_ += kw.required ? kw.name + "=.." : "[" + kw.name + "=..]";
+  }
+
+  str_ += ")";
+  str_ += "\n--- " + desc;
+  if (!example.empty()) {
+    str_ += "\n--- e.g. " + example;
+  }
+
+  return str_;
+}
+
+void FunctionRegistry::add(FunctionSpec spec) {
+  if (spec.name.empty()) {
+    throw std::invalid_argument("dexpr: cannot register a function with no name");
+  }
+  // Structural checks only; validate_registry() checks the spec against its
+  // example.
+  if (spec.min_positional < 0 || spec.max_positional < spec.min_positional) {
+    throw std::invalid_argument("dexpr: function '" + spec.name +
+                                "' has an impossible positional arity");
+  }
+  for (auto it = spec.keywords.begin(); it != spec.keywords.end(); ++it) {
+    if (it->name.empty()) {
+      throw std::invalid_argument("dexpr: function '" + spec.name +
+                                  "' has a keyword argument with no name");
+    }
+    if (std::find_if(spec.keywords.begin(), it, [&](const ParamSpec& p) {
+          return p.name == it->name;
+        }) != it) {
+      throw std::invalid_argument("dexpr: function '" + spec.name +
+                                  "' declares argument '" + it->name +
+                                  "' more than once");
+    }
+  }
+  // Refuse rather than overwrite: a replaced spec surfaces much later, as a
+  // confusing validation message.
+  if (fns_.count(spec.name) > 0) {
+    throw std::invalid_argument("dexpr: function '" + spec.name +
+                                "' is already registered");
+  }
+  const auto name = spec.name;
+  fns_.emplace(name, std::move(spec));
+}
+
+const FunctionSpec* FunctionRegistry::find(std::string_view name) const {
+  const auto it = fns_.find(name);
+  return it == fns_.end() ? nullptr : &it->second;
+}
+
+std::vector<std::string> FunctionRegistry::names() const {
+  std::vector<std::string> out;
+  out.reserve(fns_.size());
+  for (auto it = fns_.begin(); it != fns_.end(); ++it) {
+    out.push_back(it->first);
+  }
+  return out;
+}
+
+const FunctionRegistry& builtin_functions() {
+  static const FunctionRegistry reg = [] {
+    FunctionRegistry r;
+    r.add({.name = "where",
+           .desc = "applies condition to operand",
+           .min_positional = 1,
+           .max_positional = 1,
+           .keywords = {},
+           .example = "x.where(y>0)"});
+    r.add({.name = "sum",
+           .desc = "sums operand over designated indices (int or name)",
+           .min_positional = 0,
+           .max_positional = 0,
+           .keywords = {{"dims", true}},
+           .example = "x.sum(dims=['col'])"});
+    r.add({.name = "derivative",
+           .desc = "takes derivative w.r.t. `dx` over designated dimension",
+           .min_positional = 1,
+           .max_positional = 1,
+           .keywords = {{"dims", false}},
+           .example = "x.derivative(dx, dims=['lev'])"});
+    r.add({.name = "tend",
+           .desc = "calculates the tendency of a variable over time",
+           .min_positional = 0,
+           .max_positional = 0,
+           .keywords = {},
+           .example = "x.tend()"});
+    return r;
+  }();
+  return reg;
+}
+
+ValidationError::ValidationError(const std::vector<std::string>& errors)
+    : std::runtime_error([&] {
+        std::string result = "Validation errors:\n";
+        for (const auto& error : errors) {
+          result += "  - " + error + '\n';
+        }
+        return result;
+      }()) {}
+
+namespace {
+
+// `f(x)` puts an Identifier under FuncExpression::function; `x.f(y)` puts a
+// BinaryExpression{Dot} there, with the name right and the receiver left.
+struct Callee {
+  const std::string* name = nullptr; // null when the callee is not a plain name
+  const ast::Expression* receiver = nullptr; // non-null for the method form
+};
+
+struct CalleeVisitor {
+  Callee operator()(const ast::Identifier& e) const { return {&e.value, nullptr}; }
+  Callee operator()(const ast::BinaryExpression& e) const {
+    if (e.op != TokenTypes::Dot) {
+      return {};
+    }
+    // The method name must be a plain identifier: `x.(a+b)()` is not a call we
+    // can check. `x.y.f()` recurses through the receiver instead.
+    return e.right->visit([&](const auto& node) -> Callee {
+      using T = std::decay_t<decltype(node)>;
+      if constexpr (std::is_same_v<T, ast::Identifier>) {
+        return {&node.value, e.left.get()};
+      } else {
+        return {};
+      }
+    });
+  }
+  template <typename T> Callee operator()(const T&) const { return {}; }
+};
+
+// Keyword arguments parse as Assign expressions, so the two kinds of argument
+// are separated here rather than in the parser.
+const std::string* keyword_name(const ast::Expression& arg) {
+  return arg.visit([](const auto& node) -> const std::string* {
+    using T = std::decay_t<decltype(node)>;
+    if constexpr (std::is_same_v<T, ast::BinaryExpression>) {
+      if (node.op == TokenTypes::Assign) {
+        return node.left->visit([](const auto& lhs) -> const std::string* {
+          using L = std::decay_t<decltype(lhs)>;
+          if constexpr (std::is_same_v<L, ast::Identifier>) {
+            return &lhs.value;
+          } else {
+            return nullptr;
+          }
+        });
+      }
+    }
+    return nullptr;
+  });
+}
+
+class Validator {
+public:
+  explicit Validator(const FunctionRegistry& reg) : reg_(reg) {}
+
+  void run(const ast::Expression& expr) {
+    expr.visit(*this);
+  }
+
+  std::vector<std::string> take_errors() { return std::move(errors_); }
+
+  void operator()(const ast::Identifier&) const {}
+  void operator()(const ast::StringLiteral&) const {}
+  void operator()(const ast::FloatLiteral&) const {}
+  void operator()(const ast::IntegerLiteral&) const {}
+
+  void operator()(const ast::UnaryExpression& e) { run(*e.right); }
+
+  void operator()(const ast::BinaryExpression& e) {
+    run(*e.left);
+    run(*e.right);
+  }
+
+  void operator()(const ast::ArrayExpression& e) {
+    for (const auto& el : e.elements) {
+      run(*el);
+    }
+  }
+
+  void operator()(const ast::FuncExpression& e) {
+    check_call(e);
+    // Recurse even if this call failed, so one bad name does not hide the rest.
+    if (const auto callee = e.function->visit(CalleeVisitor{}); callee.receiver) {
+      run(*callee.receiver);
+    } else if (!callee.name) {
+      run(*e.function);
+    }
+    for (const auto& arg : e.args) {
+      // In `f(x=y)`, x is a parameter name, not a subexpression to check.
+      if (keyword_name(*arg) != nullptr) {
+        arg->visit([&](const auto& node) {
+          using T = std::decay_t<decltype(node)>;
+          if constexpr (std::is_same_v<T, ast::BinaryExpression>) {
+            run(*node.right);
+          }
+        });
+      } else {
+        run(*arg);
+      }
+    }
+  }
+
+private:
+  void check_call(const ast::FuncExpression& e) {
+    const auto callee = e.function->visit(CalleeVisitor{});
+    if (callee.name == nullptr) {
+      errors_.push_back("call target is not a function name: " +
+                        ast::to_string(*e.function));
+      return;
+    }
+    const std::string& name = *callee.name;
+
+    const auto* spec = reg_.find(name);
+    if (spec == nullptr) {
+      std::string msg = "unknown function '" + name + "'";
+      const auto known = reg_.names();
+      if (known.empty()) {
+        msg += "; no functions are registered";
+      } else {
+        msg += "; available: ";
+        for (std::size_t i = 0; i < known.size(); ++i) {
+          msg += (i == 0 ? "" : ", ") + known[i];
+        }
+      }
+      errors_.push_back(std::move(msg));
+      return;
+    }
+
+    int positional = 0;
+    std::set<std::string> seen_keywords;
+    for (const auto& arg : e.args) {
+      const auto* kw = keyword_name(*arg);
+      if (kw == nullptr) {
+        ++positional;
+        continue;
+      }
+      const auto known = std::find_if(
+          spec->keywords.begin(), spec->keywords.end(),
+          [&](const ParamSpec& p) { return p.name == *kw; });
+      if (known == spec->keywords.end()) {
+        std::string msg = "'" + name + "' has no argument '" + *kw + "'";
+        if (!spec->keywords.empty()) {
+          msg += "; accepts: ";
+          bool first = true;
+          for (const auto& p : spec->keywords) {
+            msg += (first ? "" : ", ") + p.name;
+            first = false;
+          }
+        }
+        errors_.push_back(std::move(msg));
+      } else if (!seen_keywords.insert(*kw).second) {
+        errors_.push_back("'" + name + "' got argument '" + *kw +
+                          "' more than once");
+      }
+    }
+
+    if (positional < spec->min_positional ||
+        positional > spec->max_positional) {
+      errors_.push_back("'" + name + "' takes " +
+                        arity_to_string(*spec) + ", got " +
+                        std::to_string(positional));
+    }
+
+    for (const auto& p : spec->keywords) {
+      if (p.required && seen_keywords.count(p.name) == 0) {
+        errors_.push_back("'" + name + "' requires argument '" + p.name + "'");
+      }
+    }
+  }
+
+  static std::string arity_to_string(const FunctionSpec& spec) {
+    if (spec.min_positional == spec.max_positional) {
+      return std::to_string(spec.min_positional) + " positional argument(s)";
+    }
+    return std::to_string(spec.min_positional) + " to " +
+           std::to_string(spec.max_positional) + " positional argument(s)";
+  }
+
+  const FunctionRegistry& reg_;
+  std::vector<std::string> errors_;
+};
+
+} // namespace
+
+void validate_calls(const ast::Expression& root, const FunctionRegistry& reg) {
+  Validator v{reg};
+  v.run(root);
+  auto errors = v.take_errors();
+  if (!errors.empty()) {
+    throw ValidationError(errors);
+  }
+}
+
+namespace {
+
+// True if any call in `e` targets `name`: catches an example that validates
+// but demonstrates a different function.
+bool calls_function(const ast::Expression& e, const std::string& name) {
+  return e.visit([&](const auto& node) -> bool {
+    using T = std::decay_t<decltype(node)>;
+    if constexpr (std::is_same_v<T, ast::FuncExpression>) {
+      const auto callee = node.function->visit(CalleeVisitor{});
+      if (callee.name != nullptr && *callee.name == name) {
+        return true;
+      }
+      if (callee.receiver != nullptr && calls_function(*callee.receiver, name)) {
+        return true;
+      }
+      for (const auto& arg : node.args) {
+        if (calls_function(*arg, name)) {
+          return true;
+        }
+      }
+      return false;
+    } else if constexpr (std::is_same_v<T, ast::BinaryExpression>) {
+      return calls_function(*node.left, name) || calls_function(*node.right, name);
+    } else if constexpr (std::is_same_v<T, ast::UnaryExpression>) {
+      return calls_function(*node.right, name);
+    } else if constexpr (std::is_same_v<T, ast::ArrayExpression>) {
+      for (const auto& el : node.elements) {
+        if (calls_function(*el, name)) {
+          return true;
+        }
+      }
+      return false;
+    } else {
+      return false;
+    }
+  });
+}
+
+} // namespace
+
+void validate_registry(const FunctionRegistry& reg) {
+  std::vector<std::string> errors;
+
+  for (const auto& entry : reg) {
+    const auto& spec = entry.second;
+    const std::string where = "'" + spec.name + "': ";
+
+    if (spec.example.empty()) {
+      errors.push_back(where + "no example; give one showing how the call is written");
+      continue;
+    }
+
+    ast::ExprPtr expr;
+    try {
+      parser::Parser parser{Lexer{spec.example}};
+      expr = parser.parse();
+    } catch (const std::exception& e) {
+      errors.push_back(where + "example '" + spec.example +
+                       "' does not parse: " + e.what());
+      continue;
+    }
+
+    try {
+      validate_calls(*expr, reg);
+    } catch (const ValidationError& e) {
+      errors.push_back(where + "example '" + spec.example +
+                       "' does not match the spec: " + e.what());
+      continue;
+    }
+
+    if (!calls_function(*expr, spec.name)) {
+      errors.push_back(where + "example '" + spec.example + "' never calls '" +
+                       spec.name + "'");
+    }
+  }
+
+  if (!errors.empty()) {
+    throw ValidationError(errors);
+  }
+}
+
+} // namespace dexpr

--- a/share/dexpr/tests/CMakeLists.txt
+++ b/share/dexpr/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ if (NOT Catch2_FOUND)
 endif()
 
 add_executable(dexpr_tests
+  test_function_registry.cpp
   test_lexer.cpp
   test_parser.cpp
 )

--- a/share/dexpr/tests/test_function_registry.cpp
+++ b/share/dexpr/tests/test_function_registry.cpp
@@ -1,0 +1,299 @@
+#include <catch2/catch_test_macros.hpp>
+#include <dexpr/ast.hpp>
+#include <dexpr/lexer.hpp>
+#include <dexpr/parser.hpp>
+#include <dexpr/supported_functions.hpp>
+
+#include <string>
+
+namespace dexpr {
+
+namespace { // anonymous
+
+// Stands in for a component's vocabulary, covering each shape validate_calls
+// has to reason about.
+FunctionRegistry test_registry() {
+  FunctionRegistry reg;
+  reg.add({.name = "mean",
+           .desc = "average over a dimension",
+           .min_positional = 1,
+           .max_positional = 1,
+           .keywords = {{"weights", false}},
+           .example = "T_mid.mean('lev')"});
+  reg.add({.name = "prev",
+           .desc = "value at the previous step",
+           .min_positional = 0,
+           .max_positional = 0,
+           .keywords = {},
+           .example = "T_mid.prev()"});
+  reg.add({.name = "clamp",
+           .desc = "bound a field",
+           .min_positional = 1,
+           .max_positional = 2,
+           .keywords = {{"fill", true}},
+           .example = "clamp(T_mid, fill=0)"});
+  return reg;
+}
+
+// Returns "" if `input` validates, else the ValidationError message.
+std::string validation_error(const std::string& input,
+                             const FunctionRegistry& reg) {
+  parser::Parser parser{Lexer{input}};
+  const auto expr = parser.parse();
+  REQUIRE(expr != nullptr);
+  try {
+    validate_calls(*expr, reg);
+  } catch (const ValidationError& e) {
+    return e.what();
+  }
+  return "";
+}
+
+bool contains(const std::string& haystack, const std::string& needle) {
+  return haystack.find(needle) != std::string::npos;
+}
+
+// Returns "" if `reg` describes itself consistently, else the error message.
+std::string registry_error(const FunctionRegistry& reg) {
+  try {
+    validate_registry(reg);
+  } catch (const ValidationError& e) {
+    return e.what();
+  }
+  return "";
+}
+
+// Every field spelled out: -Wmissing-field-initializers requires it.
+FunctionSpec spec(std::string name, int min_pos, int max_pos,
+                  std::vector<ParamSpec> kws, std::string example) {
+  return FunctionSpec{std::move(name), "a description", min_pos, max_pos,
+                      std::move(kws),  std::move(example)};
+}
+
+} // anonymous namespace
+
+TEST_CASE("registry_add_and_find") {
+  FunctionRegistry reg;
+  CHECK(reg.find("mean") == nullptr);
+  CHECK_FALSE(reg.contains("mean"));
+
+  reg.add(spec("mean", 0, 0, {}, "x.mean()"));
+  REQUIRE(reg.find("mean") != nullptr);
+  CHECK(reg.find("mean")->desc == "a description");
+  CHECK(reg.contains("mean"));
+
+  // Lookups are case sensitive, like identifiers everywhere else.
+  CHECK(reg.find("Mean") == nullptr);
+}
+
+TEST_CASE("registry_rejects_duplicates") {
+  FunctionRegistry reg;
+  reg.add(spec("mean", 0, 0, {}, "x.mean()"));
+  CHECK_THROWS_AS(reg.add(spec("mean", 0, 0, {}, "x.mean()")),
+                  std::invalid_argument);
+  // The first registration is the one that stands.
+  REQUIRE(reg.find("mean") != nullptr);
+  CHECK(reg.find("mean")->example == "x.mean()");
+
+  CHECK_THROWS_AS(reg.add(spec("", 0, 0, {}, "x()")),
+                  std::invalid_argument);
+}
+
+TEST_CASE("registry_names_are_ordered") {
+  const auto reg = test_registry();
+  const auto names = reg.names();
+  REQUIRE(names.size() == 3);
+  CHECK(names[0] == "clamp");
+  CHECK(names[1] == "mean");
+  CHECK(names[2] == "prev");
+}
+
+TEST_CASE("builtin_functions_are_seeded") {
+  const auto& reg = builtin_functions();
+  CHECK(reg.contains("where"));
+  CHECK(reg.contains("sum"));
+  CHECK(reg.contains("derivative"));
+  CHECK(reg.contains("tend"));
+  // Nothing consults the builtins implicitly; an empty registry knows nothing.
+  CHECK_FALSE(FunctionRegistry{}.contains("where"));
+}
+
+TEST_CASE("validate_accepts_well_formed_calls") {
+  const auto reg = test_registry();
+
+  CHECK(validation_error("T_mid.mean('lev')", reg) == "");
+  CHECK(validation_error("T_mid.mean('lev', weights='dp')", reg) == "");
+  CHECK(validation_error("T_mid.prev()", reg) == "");
+  CHECK(validation_error("clamp(T_mid, fill=0)", reg) == "");
+  CHECK(validation_error("clamp(T_mid, 1, fill=0)", reg) == "");
+  // `f(x)` and `x.f()` both validate: the receiver is not positional. A
+  // component that implements only one spelling rejects the other itself.
+  CHECK(validation_error("T_mid.clamp(1, fill=0)", reg) == "");
+
+  // Expressions with no calls at all are trivially valid.
+  CHECK(validation_error("(qc+qv)*p_mid", reg) == "");
+  CHECK(validation_error("['col', 'lev']", reg) == "");
+}
+
+TEST_CASE("validate_rejects_unknown_function") {
+  const auto reg = test_registry();
+
+  const auto msg = validation_error("T_mid.meen('lev')", reg);
+  CHECK(contains(msg, "unknown function 'meen'"));
+  // The message lists what is available.
+  CHECK(contains(msg, "clamp, mean, prev"));
+
+  CHECK(contains(validation_error("nope(x)", FunctionRegistry{}),
+                 "no functions are registered"));
+}
+
+TEST_CASE("validate_rejects_bad_arity") {
+  const auto reg = test_registry();
+
+  CHECK(contains(validation_error("T_mid.mean()", reg),
+                 "'mean' takes 1 positional argument(s), got 0"));
+  CHECK(contains(validation_error("T_mid.mean('lev', 'col')", reg),
+                 "'mean' takes 1 positional argument(s), got 2"));
+  CHECK(contains(validation_error("T_mid.prev(1)", reg),
+                 "'prev' takes 0 positional argument(s), got 1"));
+  CHECK(contains(validation_error("clamp(fill=0)", reg),
+                 "'clamp' takes 1 to 2 positional argument(s), got 0"));
+
+  // Keyword arguments do not count towards positional arity.
+  CHECK(validation_error("T_mid.mean('lev', weights='dp')", reg) == "");
+}
+
+TEST_CASE("validate_rejects_bad_keywords") {
+  const auto reg = test_registry();
+
+  const auto msg = validation_error("T_mid.mean('lev', weight='dp')", reg);
+  CHECK(contains(msg, "'mean' has no argument 'weight'"));
+  CHECK(contains(msg, "accepts: weights"));
+
+  CHECK(contains(validation_error("T_mid.prev(x=1)", reg),
+                 "'prev' has no argument 'x'"));
+  CHECK(contains(validation_error("T_mid.mean('lev', weights='dp', weights='dz')", reg),
+                 "got argument 'weights' more than once"));
+  CHECK(contains(validation_error("clamp(T_mid)", reg),
+                 "'clamp' requires argument 'fill'"));
+}
+
+TEST_CASE("validate_recurses_into_operands_and_arguments") {
+  const auto reg = test_registry();
+
+  // Receiver of a method call.
+  CHECK(contains(validation_error("T_mid.meen('lev').mean('col')", reg),
+                 "unknown function 'meen'"));
+  // Inside a positional argument.
+  CHECK(contains(validation_error("clamp(a.meen('lev'), fill=0)", reg),
+                 "unknown function 'meen'"));
+  // Inside a keyword's value; the keyword name itself is not looked up.
+  CHECK(contains(validation_error("T_mid.mean('lev', weights=a.meen('c'))", reg),
+                 "unknown function 'meen'"));
+  // Across operators, unary operators, and array elements.
+  CHECK(contains(validation_error("qc + a.meen('lev')", reg),
+                 "unknown function 'meen'"));
+  CHECK(contains(validation_error("not a.meen('lev')", reg),
+                 "unknown function 'meen'"));
+  CHECK(contains(validation_error("[a.meen('lev')]", reg),
+                 "unknown function 'meen'"));
+}
+
+TEST_CASE("validate_collects_every_problem") {
+  const auto reg = test_registry();
+
+  // All three in one pass.
+  const auto msg = validation_error("T_mid.meen('lev') + qc.prev(1) + a.mean()", reg);
+  CHECK(contains(msg, "unknown function 'meen'"));
+  CHECK(contains(msg, "'prev' takes 0 positional argument(s), got 1"));
+  CHECK(contains(msg, "'mean' takes 1 positional argument(s), got 0"));
+}
+
+TEST_CASE("validate_rejects_non_name_callee") {
+  const auto reg = test_registry();
+  CHECK(contains(validation_error("(a+b)(c)", reg),
+                 "call target is not a function name"));
+}
+
+TEST_CASE("registry_rejects_malformed_specs") {
+  FunctionRegistry reg;
+  // Arity that can never be satisfied
+  CHECK_THROWS_AS(reg.add(spec("a", 2, 1, {}, "x.a(1)")), std::invalid_argument);
+  CHECK_THROWS_AS(reg.add(spec("b", -1, -1, {}, "x.b()")), std::invalid_argument);
+  // Keyword arguments that cannot be addressed
+  CHECK_THROWS_AS(reg.add(spec("c", 0, 0, {{"", true}}, "x.c()")),
+                  std::invalid_argument);
+  CHECK_THROWS_AS(reg.add(spec("e", 0, 0, {{"dims", true}, {"dims", false}}, "x.e()")),
+                  std::invalid_argument);
+  // None of them landed
+  CHECK(reg.names().empty());
+}
+
+TEST_CASE("validate_registry_accepts_a_self_consistent_vocabulary") {
+  CHECK(registry_error(test_registry()) == "");
+  // The builtins must describe themselves correctly too
+  CHECK(registry_error(builtin_functions()) == "");
+}
+
+TEST_CASE("validate_registry_catches_a_spec_its_example_contradicts") {
+  // Declared arity contradicts the example.
+  FunctionRegistry wrong_arity;
+  wrong_arity.add(spec("mean", 0, 0, {}, "T_mid.mean('lev')"));
+  CHECK(contains(registry_error(wrong_arity), "does not match the spec"));
+
+  // A keyword the spec never declared
+  FunctionRegistry wrong_kw;
+  wrong_kw.add(spec("mean", 1, 1, {}, "T_mid.mean('lev', weights='dp')"));
+  CHECK(contains(registry_error(wrong_kw), "has no argument 'weights'"));
+
+  // A required keyword the example forgets
+  FunctionRegistry missing_kw;
+  missing_kw.add(spec("isel", 0, 0, {{"lev", true}}, "T_mid.isel()"));
+  CHECK(contains(registry_error(missing_kw), "requires argument 'lev'"));
+
+  // An example that is not an expression at all
+  FunctionRegistry unparseable;
+  unparseable.add(spec("mean", 1, 1, {}, "T_mid.mean('lev'"));
+  CHECK(contains(registry_error(unparseable), "does not parse"));
+
+  // An example demonstrating somebody else's function
+  FunctionRegistry wrong_function;
+  wrong_function.add(spec("mean", 1, 1, {}, "T_mid.mean('lev')"));
+  wrong_function.add(spec("prev", 0, 0, {}, "T_mid.mean('lev')"));
+  CHECK(contains(registry_error(wrong_function), "never calls 'prev'"));
+
+  // No example at all: nothing to check the spec against
+  FunctionRegistry no_example;
+  no_example.add(spec("mean", 1, 1, {}, ""));
+  CHECK(contains(registry_error(no_example), "no example"));
+}
+
+TEST_CASE("validate_registry_reports_every_bad_spec_at_once") {
+  FunctionRegistry reg;
+  reg.add(spec("a", 0, 0, {}, "x.a("));
+  reg.add(spec("b", 0, 0, {}, ""));
+  const auto msg = registry_error(reg);
+  CHECK(contains(msg, "'a'"));
+  CHECK(contains(msg, "'b'"));
+}
+
+TEST_CASE("function_spec_to_string") {
+  FunctionSpec s{.name = "mean",
+                 .desc = "average over a dimension",
+                 .min_positional = 1,
+                 .max_positional = 2,
+                 .keywords = {{"weights", false}, {"dim", true}},
+                 .example = "T_mid.mean('lev', dim='x')"};
+  const auto str = s.to_string();
+  CHECK(contains(str, "mean("));
+  CHECK(contains(str, "<arg>"));
+  CHECK(contains(str, "[<arg>]"));
+  CHECK(contains(str, "[weights=..]"));
+  CHECK(contains(str, "dim=.."));
+  CHECK(contains(str, "average over a dimension"));
+
+  // `dexpr functions` shows how to write the call, not just its shape.
+  CHECK(contains(str, "e.g. T_mid.mean('lev', dim='x')"));
+}
+
+} // namespace dexpr

--- a/share/dexpr/tools/dexpr.cpp
+++ b/share/dexpr/tools/dexpr.cpp
@@ -1,22 +1,66 @@
 #include <iostream>
 #include <string_view>
 
+#include <dexpr/ast.hpp>
+#include <dexpr/lexer.hpp>
+#include <dexpr/parser.hpp>
 #include <dexpr/supported_functions.hpp>
 
 namespace {
 
 void print_functions() {
-    std::cout << "Supported functions\n\n";
+    // Builtins only; a model's own vocabulary is a superset of this.
+    std::cout << "Builtin functions\n\n";
 
-    for (const auto& function : dexpr::supported) {
-        std::cout << "  " << function << '\n';
+    for (const auto& entry : dexpr::builtin_functions()) {
+        std::cout << "  " << entry.second << '\n';
     }
+}
+
+// Checks grammar plus the builtins. A component's own functions are unknown
+// here; it checks those by calling validate_calls() with its own registry.
+int check_expression(std::string_view input) {
+    dexpr::ast::ExprPtr expr;
+    try {
+        dexpr::parser::Parser parser{dexpr::Lexer{std::string{input}}};
+        expr = parser.parse();
+    } catch (const std::exception& e) {
+        std::cerr << "does not parse:\n" << e.what() << '\n';
+        return 1;
+    }
+
+    std::cout << "parsed as: " << dexpr::ast::to_string(*expr) << '\n';
+
+    try {
+        dexpr::validate_calls(*expr, dexpr::builtin_functions());
+    } catch (const dexpr::ValidationError& e) {
+        std::cerr << e.what();
+        return 1;
+    }
+
+    std::cout << "ok\n";
+    return 0;
+}
+
+// The builtins against their own examples; same check a component runs.
+int check_registry() {
+    try {
+        dexpr::validate_registry(dexpr::builtin_functions());
+    } catch (const dexpr::ValidationError& e) {
+        std::cerr << e.what();
+        return 1;
+    }
+    std::cout << "builtin functions: "
+              << dexpr::builtin_functions().names().size() << " ok\n";
+    return 0;
 }
 
 void print_help() {
     std::cout <<
 R"(Usage:
-    dexpr functions
+    dexpr functions          list the builtin functions
+    dexpr check <expr>       parse <expr> and check its calls
+    dexpr check-registry     check every builtin function against its example
     dexpr help
 )";
 }
@@ -34,6 +78,18 @@ int main(int argc, char* argv[]) {
     if (command == "functions") {
         print_functions();
         return 0;
+    }
+
+    if (command == "check") {
+        if (argc < 3) {
+            std::cerr << "check needs an expression\n";
+            return 1;
+        }
+        return check_expression(argv[2]);
+    }
+
+    if (command == "check-registry") {
+        return check_registry();
     }
 
     if (command == "help") {

--- a/share/dexpr/tools/dexpr.cpp
+++ b/share/dexpr/tools/dexpr.cpp
@@ -13,7 +13,8 @@ void print_functions() {
     std::cout << "Builtin functions\n\n";
 
     for (const auto& entry : dexpr::builtin_functions()) {
-        std::cout << "  " << entry.second << '\n';
+        // Each spec spans a few lines, so separate entries with a blank one.
+        std::cout << "  " << entry.second << "\n\n";
     }
 }
 


### PR DESCRIPTION
hooking up dexpr inside of EAMxx in a purely additive manner for now (i.e., regexes still work). This necessitated a minor addition in dexpr (allowing flexible interfaces/validators) and then basic extensions in EAMxx. In theory, should be less challenging to review than previous PRs. (Note that in the future the dexpr facilities will replace a lot of diags in EAMxx, but we will cross that bridge when we get to it...)