### PR TITLE
Limit maximum evaporation from ELM lakes

### DIFF
--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -2158,6 +2158,18 @@ Runtime flag to turn on/off variable soil thickness.
 Runtime flag to turn on/off lake water storage.
 </entry>
 
+<entry id="lake_evap_cap_method"
+       type="char*32"
+       category="default_settings"
+       group="elm_inparm"
+       valid_values="rain_snow,rain_snow_h2osno,wslake"
+       value="rain_snow" >
+Method used to cap lake evaporation by available water. 'rain_snow' caps evaporation at this
+timestep's rain+snow forcing (forc_rain+forc_snow). 'rain_snow_h2osno' additionally includes
+the lake column's persistent snowpack (h2osno). 'wslake' (storage-based cap using lake water
+storage) is reserved for a future implementation and currently endruns.
+</entry>
+
 <!-- ========================================================================================  -->
 <!-- Namelist options for downscaling from grid to topounit                                    -->
 <!-- ========================================================================================  -->

--- a/components/elm/bld/namelist_files/namelist_definition.xml
+++ b/components/elm/bld/namelist_files/namelist_definition.xml
@@ -2162,12 +2162,11 @@ Runtime flag to turn on/off lake water storage.
        type="char*32"
        category="default_settings"
        group="elm_inparm"
-       valid_values="rain_snow,rain_snow_h2osno,wslake"
-       value="rain_snow" >
-Method used to cap lake evaporation by available water. 'rain_snow' caps evaporation at this
-timestep's rain+snow forcing (forc_rain+forc_snow). 'rain_snow_h2osno' additionally includes
-the lake column's persistent snowpack (h2osno). 'wslake' (storage-based cap using lake water
-storage) is reserved for a future implementation and currently endruns.
+       valid_values="none,rain_snow,rain_snow_h2osno"
+       value="none" >
+Method used to cap lake evaporation by available water. 'none' applies no cap. 'rain_snow' caps
+evaporation at this timestep's rain+snow forcing (forc_rain+forc_snow). 'rain_snow_h2osno'
+additionally includes the lake column's persistent snowpack (h2osno).
 </entry>
 
 <!-- ========================================================================================  -->

--- a/components/elm/src/biogeophys/LakeFluxesMod.F90
+++ b/components/elm/src/biogeophys/LakeFluxesMod.F90
@@ -52,7 +52,7 @@ contains
     use elm_varpar          , only : nlevlak
     use elm_varcon          , only : hvap, hsub, hfus, cpair, cpliq, tkwat, tkice, tkair
     use elm_varcon          , only : sb, vkc, grav, denh2o, tfrz, spval, zsno
-    use elm_varctl          , only : iulog, use_lch4, use_firn_percolation_and_compaction
+    use elm_varctl          , only : iulog, use_lch4, use_firn_percolation_and_compaction, lake_evap_cap_method
     use LakeCon             , only : betavis, z0frzlake, tdmax, emg_lake
     use LakeCon             , only : lake_use_old_fcrit_minz0
     use LakeCon             , only : minz0lake, cur0, cus, curm, fcrit
@@ -135,6 +135,8 @@ contains
     real(r8) :: fm(bounds%begp:bounds%endp)        ! needed for BGC only to diagnose 10m wind speed
     real(r8) :: bw                                 ! partial density of water (ice + liquid)
     real(r8) :: t_grnd_temp                        ! Used in surface flux correction over frozen ground
+    real(r8) :: qflx_evap_cap                      ! water-availability cap on qflx_evap_soi (kg/m2/s)
+    logical  :: evap_water_limited                 ! true if qflx_evap_soi(p) was capped by water availability this iteration
     real(r8) :: betaprime(bounds%begc:bounds%endc) ! Effective beta: sabg_lyr(p,jtop) for snow layers, beta otherwise
     real(r8) :: e_ref2m                            ! 2 m height surface saturated vapor pressure [Pa]
     real(r8) :: de2mdT                             ! derivative of 2 m height surface saturated vapor pressure on t_ref2m
@@ -464,6 +466,32 @@ contains
             elseif(t_grnd(c)<tgbef(c)-20._r8)then
               t_grnd(c)=tgbef(c)-20._r8
             endif
+
+            ! If the t_grnd solved above would evaporate more than water availability allows,
+            ! evaporation is not actually a function of t_grnd in this regime -- there is no
+            ! more water to respond with. Drop its temperature-derivative from bx, replace it
+            ! with a fixed loss in ax, and re-solve so t_grnd (and everything downstream in
+            ! this iteration: dth/dqh/zeta/obu/roughness lengths below) stays self-consistent
+            ! with the capped evaporation instead of the discarded unconstrained value.
+            evap_water_limited = .false.
+            if (lake_evap_cap_method == 'rain_snow') then
+               qflx_evap_cap = max(forc_rain(t) + forc_snow(t), 0._r8)
+               if (forc_rho(t)*(qsatg(c)+qsatgdT(c)*(t_grnd(c)-tgbef(c))-forc_q(t))/raw(p) > qflx_evap_cap) then
+                  evap_water_limited = .true.
+                  ax  = betaprime(c)*sabg(p) + emg_lake*forc_lwrad(t) + 3._r8*stftg3(p)*tgbef(c) &
+                       + forc_rho(t)*cpair/rah(p)*thm(p) &
+                       - htvp(c)*qflx_evap_cap &
+                       + tksur(c)*tsur(c)/dzsur(c)
+                  bx  = 4._r8*stftg3(p) + forc_rho(t)*cpair/rah(p) + tksur(c)/dzsur(c)
+                  t_grnd(c) = ax/bx
+                  if(t_grnd(c)>tgbef(c)+20._r8)then
+                    t_grnd(c)=tgbef(c)+20._r8
+                  elseif(t_grnd(c)<tgbef(c)-20._r8)then
+                    t_grnd(c)=tgbef(c)-20._r8
+                  endif
+               end if
+            end if
+
             ! Update htvp
             if (t_grnd(c) > tfrz) then
                htvp(c) = hvap
@@ -475,7 +503,11 @@ contains
             ! using ground temperatures from previous time step
 
             eflx_sh_grnd(p) = forc_rho(t)*cpair*(t_grnd(c)-thm(p))/rah(p)
-            qflx_evap_soi(p) = forc_rho(t)*(qsatg(c)+qsatgdT(c)*(t_grnd(c)-tgbef(c))-forc_q(t))/raw(p)
+            if (evap_water_limited) then
+               qflx_evap_soi(p) = qflx_evap_cap
+            else
+               qflx_evap_soi(p) = forc_rho(t)*(qsatg(c)+qsatgdT(c)*(t_grnd(c)-tgbef(c))-forc_q(t))/raw(p)
+            end if
 
             ! Re-calculate saturated vapor pressure, specific humidity and their
             ! derivatives at lake surface
@@ -604,6 +636,19 @@ contains
             htvp(c) = hvap
          else
             htvp(c) = hsub
+         end if
+
+         ! Backstop cap for the t_grnd overrides just above: those force t_grnd directly
+         ! (freezing point, or convective mixing to t_lake) rather than solving it from ax/bx,
+         ! so there is no equation to re-solve against the cap the way the ITERATION loop does
+         ! above. Applied here, before eflx_soil_grnd/eflx_gnet below are assembled from
+         ! qflx_evap_soi, so any energy that can no longer leave as latent heat is left to warm
+         ! the lake/ground via eflx_gnet instead. Never clamps condensation (qflx_evap_soi < 0).
+         ! In practice this only binds for the convective-mixing branch (t_grnd forced warmer);
+         ! the freezing-point branch only forces t_grnd colder than an already-capped value.
+         if (lake_evap_cap_method == 'rain_snow') then
+            qflx_evap_cap = max(forc_rain(t) + forc_snow(t), 0._r8)
+            qflx_evap_soi(p) = min(qflx_evap_soi(p), qflx_evap_cap)
          end if
 
          ! Net longwave from ground to atmosphere

--- a/components/elm/src/biogeophys/LakeFluxesMod.F90
+++ b/components/elm/src/biogeophys/LakeFluxesMod.F90
@@ -60,6 +60,7 @@ contains
     use FrictionVelocityMod , only : FrictionVelocity, MoninObukIni, &
          implicit_stress, atm_gustiness, force_land_gustiness
     use elm_time_manager    , only : get_nstep
+    use timeinfoMod         , only : dtime_mod
     !
     ! !ARGUMENTS:
     type(bounds_type)      , intent(in)    :: bounds
@@ -137,6 +138,7 @@ contains
     real(r8) :: t_grnd_temp                        ! Used in surface flux correction over frozen ground
     real(r8) :: qflx_evap_cap                      ! water-availability cap on qflx_evap_soi (kg/m2/s)
     logical  :: evap_water_limited                 ! true if qflx_evap_soi(p) was capped by water availability this iteration
+    real(r8) :: dtime                               ! land model time step (sec)
     real(r8) :: betaprime(bounds%begc:bounds%endc) ! Effective beta: sabg_lyr(p,jtop) for snow layers, beta otherwise
     real(r8) :: e_ref2m                            ! 2 m height surface saturated vapor pressure [Pa]
     real(r8) :: de2mdT                             ! derivative of 2 m height surface saturated vapor pressure on t_ref2m
@@ -195,6 +197,7 @@ contains
 
          h2osoi_liq       =>    col_ws%h2osoi_liq         , & ! Input:  [real(r8) (:,:) ]  liquid water (kg/m2)
          h2osoi_ice       =>    col_ws%h2osoi_ice         , & ! Input:  [real(r8) (:,:) ]  ice lens (kg/m2)
+         h2osno           =>    col_ws%h2osno             , & ! Input:  [real(r8) (:)   ]  snow water (mm H2O)
 
          t_lake           =>    col_es%t_lake            , & ! Input:  [real(r8) (:,:) ]  lake temperature (Kelvin)
          t_soisno         =>    col_es%t_soisno          , & ! Input:  [real(r8) (:,:) ]  soil (or snow) temperature (Kelvin)
@@ -248,6 +251,7 @@ contains
       z0qg_col => frictionvel_vars%z0qg_col
 
       kva0temp = 20._r8 + tfrz
+      dtime = dtime_mod
 
       do fp = 1, num_lakep
          p = filter_lakep(fp)
@@ -474,8 +478,11 @@ contains
             ! this iteration: dth/dqh/zeta/obu/roughness lengths below) stays self-consistent
             ! with the capped evaporation instead of the discarded unconstrained value.
             evap_water_limited = .false.
-            if (lake_evap_cap_method == 'rain_snow') then
+            if (lake_evap_cap_method == 'rain_snow' .or. lake_evap_cap_method == 'rain_snow_h2osno') then
                qflx_evap_cap = max(forc_rain(t) + forc_snow(t), 0._r8)
+               if (lake_evap_cap_method == 'rain_snow_h2osno') then
+                  qflx_evap_cap = qflx_evap_cap + h2osno(c)/dtime
+               end if
                if (forc_rho(t)*(qsatg(c)+qsatgdT(c)*(t_grnd(c)-tgbef(c))-forc_q(t))/raw(p) > qflx_evap_cap) then
                   evap_water_limited = .true.
                   ax  = betaprime(c)*sabg(p) + emg_lake*forc_lwrad(t) + 3._r8*stftg3(p)*tgbef(c) &
@@ -646,8 +653,11 @@ contains
          ! the lake/ground via eflx_gnet instead. Never clamps condensation (qflx_evap_soi < 0).
          ! In practice this only binds for the convective-mixing branch (t_grnd forced warmer);
          ! the freezing-point branch only forces t_grnd colder than an already-capped value.
-         if (lake_evap_cap_method == 'rain_snow') then
+         if (lake_evap_cap_method == 'rain_snow' .or. lake_evap_cap_method == 'rain_snow_h2osno') then
             qflx_evap_cap = max(forc_rain(t) + forc_snow(t), 0._r8)
+            if (lake_evap_cap_method == 'rain_snow_h2osno') then
+               qflx_evap_cap = qflx_evap_cap + h2osno(c)/dtime
+            end if
             qflx_evap_soi(p) = min(qflx_evap_soi(p), qflx_evap_cap)
          end if
 

--- a/components/elm/src/main/controlMod.F90
+++ b/components/elm/src/main/controlMod.F90
@@ -759,9 +759,10 @@ contains
 
     ! Lake evaporation cap method
     if (lake_evap_cap_method /= 'rain_snow' .and. &
+        lake_evap_cap_method /= 'rain_snow_h2osno' .and. &
         lake_evap_cap_method /= 'wslake') then
        write(iulog,*)'lake_evap_cap_method = ',trim(lake_evap_cap_method), ' is not supported'
-       call endrun(msg=' ERROR:: choices are rain_snow or wslake' // &
+       call endrun(msg=' ERROR:: choices are rain_snow, rain_snow_h2osno, or wslake' // &
             errMsg(__FILE__, __LINE__))
     endif
     if (lake_evap_cap_method == 'wslake') then

--- a/components/elm/src/main/controlMod.F90
+++ b/components/elm/src/main/controlMod.F90
@@ -41,6 +41,8 @@ module controlMod
   use elm_varcon              , only: h2osno_max
   use FanMod                  , only: nh4_ads_coef
   use AllocationMod           , only: nu_com_phosphatase,nu_com_nfix
+  use elm_varctl              , only: nu_com, use_var_soil_thick
+  use elm_varctl              , only: use_lake_wat_storage, lake_evap_cap_method
   use seq_drydep_mod          , only: drydep_method, DD_XLND, n_drydep
   use EcosystemBalanceCheckMod, only: bgc_balance_check_tolerance => balance_check_tolerance
   use elm_varpar              , only: elmfates_carbon_only
@@ -360,7 +362,7 @@ contains
 
     namelist /elm_inparm/ use_dynroot
 
-    namelist /elm_inparm/ use_var_soil_thick, use_lake_wat_storage
+    namelist /elm_inparm/ use_var_soil_thick, use_lake_wat_storage, lake_evap_cap_method
 
     namelist /elm_inparm/ &
          use_vsfm, vsfm_satfunc_type, vsfm_use_dynamic_linesearch, &
@@ -755,6 +757,18 @@ contains
             errMsg(__FILE__, __LINE__))
     endif
 
+    ! Lake evaporation cap method
+    if (lake_evap_cap_method /= 'rain_snow' .and. &
+        lake_evap_cap_method /= 'wslake') then
+       write(iulog,*)'lake_evap_cap_method = ',trim(lake_evap_cap_method), ' is not supported'
+       call endrun(msg=' ERROR:: choices are rain_snow or wslake' // &
+            errMsg(__FILE__, __LINE__))
+    endif
+    if (lake_evap_cap_method == 'wslake') then
+       call endrun(msg=' ERROR:: lake_evap_cap_method = wslake is not yet implemented' // &
+            errMsg(__FILE__, __LINE__))
+    endif
+
     if (masterproc) then
        write(iulog,*) 'Successfully initialized run control settings'
        write(iulog,*)
@@ -922,6 +936,8 @@ contains
     call mpi_bcast (use_dynroot, 1, MPI_LOGICAL, 0, mpicom, ier)
 
     call mpi_bcast (use_lake_wat_storage, 1, MPI_LOGICAL, 0, mpicom, ier)
+
+    call mpi_bcast (lake_evap_cap_method, len(lake_evap_cap_method), MPI_CHARACTER, 0, mpicom, ier)
 
     if ((use_cn .or. use_fates) .and. use_vertsoilc) then
        ! vertical soil mixing variables
@@ -1123,6 +1139,7 @@ contains
     write(iulog,*) '    use_vertsoilc = ', use_vertsoilc
     write(iulog,*) '    use_var_soil_thick = ', use_var_soil_thick
     write(iulog,*) '    use_lake_wat_storage = ', use_lake_wat_storage
+    write(iulog,*) '    lake_evap_cap_method = ', lake_evap_cap_method
     write(iulog,*) '    use_extralakelayers = ', use_extralakelayers
     write(iulog,*) '    use_extrasnowlayers = ', use_extrasnowlayers
     write(iulog,*) '    use_firn_percolation_and_compaction = ', use_firn_percolation_and_compaction

--- a/components/elm/src/main/controlMod.F90
+++ b/components/elm/src/main/controlMod.F90
@@ -758,15 +758,16 @@ contains
     endif
 
     ! Lake evaporation cap method
-    if (lake_evap_cap_method /= 'rain_snow' .and. &
+    if (lake_evap_cap_method /= 'none' .and. &
+        lake_evap_cap_method /= 'rain_snow' .and. &
         lake_evap_cap_method /= 'rain_snow_h2osno' .and. &
         lake_evap_cap_method /= 'wslake') then
        write(iulog,*)'lake_evap_cap_method = ',trim(lake_evap_cap_method), ' is not supported'
-       call endrun(msg=' ERROR:: choices are rain_snow, rain_snow_h2osno, or wslake' // &
+       call endrun(msg=' ERROR:: choices are none, rain_snow, or rain_snow_h2osno' // &
             errMsg(__FILE__, __LINE__))
     endif
     if (lake_evap_cap_method == 'wslake') then
-       call endrun(msg=' ERROR:: lake_evap_cap_method = wslake is not yet implemented' // &
+       call endrun(msg=' ERROR:: lake_evap_cap_method = wslake is not implemented' // &
             errMsg(__FILE__, __LINE__))
     endif
 

--- a/components/elm/src/main/elm_varctl.F90
+++ b/components/elm/src/main/elm_varctl.F90
@@ -401,7 +401,7 @@ module elm_varctl
   logical, public :: use_atm_downscaling_to_topunit  = .false.
   character(len = SHR_KIND_CS), public :: precip_downscaling_method  = 'ERMM' ! Precip downscaling method values can be ERMM or FNM
   logical, public :: use_lake_wat_storage = .false.
-  character(len = SHR_KIND_CS), public :: lake_evap_cap_method = 'rain_snow' ! Lake evap cap method values can be rain_snow, rain_snow_h2osno, or wslake
+  character(len = SHR_KIND_CS), public :: lake_evap_cap_method = 'none' ! Lake evap cap method values can be none, rain_snow, or rain_snow_h2osno
   logical, public :: use_top_solar_rad   = .false.  ! TOP : sub-grid topographic effect on surface solar radiation
   logical, public :: use_finetop_rad     = .false.  ! fineTOP : fine(grid)-scale topographic effect on surface radiation balance (longwave + shortwave)
   

--- a/components/elm/src/main/elm_varctl.F90
+++ b/components/elm/src/main/elm_varctl.F90
@@ -401,7 +401,7 @@ module elm_varctl
   logical, public :: use_atm_downscaling_to_topunit  = .false.
   character(len = SHR_KIND_CS), public :: precip_downscaling_method  = 'ERMM' ! Precip downscaling method values can be ERMM or FNM
   logical, public :: use_lake_wat_storage = .false.
-  character(len = SHR_KIND_CS), public :: lake_evap_cap_method = 'rain_snow' ! Lake evap cap method values can be rain_snow or wslake
+  character(len = SHR_KIND_CS), public :: lake_evap_cap_method = 'rain_snow' ! Lake evap cap method values can be rain_snow, rain_snow_h2osno, or wslake
   logical, public :: use_top_solar_rad   = .false.  ! TOP : sub-grid topographic effect on surface solar radiation
   logical, public :: use_finetop_rad     = .false.  ! fineTOP : fine(grid)-scale topographic effect on surface radiation balance (longwave + shortwave)
   

--- a/components/elm/src/main/elm_varctl.F90
+++ b/components/elm/src/main/elm_varctl.F90
@@ -401,6 +401,7 @@ module elm_varctl
   logical, public :: use_atm_downscaling_to_topunit  = .false.
   character(len = SHR_KIND_CS), public :: precip_downscaling_method  = 'ERMM' ! Precip downscaling method values can be ERMM or FNM
   logical, public :: use_lake_wat_storage = .false.
+  character(len = SHR_KIND_CS), public :: lake_evap_cap_method = 'rain_snow' ! Lake evap cap method values can be rain_snow or wslake
   logical, public :: use_top_solar_rad   = .false.  ! TOP : sub-grid topographic effect on surface solar radiation
   logical, public :: use_finetop_rad     = .false.  ! fineTOP : fine(grid)-scale topographic effect on surface radiation balance (longwave + shortwave)
   


### PR DESCRIPTION
Adds a new namelist variable `lake_evap_cap_method` that can limit maximum
evaporation from lakes based as:
- `none`: No limit on evaporation (default model behavior)
- `rain_snow`: Evap to be less than equal to the amount of incoming rainfall and snowfall
- `rain_snow_h2osno`: Evap to be less than equal to the amount of incoming rainfall and snowfall
   plus existing snow

[BFB]