### PR TITLE
Include atmospheric pressure in the sea-surface tilt passed to sea ice

### DIFF
--- a/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_diagnostics.F
@@ -488,10 +488,11 @@ contains
          ! outputs: pressureAdjustedSSH, gradSSH
          if (landIcePressureOn) then
             call ocn_diagnostic_solve_ssh(forcingPool, ssh, seaIcePressure, &
-                   pressureAdjustedSSH, gradSSH, landIceDraftForSsh=landIceDraftForSsh )
+                   atmosphericPressure, pressureAdjustedSSH, gradSSH, &
+                   landIceDraftForSsh=landIceDraftForSsh )
         else
             call ocn_diagnostic_solve_ssh(forcingPool, ssh, seaIcePressure, &
-                   pressureAdjustedSSH, gradSSH)
+                   atmosphericPressure, pressureAdjustedSSH, gradSSH)
          end if
 
       end if ! full_compute
@@ -2939,7 +2940,8 @@ contains
 !
 !-----------------------------------------------------------------------
    subroutine ocn_diagnostic_solve_ssh(forcingPool, ssh, seaIcePressure, &
-                pressureAdjustedSSH, gradSSH, landIceDraftForSsh)!{{{
+                atmosphericPressure, pressureAdjustedSSH, gradSSH, &
+                landIceDraftForSsh)!{{{
 
       implicit none
 
@@ -2954,6 +2956,8 @@ contains
          ssh
       real (kind=RKIND), dimension(:), intent(in) :: &
          seaIcePressure
+      real (kind=RKIND), dimension(:), intent(in) :: &
+         atmosphericPressure
       real (kind=RKIND), dimension(:), optional, intent(in) :: &
          landIceDraftForSsh
 
@@ -2980,13 +2984,17 @@ contains
 
       nCells = nCellsHalo( 1 )
 #ifdef MPAS_OPENACC
-      !$acc parallel loop present(seaIcePressure, pressureAdjustedSSH, ssh)
+      !$acc parallel loop present(seaIcePressure, atmosphericPressure, &
+      !$acc                       pressureAdjustedSSH, ssh)
 #else
       !$omp parallel
       !$omp do schedule(runtime)
 #endif
       do iCell = 1, nCells
-         pressureAdjustedSSH(iCell) = ssh(iCell) + ( seaIcePressure(iCell) / ( gravity * rho_sw ) )
+         pressureAdjustedSSH(iCell) = ssh(iCell) + ( &
+            (seaIcePressure(iCell) + atmosphericPressure(iCell)) / &
+            ( gravity * rho_sw ) &
+         )
       end do
 #ifndef MPAS_OPENACC
       !$omp end do


### PR DESCRIPTION
## Summary

`ocn_diagnostic_solve_ssh` now adds `atmosphericPressure` to `seaIcePressure`, when forming `pressureAdjustedSSH`. `gradSSH` — the field exported to the coupler as `seaSurfaceTilt` — is therefore the gradient of the *full* surface pressure head (excluding `frazilSurfacePressure` and `landIcePressure`) rather than only the geometric SSH plus sea-ice loading.

## Motivation

Fix the bug described in https://github.com/E3SM-Project/E3SM/issues/8688

## Changes

- Code change located in `ocn_comp_mct`: `pressureAdjustedSSH = ssh + (seaIcePressure + atmosphericPressure) / (gravity * rho_sw)`.
- `pressureAdjustedSSH` only directly affects MPAS-Seaice, not MPAS-Ocean

## Notes / open question

This PR leaves unchanged the use of sea-ice pressure from the previous coupling interval for the sea surface tilt. Note that `mpas_seaice_velocity_solver.F` updates `totalMass` on each dynamic subcycle before computing the tilt term. Whether the sea-ice pressure gradient should instead be built from the updated sea-ice mass — and therefore be computed on the sea-ice side rather than folded into `gradSSH` — remains open and is not addressed here.

## Testing

Non bit-for-bit changes for any configuration with active sea ice and ocean components.

Fixes https://github.com/E3SM-Project/E3SM/issues/8688