### PR TITLE
EAMxx: change how FieldGroup's are handled

### DIFF
--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -417,9 +417,9 @@ void AtmosphereDriver::reset_accumulated_fields ()
     }
 
     auto accum_group = m_field_mgr->get_field_group("ACCUMULATED", grid_name);
-    for (auto f_it : accum_group.m_individual_fields) {
-      auto& track = f_it.second->get_header().get_tracking();
-      f_it.second->deep_copy(zero);
+    for (auto f_it : accum_group.individual_fields()) {
+      auto& track = f_it.second.get_header().get_tracking();
+      f_it.second.deep_copy(zero);
       track.set_accum_start_time(m_current_ts);
     }
   }
@@ -654,11 +654,11 @@ void AtmosphereDriver::create_fields()
 
   // Process input groups
   for (const auto& g : m_atm_process_group->get_groups_in()) {
-    if (g.m_monolithic_field)
-      set_groups(*g.m_monolithic_field);
+    if (g.has_monolithic_field())
+      set_groups(g.monolithic_field());
     else
-      for (const auto& it : g.m_individual_fields)
-        set_groups(*it.second);
+      for (const auto& it : g.individual_fields())
+        set_groups(it.second);
   }
 
   auto& driver_options_pl = m_atm_params.sublist("driver_options");
@@ -977,17 +977,17 @@ void AtmosphereDriver::restart_model ()
       // No field needs to be restarted on this grid.
       continue;
     }
-    const auto& restart_fnames = m_field_mgr->get_group_info("RESTART", gn).m_fields_names;
+    auto restart_group = m_field_mgr->get_field_group("RESTART", gn);
     std::vector<Field> fields;
-    for (const auto& fn : restart_fnames) {
+    for (const auto& it : restart_group.individual_fields()) {
       // If the field has a parent, and the parent is also in the RESTART group,
       // then skip it, since restarting the parent will restart the child too
-      auto f = m_field_mgr->get_field(fn,gn);
+      const auto& f = it.second;
       auto p = f.get_header().get_parent();
       if (p and ekat::contains(p->get_tracking().get_groups_names(),"RESTART")) {
         continue;
       }
-      fields.push_back(m_field_mgr->get_field(fn,gn));
+      fields.push_back(f);
     }
     auto grid = m_grids_manager->get_grid(gn);
     read_fields(filename,fields,grid->get_partitioned_dim_gids(),m_atm_comm);
@@ -1208,15 +1208,15 @@ void AtmosphereDriver::set_initial_conditions ()
   // ...then the input groups
   m_atm_logger->debug("    [EAMxx] Processing input groups ...");
   for (const auto& g : m_atm_process_group->get_groups_in()) {
-    if (g.m_monolithic_field) {
-      const auto& mf = *g.m_monolithic_field;
+    if (g.has_monolithic_field()) {
+      const auto& mf = g.monolithic_field();
       const auto& mfgroups = mf.get_header().get_tracking().get_groups_names();
       if (not ekat::contains(mfgroups, "ACCUMULATED")) {
         process_ic_field(mf);
       }
     }
-    for (auto it : g.m_individual_fields) {
-      const auto& f = *it.second;
+    for (auto it : g.individual_fields()) {
+      const auto& f = it.second;
       const auto& fgroups = f.get_header().get_tracking().get_groups_names();
       if (not ekat::contains(fgroups, "ACCUMULATED")) {
         process_ic_field(f);
@@ -1338,8 +1338,8 @@ void AtmosphereDriver::set_initial_conditions ()
   // is valid (all entries have been inited). Let's fix that.
   m_atm_logger->debug("    [EAMxx] Processing subfields ...");
   for (const auto& g : m_atm_process_group->get_groups_in()) {
-    if (g.m_monolithic_field) {
-      auto& track = g.m_monolithic_field->get_header().get_tracking();
+    if (g.has_monolithic_field()) {
+      auto& track = g.monolithic_field().get_header_ptr()->get_tracking();
       if (not track.get_time_stamp().is_valid()) {
         // The groups monolithic field has not been inited. Check if all the subfields
         // have been inited. If so, init the timestamp of the monlithic field too.
@@ -1724,8 +1724,8 @@ void AtmosphereDriver::run (const int dt) {
     }
 
     auto rescale_group = m_field_mgr->get_field_group("DIVIDE_BY_DT", gname);
-    for (auto f_it : rescale_group.m_individual_fields) {
-      f_it.second->scale(Real(1) / dt);
+    for (auto f_it : rescale_group.individual_fields()) {
+      f_it.second.scale(Real(1) / dt);
     }
   }
 

--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -618,13 +618,6 @@ void AtmosphereDriver::create_fields()
   for (const auto& f : m_atm_process_group->get_internal_fields()) {
     m_field_mgr->add_field(f);
 
-    // Internal fields have their group names set by the processes that create them.
-    // Hence, simply add them to all the groups they are marked as part of
-    const auto& ftrack = f.get_header().get_tracking();
-    const auto& fid    = f.get_header().get_identifier();
-    for (const auto& gn : ftrack.get_groups_names()) {
-      m_field_mgr->add_to_group(fid, gn);
-    }
   }
 
   // Now go through the input fields/groups to the atm proc group,
@@ -636,14 +629,20 @@ void AtmosphereDriver::create_fields()
     return name=="phis" or name=="sgh" or name=="sgh30";
   };
 
+  for (const auto& gn : m_grids_manager->get_grid_names()) {
+    m_field_mgr->register_group(GroupRequest("RESTART",gn));
+    m_field_mgr->register_group(GroupRequest("STARTUP",gn));
+    m_field_mgr->register_group(GroupRequest("TOPOGRAPHY",gn));
+  }
+
   auto set_groups = [&](const Field& f) {
-    const auto& fid = f.get_header().get_identifier();
     const auto& fgroups = f.get_header().get_tracking().get_groups_names();
     if (not ekat::contains(fgroups, "ACCUMULATED")) {
-      m_field_mgr->add_to_group(fid, "RESTART");
-      m_field_mgr->add_to_group(fid, "STARTUP");
-      if (is_topography_field(fid.name())) {
-        m_field_mgr->add_to_group(fid, "TOPOGRAPHY");
+      const auto& grid_name = f.get_header().get_identifier().get_grid_name();
+      m_field_mgr->add_to_group(f.name(), grid_name, "RESTART");
+      m_field_mgr->add_to_group(f.name(), grid_name, "STARTUP");
+      if (is_topography_field(f.name())) {
+        m_field_mgr->add_to_group(f.name(), grid_name, "TOPOGRAPHY");
       }
     }
   };

--- a/components/eamxx/src/control/atmosphere_driver.cpp
+++ b/components/eamxx/src/control/atmosphere_driver.cpp
@@ -1165,27 +1165,11 @@ void AtmosphereDriver::set_initial_conditions ()
       // will be properly computed in the dynamics interface.
       auto& this_grid_ic_fnames = ic_fields_names[grid_name];
       auto c = f.get_header().get_children();
+
+      // If this field is the parent of other subfields, we only read from file the subfields.
       if (c.size()==0) {
-        // If this field is the parent of other subfields, we only read from file the subfields.
         if (not ekat::contains(this_grid_ic_fnames,fname)) {
           this_grid_ic_fnames.push_back(fname);
-          m_fields_inited[grid_name].push_back(fname);
-        }
-      } else if (fvphyshack and grid_name == "physics_gll") {
-        // [CGLL ICs in pg2] I tried doing something like this in
-        // HommeDynamics::set_grids, but I couldn't find the means to get the
-        // list of fields. I think the issue is that you can't access group
-        // objects until some registration period ends. So instead do it here,
-        // where the list is definitely available.
-        for (const auto& e : c) {
-          const auto f = e.lock();
-          const auto& fid = f->get_identifier();
-          const auto& fname = fid.name();
-          if (ic_pl.isParameter(fname) and ic_pl.isType<double>(fname)) {
-            initialize_constant_field(fid, ic_pl);
-          } else {
-            this_grid_ic_fnames.push_back(fname);
-          }
           m_fields_inited[grid_name].push_back(fname);
         }
       }

--- a/components/eamxx/src/control/tests/dummy_atm_proc.hpp
+++ b/components/eamxx/src/control/tests/dummy_atm_proc.hpp
@@ -91,8 +91,8 @@ public:
       });
     } else if (m_name=="Group to Group") {
       const auto& g = get_group_out("The Group");
-      const auto view_B = g.m_individual_fields.at("B")->get_view<Real**>();
-      const auto view_C = g.m_individual_fields.at("C")->get_view<Real**>();
+      const auto view_B = g.individual_fields().at("B").get_view<Real**>();
+      const auto view_C = g.individual_fields().at("C").get_view<Real**>();
 
       Kokkos::parallel_for(policy,KOKKOS_LAMBDA(const int idx) {
         const int icol = idx / nlevs;
@@ -103,8 +103,8 @@ public:
       });
     } else {
       const auto& g = get_group_in("The Group");
-      const auto view_B = g.m_individual_fields.at("B")->get_view<const Real**>();
-      const auto view_C = g.m_individual_fields.at("C")->get_view<const Real**>();
+      const auto view_B = g.individual_fields().at("B").get_view<const Real**>();
+      const auto view_C = g.individual_fields().at("C").get_view<const Real**>();
       const auto view_A = get_field_out("A").get_view<Real**>();
 
       Kokkos::parallel_for(policy,KOKKOS_LAMBDA(const int idx) {

--- a/components/eamxx/src/dynamics/homme/eamxx_homme_fv_phys.cpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_fv_phys.cpp
@@ -112,7 +112,7 @@ void HommeDynamics::fv_phys_dyn_to_fv_phys (const util::TimeStamp& ts, const boo
     t.T_mid = Homme::ExecView<Real***>("T_mid_tmp", nelem, npg, npacks*N);
     t.horiz_winds = Homme::ExecView<Real****>("horiz_winds_tmp", nelem, npg, 2, npacks*N);
     // Really need just the first tracer.
-    const auto qsize = get_group_out("tracers", pgn).m_monolithic_field->get_view<Real***>().extent_int(1);
+    const auto qsize = get_group_out("tracers", pgn).monolithic_field().get_view<Real***>().extent_int(1);
     t.tracers = Homme::ExecView<Real****>("tracers_tmp", nelem, npg, qsize, npacks*N);
     remap_dyn_to_fv_phys(&t);
     assert(ncols == nelem*npg);
@@ -144,8 +144,8 @@ void HommeDynamics::fv_phys_dyn_to_fv_phys (const util::TimeStamp& ts, const boo
       auto f = get_field_out("tke_shear_strain3d_components",pgn);
       f.get_header().get_tracking().update_time_stamp(ts);
     }
-    auto Q = get_group_out("tracers",pgn).m_monolithic_field;
-    Q->get_header().get_tracking().update_time_stamp(ts);
+    auto Q = get_group_out("tracers",pgn).monolithic_field();
+    Q.get_header().get_tracking().update_time_stamp(ts);
   }
   update_pressure(m_phys_grid);
 }
@@ -175,7 +175,7 @@ void HommeDynamics::remap_dyn_to_fv_phys (GllFvRemapTmp* t) const {
   const auto npg = m_phys_grid_pgN*m_phys_grid_pgN;
   const auto& gn = m_phys_grid->name();
   const auto nlev = get_field_out("T_mid", gn).get_view<Real**>().extent_int(1);
-  const auto nq = get_group_out("tracers").m_monolithic_field->get_view<Real***>().extent_int(1);
+  const auto nq = get_group_out("tracers").monolithic_field().get_view<Real***>().extent_int(1);
   assert(get_field_out("T_mid", gn).get_view<Real**>().extent_int(0) == nelem*npg);
   assert(get_field_out("horiz_winds", gn).get_view<Real***>().extent_int(1) == 2);
 
@@ -195,7 +195,7 @@ void HommeDynamics::remap_dyn_to_fv_phys (GllFvRemapTmp* t) const {
     t ? t->horiz_winds.data() : get_field_out("horiz_winds", gn).get_view<Real***>().data(),
     nelem, npg, 2, nlev);
   const auto q = Homme::GllFvRemap::Phys3T(
-    t ? t->tracers.data() : get_group_out("tracers", gn).m_monolithic_field->get_view<Real***>().data(),
+    t ? t->tracers.data() : get_group_out("tracers", gn).monolithic_field().get_view<Real***>().data(),
     nelem, npg, nq, nlev);
   const auto dp = Homme::GllFvRemap::Phys2T(
     get_field_out("pseudo_density", gn).get_view<Real**>().data(),
@@ -229,7 +229,7 @@ void HommeDynamics::remap_fv_phys_to_dyn () const {
   const auto npg = m_phys_grid_pgN*m_phys_grid_pgN;
   const auto& gn = m_phys_grid->name();
   const auto nlev = m_helper_fields.at("FT_phys").get_view<const Real**>().extent_int(1);
-  const auto nq = get_group_in("tracers", gn).m_monolithic_field->get_view<const Real***>().extent_int(1);
+  const auto nq = get_group_in("tracers", gn).monolithic_field().get_view<const Real***>().extent_int(1);
   assert(m_helper_fields.at("FT_phys").get_view<const Real**>().extent_int(0) == nelem*npg);
 
   const auto uv_ndim = m_helper_fields.at("FM_phys").get_view<const Real***>().extent_int(1);
@@ -242,7 +242,7 @@ void HommeDynamics::remap_fv_phys_to_dyn () const {
     m_helper_fields.at("FM_phys").get_view<const Real***>().data(),
     nelem, npg, uv_ndim, nlev);
   const auto q = Homme::GllFvRemap::CPhys3T(
-    get_group_in("tracers", gn).m_monolithic_field->get_view<const Real***>().data(),
+    get_group_in("tracers", gn).monolithic_field().get_view<const Real***>().data(),
     nelem, npg, nq, nlev);
 
   const auto& params = c.get<Homme::SimulationParams>();

--- a/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp
@@ -418,10 +418,6 @@ void HommeDynamics::initialize_impl (const RunType run_type)
       get_field_out("pseudo_density",pgn).get_header().get_tracking().get_providers().size()==1,
       "Error! Someone other than dynamics is trying to update the pseudo_density.\n");
 
-  // The groups 'tracers' and 'tracers_mass_dyn' should contain the same fields
-  EKAT_REQUIRE_MSG(not get_group_out("Q",pgn).m_info->empty(),
-    "Error! There should be at least one tracer (qv) in the tracers group.\n");
-
   // Create remaining internal fields
   constexpr int NGP  = HOMMEXX_NP;
   const int nelem = m_dyn_grid->get_num_local_dofs()/(NGP*NGP);
@@ -613,10 +609,14 @@ void HommeDynamics::set_computed_group_impl (const FieldGroup& group)
   const auto& c = Homme::Context::singleton();
         auto& tracers = c.get<Homme::Tracers>();
 
-  if (group.m_info->m_group_name=="tracers") {
+  if (group.name()=="tracers") {
+    // The groups 'tracers' and 'tracers_mass_dyn' should contain the same fields
+    const int qsize = group.size();
+    EKAT_REQUIRE_MSG(qsize,
+      "Error! There should be at least one tracer (qv) in the tracers group.\n");
+
     // Set runtime number of tracers in Homme
     auto& params = c.get<Homme::SimulationParams>();
-    const int qsize = group.m_info->size();
     params.qsize = qsize;           // Set in the CXX data structure
     set_homme_param("qsize",qsize); // Set in the F90 module
     tracers.init(tracers.num_elems(),qsize);

--- a/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp
+++ b/components/eamxx/src/dynamics/homme/eamxx_homme_process_interface.cpp
@@ -457,7 +457,7 @@ void HommeDynamics::initialize_impl (const RunType run_type)
     // ftype!=FORCING_0:
     //  1) remap Q_pgn->FQ_dyn
     // Remap Q directly into FQ, tendency computed in pre_process step
-    m_p2d_remapper->register_field(*get_group_out("Q",pgn).m_monolithic_field,m_helper_fields.at("FQ_dyn"));
+    m_p2d_remapper->register_field(get_group_out("Q",pgn).monolithic_field(),m_helper_fields.at("FQ_dyn"));
     m_p2d_remapper->register_field(m_helper_fields.at("FT_phys"),m_helper_fields.at("FT_dyn"));
 
     // FM has 3 components on dyn grid, but only 2 on phys grid
@@ -472,7 +472,7 @@ void HommeDynamics::initialize_impl (const RunType run_type)
     m_d2p_remapper->register_field(get_internal_field("v_dyn"),get_field_out("horiz_winds"));
     m_d2p_remapper->register_field(get_internal_field("dp3d_dyn"), get_field_out("pseudo_density"));
     m_d2p_remapper->register_field(get_internal_field("ps_dyn"), get_field_out("ps"));
-    m_d2p_remapper->register_field(m_helper_fields.at("Q_dyn"),*get_group_out("Q",pgn).m_monolithic_field);
+    m_d2p_remapper->register_field(m_helper_fields.at("Q_dyn"),get_group_out("Q",pgn).monolithic_field());
     m_d2p_remapper->register_field(m_helper_fields.at("omega_dyn"), get_field_out("omega"));
 
     if (params.do_3d_turbulence) {
@@ -532,7 +532,7 @@ void HommeDynamics::initialize_impl (const RunType run_type)
   using Interval = FieldWithinIntervalCheck;
   using LowerBound = FieldLowerBoundCheck;
 
-  add_postcondition_check<LowerBound>(*get_group_out("Q",pgn).m_monolithic_field,m_phys_grid,0,true);
+  add_postcondition_check<LowerBound>(get_group_out("Q",pgn).monolithic_field(),m_phys_grid,0,true);
   add_postcondition_check<Interval>(get_field_out("T_mid",pgn),m_phys_grid,100.0, 500.0,false);
   add_postcondition_check<Interval>(get_field_out("horiz_winds",pgn),m_phys_grid,-400.0, 400.0,false);
   add_postcondition_check<Interval>(get_field_out("ps"),m_phys_grid,30000.0, 120000.0,false);
@@ -764,7 +764,7 @@ void HommeDynamics::homme_post_process (const double dt) {
   const auto dp_dry_view    = get_field_out("pseudo_density_dry").get_view<Pack**>();
   const auto p_dry_int_view = get_field_out("p_dry_int").get_view<Pack**>();
   const auto p_dry_mid_view = get_field_out("p_dry_mid").get_view<Pack**>();
-  const auto Q_view   = get_group_out("Q",pgn).m_monolithic_field->get_view<Pack***>();
+  const auto Q_view   = get_group_out("Q",pgn).monolithic_field().get_view<Pack***>();
 
   const auto T_view  = get_field_out("T_mid").get_view<Pack**>();
   const auto T_prev_view = m_helper_fields.at("FT_phys").get_view<Pack**>();
@@ -1105,7 +1105,7 @@ void HommeDynamics::restart_homme_state () {
   auto qv_prev_ref = std::make_shared<Field>();
   auto Q_dyn = m_helper_fields.at("Q_dyn");
   if (params.ftype==Homme::ForcingAlg::FORCING_2) {
-    auto Q_old = *get_group_in("Q",pgn).m_monolithic_field;
+    auto Q_old = get_group_in("Q",pgn).monolithic_field();
     m_ic_remapper->register_field(Q_old,Q_dyn);
 
     // Grab qv_ref_old from Q_old
@@ -1211,7 +1211,7 @@ void HommeDynamics::initialize_homme_state () {
   m_ic_remapper->register_field(get_field_in("ps",rgn),get_internal_field("ps_dyn"));
   m_ic_remapper->register_field(get_field_in("phis",rgn),m_helper_fields.at("phis_dyn"));
   m_ic_remapper->register_field(get_field_in("T_mid",rgn),get_internal_field("vtheta_dp_dyn"));
-  m_ic_remapper->register_field(*get_group_in("tracers",rgn).m_monolithic_field,m_helper_fields.at("Q_dyn"));
+  m_ic_remapper->register_field(get_group_in("tracers",rgn).monolithic_field(),m_helper_fields.at("Q_dyn"));
   m_ic_remapper->registration_ends();
   m_ic_remapper->remap_fwd();
 

--- a/components/eamxx/src/physics/iop_forcing/eamxx_iop_forcing_process_interface.cpp
+++ b/components/eamxx/src/physics/iop_forcing/eamxx_iop_forcing_process_interface.cpp
@@ -61,18 +61,18 @@ IOPForcing::create_requests()
 void IOPForcing::
 set_computed_group_impl (const FieldGroup& group)
 {
-  EKAT_REQUIRE_MSG(group.m_info->size() >= 1,
+  EKAT_REQUIRE_MSG(group.size() >= 1,
                    "Error! IOPForcing requires at least qv as tracer input.\n");
 
-  const auto& name = group.m_info->m_group_name;
+  const auto& name = group.name();
 
   EKAT_REQUIRE_MSG(name=="tracers",
     "Error! IOPForcing was not expecting a field group called '" << name << "\n");
 
-  EKAT_REQUIRE_MSG(group.m_info->m_monolithic_allocation,
+  EKAT_REQUIRE_MSG(group.has_monolithic_field(),
       "Error! IOPForcing expects a monolithic allocation for tracers.\n");
 
-  m_num_tracers = group.m_info->size();
+  m_num_tracers = group.size();
 }
 // =========================================================================================
 size_t IOPForcing::requested_buffer_size_in_bytes() const
@@ -278,7 +278,7 @@ void IOPForcing::run_impl (const double dt)
   const auto horiz_winds = get_field_out("horiz_winds").get_view<Pack***>();
   const auto T_mid = get_field_out("T_mid").get_view<Pack**>();
   const auto qv = get_field_out("qv").get_view<Pack**>();
-  const auto Q = get_group_out("tracers").m_monolithic_field->get_view<Pack***>();
+  const auto Q = get_group_out("tracers").monolithic_field().get_view<Pack***>();
 
   // Load data from IOP files, if necessary
   // TODO: this is using the TS from the beg of the step. Should it use end_of_step_ts() instead?

--- a/components/eamxx/src/physics/mam/eamxx_mam_srf_and_online_emissions_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_srf_and_online_emissions_process_interface.cpp
@@ -338,9 +338,6 @@ void MAMSrfOnlineEmiss::initialize_impl(const RunType run_type) {
     }
   }
 
-    // Current month ( 0-based)
-    const int curr_month = start_of_step_ts().get_month() - 1;
-
   //-----------------------------------------------------------------
   // Read Soil erodibility data
   //-----------------------------------------------------------------

--- a/components/eamxx/src/physics/p3/impl/p3_rain_sed_impl.hpp
+++ b/components/eamxx/src/physics/p3/impl/p3_rain_sed_impl.hpp
@@ -150,7 +150,7 @@ void Functions<S,D>
         index_pack.set(lt_zero, 0);
         // Evaluate the gather with valid indices on masked lanes too. Kokkos
         // evaluates vector expressions before applying the mask below.
-        const auto gt_last = index_pack >= sflux_qx.extent(0);
+        const auto gt_last = index_pack >= sflux_qx.extent_int(0);
         index_pack.set(gt_last, sflux_qx.extent(0)-1);
         const auto flux_qx_pk = index(sflux_qx, index_pack);
         precip_liq_flux(pk).set(range_mask, precip_liq_flux(pk) + flux_qx_pk);

--- a/components/eamxx/src/physics/p3/tests/p3_tests.cpp
+++ b/components/eamxx/src/physics/p3/tests/p3_tests.cpp
@@ -22,7 +22,7 @@ TEST_CASE("P3DataIterator", "p3") {
     REQUIRE(f.extent[1] == nlev);
     REQUIRE(f.extent[2] == 1);
     REQUIRE(f.data == d->qv.data());
-    REQUIRE(f.size == nlev);
+    REQUIRE(static_cast<int>(f.size) == nlev);
   }
 }
 

--- a/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
+++ b/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
@@ -141,19 +141,19 @@ void SHOCMacrophysics::create_requests()
 void SHOCMacrophysics::
 set_computed_group_impl (const FieldGroup& group)
 {
-  EKAT_REQUIRE_MSG(group.m_info->size() >= 3,
+  EKAT_REQUIRE_MSG(group.info()->size() >= 3,
                    "Error! Shoc requires at least 3 tracers (tke, qv, qc) as inputs.");
 
-  const auto& name = group.m_info->m_group_name;
+  const auto& name = group.info()->m_group_name;
 
   EKAT_REQUIRE_MSG(name=="turbulence_advected_tracers",
     "Error! We were not expecting a field group called '" << name << "\n");
 
-  EKAT_REQUIRE_MSG(group.m_info->m_monolithic_allocation,
+  EKAT_REQUIRE_MSG(group.info()->m_monolithic_allocation,
       "Error! Shoc expects a monolithic allocation for tracers.\n");
 
   // Calculate number of advected tracers
-  m_num_tracers = group.m_info->size();
+  m_num_tracers = group.info()->size();
 }
 
 // =========================================================================================
@@ -305,7 +305,7 @@ void SHOCMacrophysics::initialize_impl (const RunType run_type)
   if (runtime_options.do_3d_turb) {
     shear_strain3d_components = get_field_in("tke_shear_strain3d_components").get_view<const Pack***>();
   }
-  const auto& qtracers            = get_group_out("turbulence_advected_tracers").m_monolithic_field->get_strided_view<Pack***>();
+  const auto& qtracers            = get_group_out("turbulence_advected_tracers").monolithic_field().get_strided_view<Pack***>();
   const auto& qc                  = get_field_out("qc").get_view<Pack**>();
   const auto& qv                  = get_field_out("qv").get_view<Pack**>();
   const auto& tke                 = get_field_out("tke").get_view<Pack**>();

--- a/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
+++ b/components/eamxx/src/physics/shoc/eamxx_shoc_process_interface.cpp
@@ -141,19 +141,17 @@ void SHOCMacrophysics::create_requests()
 void SHOCMacrophysics::
 set_computed_group_impl (const FieldGroup& group)
 {
-  EKAT_REQUIRE_MSG(group.info()->size() >= 3,
+  EKAT_REQUIRE_MSG(group.size() >= 3,
                    "Error! Shoc requires at least 3 tracers (tke, qv, qc) as inputs.");
 
-  const auto& name = group.info()->m_group_name;
+  EKAT_REQUIRE_MSG(group.name()=="turbulence_advected_tracers",
+    "Error! We were not expecting a field group called '" << group.name() << "\n");
 
-  EKAT_REQUIRE_MSG(name=="turbulence_advected_tracers",
-    "Error! We were not expecting a field group called '" << name << "\n");
-
-  EKAT_REQUIRE_MSG(group.info()->m_monolithic_allocation,
+  EKAT_REQUIRE_MSG(group.has_monolithic_field(),
       "Error! Shoc expects a monolithic allocation for tracers.\n");
 
   // Calculate number of advected tracers
-  m_num_tracers = group.info()->size();
+  m_num_tracers = group.size();
 }
 
 // =========================================================================================

--- a/components/eamxx/src/share/atm_process/atmosphere_process.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process.cpp
@@ -324,9 +324,9 @@ void AtmosphereProcess::set_computed_field (const Field& f) {
 
 void AtmosphereProcess::set_required_group (const FieldGroup& group) {
   // Sanity check
-  EKAT_REQUIRE_MSG (has_required_group(group.m_info->m_group_name,group.grid_name()),
+  EKAT_REQUIRE_MSG (has_required_group(group.info()->m_group_name,group.grid_name()),
     "Error! This atmosphere process does not require the input group.\n"
-    "   group name: " + group.m_info->m_group_name + "\n"
+    "   group name: " + group.info()->m_group_name + "\n"
     "   grid name : " + group.grid_name() + "\n"
     "   atm process: " + this->name() + "\n"
     "Something is wrong up the call stack. Please, contact developers.\n");
@@ -336,11 +336,11 @@ void AtmosphereProcess::set_required_group (const FieldGroup& group) {
     // AtmosphereProcessGroup is just a "container" of *real* atm processes,
     // so don't add me as customer if I'm an atm proc group.
     if (this->type()!=AtmosphereProcessType::Group) {
-      if (group.m_monolithic_field) {
-        add_me_as_customer(*group.m_monolithic_field);
+      if (group.has_monolithic_field()) {
+        add_me_as_customer(group.monolithic_field());
       } else {
-        for (auto& it : group.m_individual_fields) {
-          add_me_as_customer(*it.second);
+        for (auto& it : group.individual_fields()) {
+          add_me_as_customer(it.second);
         }
       }
     }
@@ -353,9 +353,9 @@ void AtmosphereProcess::set_required_group (const FieldGroup& group) {
 
 void AtmosphereProcess::set_computed_group (const FieldGroup& group) {
   // Sanity check
-  EKAT_REQUIRE_MSG (has_computed_group(group.m_info->m_group_name,group.grid_name()),
+  EKAT_REQUIRE_MSG (has_computed_group(group.info()->m_group_name,group.grid_name()),
     "Error! This atmosphere process does not compute the input group.\n"
-    "   group name: " + group.m_info->m_group_name + "\n"
+    "   group name: " + group.info()->m_group_name + "\n"
     "   grid name : " + group.grid_name() + "\n"
     "   atm process: " + this->name() + "\n"
     "Something is wrong up the call stack. Please, contact developers.\n");
@@ -365,11 +365,11 @@ void AtmosphereProcess::set_computed_group (const FieldGroup& group) {
     // AtmosphereProcessGroup is just a "container" of *real* atm processes,
     // so don't add me as provider if I'm an atm proc group.
     if (this->type()!=AtmosphereProcessType::Group) {
-      if (group.m_monolithic_field) {
-        add_me_as_provider(*group.m_monolithic_field);
+      if (group.has_monolithic_field()) {
+        add_me_as_provider(group.monolithic_field());
       } else {
-        for (auto& it : group.m_individual_fields) {
-          add_me_as_provider(*it.second);
+        for (auto& it : group.individual_fields()) {
+          add_me_as_provider(it.second);
         }
       }
     }
@@ -447,9 +447,9 @@ void AtmosphereProcess::run_property_check (const prop_check_ptr&       property
           }
         }
         for (const auto& g : m_groups_in) {
-          for (const auto& f : g.m_individual_fields) {
-            if (f.second->get_header().get_identifier().get_layout().has_tags(tags)) {
-              print_field_hyperslab (*f.second,tags,idx,ss);
+          for (const auto& it : g.individual_fields()) {
+            if (it.second.get_header().get_identifier().get_layout().has_tags(tags)) {
+              print_field_hyperslab (it.second,tags,idx,ss);
               ss << " -----------------------------------------------------------------------\n";
             }
           }
@@ -462,9 +462,9 @@ void AtmosphereProcess::run_property_check (const prop_check_ptr&       property
           }
         }
         for (const auto& g : m_groups_out) {
-          for (const auto& f : g.m_individual_fields) {
-            if (f.second->get_header().get_identifier().get_layout().has_tags(tags)) {
-              print_field_hyperslab (*f.second,tags,idx,ss);
+          for (const auto& it : g.individual_fields()) {
+            if (it.second.get_header().get_identifier().get_layout().has_tags(tags)) {
+              print_field_hyperslab (it.second,tags,idx,ss);
               ss << " -----------------------------------------------------------------------\n";
             }
           }
@@ -611,11 +611,11 @@ void AtmosphereProcess::update_time_stamps () {
     f.get_header().get_tracking().update_time_stamp(t);
   }
   for (auto& g : m_groups_out) {
-    if (g.m_monolithic_field) {
-      g.m_monolithic_field->get_header().get_tracking().update_time_stamp(t);
+    if (g.has_monolithic_field()) {
+      g.monolithic_field().get_header().get_tracking().update_time_stamp(t);
     } else {
-      for (auto& f : g.m_individual_fields) {
-        f.second->get_header().get_tracking().update_time_stamp(t);
+      for (auto& it : g.individual_fields()) {
+        it.second.get_header().get_tracking().update_time_stamp(t);
       }
     }
   }
@@ -830,25 +830,25 @@ void AtmosphereProcess::set_fields_and_groups_pointers () {
     m_fields_out_pointers[fid.name()][fid.get_grid_name()] = &f;
   }
   for (auto& g : m_groups_in) {
-    const auto& group_name = g.m_info->m_group_name;
+    const auto& group_name = g.info()->m_group_name;
     m_groups_in_pointers[group_name][g.grid_name()] = &g;
     // Also add pointers for individual fields in the group and monolithic field (if present)
-    for (const auto& [fn,fp] : g.m_individual_fields) {
-      m_fields_in_pointers[fn][g.grid_name()] = fp.get();
+    for (auto& [fn,f] : g.individual_fields()) {
+      m_fields_in_pointers[fn][g.grid_name()] = &f;
     }
-    if (g.m_monolithic_field) {
-      m_fields_in_pointers[group_name][g.grid_name()] = g.m_monolithic_field.get();
+    if (g.has_monolithic_field()) {
+      m_fields_in_pointers[group_name][g.grid_name()] = &g.monolithic_field();
     }
   }
   for (auto& g : m_groups_out) {
-    const auto& group_name = g.m_info->m_group_name;
+    const auto& group_name = g.info()->m_group_name;
     m_groups_out_pointers[group_name][g.grid_name()] = &g;
     // Also add pointers for individual fields in the group and monolithic field (if present)
-    for (const auto& [fn,fp] : g.m_individual_fields) {
-      m_fields_out_pointers[fn][g.grid_name()] = fp.get();
+    for (auto& [fn,f] : g.individual_fields()) {
+      m_fields_out_pointers[fn][g.grid_name()] = &f;
     }
-    if (g.m_monolithic_field) {
-      m_fields_out_pointers[group_name][g.grid_name()] = g.m_monolithic_field.get();
+    if (g.has_monolithic_field()) {
+      m_fields_out_pointers[group_name][g.grid_name()] = &g.monolithic_field();
     }
   }
   for (auto& f : m_internal_fields) {
@@ -1018,7 +1018,7 @@ get_group_in_impl(const std::string& group_name, const std::string& grid_name) c
         "   group name: " + group_name + "\n"
         "   grid name: " + grid_name + "\n");
   }
-  static FieldGroup g("");
+  static FieldGroup g("ERROR","ERROR");
   return g;
 }
 
@@ -1041,7 +1041,7 @@ get_group_in_impl(const std::string& group_name) const {
         "   atm proc name: " + this->name() + "\n"
         "   group name: " + group_name + "\n");
   }
-  static FieldGroup g("");
+  static FieldGroup g("ERROR","ERROR");
   return g;
 }
 
@@ -1058,7 +1058,7 @@ get_group_out_impl(const std::string& group_name, const std::string& grid_name) 
         "   group name: " + group_name + "\n"
         "   grid name: " + grid_name + "\n");
   }
-  static FieldGroup g("");
+  static FieldGroup g("ERROR","ERROR");
   return g;
 }
 
@@ -1081,7 +1081,7 @@ get_group_out_impl(const std::string& group_name) const {
         "   atm proc name: " + this->name() + "\n"
         "   group name: " + group_name + "\n");
   }
-  static FieldGroup g("");
+  static FieldGroup g("ERROR","ERROR");
   return g;
 }
 
@@ -1150,10 +1150,10 @@ void AtmosphereProcess
   const auto rmg = [&] (std::list<FieldGroup>& fields, strmap_t<strmap_t<FieldGroup*>>& ptrs) {
     std::vector<It> rm_its;
     for (It it = fields.begin(); it != fields.end(); ++it) {
-      if (it->m_info->m_group_name == group_name and it->grid_name() == grid_name) {
+      if (it->info()->m_group_name == group_name and it->grid_name() == grid_name) {
         rm_its.push_back(it);
         ptrs[group_name][grid_name] = nullptr;
-        for (auto& kv : it->m_individual_fields)
+        for (auto& kv : it->individual_fields())
           remove_field(kv.first, grid_name);
       }
     }
@@ -1219,12 +1219,12 @@ void AtmosphereProcess::add_py_fields (const FieldGroup& group)
 {
 #ifdef EAMXX_HAS_PYTHON
   if (m_py_module.has_value()) {
-    if (group.m_monolithic_field) {
-      const auto& f = group.m_monolithic_field;
-      add_py_fields(*f);
+    if (group.has_monolithic_field()) {
+      const auto& f = group.monolithic_field();
+      add_py_fields(f);
     } else {
-      for (const auto& [name,f] : group.m_individual_fields) {
-        add_py_fields(*f);
+      for (const auto& [name,f] : group.individual_fields()) {
+        add_py_fields(f);
       }
     }
   }

--- a/components/eamxx/src/share/atm_process/atmosphere_process.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process.cpp
@@ -324,9 +324,9 @@ void AtmosphereProcess::set_computed_field (const Field& f) {
 
 void AtmosphereProcess::set_required_group (const FieldGroup& group) {
   // Sanity check
-  EKAT_REQUIRE_MSG (has_required_group(group.info()->m_group_name,group.grid_name()),
+  EKAT_REQUIRE_MSG (has_required_group(group.name(),group.grid_name()),
     "Error! This atmosphere process does not require the input group.\n"
-    "   group name: " + group.info()->m_group_name + "\n"
+    "   group name: " + group.name() + "\n"
     "   grid name : " + group.grid_name() + "\n"
     "   atm process: " + this->name() + "\n"
     "Something is wrong up the call stack. Please, contact developers.\n");
@@ -353,9 +353,9 @@ void AtmosphereProcess::set_required_group (const FieldGroup& group) {
 
 void AtmosphereProcess::set_computed_group (const FieldGroup& group) {
   // Sanity check
-  EKAT_REQUIRE_MSG (has_computed_group(group.info()->m_group_name,group.grid_name()),
+  EKAT_REQUIRE_MSG (has_computed_group(group.name(),group.grid_name()),
     "Error! This atmosphere process does not compute the input group.\n"
-    "   group name: " + group.info()->m_group_name + "\n"
+    "   group name: " + group.name() + "\n"
     "   grid name : " + group.grid_name() + "\n"
     "   atm process: " + this->name() + "\n"
     "Something is wrong up the call stack. Please, contact developers.\n");
@@ -830,7 +830,7 @@ void AtmosphereProcess::set_fields_and_groups_pointers () {
     m_fields_out_pointers[fid.name()][fid.get_grid_name()] = &f;
   }
   for (auto& g : m_groups_in) {
-    const auto& group_name = g.info()->m_group_name;
+    const auto& group_name = g.name();
     m_groups_in_pointers[group_name][g.grid_name()] = &g;
     // Also add pointers for individual fields in the group and monolithic field (if present)
     for (auto& [fn,f] : g.individual_fields()) {
@@ -841,7 +841,7 @@ void AtmosphereProcess::set_fields_and_groups_pointers () {
     }
   }
   for (auto& g : m_groups_out) {
-    const auto& group_name = g.info()->m_group_name;
+    const auto& group_name = g.name();
     m_groups_out_pointers[group_name][g.grid_name()] = &g;
     // Also add pointers for individual fields in the group and monolithic field (if present)
     for (auto& [fn,f] : g.individual_fields()) {
@@ -1146,18 +1146,17 @@ void AtmosphereProcess
 
 void AtmosphereProcess
 ::remove_group (const std::string& group_name, const std::string& grid_name) {
-  typedef std::list<FieldGroup>::iterator It;
-  const auto rmg = [&] (std::list<FieldGroup>& fields, strmap_t<strmap_t<FieldGroup*>>& ptrs) {
-    std::vector<It> rm_its;
-    for (It it = fields.begin(); it != fields.end(); ++it) {
-      if (it->info()->m_group_name == group_name and it->grid_name() == grid_name) {
-        rm_its.push_back(it);
+  const auto rmg = [&] (std::list<FieldGroup>& groups, strmap_t<strmap_t<FieldGroup*>>& ptrs) {
+    for (auto it = groups.begin(); it != groups.end();) {
+      if (it->name() == group_name and it->grid_name() == grid_name) {
         ptrs[group_name][grid_name] = nullptr;
         for (auto& kv : it->individual_fields())
           remove_field(kv.first, grid_name);
+        it = groups.erase(it);
+      } else {
+        ++it;
       }
     }
-    for (auto& it : rm_its) fields.erase(it);
   };
   rmg(m_groups_in, m_groups_in_pointers);
   rmg(m_groups_out, m_groups_out_pointers);

--- a/components/eamxx/src/share/atm_process/atmosphere_process.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process.cpp
@@ -23,10 +23,8 @@ namespace py = pybind11;
 ekat::logger::LogLevel str2LogLevel (const std::string& s) {
   using namespace ekat::logger;
 
-  ekat::logger::LogLevel log_level;
-  if (s=="off") {
-    log_level = LogLevel::off;
-  } else if (s=="trace") {
+  ekat::logger::LogLevel log_level = LogLevel::off;
+  if (s=="trace") {
     log_level = LogLevel::trace;
   } else if (s=="debug") {
     log_level = LogLevel::debug;

--- a/components/eamxx/src/share/atm_process/atmosphere_process_dag.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_dag.cpp
@@ -2,6 +2,7 @@
 #include "share/atm_process/atmosphere_process_group.hpp"
 
 #include <fstream>
+#include <ranges>
 
 namespace scream {
 
@@ -286,13 +287,10 @@ void AtmProcDAG::write_dag (const std::string& fname, const int verbosity) const
           if (verbosity>2) {
             ofile << "      <tr><td align=\"left\">  Members:";
             const auto& group = m_gr_fid_to_group.at(m_fids[gr_fid]);
-            const auto& members = group.individual_fields();
-            const auto& members_names = group.info()->m_fields_names;
             const size_t max_len = 40;
             size_t len = 0;
             size_t i = 0;
-            for (const auto& fn : members_names) {
-              const auto f = members.at(fn);
+            for (const auto& [fn,f] : group.individual_fields()) {
               std::string mfc = "<font color=\"";
               mfc += "black";
               mfc += "\">";
@@ -303,7 +301,7 @@ void AtmProcDAG::write_dag (const std::string& fname, const int verbosity) const
               ofile << " " << mfc << fn << "</font>";
               len += fn.size()+1;
               if (len>max_len) {
-                if (i<members.size()-1) {
+                if (i<group.size()-1) {
                   ofile << ",";
                 }
                 ofile << "</td></tr>";
@@ -336,13 +334,10 @@ void AtmProcDAG::write_dag (const std::string& fname, const int verbosity) const
           if (verbosity>2) {
             ofile << "      <tr><td align=\"left\">  Members:";
             const auto& group = m_gr_fid_to_group.at(m_fids[gr_fid]);
-            const auto& members = group.individual_fields();
-            const auto& members_names = group.info()->m_fields_names;
             const size_t max_len = 40;
             size_t len = 0;
             size_t i = 0;
-            for (const auto& fn : members_names) {
-              const auto f = members.at(fn);
+            for (const auto& [fn,f] : group.individual_fields()) {
               const auto& mfid = f.get_header().get_identifier();
               const auto mfid_id = get_fid_index(mfid);
               std::string mfc = "<font color=\"";
@@ -355,7 +350,7 @@ void AtmProcDAG::write_dag (const std::string& fname, const int verbosity) const
               ofile << " " << mfc << fn << "</font>";
               len += fn.size()+1;
               if (len>max_len) {
-                if (i<members.size()-1) {
+                if (i<group.size()-1) {
                   ofile << ",";
                 }
                 ofile << "</td></tr>";
@@ -473,10 +468,10 @@ add_nodes (const group_type& atm_procs)
 
       // Input groups
       for (const auto& group : proc->get_groups_in()) {
-        if (!group.info()->m_monolithic_allocation) {
+        if (not group.has_monolithic_field()) {
           // Group does not allocate a monolithic field: process fields individually
-          for (const auto& it_f : group.individual_fields()) {
-            const auto& fid = it_f.second.get_header().get_identifier();
+          for (const auto& f : std::views::values(group.individual_fields())) {
+            const auto& fid = f.get_header().get_identifier();
             const int fid_id = add_fid(fid);
             node.computed.insert(fid_id);
             m_fid_to_last_provider[fid_id] = id;
@@ -492,10 +487,10 @@ add_nodes (const group_type& atm_procs)
 
       // Output groups
       for (const auto& group : proc->get_groups_out()) {
-        if (!group.info()->m_monolithic_allocation) {
+        if (not group.has_monolithic_field()) {
           // Group does not allocate a monolithic field: process fields in the group individually
-          for (const auto& it_f : group.individual_fields()) {
-            const auto& fid = it_f.second.get_header().get_identifier();
+          for (const auto& f : std::views::values(group.individual_fields())) {
+            const auto& fid = f.get_header().get_identifier();
             const int fid_id = add_fid(fid);
             node.computed.insert(fid_id);
             m_fid_to_last_provider[fid_id] = id;
@@ -510,8 +505,8 @@ add_nodes (const group_type& atm_procs)
 
           // Additionally, each field in the group is implicitly 'computed'
           // by this node, so update their last provider
-          for (auto it_f : group.individual_fields()) {
-            const auto& fid = it_f.second.get_header().get_identifier();
+          for (const auto& f : std::views::values(group.individual_fields())) {
+            const auto& fid = f.get_header().get_identifier();
             const int fid_id = add_fid(fid);
             m_fid_to_last_provider[fid_id] = id;
           }
@@ -544,7 +539,7 @@ void AtmProcDAG::add_edges () {
     for (auto id : node.gr_required) {
       const auto& gr_fid = m_fids[id];
       const auto& group = m_gr_fid_to_group.at(gr_fid);
-      const int   size  = group.info()->size();
+      const auto  size  = group.size();
 
       int last_group_update_id = -1;
       std::vector<int> last_members_update_id(size,-1);
@@ -557,8 +552,8 @@ void AtmProcDAG::add_edges () {
       }
       // Then check when each group member was last updated
       int i=0;
-      for (auto f_it : group.individual_fields()) {
-        const auto& fid = f_it.second.get_header().get_identifier();
+      for (const auto& f : std::views::values(group.individual_fields())) {
+        const auto& fid = f.get_header().get_identifier();
         auto fid_id = std::find(m_fids.begin(),m_fids.end(),fid) - m_fids.begin();
         it = m_fid_to_last_provider.find(fid_id);
         // Note: check that last provider id is SMALLER than this node id

--- a/components/eamxx/src/share/atm_process/atmosphere_process_dag.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_dag.cpp
@@ -286,8 +286,8 @@ void AtmProcDAG::write_dag (const std::string& fname, const int verbosity) const
           if (verbosity>2) {
             ofile << "      <tr><td align=\"left\">  Members:";
             const auto& group = m_gr_fid_to_group.at(m_fids[gr_fid]);
-            const auto& members = group.m_individual_fields;
-            const auto& members_names = group.m_info->m_fields_names;
+            const auto& members = group.individual_fields();
+            const auto& members_names = group.info()->m_fields_names;
             const size_t max_len = 40;
             size_t len = 0;
             size_t i = 0;
@@ -336,14 +336,14 @@ void AtmProcDAG::write_dag (const std::string& fname, const int verbosity) const
           if (verbosity>2) {
             ofile << "      <tr><td align=\"left\">  Members:";
             const auto& group = m_gr_fid_to_group.at(m_fids[gr_fid]);
-            const auto& members = group.m_individual_fields;
-            const auto& members_names = group.m_info->m_fields_names;
+            const auto& members = group.individual_fields();
+            const auto& members_names = group.info()->m_fields_names;
             const size_t max_len = 40;
             size_t len = 0;
             size_t i = 0;
             for (const auto& fn : members_names) {
               const auto f = members.at(fn);
-              const auto& mfid = f->get_header().get_identifier();
+              const auto& mfid = f.get_header().get_identifier();
               const auto mfid_id = get_fid_index(mfid);
               std::string mfc = "<font color=\"";
               mfc += (ekat::contains(unmet,mfid_id) ? "red" : "black");
@@ -473,17 +473,17 @@ add_nodes (const group_type& atm_procs)
 
       // Input groups
       for (const auto& group : proc->get_groups_in()) {
-        if (!group.m_info->m_monolithic_allocation) {
+        if (!group.info()->m_monolithic_allocation) {
           // Group does not allocate a monolithic field: process fields individually
-          for (const auto& it_f : group.m_individual_fields) {
-            const auto& fid = it_f.second->get_header().get_identifier();
+          for (const auto& it_f : group.individual_fields()) {
+            const auto& fid = it_f.second.get_header().get_identifier();
             const int fid_id = add_fid(fid);
             node.computed.insert(fid_id);
             m_fid_to_last_provider[fid_id] = id;
           }
         } else {
           // Group allocates a monolithic field: process the monolithic field
-          const auto& gr_fid = group.m_monolithic_field->get_header().get_identifier();
+          const auto& gr_fid = group.monolithic_field().get_header().get_identifier();
           const int gr_fid_id = add_fid(gr_fid);
           node.gr_required.insert(gr_fid_id);
           m_gr_fid_to_group.emplace(gr_fid,group);
@@ -492,17 +492,17 @@ add_nodes (const group_type& atm_procs)
 
       // Output groups
       for (const auto& group : proc->get_groups_out()) {
-        if (!group.m_info->m_monolithic_allocation) {
+        if (!group.info()->m_monolithic_allocation) {
           // Group does not allocate a monolithic field: process fields in the group individually
-          for (const auto& it_f : group.m_individual_fields) {
-            const auto& fid = it_f.second->get_header().get_identifier();
+          for (const auto& it_f : group.individual_fields()) {
+            const auto& fid = it_f.second.get_header().get_identifier();
             const int fid_id = add_fid(fid);
             node.computed.insert(fid_id);
             m_fid_to_last_provider[fid_id] = id;
           }
         } else {
           // Group allocates a monolithic field: process the monolithic field
-          const auto& gr_fid = group.m_monolithic_field->get_header().get_identifier();
+          const auto& gr_fid = group.monolithic_field().get_header().get_identifier();
           const int gr_fid_id = add_fid(gr_fid);
           node.gr_computed.insert(gr_fid_id);
           m_fid_to_last_provider[gr_fid_id] = id;
@@ -510,8 +510,8 @@ add_nodes (const group_type& atm_procs)
 
           // Additionally, each field in the group is implicitly 'computed'
           // by this node, so update their last provider
-          for (auto it_f : group.m_individual_fields) {
-            const auto& fid = it_f.second->get_header().get_identifier();
+          for (auto it_f : group.individual_fields()) {
+            const auto& fid = it_f.second.get_header().get_identifier();
             const int fid_id = add_fid(fid);
             m_fid_to_last_provider[fid_id] = id;
           }
@@ -544,7 +544,7 @@ void AtmProcDAG::add_edges () {
     for (auto id : node.gr_required) {
       const auto& gr_fid = m_fids[id];
       const auto& group = m_gr_fid_to_group.at(gr_fid);
-      const int   size  = group.m_info->size();
+      const int   size  = group.info()->size();
 
       int last_group_update_id = -1;
       std::vector<int> last_members_update_id(size,-1);
@@ -557,8 +557,8 @@ void AtmProcDAG::add_edges () {
       }
       // Then check when each group member was last updated
       int i=0;
-      for (auto f_it : group.m_individual_fields) {
-        const auto& fid = f_it.second->get_header().get_identifier();
+      for (auto f_it : group.individual_fields()) {
+        const auto& fid = f_it.second.get_header().get_identifier();
         auto fid_id = std::find(m_fids.begin(),m_fids.end(),fid) - m_fids.begin();
         it = m_fid_to_last_provider.find(fid_id);
         // Note: check that last provider id is SMALLER than this node id

--- a/components/eamxx/src/share/atm_process/atmosphere_process_group.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_group.cpp
@@ -8,6 +8,7 @@
 #include <ekat_assert.hpp>
 
 #include <memory>
+#include <ranges>
 
 namespace scream {
 
@@ -511,7 +512,7 @@ set_required_field (const Field& f) {
       if (g.grid_name()!=fid.get_grid_name()) {
         continue;
       }
-      for (const auto& fn : g.info()->m_fields_names) {
+      for (const auto& fn : std::views::keys(g.individual_fields())) {
         if (fid.name()==fn) {
           computed = true;
           goto endloop;
@@ -546,7 +547,7 @@ set_required_group (const FieldGroup& group) {
   // Find the first process that requires this group
   int first_proc_that_needs_group = -1;
   for (int iproc=0; iproc<m_group_size; ++iproc) {
-    if (m_atm_processes[iproc]->has_required_group(group.info()->m_group_name,group.grid_name())) {
+    if (m_atm_processes[iproc]->has_required_group(group.name(),group.grid_name())) {
       first_proc_that_needs_group = iproc;
       break;
     }
@@ -554,7 +555,7 @@ set_required_group (const FieldGroup& group) {
 
   EKAT_REQUIRE_MSG (first_proc_that_needs_group>=0,
     "Error! This atmosphere process does not require the input group.\n"
-    "   group name: " + group.info()->m_group_name + "\n"
+    "   group name: " + group.name() + "\n"
     "   grid name : " + group.grid_name() + "\n"
     "   atm process: " + this->name() + "\n"
     "Something is wrong up the call stack. Please, contact developers.\n");
@@ -582,7 +583,7 @@ set_required_group (const FieldGroup& group) {
         if (g.grid_name()!=group.grid_name()) {
           continue;
         }
-        for (const auto& f : g.info()->m_fields_names) {
+        for (const auto& f : std::views::keys(g.individual_fields())) {
           if (f==fn) {
             computed.insert(fn);
             goto endloop;
@@ -594,12 +595,11 @@ set_required_group (const FieldGroup& group) {
   // Yes, goto statement are not the prettiest C++ feature, but they allow to
   // break from multiple nested loops without the need of several checks.
 endloop:
-    if (computed.size()==group.info()->m_fields_names.size()) {
+    if (computed.size()==group.size())
       break;
-    }
   }
 
-  if (computed.size()==group.info()->m_fields_names.size()) {
+  if (computed.size()==group.size()) {
     // We compute all the fields in the group *before* any atm proc
     // that requires this group. Simply set the group in those atm
     // proc that require it, without storing it as an input to this group.
@@ -617,7 +617,7 @@ void AtmosphereProcessGroup::
 set_required_group_impl (const FieldGroup& group)
 {
   for (auto atm_proc : m_atm_processes) {
-    if (atm_proc->has_required_group(group.info()->m_group_name,group.grid_name())) {
+    if (atm_proc->has_required_group(group.name(),group.grid_name())) {
       atm_proc->set_required_group(group);
     }
   }
@@ -627,14 +627,14 @@ void AtmosphereProcessGroup::
 set_computed_group_impl (const FieldGroup& group)
 {
   for (auto atm_proc : m_atm_processes) {
-    if (atm_proc->has_computed_group(group.info()->m_group_name,group.grid_name())) {
+    if (atm_proc->has_computed_group(group.name(),group.grid_name())) {
       atm_proc->set_computed_group(group);
     }
     // In sequential scheduling, some groups may be computed by
     // a process and used by the next one. In this case, the group
     // may not figure as 'input' for the group, but we still
     // need to set it in the processes that need it.
-    if (atm_proc->has_required_group(group.info()->m_group_name,group.grid_name())) {
+    if (atm_proc->has_required_group(group.name(),group.grid_name())) {
       atm_proc->set_required_group(group.get_const());
     }
   }

--- a/components/eamxx/src/share/atm_process/atmosphere_process_group.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_group.cpp
@@ -316,11 +316,11 @@ void AtmosphereProcessGroup::add_postcondition_nan_checks () const {
 
       for (const auto& g : proc->get_groups_out()) {
         const auto& grid = m_grids_manager->get_grid(g.grid_name());
-        for (const auto& f : g.m_individual_fields) {
-          if (f.second->data_type()==DataType::IntType)
+        for (const auto& it : g.individual_fields()) {
+          if (it.second.data_type()==DataType::IntType)
             continue;
 
-          auto nan_check = std::make_shared<FieldNaNCheck>(*f.second,grid);
+          auto nan_check = std::make_shared<FieldNaNCheck>(it.second,grid);
           proc->add_postcondition_check(nan_check, CheckFailHandling::Fatal);
         }
       }
@@ -511,7 +511,7 @@ set_required_field (const Field& f) {
       if (g.grid_name()!=fid.get_grid_name()) {
         continue;
       }
-      for (const auto& fn : g.m_info->m_fields_names) {
+      for (const auto& fn : g.info()->m_fields_names) {
         if (fid.name()==fn) {
           computed = true;
           goto endloop;
@@ -546,7 +546,7 @@ set_required_group (const FieldGroup& group) {
   // Find the first process that requires this group
   int first_proc_that_needs_group = -1;
   for (int iproc=0; iproc<m_group_size; ++iproc) {
-    if (m_atm_processes[iproc]->has_required_group(group.m_info->m_group_name,group.grid_name())) {
+    if (m_atm_processes[iproc]->has_required_group(group.info()->m_group_name,group.grid_name())) {
       first_proc_that_needs_group = iproc;
       break;
     }
@@ -554,7 +554,7 @@ set_required_group (const FieldGroup& group) {
 
   EKAT_REQUIRE_MSG (first_proc_that_needs_group>=0,
     "Error! This atmosphere process does not require the input group.\n"
-    "   group name: " + group.m_info->m_group_name + "\n"
+    "   group name: " + group.info()->m_group_name + "\n"
     "   grid name : " + group.grid_name() + "\n"
     "   atm process: " + this->name() + "\n"
     "Something is wrong up the call stack. Please, contact developers.\n");
@@ -567,9 +567,9 @@ set_required_group (const FieldGroup& group) {
   // NOTE: we still check also the groups computed by the previous procs,
   //       in case they contain all the fields in this group.
   std::set<std::string> computed;
-  for (const auto& it : group.m_individual_fields) {
+  for (const auto& it : group.individual_fields()) {
     const auto& fn = it.first;
-    const auto& fid = it.second->get_header().get_identifier();
+    const auto& fid = it.second.get_header().get_identifier();
     for (int iproc=0; iproc<first_proc_that_needs_group; ++iproc) {
       if (m_atm_processes[iproc]->has_computed_field(fid)) {
         computed.insert(fid.name());
@@ -582,7 +582,7 @@ set_required_group (const FieldGroup& group) {
         if (g.grid_name()!=group.grid_name()) {
           continue;
         }
-        for (const auto& f : g.m_info->m_fields_names) {
+        for (const auto& f : g.info()->m_fields_names) {
           if (f==fn) {
             computed.insert(fn);
             goto endloop;
@@ -594,12 +594,12 @@ set_required_group (const FieldGroup& group) {
   // Yes, goto statement are not the prettiest C++ feature, but they allow to
   // break from multiple nested loops without the need of several checks.
 endloop:
-    if (computed.size()==group.m_info->m_fields_names.size()) {
+    if (computed.size()==group.info()->m_fields_names.size()) {
       break;
     }
   }
 
-  if (computed.size()==group.m_info->m_fields_names.size()) {
+  if (computed.size()==group.info()->m_fields_names.size()) {
     // We compute all the fields in the group *before* any atm proc
     // that requires this group. Simply set the group in those atm
     // proc that require it, without storing it as an input to this group.
@@ -617,7 +617,7 @@ void AtmosphereProcessGroup::
 set_required_group_impl (const FieldGroup& group)
 {
   for (auto atm_proc : m_atm_processes) {
-    if (atm_proc->has_required_group(group.m_info->m_group_name,group.grid_name())) {
+    if (atm_proc->has_required_group(group.info()->m_group_name,group.grid_name())) {
       atm_proc->set_required_group(group);
     }
   }
@@ -627,14 +627,14 @@ void AtmosphereProcessGroup::
 set_computed_group_impl (const FieldGroup& group)
 {
   for (auto atm_proc : m_atm_processes) {
-    if (atm_proc->has_computed_group(group.m_info->m_group_name,group.grid_name())) {
+    if (atm_proc->has_computed_group(group.info()->m_group_name,group.grid_name())) {
       atm_proc->set_computed_group(group);
     }
     // In sequential scheduling, some groups may be computed by
     // a process and used by the next one. In this case, the group
     // may not figure as 'input' for the group, but we still
     // need to set it in the processes that need it.
-    if (atm_proc->has_required_group(group.m_info->m_group_name,group.grid_name())) {
+    if (atm_proc->has_required_group(group.info()->m_group_name,group.grid_name())) {
       atm_proc->set_required_group(group.get_const());
     }
   }

--- a/components/eamxx/src/share/atm_process/atmosphere_process_hash.cpp
+++ b/components/eamxx/src/share/atm_process/atmosphere_process_hash.cpp
@@ -152,8 +152,8 @@ void hash_if (const std::list<Field>& fs, HashType& accum, const Lambda& conditi
 
 void hash (const std::list<FieldGroup>& fgs, HashType& accum) {
   for (const auto& g : fgs)
-    for (const auto& e : g.m_individual_fields)
-      hash(*e.second, accum);
+    for (const auto& e : g.individual_fields())
+      hash(e.second, accum);
 }
 
 } // namespace anon
@@ -208,10 +208,10 @@ void AtmosphereProcess
         hash(f,laccum.back());
       }
       for (const auto& g : m_groups_in) {
-        for (const auto& [fn,f] : g.m_individual_fields) {
+        for (const auto& [fn,f] : g.individual_fields()) {
           laccum.emplace_back();
-          hash_names.push_back(make_hash_name(*f));
-          hash(*f,laccum.back());
+          hash_names.push_back(make_hash_name(f));
+          hash(f,laccum.back());
         }
       }
     } else {
@@ -221,10 +221,10 @@ void AtmosphereProcess
         hash(f,laccum.back());
       }
       for (const auto& g : m_groups_out) {
-        for (const auto& [fn,f] : g.m_individual_fields) {
+        for (const auto& [fn,f] : g.individual_fields()) {
           laccum.emplace_back();
-          hash_names.push_back(make_hash_name(*f));
-          hash(*f,laccum.back());
+          hash_names.push_back(make_hash_name(f));
+          hash(f,laccum.back());
         }
       }
     }

--- a/components/eamxx/src/share/data_managers/IOPDataManager.cpp
+++ b/components/eamxx/src/share/data_managers/IOPDataManager.cpp
@@ -630,7 +630,7 @@ set_fields_from_iop_data(const field_mgr_ptr field_mgr, const std::string& grid_
 
   if (m_params.get<bool>("zero_non_iop_tracers") && field_mgr->has_group("tracers", grid_name)) {
     // Zero out all tracers before setting iop tracers (if requested)
-    field_mgr->get_field_group("tracers", grid_name).m_monolithic_field->deep_copy(0);
+    field_mgr->get_field_group("tracers", grid_name).monolithic_field().deep_copy(0);
   }
 
   EKAT_REQUIRE_MSG(grid_name == "physics_gll",

--- a/components/eamxx/src/share/data_managers/IOPDataManager.cpp
+++ b/components/eamxx/src/share/data_managers/IOPDataManager.cpp
@@ -653,7 +653,7 @@ set_fields_from_iop_data(const field_mgr_ptr field_mgr, const std::string& grid_
   view_2d<Real> T_mid, qv, nc, qc, qi, ni;
   view_3d<Real> horiz_winds;
 
-  Real ps_iop;
+  Real ps_iop = -1;
   view_1d<Real> t_iop, u_iop, v_iop, qv_iop, nc_iop, qc_iop, qi_iop, ni_iop;
 
   if (set_ps) {

--- a/components/eamxx/src/share/data_managers/IOPDataManager.hpp
+++ b/components/eamxx/src/share/data_managers/IOPDataManager.hpp
@@ -136,8 +136,6 @@ private:
 
   TimeInfo m_time_info;
 
-  Real m_dynamics_dx_size;
-
   std::map<std::string,grid_ptr> m_io_grids;
 
   std::map<std::string, Field> m_iop_fields;

--- a/components/eamxx/src/share/data_managers/field_group_info.hpp
+++ b/components/eamxx/src/share/data_managers/field_group_info.hpp
@@ -21,8 +21,6 @@ namespace scream {
  *   - a list of the field names associated to this group;
  *   - whether the field were allocated as a single monolithic field,
  *     with each field extracted as a "subview" of the monolithic one;
- *   - if the group allocated a monolithic field, also store for each
- *     subfield the index that was used to extract the corresponding subview.
  */
 
 struct FieldGroupInfo
@@ -34,8 +32,6 @@ struct FieldGroupInfo
     : m_group_name (group_name)
     , m_fields_names{}
     , m_monolithic_allocation (false)
-    , m_subview_dim(-1)
-    , m_subview_idx{}
   {
     // Nothing to do here
   }
@@ -50,7 +46,7 @@ struct FieldGroupInfo
   ci_string m_group_name;
 
   // The names of the fields in this group
-  std::list<ci_string>   m_fields_names;
+  std::set<ci_string>   m_fields_names;
 
   // Store the grid which registered each field
   std::map<ci_string, std::set<ci_string>> m_grid_registered;
@@ -62,16 +58,10 @@ struct FieldGroupInfo
   // the group to exist.
   std::set<ci_string> m_requested_grids;
 
-  // Whether the group allocated a monolithic field
+  // Whether the group allocated a monolithic field.
+  // NOTE: if monolithic, it will be monolithic across grids,
+  //       and contain the same fields across all grids
   bool m_monolithic_allocation = false;
-
-  // If we allocate a monolithic field, each field is subviewed
-  // along a different entry along the same dimension.
-  int m_subview_dim = -1;
-
-  // If we allocate a monolithic field, for each field name,
-  // store the idx used to subview each individual field.
-  std::map<ci_string,int>  m_subview_idx;
 };
 
 inline bool operator== (const FieldGroupInfo& lhs,
@@ -79,9 +69,7 @@ inline bool operator== (const FieldGroupInfo& lhs,
 {
   return lhs.m_group_name==rhs.m_group_name &&
          lhs.m_fields_names==rhs.m_fields_names &&
-         lhs.m_monolithic_allocation==rhs.m_monolithic_allocation &&
-         lhs.m_subview_dim==rhs.m_subview_dim &&
-         lhs.m_subview_idx==rhs.m_subview_idx;
+         lhs.m_monolithic_allocation==rhs.m_monolithic_allocation;
 }
 
 } // namespace scream

--- a/components/eamxx/src/share/data_managers/field_manager.cpp
+++ b/components/eamxx/src/share/data_managers/field_manager.cpp
@@ -521,6 +521,26 @@ void FieldManager::registration_ends ()
         // See below where we assume idim is 1
         EKAT_REQUIRE_MSG(idim==1, "Error! idim is assumed to be 1 in FieldManager::registration_ends().\n");
 
+        // If the cluster contains 2+ groups, ensure that also the individual groups
+        // do have a monolithic field in the repo.
+        if (cluster.size()>1) {
+          int vec_idx = c_layout.get_vector_component_idx();
+          for (auto group_name : cluster) {
+            const auto& info = *m_field_group_info.at(group_name);
+            // Find the first field of this group in the ordered cluster names.
+            auto it = std::find_first_of(cluster_ordered_fields.begin(),cluster_ordered_fields.end(),
+                                            info.m_fields_names.begin(),info.m_fields_names.end());
+            int beg = std::distance(cluster_ordered_fields.begin(),it);
+            int end = beg + info.size();
+
+            auto sub_layout = c_layout.clone().reset_dim(vec_idx,info.size());;
+            auto sub_fid = c_fid.clone(group_name).reset_layout(sub_layout);
+            register_field(sub_fid);
+            auto& sub_C = m_fields.at(cluster_grid_name).at(group_name);
+            *sub_C = C->subfield (group_name,vec_idx, beg, end);
+          }
+        }
+
         // Create all individual subfields
         for (const auto& fn : cluster_ordered_fields) {
           const auto pos = ekat::find(cluster_ordered_fields,fn);
@@ -577,7 +597,7 @@ void FieldManager::registration_ends ()
         info.m_monolithic_allocation = true;
 
         // The subview indices will need to be corrected in the case of this group being
-        // itself a subfile of the cluster field. We are guarenteed that the indices
+        // itself a subgroup of the cluster field. We are guarenteed that the indices
         // are contiguous, so just calculate the min idx and subtract from all fields indices.
         int min_idx = std::numeric_limits<int>::max();
         for (auto& it : info.m_subview_idx) {

--- a/components/eamxx/src/share/data_managers/field_manager.cpp
+++ b/components/eamxx/src/share/data_managers/field_manager.cpp
@@ -87,30 +87,8 @@ void FieldManager::register_field (const FieldRequest& req)
   m_fields[grid_name][id.name()]->get_header().get_alloc_properties().request_allocation(req.pack_size);
 
   // Finally, add the field to the given groups
-  // Note: we do *not* set the group info struct in the field header yet.
-  //       we will do that when we end the registration phase.
-  //       The reason is that at registration_ends we will know *all* the groups
-  //       that each field belongs to.
   for (const auto& group_name : req.groups) {
-    // Get group (and init ptr, if necessary)
-    auto& group_info = m_field_group_info[group_name];
-    if (not group_info) {
-      group_info = std::make_shared<FieldGroupInfo>(group_name);
-    }
-
-    // Add the field name to the list of fields belonging to this group
-    if (not ekat::contains(group_info->m_fields_names,id.name())) {
-      group_info->m_fields_names.push_back(id.name());
-    }
-
-    // Add which grid has registered this field
-    if (not ekat::contains(group_info->m_grid_registered[id.name()], grid_name)) {
-      group_info->m_grid_registered[id.name()].push_back(grid_name);
-    }
-
-    // Ensure that each group in m_field_group_info also appears in the m_group_requests map by
-    // adding a "trivial" GroupRequest for this group, meaning no monolithic allocation and pack size 1.
-    register_group(GroupRequest(group_name, grid_name));
+    add_to_group(id.name(),grid_name,group_name);
   }
 }
 
@@ -126,30 +104,22 @@ void FieldManager::register_group (const GroupRequest& req)
   // and create an empty group info (if it does not already exist)
   m_group_requests[req.grid][req.name].insert(req);
 
-  auto& group_info = m_field_group_info[req.name];
-  if (not group_info) {
-    group_info = std::make_shared<FieldGroupInfo>(req.name);
-    group_info->m_monolithic_allocation = (req.monolithic_alloc==MonolithicAlloc::Required);
-  } else if (not group_info->m_monolithic_allocation) {
-    group_info->m_monolithic_allocation = (req.monolithic_alloc==MonolithicAlloc::Required);
-  }
-
-  if (not ekat::contains(group_info->m_requested_grids, req.grid)) {
-    group_info->m_requested_grids.push_back(req.grid);
-  }
+  auto& info = m_field_group_info[req.name];
+  if (not info)
+    info = std::make_shared<FieldGroupInfo>(req.name);
+  info->m_requested_grids.insert(req.grid);
+  info->m_monolithic_allocation |= req.monolithic_alloc==MonolithicAlloc::Required;
 }
 
 void FieldManager::
 add_to_group (const std::string& field_name, const std::string& grid_name, const std::string& group_name)
 {
-  EKAT_REQUIRE_MSG (m_repo_state==RepoState::Closed,
-      "Error! You cannot call 'add_to_group' until after 'registration_ends' has been called.\n");
-  auto& group = m_field_group_info[group_name];
-  if (not group) {
-    group = std::make_shared<FieldGroupInfo>(group_name);
-  }
-  EKAT_REQUIRE_MSG (not group->m_monolithic_allocation,
-      "Error! Cannot add fields to a group that has a monolithic allocation.\n"
+  auto& info = m_field_group_info[group_name];
+  if (not info)
+    info = std::make_shared<FieldGroupInfo>(group_name);
+
+  EKAT_REQUIRE_MSG (m_repo_state==RepoState::Open or not info->m_monolithic_allocation,
+      "Error! Cannot add fields to a group that has a monolithic allocation once registration has ended.\n"
       "   field name: " + field_name + "\n"
       "   group name: " + group_name + "\n");
 
@@ -159,15 +129,33 @@ add_to_group (const std::string& field_name, const std::string& grid_name, const
       "   grid name:  " + grid_name + "\n"
       "   group name: " + group_name + "\n");
 
-  if (not ekat::contains(group->m_fields_names, field_name)) {
-    group->m_fields_names.push_back(field_name);
-  }
-  if (not ekat::contains(group->m_grid_registered[field_name], grid_name)) {
-    group->m_grid_registered[field_name].push_back(grid_name);
-  }
+  if (not ekat::contains(info->m_fields_names, field_name))
+    info->m_fields_names.push_back(field_name);
 
-  auto& ft = get_field(field_name, grid_name).get_header().get_tracking();
-  ft.add_group(group_name);
+  info->m_grid_registered[field_name].insert(grid_name);
+
+  // This method can be called
+  //  A) during regular field registration
+  //  B) at the end of registration_ends, to add each created field to its groups
+  //  C) after registration ended, to extent a group (possibly on one particular grid)
+  // In case A, repo will be Open, and no FieldGroup is created. For B/C, the repo is closed,
+  // and we have all necessary info to ensure the stored group has all fields set
+  if (m_repo_state==RepoState::Closed) {
+    auto& group = m_field_groups[grid_name][group_name];
+    if (group==nullptr)
+      group = std::make_shared<FieldGroup>(info,grid_name);
+
+    if (group->individual_fields().count(field_name)==0)
+      group->set_field(get_field(field_name,grid_name));
+
+    if (group->info()->m_monolithic_allocation and not group->has_monolithic_field())
+      group->set_monolithic_field(get_field(group_name,grid_name));
+
+    // If this method is called after registration_ends, this is needed.
+    // If it's called from inside registration_ends, it's redundant (but innocuous).
+    auto& ft = get_field(field_name, grid_name).get_header().get_tracking();
+    ft.add_group(group_name);
+  }
 }
 
 bool FieldManager::
@@ -217,36 +205,7 @@ get_group_info (const std::string& group_name, const std::string& grid_name) con
   EKAT_REQUIRE_MSG (has_group(group_name, grid_name),
     "Error! Field group '" + group_name + "' on grid '" + grid_name + "' not found.\n");
 
-  auto info = *m_field_group_info.at(group_name);
-
-  if (info.m_monolithic_allocation) {
-    // All fields in a group with a monolithic allocation should exist on any grid in that group
-    for (const auto& fname : info.m_fields_names) {
-      EKAT_REQUIRE_MSG(has_field(fname, grid_name),
-        "Internal FieldManager Error! Groups with monolithic allocation must contain all "
-        "fields in m_fields_names on any grid from m_grids_in_group.\n"
-        "The following field should, but does not, exist:\n"
-        "  - Group: " + group_name + "\n"
-        "  - Field: " + fname + "\n"
-        "  - Grid:  " + grid_name + "\n");
-    }
-  } else {
-    // For all other groups, remove fields in the group
-    // that do not exist on the requested grid
-    std::list<ci_string> remove_fnames;
-    for (const auto& fname : info.m_fields_names) {
-      if (not ekat::contains(info.m_grid_registered.at(fname), grid_name)) {
-        remove_fnames.push_back(fname);
-      }
-    }
-    for (auto fname : remove_fnames) {
-      info.m_fields_names.remove(fname);
-      info.m_grid_registered.erase(fname);
-      info.m_subview_idx.erase(fname);
-    }
-  }
-
-  return info;
+  return *m_field_group_info.at(group_name);
 }
 
 FieldGroup FieldManager::
@@ -258,89 +217,7 @@ get_field_group (const std::string& group_name, const std::string& grid_name)
   EKAT_REQUIRE_MSG (has_group(group_name, grid_name),
       "Error! Field group '" + group_name + "' on grid '" + grid_name + "' not found.\n");
 
-  // If FieldGroup has already been built, return that
-  if (m_field_groups.at(grid_name).find(group_name) != m_field_groups.at(grid_name).end()) {
-    return *m_field_groups.at(grid_name).at(group_name);
-  }
-
-  // FieldGroup does not yet exist, create entry in m_field_groups
-  auto& group = m_field_groups[grid_name][group_name];
-  group = std::make_shared<FieldGroup>(group_name);
-
-  // Set the info in the group
-  group->m_info = std::make_shared<FieldGroupInfo>(get_group_info(group_name, grid_name));
-
-  // Find all the fields registered on given grid and set them in the group
-  for (const auto& fname : group->m_info->m_fields_names) {
-    group->m_individual_fields[fname] = m_fields.at(grid_name).at(fname);
-  }
-
-  // Fetch the monolithic field (if applicable)
-  if (group->m_info->m_monolithic_allocation) {
-    // All fields in a group have the same parent, get the parent from the 1st one
-    const auto& parent_header = group->m_individual_fields.begin()->second->get_header().get_parent();
-
-    EKAT_REQUIRE_MSG(parent_header!=nullptr,
-      "Error! A field belonging to a field group with monolithic allocation is missing its 'parent'.\n");
-
-    const auto& parent_id = parent_header->get_identifier();
-
-    EKAT_REQUIRE_MSG(has_field(parent_id.name(), grid_name),
-      "Internal FieldManager Error! Parent field must exist in the FieldManager:\n"
-      "  - Group: " + group_name + "\n"
-      "  - Bundeled field: " + parent_id.name() + "\n"
-      "  - Grid:  " + grid_name + "\n");
-
-    const auto& parent_field = m_fields.at(grid_name).at(parent_id.name());
-
-    // Get the parent field of one of the group fields and check if
-    // all it's children are in the group.
-    bool all_children_in_group = true;
-    for (auto child : parent_header->get_children()) {
-      bool in_group = false;
-      for (auto f : group->m_individual_fields) {
-        if (child.lock()->get_identifier() == f.second->get_header().get_identifier()) {
-          in_group = true;
-          break;
-        }
-      }
-      if (not in_group) {
-        all_children_in_group = false;
-        break;
-      }
-    }
-
-    // Set m_monolithic_field field
-    if (all_children_in_group) {
-      // If all children are in the group, this is the parent group and
-      // we can just query the monolithic field and set here
-      group->m_monolithic_field = parent_field;
-    } else {
-      // If children exist that aren't in this group, we need to get a
-      // subfield of the parent group containing indices of group fields
-      std::vector<int> ordered_subview_indices;
-      for (auto fn : group->m_info->m_fields_names) {
-        const auto parent_child_index =
-          m_field_group_info.at(parent_field->name())->m_subview_idx.at(fn);
-        ordered_subview_indices.push_back(parent_child_index);
-      }
-      std::sort(ordered_subview_indices.begin(),ordered_subview_indices.end());
-
-      // Check that all subview indices are contiguous
-      size_t span = ordered_subview_indices.back() - ordered_subview_indices.front() + 1;
-      EKAT_REQUIRE_MSG (ordered_subview_indices.size()==span,
-        "Error! Non-contiguous subview indices found in group \""+group_name+"\"\n");
-
-      group->m_monolithic_field = std::make_shared<Field>(
-        parent_field->subfield(
-          group_name, parent_header->get_identifier().get_units(),
-          group->m_info->m_subview_dim,
-          ordered_subview_indices.front(), ordered_subview_indices.back()+1));
-
-    }
-  }
-
-  return *group;
+  return *m_field_groups.at(grid_name).at(group_name);
 }
 
 void FieldManager::
@@ -737,21 +614,28 @@ void FieldManager::registration_ends ()
       it.second->allocate_view();
     }
 
-    for (const auto& it : m_field_group_info) {
-      if (m_group_requests.at(grid_name).find(it.first)!=m_group_requests.at(grid_name).end()) {
-        // Get fields in this group
-        auto group_info = it.second;
-        const auto& fnames = group_info->m_fields_names;
-        for (const auto& fn : fnames) {
-          // Update the field tracking
-          m_fields.at(grid_name).at(fn)->get_header().get_tracking().add_group(group_info->m_group_name);
-        }
-      }
-    }
+    // for (const auto& it : m_field_group_info) {
+    //   if (m_group_requests.at(grid_name).find(it.first)!=m_group_requests.at(grid_name).end()) {
+    //     // Get fields in this group
+    //     auto group_info = it.second;
+    //     const auto& fnames = group_info->m_fields_names;
+    //     for (const auto& fn : fnames) {
+    //       // Update the field tracking
+    //       m_fields.at(grid_name).at(fn)->get_header().get_tracking().add_group(group_info->m_group_name);
+    //     }
+    //   }
+    // }
   }
 
   // Prohibit further registration of fields to this repo
   m_repo_state = RepoState::Closed;
+
+  // Loop through all the FieldGroupInfo stored, and call add_to_group to start creating the actual
+  // FieldGroup objects in the m_field_groups registry
+  for (const auto& [group_name, info] : m_field_group_info)
+    for (const auto& [field_name, grids] : info->m_grid_registered)
+      for (const auto& grid_name : grids)
+        add_to_group(field_name,grid_name,group_name);
 }
 
 void FieldManager::clean_up() {

--- a/components/eamxx/src/share/data_managers/field_manager.cpp
+++ b/components/eamxx/src/share/data_managers/field_manager.cpp
@@ -196,18 +196,6 @@ Field& FieldManager::get_field (const std::string& name, const std::string& grid
   return *m_fields.at(grid_name).at(name);
 }
 
-FieldGroupInfo FieldManager::
-get_group_info (const std::string& group_name, const std::string& grid_name) const
-{
-  // Sanity checks
-  EKAT_REQUIRE_MSG(m_repo_state==RepoState::Closed,
-    "Error! Cannot get field groups from the repo while registration has not yet completed.\n");
-  EKAT_REQUIRE_MSG (has_group(group_name, grid_name),
-    "Error! Field group '" + group_name + "' on grid '" + grid_name + "' not found.\n");
-
-  return *m_field_group_info.at(group_name);
-}
-
 FieldGroup FieldManager::
 get_field_group (const std::string& group_name, const std::string& grid_name)
 {

--- a/components/eamxx/src/share/data_managers/field_manager.cpp
+++ b/components/eamxx/src/share/data_managers/field_manager.cpp
@@ -88,7 +88,10 @@ void FieldManager::register_field (const FieldRequest& req)
 
   // Finally, add the field to the given groups
   for (const auto& group_name : req.groups) {
-    add_to_group(id.name(),grid_name,group_name);
+    register_group(GroupRequest(group_name,grid_name));
+    auto& info = m_field_group_info[group_name];
+    info->m_fields_names.insert(id.name());
+    info->m_grid_registered[id.name()].insert(grid_name);
   }
 }
 
@@ -99,6 +102,7 @@ void FieldManager::register_group (const GroupRequest& req)
     "Error! Attempting to register group on grid not in the FM's grids manager:\n"
     "  - GroupRequest grid:  " + req.grid + "\n"
     "  - Grids stored by FM: " + m_grids_mgr->print_available_grids() + "\n");
+
 
   // Groups have to be handled once registration is over, so for now simply store the request,
   // and create an empty group info (if it does not already exist)
@@ -114,68 +118,19 @@ void FieldManager::register_group (const GroupRequest& req)
 void FieldManager::
 add_to_group (const std::string& field_name, const std::string& grid_name, const std::string& group_name)
 {
-  auto& info = m_field_group_info[group_name];
-  if (not info)
-    info = std::make_shared<FieldGroupInfo>(group_name);
-
-  EKAT_REQUIRE_MSG (m_repo_state==RepoState::Open or not info->m_monolithic_allocation,
-      "Error! Cannot add fields to a group that has a monolithic allocation once registration has ended.\n"
-      "   field name: " + field_name + "\n"
-      "   group name: " + group_name + "\n");
-
-  EKAT_REQUIRE_MSG (has_field(field_name, grid_name),
-      "Error! Cannot add field to group, since the field is not present in this FieldManager.\n"
-      "   field name: " + field_name + "\n"
-      "   grid name:  " + grid_name + "\n"
-      "   group name: " + group_name + "\n");
-
-  if (not ekat::contains(info->m_fields_names, field_name))
-    info->m_fields_names.push_back(field_name);
-
-  info->m_grid_registered[field_name].insert(grid_name);
-
-  // This method can be called
-  //  A) during regular field registration
-  //  B) at the end of registration_ends, to add each created field to its groups
-  //  C) after registration ended, to extent a group (possibly on one particular grid)
-  // In case A, repo will be Open, and no FieldGroup is created. For B/C, the repo is closed,
-  // and we have all necessary info to ensure the stored group has all fields set
-  if (m_repo_state==RepoState::Closed) {
-    auto& group = m_field_groups[grid_name][group_name];
-    if (group==nullptr)
-      group = std::make_shared<FieldGroup>(info,grid_name);
-
-    if (group->individual_fields().count(field_name)==0)
-      group->set_field(get_field(field_name,grid_name));
-
-    if (group->info()->m_monolithic_allocation and not group->has_monolithic_field())
-      group->set_monolithic_field(get_field(group_name,grid_name));
-
-    // If this method is called after registration_ends, this is needed.
-    // If it's called from inside registration_ends, it's redundant (but innocuous).
-    auto& ft = get_field(field_name, grid_name).get_header().get_tracking();
-    ft.add_group(group_name);
-  }
+  add_to_group_internal(field_name,grid_name,group_name,false);
 }
 
 bool FieldManager::
 has_field (const std::string& field_name, const std::string& grid_name) const {
-  return m_fields.at(grid_name).find(field_name)!=m_fields.at(grid_name).end();
+  return m_fields.find(grid_name)!=m_fields.end() and
+         m_fields.at(grid_name).find(field_name)!=m_fields.at(grid_name).end();
 }
 
 bool FieldManager::
 has_group (const std::string& group_name, const std::string& grid_name) const {
-  // Return true if there exists a group "name" and group
-  // "name" has at least one field registered on "grid_name"
-  if (m_field_group_info.count(group_name)>0) {
-    auto& group_info = m_field_group_info.at(group_name);
-    for (auto& fname : group_info->m_fields_names) {
-      if (ekat::contains(group_info->m_grid_registered.at(fname), grid_name)) {
-        return true;
-      }
-    }
-  }
-  return false;
+  return m_field_groups.find(grid_name)!=m_field_groups.end() and
+         m_field_groups.at(grid_name).find(group_name)!=m_field_groups.at(grid_name).end();
 }
 
 Field FieldManager::get_field (const std::string& name, const std::string& grid_name) const {
@@ -312,7 +267,7 @@ void FieldManager::registration_ends ()
     // we will remove this group.
     groups_with_monolithic_allocation.push_front("__qv__");
     m_field_group_info.emplace("__qv__",std::make_shared<FieldGroupInfo>("__qv__"));
-    m_field_group_info.at("__qv__")->m_fields_names.push_back("qv");
+    m_field_group_info.at("__qv__")->m_fields_names.insert("qv");
     qv_must_come_first = true;
   }
 
@@ -324,8 +279,8 @@ void FieldManager::registration_ends ()
     using cluster_type = std::list<std::string>;
 
     // Determine if two lists have elements in common (does not compute the intersection)
-    auto intersect = [] (const std::list<ci_string>& lhs,
-                        const std::list<ci_string>& rhs) -> bool {
+    auto intersect = [] (const std::set<ci_string>& lhs,
+                        const std::set<ci_string>& rhs) -> bool {
       for (const auto& s : lhs) {
         if (ekat::contains(rhs,s)) {
           return true;
@@ -372,28 +327,24 @@ void FieldManager::registration_ends ()
 
       LOL_t groups_fields;
       for (const auto& gn : cluster) {
-        groups_fields.push_back(m_field_group_info.at(gn)->m_fields_names);
+        auto gn_set = m_field_group_info.at(gn)->m_fields_names;
+        auto gn_list = std::list<ci_string>(gn_set.begin(),gn_set.end());
+        groups_fields.push_back(gn_list);
         ::scream::sort(groups_fields.back());
       }
 
       auto cluster_ordered_fields = contiguous_superset(groups_fields);
 
-      if (cluster_ordered_fields.size()==0) {
-        // We were not able to accommodate all the allocation requests for the groups
-        // in this cluster. We have to error out. But first, let's print some
-        // information, so the developers/users can have a shot at fixing this
-        // (e.g., by changing the request for monolithic allocation in some Atm Proc).
-        std::cout << "Error! Field manager was not able to accommodate the following\n"
-                  << "       requests for monolithically allocated groups:\n";
-        for (const auto& gn : cluster) {
-          std::cout << "   - " << gn << "\n";
-        }
-        std::cout << "       Consdier modifying the Atm Procs where these groups are requested.\n";
+      // If contiguous_superset returns a list of size 0, it means it was NOT
+      // able to accommodate all the contiguous allocation requests for the
+      // groups in this cluster. We must error out here.
+      EKAT_REQUIRE_MSG(cluster_ordered_fields.size()>0,
+          "Error! Field manager was not able to accommodate the following\n"
+          "       requests for monolithically allocated groups:\n"
+          " - " + ekat::join(cluster,"\n - ") + "\n"
+          "       Consdier modifying the Atm Procs where these groups are requested.\n");
 
-        EKAT_ERROR_MSG (" -- ERROR --\n");
-      }
-
-      // Ok, if we got here, it means we can allocate the cluster as a field, and then subview all the groups
+      // If we got here, it means we can allocate the cluster as a field, and then subview all the groups
       // Steps:
       //  - check if there's a group in the cluster containing all the fields. If yes, use that group
       //    name for the grouped field, otherwise make one up from the names of all groups in the cluster.
@@ -514,47 +465,57 @@ void FieldManager::registration_ends ()
         // Allocate
         C->allocate_view();
 
-        // Note: as of 02/2021, idim should *always* be 1, but we store it just in case,
+        // Note: as of 02/2021, subview_dim should *always* be 1, but we store it just in case,
         //       to avoid bugs in the future.
         const auto& C_tags = C->get_header().get_identifier().get_layout().tags();
-        const int idim = std::distance(C_tags.begin(),ekat::find(C_tags,CMP));
-        // See below where we assume idim is 1
-        EKAT_REQUIRE_MSG(idim==1, "Error! idim is assumed to be 1 in FieldManager::registration_ends().\n");
-
-        // If the cluster contains 2+ groups, ensure that also the individual groups
-        // do have a monolithic field in the repo.
-        if (cluster.size()>1) {
-          int vec_idx = c_layout.get_vector_component_idx();
-          for (auto group_name : cluster) {
-            const auto& info = *m_field_group_info.at(group_name);
-            // Find the first field of this group in the ordered cluster names.
-            auto it = std::find_first_of(cluster_ordered_fields.begin(),cluster_ordered_fields.end(),
-                                            info.m_fields_names.begin(),info.m_fields_names.end());
-            int beg = std::distance(cluster_ordered_fields.begin(),it);
-            int end = beg + info.size();
-
-            auto sub_layout = c_layout.clone().reset_dim(vec_idx,info.size());;
-            auto sub_fid = c_fid.clone(group_name).reset_layout(sub_layout);
-            register_field(sub_fid);
-            auto& sub_C = m_fields.at(cluster_grid_name).at(group_name);
-            *sub_C = C->subfield (group_name,vec_idx, beg, end);
-          }
-        }
+        const int subview_dim = std::distance(C_tags.begin(),ekat::find(C_tags,CMP));
+        // See below where we assume subview_dim is 1
+        EKAT_REQUIRE_MSG(subview_dim==1, "Error! subview_dim is assumed to be 1 in FieldManager::registration_ends().\n");
 
         // Create all individual subfields
         for (const auto& fn : cluster_ordered_fields) {
-          const auto pos = ekat::find(cluster_ordered_fields,fn);
-          const auto idx = std::distance(cluster_ordered_fields.begin(),pos);
-
           const auto& f = m_fields.at(cluster_grid_name).at(fn);
+          const auto pos = ekat::find(cluster_ordered_fields,fn);
+          const int idx = std::distance(cluster_ordered_fields.begin(),pos);
+
           const auto& fid = f->get_header().get_identifier();
           EKAT_REQUIRE_MSG (fid.get_units()!=ekat::units::Units::invalid(),
               "Error! A field was registered without providing valid units.\n"
               "  - field id: " + fid.get_id_string() + "\n");
-          auto fi = C->subfield(fn,fid.get_units(),idim,idx);
+          auto fi = C->subfield(fn,fid.get_units(),subview_dim,idx);
 
           // Overwrite existing field with subfield
           *f = fi;
+        }
+
+        // Set up individual groups: create the monolithic field (if needed) and set fields in the FieldGroup objects
+        for (auto group_name : cluster) {
+          // "__qv__" is a fake group, used only to ensure that qv is the 1st field in the tracers group.
+          if (group_name=="__qv__")
+            continue;
+
+          const auto& info = *m_field_group_info.at(group_name);
+          const auto& fnames = info.m_fields_names;
+          auto& group = m_field_groups[cluster_grid_name][group_name];
+          if (not group)
+            group = std::make_shared<FieldGroup>(group_name,cluster_grid_name);
+
+          if (group_name==cluster_name) {
+            // Simple: the monolithic field is the whole cluster
+            group->set_monolithic_field(*C);
+          } else {
+            // Find the first field of this group in the ordered cluster names.
+            auto first = std::find_first_of(cluster_ordered_fields.begin(),cluster_ordered_fields.end(),
+                                            fnames.begin(),fnames.end());
+            int subview_beg = std::distance(cluster_ordered_fields.begin(),first);
+            int subview_end = subview_beg+fnames.size();
+            auto sub_layout = c_layout.clone().reset_dim(subview_dim,info.size());;
+            auto sub_fid = c_fid.clone(group_name).reset_layout(sub_layout);
+            register_field(sub_fid);
+            auto& monolithic_f = *m_fields.at(cluster_grid_name).at(group_name);
+            monolithic_f = C->subfield (group_name,subview_dim,subview_beg,subview_end);
+            group->set_monolithic_field(monolithic_f);
+          }
         }
       }
 
@@ -563,76 +524,17 @@ void FieldManager::registration_ends ()
         m_field_group_info.erase(m_field_group_info.find("__qv__"));
         cluster.erase(ekat::find(cluster,"__qv__"));
       }
-
-      // Now, update the group info of all the field groups in the cluster
-      for (const auto& gn : cluster) {
-        auto& info = *m_field_group_info.at(gn);
-        const auto n = info.size();
-
-        // Find the first field of this group in the ordered cluster names.
-        auto first = std::find_first_of(cluster_ordered_fields.begin(),cluster_ordered_fields.end(),
-                                        info.m_fields_names.begin(),info.m_fields_names.end());
-        auto last = std::next(first,n);
-
-        // Some sanity checks: info.m_fields_names should be a rearrangement of what is
-        // in cluster_odered_fields[first,last)
-        EKAT_REQUIRE_MSG(first!=cluster_ordered_fields.end(),
-            "Error! Could not find any field of this group in the ordered cluster.\n"
-            "       Group name: " + gn + "\n");
-        EKAT_REQUIRE_MSG(std::distance(last,cluster_ordered_fields.end())>=0,
-            "Error! Something went wrong while looking for fields of this group in the ordered cluster.\n"
-            "       Group name: " + gn + "\n");
-        EKAT_REQUIRE_MSG(std::is_permutation(first,last,info.m_fields_names.begin(),info.m_fields_names.end()),
-            "Error! Something went wrong while looking for fields of this group in the ordered cluster.\n"
-            "       Group name: " + gn + "\n");
-
-        // Update the list of fields in the group info, mark it as monolithically
-        // allocated, and update the subfield indices too.
-        info.m_fields_names.clear();
-        for (auto it=first; it!=last; ++it) {
-          info.m_fields_names.push_back(*it);
-          info.m_subview_dim = 1; // Assumption is checked above
-          info.m_subview_idx [*it] = std::distance(cluster_ordered_fields.begin(),it);
-        }
-        info.m_monolithic_allocation = true;
-
-        // The subview indices will need to be corrected in the case of this group being
-        // itself a subgroup of the cluster field. We are guarenteed that the indices
-        // are contiguous, so just calculate the min idx and subtract from all fields indices.
-        int min_idx = std::numeric_limits<int>::max();
-        for (auto& it : info.m_subview_idx) {
-          if (it.second<min_idx) {
-            min_idx = it.second;
-          }
-        }
-        for (auto& it : info.m_subview_idx) {
-          it.second -= min_idx;
-        }
-      }
     }
   }
 
   for (auto grid_name : m_grids_mgr->get_grid_names()) {
     for (auto& it : m_fields.at(grid_name)) {
-      if (it.second->is_allocated()) {
-        // If the field has been already allocated, then it was in a bunlded group, so skip it.
+      if (it.second->is_allocated())
+        // If the field has been already allocated, then it was in a monolithic group, so skip it.
         continue;
-      }
       // A brand new field. Allocate it
       it.second->allocate_view();
     }
-
-    // for (const auto& it : m_field_group_info) {
-    //   if (m_group_requests.at(grid_name).find(it.first)!=m_group_requests.at(grid_name).end()) {
-    //     // Get fields in this group
-    //     auto group_info = it.second;
-    //     const auto& fnames = group_info->m_fields_names;
-    //     for (const auto& fn : fnames) {
-    //       // Update the field tracking
-    //       m_fields.at(grid_name).at(fn)->get_header().get_tracking().add_group(group_info->m_group_name);
-    //     }
-    //   }
-    // }
   }
 
   // Prohibit further registration of fields to this repo
@@ -643,7 +545,7 @@ void FieldManager::registration_ends ()
   for (const auto& [group_name, info] : m_field_group_info)
     for (const auto& [field_name, grids] : info->m_grid_registered)
       for (const auto& grid_name : grids)
-        add_to_group(field_name,grid_name,group_name);
+        add_to_group_internal(field_name,grid_name,group_name,true);
 }
 
 void FieldManager::clean_up() {
@@ -684,34 +586,45 @@ void FieldManager::add_field (const Field& f) {
       "Error! The method 'add_field' requires the input field to not be already existing.\n"
       "  - field name: " + f.get_header().get_identifier().name() + "\n");
 
-  const auto& groups = f.get_header().get_tracking().get_groups_names();
-  for (const auto& group_name : groups) {
-    auto& group_info = m_field_group_info[group_name];
-    if (group_info) {
-
-      EKAT_REQUIRE_MSG (not group_info->m_monolithic_allocation,
-        "Error! When calling 'add_field', one of the following must be true:\n"
-        "  - the input field is not be part of any group,\n"
-        "  - there were no group requests for any of the field groups.\n"
-        "  - the groups that the field belongs to do NOT have a monolithic field.\n"
-        "The reason for this is that otherwise we *might* have missed some inclusion dependency\n"
-        "when we allocated the fields for one of those groups.\n");
-    } else {
-      // This group was not initially requested, so create a new group info
-      group_info = std::make_shared<FieldGroupInfo>(group_name);
-    }
-
-    // Add this field to the group info
-    if (not ekat::contains(group_info->m_fields_names,f.name())) {
-      group_info->m_fields_names.emplace_back(f.name());
-    }
-  }
-
   // All good, add the field to the repo
   m_fields[grid_name][f.get_header().get_identifier().name()] = std::make_shared<Field>(f);
 
   // If it was not closed before, it is now
   m_repo_state = RepoState::Closed;
+
+  const auto& groups = f.get_header().get_tracking().get_groups_names();
+  for (const auto& group_name : groups) {
+    add_to_group(f.name(),grid_name,group_name);
+  }
+}
+
+void FieldManager::
+add_to_group_internal (const std::string& field_name, const std::string& grid_name,
+                       const std::string& group_name, const bool monolithic_ok)
+{
+  EKAT_REQUIRE_MSG (has_field(field_name, grid_name),
+      "Error! Cannot add field to group, since the field is not present in this FieldManager.\n"
+      "   field name: " + field_name + "\n"
+      "   grid name:  " + grid_name + "\n"
+      "   group name: " + group_name + "\n");
+
+  auto& group = m_field_groups[grid_name][group_name];
+  if (not group)
+    group = std::make_shared<FieldGroup>(group_name,grid_name);
+
+  EKAT_REQUIRE_MSG (not group->has_monolithic_field() or monolithic_ok,
+      "Error! Cannot add fields to a group that stores a monolithic field after registration has ended.\n"
+      "   field name: " + field_name + "\n"
+      "   group name: " + group_name + "\n"
+      "   grid name : " + grid_name + "\n");
+
+  auto f = get_field(field_name,grid_name);
+  if (group->individual_fields().count(field_name)==0)
+    group->set_field(f);
+
+  // If this method is called from add_field, it is redundant, but otherwise it's needed.
+  auto& ft = f.get_header().get_tracking();
+  ft.add_group(group_name);
 }
 
 void FieldManager::pre_process_monolithic_group_requests () {
@@ -735,8 +648,11 @@ void FieldManager::pre_process_monolithic_group_requests () {
     // Register fields on all grids
     for (auto field_name : group_info->m_fields_names) {
       for (auto grid_name : grids_in_group) {
-        // Field already registered on grid, nothing to do
-        if (has_field(field_name, grid_name)) continue;
+        // Field already registered on grid. Just make sure group_info has it down for this grid
+        if (has_field(field_name, grid_name)) {
+          group_info->m_grid_registered[field_name].insert(grid_name);
+          continue;
+        }
 
         // Find the grid which registered this field.
         // Note: We require *exactly one* grid has registered the field
@@ -760,11 +676,7 @@ void FieldManager::pre_process_monolithic_group_requests () {
         const auto fl = m_grids_mgr->get_grid(grid_name)->equivalent_layout(src_fid.get_layout());
         auto fid = src_fid.clone().reset_layout(fl).reset_grid(grid_name);
 
-        // Register the field for each group req
-        for (auto greq : m_group_requests.at(grid_name).at(group_name)) {
-          FieldRequest req(fid, greq.name, greq.pack_size);
-          register_field(req);
-        }
+        register_field(FieldRequest(fid,group_name));
       }
     }
   }

--- a/components/eamxx/src/share/data_managers/field_manager.hpp
+++ b/components/eamxx/src/share/data_managers/field_manager.hpp
@@ -117,16 +117,14 @@ public:
     return get_field(name, m_grids_mgr->get_repo().begin()->second->name());
   }
 
-  FieldGroupInfo get_group_info (const std::string& group_name) const {
-    EKAT_ASSERT_MSG(m_grids_mgr->size() == 1,
-      "Error! More than one grid exists for FieldManager, must specify grid name to query for FieldGroupInfo.\n"
-      "  - Group name: " + group_name + "\n"
-      "  - Grids in FM: " + m_grids_mgr->print_available_grids() + "\n");
-    return get_group_info(group_name, m_grids_mgr->get_repo().begin()->second->name());
-  }
-  FieldGroupInfo get_group_info (const std::string& group_name, const std::string& grid_name) const;
-
   FieldGroup get_field_group (const std::string& name, const std::string& grid_name);
+  FieldGroup get_field_group (const std::string& name) {
+    EKAT_ASSERT_MSG(m_grids_mgr->size() == 1,
+      "Error! More than one grid exists for FieldManager, must specify grid name to get group.\n"
+      "  - Field name: " + name + "\n"
+      "  - Grids in FM: " + m_grids_mgr->print_available_grids() + "\n");
+    return get_field_group(name, m_grids_mgr->get_repo().begin()->second->name());
+  }
 
   const std::map<ci_string,std::shared_ptr<Field>>&
   get_repo () const {

--- a/components/eamxx/src/share/data_managers/field_manager.hpp
+++ b/components/eamxx/src/share/data_managers/field_manager.hpp
@@ -37,8 +37,8 @@ public:
   using header_type         = typename Field::header_type;
   using identifier_type     = typename Field::identifier_type;
   using ci_string           = typename identifier_type::ci_string;
-  using repo_type           = std::map<ci_string,std::map<ci_string,std::shared_ptr<Field>>>;
-  using field_group_type    = std::map<ci_string,std::map<ci_string,std::shared_ptr<FieldGroup>>>;
+  using field_repo_type     = std::map<ci_string,std::map<ci_string,std::shared_ptr<Field>>>;
+  using group_repo_type     = std::map<ci_string,std::map<ci_string,std::shared_ptr<FieldGroup>>>;
   using group_info_map      = std::map<ci_string, std::shared_ptr<FieldGroupInfo>>;
 
   // Constructor(s)
@@ -165,11 +165,11 @@ protected:
   // The state of the repository
   RepoState m_repo_state;
 
-  // The actual repo.
-  repo_type           m_fields;
+  // The field repo: m_fields[grid_name][field_name] = f
+  field_repo_type     m_fields;
 
-  // Preprocessed field groups
-  field_group_type    m_field_groups;
+  // The group repo: m_field_groups[grid_name][group_name] = g
+  group_repo_type     m_field_groups;
 
   // The map group_name -> FieldGroupInfo
   group_info_map      m_field_group_info;

--- a/components/eamxx/src/share/data_managers/field_manager.hpp
+++ b/components/eamxx/src/share/data_managers/field_manager.hpp
@@ -3,6 +3,7 @@
 
 #include "share/data_managers/grids_manager.hpp"
 #include "share/data_managers/field_request.hpp"
+#include "share/data_managers/field_group_info.hpp"
 #include "share/grid/abstract_grid.hpp"
 #include "share/field/field.hpp"
 #include "share/field/field_group.hpp"
@@ -77,7 +78,6 @@ public:
     return add_to_group(field_name, m_grids_mgr->get_repo().begin()->second->name(),group_name);
   }
   void add_to_group (const std::string& field_name, const std::string& grid_name, const std::string& group_name);
-  void add_to_group (const identifier_type& id, const std::string& group_name) { add_to_group(id.name(), id.get_grid_name(), group_name); }
 
   // Query for a particular field or group of fields
   bool has_field (const std::string& field_name, const std::string& grid_name) const;
@@ -158,6 +158,9 @@ public:
 
 protected:
 
+  // Called by add_to_group, but skips some checks. Used at the end of registration_ends.
+  void add_to_group_internal (const std::string& field_name, const std::string& grid_name,
+                              const std::string& group_name, const bool monolithic_ok);
   void pre_process_monolithic_group_requests ();
 
   // The state of the repository

--- a/components/eamxx/src/share/data_managers/library_grids_manager.hpp
+++ b/components/eamxx/src/share/data_managers/library_grids_manager.hpp
@@ -20,7 +20,7 @@ public:
 
   virtual ~LibraryGridsManager () = default;
 
-  std::string name () const { return "Library grids_manager"; }
+  std::string name () const override { return "Library grids_manager"; }
 
   void build_grids () override {}
 
@@ -35,7 +35,7 @@ public:
 protected:
   remapper_ptr_type
   do_create_remapper (const grid_ptr_type from_grid,
-                      const grid_ptr_type to_grid) const
+                      const grid_ptr_type to_grid) const override
   {
     EKAT_ERROR_MSG (
         "Error! LibraryGridsManager is not capable of creating remappers.\n"

--- a/components/eamxx/src/share/data_managers/tests/field_mgr_tests.cpp
+++ b/components/eamxx/src/share/data_managers/tests/field_mgr_tests.cpp
@@ -112,12 +112,12 @@ TEST_CASE("field_mgr", "") {
   auto gr1_1 = field_mgr.get_field_group("group_1", "grid1");
   auto gr1_2 = field_mgr.get_field_group("group_1", "grid2");
   auto gr2_2 = field_mgr.get_field_group("group_2", "grid2");
-  REQUIRE (gr1_1.info()->m_fields_names.size()==1);
-  REQUIRE (gr1_2.info()->m_fields_names.size()==1);
-  REQUIRE (gr2_2.info()->m_fields_names.size()==1);
-  REQUIRE (ekat::contains(gr1_1.info()->m_fields_names,"Field2"));
-  REQUIRE (ekat::contains(gr1_2.info()->m_fields_names,"Field1"));
-  REQUIRE (ekat::contains(gr2_2.info()->m_fields_names,"Field1"));
+  REQUIRE (gr1_1.size()==1);
+  REQUIRE (gr1_2.size()==1);
+  REQUIRE (gr2_2.size()==1);
+  REQUIRE (gr1_1.individual_fields().count("field2")==1);
+  REQUIRE (gr1_2.individual_fields().count("field1")==1);
+  REQUIRE (gr2_2.individual_fields().count("field1")==1);
 
   // Check alloc props for f1 and f2 (which requested pack size > 1)
   auto f1_1_padding = f1_1.get_header().get_alloc_properties().get_padding();
@@ -185,18 +185,16 @@ TEST_CASE("tracers_group", "") {
   auto b2 = field_mgr.get_field("b", gn2);
   auto c2 = field_mgr.get_field("c", gn2);
 
-  // No subtracer field should exist since it is not
-  // a parent of any field.
-  REQUIRE_THROWS (field_mgr.get_field("subtracers", gn1));
-  REQUIRE_THROWS (field_mgr.get_field("subtracers", gn2));
-
   // The field_mgr should have allocated the group as a monolith
   auto tracers1 = field_mgr.get_field_group("tracers", gn1);
   auto tracers2 = field_mgr.get_field_group("tracers", gn2);
   auto subtracers = field_mgr.get_field_group("subtracers", gn1);
-  REQUIRE (tracers1.info()->m_monolithic_allocation);
-  REQUIRE (tracers2.info()->m_monolithic_allocation);
-  REQUIRE (subtracers.info()->m_monolithic_allocation);
+  REQUIRE (tracers1.has_monolithic_field());
+  REQUIRE (tracers2.has_monolithic_field());
+  REQUIRE (subtracers.has_monolithic_field());
+  REQUIRE (tracers1.size()==4);
+  REQUIRE (tracers2.size()==4);
+  REQUIRE (subtracers.size()==2);
 
   // The monolithic field in the tracers group should match the field we get from the field_mgr
   REQUIRE (T1.is_aliasing(tracers1.monolithic_field()));
@@ -226,20 +224,27 @@ TEST_CASE("tracers_group", "") {
     subtracers.monolithic_field().get_header().get_parent() != nullptr &&
     subtracers.monolithic_field().get_header().get_parent().get() == &T1.get_header()));
 
-  const auto idx_qv1 = tracers1.info()->m_subview_idx.at("qv");
-  const auto idx_a1 = tracers1.info()->m_subview_idx.at("a");
-  const auto idx_b1 = tracers1.info()->m_subview_idx.at("b");
-  const auto idx_c1 = tracers1.info()->m_subview_idx.at("c");
-  const auto idx_qv2 = tracers2.info()->m_subview_idx.at("qv");
-  const auto idx_a2 = tracers2.info()->m_subview_idx.at("a");
-  const auto idx_b2 = tracers2.info()->m_subview_idx.at("b");
-  const auto idx_c2 = tracers2.info()->m_subview_idx.at("c");
+  const auto qv1_sub = tracers1.individual_fields().at("qv");
+  const auto a1_sub = tracers1.individual_fields().at("a");
+  const auto b1_sub = tracers1.individual_fields().at("b");
+  const auto c1_sub = tracers1.individual_fields().at("c");
+  const auto qv2_sub = tracers2.individual_fields().at("qv");
+  const auto a2_sub = tracers2.individual_fields().at("a");
+  const auto b2_sub = tracers2.individual_fields().at("b");
+  const auto c2_sub = tracers2.individual_fields().at("c");
 
-  const auto sub_idx_b1 = subtracers.info()->m_subview_idx.at("b");
-  const auto sub_idx_c1 = subtracers.info()->m_subview_idx.at("c");
+  auto idx_qv1 = qv1_sub.get_header().get_alloc_properties().get_subview_info().slice_idx;
+  auto idx_a1 = a1_sub.get_header().get_alloc_properties().get_subview_info().slice_idx;
+  auto idx_b1 = b1_sub.get_header().get_alloc_properties().get_subview_info().slice_idx;
+  auto idx_c1 = c1_sub.get_header().get_alloc_properties().get_subview_info().slice_idx;
+  auto idx_qv2 = qv2_sub.get_header().get_alloc_properties().get_subview_info().slice_idx;
+  auto idx_a2 = a2_sub.get_header().get_alloc_properties().get_subview_info().slice_idx;
+  auto idx_b2 = b2_sub.get_header().get_alloc_properties().get_subview_info().slice_idx;
+  auto idx_c2 = c2_sub.get_header().get_alloc_properties().get_subview_info().slice_idx;
 
   // Subview indices of all groups should be identical over requested grids
   REQUIRE (idx_qv1 == idx_qv2);
+  REQUIRE (idx_qv1 == 0); // qv should always be the first tracer
   REQUIRE (idx_a1 == idx_a2);
   REQUIRE (idx_b1 == idx_b2);
   REQUIRE (idx_c1 == idx_c2);
@@ -249,10 +254,6 @@ TEST_CASE("tracers_group", "") {
   REQUIRE ((0<=idx_a1 and idx_a1<=3));
   REQUIRE ((0<=idx_b1 and idx_b1<=3));
   REQUIRE ((0<=idx_c1 and idx_c1<=3));
-
-  // Indices of sub tracers should be between [0,2)
-  REQUIRE ((0<=sub_idx_b1 and sub_idx_b1<=1));
-  REQUIRE ((0<=sub_idx_c1 and sub_idx_c1<=1));
 
   // Now fill tracer field with random values
   int seed = get_random_test_seed(&comm);
@@ -300,6 +301,8 @@ TEST_CASE("tracers_group", "") {
   sub_T1.sync_to_host();
   auto sub_T1_h = sub_T1.get_strided_view<Real***,Host>();
 
+  int sub_idx_b1 = idx_b1<idx_c1 ? 0 : 1;
+  int sub_idx_c1 = idx_b1<idx_c1 ? 1 : 0;
   for (int icol=0; icol<ncols1; ++icol) {
     for (int ilev=0; ilev<nlevs; ++ilev) {
       REQUIRE (sub_T1_h(icol,sub_idx_b1,ilev)==b1_h(icol,ilev));

--- a/components/eamxx/src/share/data_managers/tests/field_mgr_tests.cpp
+++ b/components/eamxx/src/share/data_managers/tests/field_mgr_tests.cpp
@@ -109,15 +109,15 @@ TEST_CASE("field_mgr", "") {
   REQUIRE (field_mgr.has_group("group_2", "grid2"));
 
   // Check that the groups in the field_mgr contain the correct fields
-  auto gr1_1 = field_mgr.get_group_info("group_1", "grid1");
-  auto gr1_2 = field_mgr.get_group_info("group_1", "grid2");
-  auto gr2_2 = field_mgr.get_group_info("group_2", "grid2");
-  REQUIRE (gr1_1.m_fields_names.size()==1);
-  REQUIRE (gr1_2.m_fields_names.size()==1);
-  REQUIRE (gr2_2.m_fields_names.size()==1);
-  REQUIRE (ekat::contains(gr1_1.m_fields_names,"Field2"));
-  REQUIRE (ekat::contains(gr1_2.m_fields_names,"Field1"));
-  REQUIRE (ekat::contains(gr2_2.m_fields_names,"Field1"));
+  auto gr1_1 = field_mgr.get_field_group("group_1", "grid1");
+  auto gr1_2 = field_mgr.get_field_group("group_1", "grid2");
+  auto gr2_2 = field_mgr.get_field_group("group_2", "grid2");
+  REQUIRE (gr1_1.info()->m_fields_names.size()==1);
+  REQUIRE (gr1_2.info()->m_fields_names.size()==1);
+  REQUIRE (gr2_2.info()->m_fields_names.size()==1);
+  REQUIRE (ekat::contains(gr1_1.info()->m_fields_names,"Field2"));
+  REQUIRE (ekat::contains(gr1_2.info()->m_fields_names,"Field1"));
+  REQUIRE (ekat::contains(gr2_2.info()->m_fields_names,"Field1"));
 
   // Check alloc props for f1 and f2 (which requested pack size > 1)
   auto f1_1_padding = f1_1.get_header().get_alloc_properties().get_padding();

--- a/components/eamxx/src/share/data_managers/tests/field_mgr_tests.cpp
+++ b/components/eamxx/src/share/data_managers/tests/field_mgr_tests.cpp
@@ -194,13 +194,13 @@ TEST_CASE("tracers_group", "") {
   auto tracers1 = field_mgr.get_field_group("tracers", gn1);
   auto tracers2 = field_mgr.get_field_group("tracers", gn2);
   auto subtracers = field_mgr.get_field_group("subtracers", gn1);
-  REQUIRE (tracers1.m_info->m_monolithic_allocation);
-  REQUIRE (tracers2.m_info->m_monolithic_allocation);
-  REQUIRE (subtracers.m_info->m_monolithic_allocation);
+  REQUIRE (tracers1.info()->m_monolithic_allocation);
+  REQUIRE (tracers2.info()->m_monolithic_allocation);
+  REQUIRE (subtracers.info()->m_monolithic_allocation);
 
   // The monolithic field in the tracers group should match the field we get from the field_mgr
-  REQUIRE (T1.is_aliasing(*tracers1.m_monolithic_field));
-  REQUIRE (T2.is_aliasing(*tracers2.m_monolithic_field));
+  REQUIRE (T1.is_aliasing(tracers1.monolithic_field()));
+  REQUIRE (T2.is_aliasing(tracers2.monolithic_field()));
 
   // Require that the parent of each field is the "tracers" group
   auto qv1_p = qv1.get_header().get_parent();
@@ -223,20 +223,20 @@ TEST_CASE("tracers_group", "") {
 
   // Require subtracers monolith is subfield of tracers
   REQUIRE ((
-    subtracers.m_monolithic_field->get_header().get_parent() != nullptr &&
-    subtracers.m_monolithic_field->get_header().get_parent().get() == &T1.get_header()));
+    subtracers.monolithic_field().get_header().get_parent() != nullptr &&
+    subtracers.monolithic_field().get_header().get_parent().get() == &T1.get_header()));
 
-  const auto idx_qv1 = tracers1.m_info->m_subview_idx.at("qv");
-  const auto idx_a1 = tracers1.m_info->m_subview_idx.at("a");
-  const auto idx_b1 = tracers1.m_info->m_subview_idx.at("b");
-  const auto idx_c1 = tracers1.m_info->m_subview_idx.at("c");
-  const auto idx_qv2 = tracers2.m_info->m_subview_idx.at("qv");
-  const auto idx_a2 = tracers2.m_info->m_subview_idx.at("a");
-  const auto idx_b2 = tracers2.m_info->m_subview_idx.at("b");
-  const auto idx_c2 = tracers2.m_info->m_subview_idx.at("c");
+  const auto idx_qv1 = tracers1.info()->m_subview_idx.at("qv");
+  const auto idx_a1 = tracers1.info()->m_subview_idx.at("a");
+  const auto idx_b1 = tracers1.info()->m_subview_idx.at("b");
+  const auto idx_c1 = tracers1.info()->m_subview_idx.at("c");
+  const auto idx_qv2 = tracers2.info()->m_subview_idx.at("qv");
+  const auto idx_a2 = tracers2.info()->m_subview_idx.at("a");
+  const auto idx_b2 = tracers2.info()->m_subview_idx.at("b");
+  const auto idx_c2 = tracers2.info()->m_subview_idx.at("c");
 
-  const auto sub_idx_b1 = subtracers.m_info->m_subview_idx.at("b");
-  const auto sub_idx_c1 = subtracers.m_info->m_subview_idx.at("c");
+  const auto sub_idx_b1 = subtracers.info()->m_subview_idx.at("b");
+  const auto sub_idx_c1 = subtracers.info()->m_subview_idx.at("c");
 
   // Subview indices of all groups should be identical over requested grids
   REQUIRE (idx_qv1 == idx_qv2);
@@ -295,10 +295,10 @@ TEST_CASE("tracers_group", "") {
 
   // Check that changing sub tracers change tracers group and individual tracers
   T1.deep_copy(0.0);
-  auto& sub_T1 = subtracers.m_monolithic_field;
-  randomize_uniform(*sub_T1,seed++);
-  sub_T1->sync_to_host();
-  auto sub_T1_h = sub_T1->get_strided_view<Real***,Host>();
+  auto& sub_T1 = subtracers.monolithic_field();
+  randomize_uniform(sub_T1,seed++);
+  sub_T1.sync_to_host();
+  auto sub_T1_h = sub_T1.get_strided_view<Real***,Host>();
 
   for (int icol=0; icol<ncols1; ++icol) {
     for (int ilev=0; ilev<nlevs; ++ilev) {
@@ -308,30 +308,30 @@ TEST_CASE("tracers_group", "") {
   }
 
   // Check that the field ptrs stored in the group are the same as the fields
-  auto qv1_ptr = tracers1.m_individual_fields.at("qv");
-  auto a1_ptr = tracers1.m_individual_fields.at("a");
-  auto b1_ptr = tracers1.m_individual_fields.at("b");
-  auto c1_ptr = tracers1.m_individual_fields.at("c");
+  auto qv1_from_group = tracers1.individual_fields().at("qv");
+  auto a1_from_group = tracers1.individual_fields().at("a");
+  auto b1_from_group = tracers1.individual_fields().at("b");
+  auto c1_from_group = tracers1.individual_fields().at("c");
 
-  REQUIRE (qv1_ptr->is_aliasing(qv1));
-  REQUIRE (a1_ptr->is_aliasing(a1));
-  REQUIRE (b1_ptr->is_aliasing(b1));
-  REQUIRE (c1_ptr->is_aliasing(c1));
+  REQUIRE (qv1_from_group.is_aliasing(qv1));
+  REQUIRE (a1_from_group.is_aliasing(a1));
+  REQUIRE (b1_from_group.is_aliasing(b1));
+  REQUIRE (c1_from_group.is_aliasing(c1));
 
-  auto qv2_ptr = tracers2.m_individual_fields.at("qv");
-  auto a2_ptr = tracers2.m_individual_fields.at("a");
-  auto b2_ptr = tracers2.m_individual_fields.at("b");
-  auto c2_ptr = tracers2.m_individual_fields.at("c");
+  auto qv2_from_group = tracers2.individual_fields().at("qv");
+  auto a2_from_group = tracers2.individual_fields().at("a");
+  auto b2_from_group = tracers2.individual_fields().at("b");
+  auto c2_from_group = tracers2.individual_fields().at("c");
 
-  REQUIRE (qv2_ptr->is_aliasing(qv2));
-  REQUIRE (a2_ptr->is_aliasing(a2));
-  REQUIRE (b2_ptr->is_aliasing(b2));
-  REQUIRE (c2_ptr->is_aliasing(c2));
+  REQUIRE (qv2_from_group.is_aliasing(qv2));
+  REQUIRE (a2_from_group.is_aliasing(a2));
+  REQUIRE (b2_from_group.is_aliasing(b2));
+  REQUIRE (c2_from_group.is_aliasing(c2));
 
-  b1_ptr = subtracers.m_individual_fields.at("b");
-  c1_ptr = subtracers.m_individual_fields.at("c");
-  REQUIRE (b1_ptr->is_aliasing(b1));
-  REQUIRE (c1_ptr->is_aliasing(c1));
+  b1_from_group = subtracers.individual_fields().at("b");
+  c1_from_group = subtracers.individual_fields().at("c");
+  REQUIRE (b1_from_group.is_aliasing(b1));
+  REQUIRE (c1_from_group.is_aliasing(c1));
 }
 
 } // anonymous scream

--- a/components/eamxx/src/share/field/field_group.cpp
+++ b/components/eamxx/src/share/field/field_group.cpp
@@ -2,49 +2,67 @@
 
 namespace scream {
 
-FieldGroup::FieldGroup (const std::string& name)
- : m_info (new FieldGroupInfo(name))
+FieldGroup::FieldGroup (const std::string& name, const std::string& grid_name)
+ : FieldGroup(std::make_shared<FieldGroupInfo>(name),grid_name)
 {
   // Nothing to do here
 }
 
 FieldGroup::
-FieldGroup (const FieldGroupInfo& info)
- : m_info (new FieldGroupInfo(info))
+FieldGroup (const std::shared_ptr<FieldGroupInfo>& info,
+            const std::string& grid_name)
+ : m_info (info)
+ , m_grid_name(grid_name)
 {
-  // Nothing to do here
+  m_individual_fields = std::make_shared<std::map<ci_string,Field>>();
 }
 
 FieldGroup
-FieldGroup::get_const () const {
-  FieldGroup gr(*m_info);
-  if (m_info->m_monolithic_allocation) {
-    gr.m_monolithic_field = std::make_shared<Field>(m_monolithic_field->get_const());
-  }
-  for (const auto& it : m_individual_fields) {
-    gr.m_individual_fields[it.first] = std::make_shared<Field>(it.second->get_const());
-  }
-  return gr;
+FieldGroup::get_const () const
+{
+  FieldGroup cgroup(m_info,m_grid_name);
+  if (m_monolithic_field!=nullptr)
+    cgroup.m_monolithic_field = std::make_shared<Field>(m_monolithic_field->get_const());
+
+  for (const auto& it : *m_individual_fields)
+    cgroup.set_field(it.second.get_const());
+
+  return cgroup;
 }
 
-const std::string& FieldGroup::grid_name () const {
-  EKAT_REQUIRE_MSG(m_individual_fields.size()>0 || m_monolithic_field,
-      "Error! Cannot establish the group grid name until fields have been added.\n");
+void FieldGroup::
+set_field (const Field& f)
+{
+  EKAT_REQUIRE_MSG (m_individual_fields->count(f.name())==0,
+      "[FieldGroup] Error! Cannot reset an individual field once set.\n"
+      " - group name: " + m_info->m_group_name + "\n"
+      " - grid name : " + m_grid_name + "\n"
+      " - field name: " + f.name() + "\n");
+  EKAT_REQUIRE_MSG (ekat::contains(m_info->m_fields_names,f.name()),
+      "[FieldGroup] Error! Field was not listed as part of the group.\n"
+      " - group name: " + m_info->m_group_name + "\n"
+      " - grid name : " + m_grid_name + "\n"
+      " - field name: " + f.name() + "\n");
 
-  if (m_monolithic_field) {
-    const auto& id = m_monolithic_field->get_header().get_identifier();
-    return id.get_grid_name();
-  } else {
-    const auto& id = m_individual_fields.begin()->second->get_header().get_identifier();
-    return id.get_grid_name();
-  }
+
+  (*m_individual_fields)[f.name()] = f;
 }
 
-void FieldGroup::copy_fields (const FieldGroup& src) {
-  m_monolithic_field = src.m_monolithic_field;
-  for (auto it : src.m_individual_fields) {
-    m_individual_fields[it.first] = it.second;
-  }
+void FieldGroup::set_monolithic_field (const Field& f)
+{
+  EKAT_REQUIRE_MSG (m_monolithic_field==nullptr,
+      "[FieldGroup] Error! Cannot reset the monolithic field once set.\n"
+      " - group name: " + m_info->m_group_name + "\n"
+      " - grid name : " + m_grid_name + "\n"
+      " - field name: " + f.name() + "\n");
+
+  EKAT_REQUIRE_MSG (m_info->m_monolithic_allocation,
+      "[FieldGroup] Error! Cannot set the monolithic field if monolithic allocation was not requested.\n"
+      " - group name: " + m_info->m_group_name + "\n"
+      " - grid name : " + m_grid_name + "\n"
+      " - field name: " + f.name() + "\n");
+
+  m_monolithic_field = std::make_shared<Field>(f);
 }
 
 } // namespace scream

--- a/components/eamxx/src/share/field/field_group.cpp
+++ b/components/eamxx/src/share/field/field_group.cpp
@@ -3,29 +3,20 @@
 namespace scream {
 
 FieldGroup::FieldGroup (const std::string& name, const std::string& grid_name)
- : FieldGroup(std::make_shared<FieldGroupInfo>(name),grid_name)
-{
-  // Nothing to do here
-}
-
-FieldGroup::
-FieldGroup (const std::shared_ptr<FieldGroupInfo>& info,
-            const std::string& grid_name)
- : m_info (info)
+ : m_name (name)
  , m_grid_name(grid_name)
 {
-  m_individual_fields = std::make_shared<std::map<ci_string,Field>>();
+  m_individual_fields = std::make_shared<std::map<std::string,Field>>();
+  m_monolithic_field  = std::make_shared<Field>();
 }
 
 FieldGroup
 FieldGroup::get_const () const
 {
-  FieldGroup cgroup(m_info,m_grid_name);
-  if (m_monolithic_field!=nullptr)
-    cgroup.m_monolithic_field = std::make_shared<Field>(m_monolithic_field->get_const());
-
-  for (const auto& it : *m_individual_fields)
-    cgroup.set_field(it.second.get_const());
+  FieldGroup cgroup(m_name,m_grid_name);
+  cgroup.m_monolithic_field = std::make_shared<Field>(m_monolithic_field->get_const());
+  for (auto [fn,f] : *m_individual_fields)
+    (*cgroup.m_individual_fields)[fn] = f.get_const();
 
   return cgroup;
 }
@@ -35,34 +26,66 @@ set_field (const Field& f)
 {
   EKAT_REQUIRE_MSG (m_individual_fields->count(f.name())==0,
       "[FieldGroup] Error! Cannot reset an individual field once set.\n"
-      " - group name: " + m_info->m_group_name + "\n"
-      " - grid name : " + m_grid_name + "\n"
-      " - field name: " + f.name() + "\n");
-  EKAT_REQUIRE_MSG (ekat::contains(m_info->m_fields_names,f.name()),
-      "[FieldGroup] Error! Field was not listed as part of the group.\n"
-      " - group name: " + m_info->m_group_name + "\n"
+      " - group name: " + m_name + "\n"
       " - grid name : " + m_grid_name + "\n"
       " - field name: " + f.name() + "\n");
 
+  if (has_monolithic_field()) {
+    // Run additional checks, to ensure the field is TRULY a subfield of the monolithic one
+    auto fp = f.get_header().get_parent();
+    EKAT_REQUIRE_MSG (fp!=nullptr,
+        "[FieldGroup::set_field] Error! Input field has no parent, but the group stores a monolithic_field.\n"
+        " - group name: " + m_name + "\n"
+        " - grid name : " + m_grid_name + "\n"
+        " - field name: " + f.name() + "\n");
+
+    auto mp = m_monolithic_field->get_header().get_parent();
+    if (mp==nullptr)
+      EKAT_REQUIRE_MSG (fp->get_identifier().name()==m_monolithic_field->name(),
+          "[FieldGroup::set_field] Error! Input field does not seem to be a subfield of the monolithic field.\n"
+          " - group name: " + m_name + "\n"
+          " - grid name : " + m_grid_name + "\n"
+          " - field name: " + f.name() + "\n");
+    else {
+      // Same parent field
+      EKAT_REQUIRE_MSG (fp==mp,
+          "[FieldGroup::set_field] Error! Input field does not seem to be a subfield of the monolithic field.\n"
+          " - group name: " + m_name + "\n"
+          " - grid name : " + m_grid_name + "\n"
+          " - field name: " + f.name() + "\n");
+
+      // The slice idx of f is in [m_beg,m_end] slice idx range
+      auto m_beg = m_monolithic_field->get_header().get_alloc_properties().get_subview_info().slice_idx;
+      auto m_end = m_monolithic_field->get_header().get_alloc_properties().get_subview_info().slice_idx_end;
+      auto f_idx = f.get_header().get_alloc_properties().get_subview_info().slice_idx;
+
+      EKAT_REQUIRE_MSG (m_beg<=f_idx and f_idx<m_end,
+          "[FieldGroup::set_field] Error! Input field does not seem to be a subfield of the monolithic field.\n"
+          " - group name: " + m_name + "\n"
+          " - grid name : " + m_grid_name + "\n"
+          " - field name: " + f.name() + "\n");
+    }
+  }
+
+  EKAT_REQUIRE_MSG (f.is_allocated(),
+      "[FieldGroup::set_field] Error! Input field has not yet been allocated.\n"
+      " - group name: " + m_name + "\n"
+      " - grid name : " + m_grid_name + "\n"
+      " - field name: " + f.name() + "\n");
 
   (*m_individual_fields)[f.name()] = f;
 }
 
-void FieldGroup::set_monolithic_field (const Field& f)
+void FieldGroup::
+set_monolithic_field (const Field& f)
 {
-  EKAT_REQUIRE_MSG (m_monolithic_field==nullptr,
+  EKAT_REQUIRE_MSG (not m_monolithic_field->is_allocated(),
       "[FieldGroup] Error! Cannot reset the monolithic field once set.\n"
-      " - group name: " + m_info->m_group_name + "\n"
+      " - group name: " + m_name + "\n"
       " - grid name : " + m_grid_name + "\n"
       " - field name: " + f.name() + "\n");
 
-  EKAT_REQUIRE_MSG (m_info->m_monolithic_allocation,
-      "[FieldGroup] Error! Cannot set the monolithic field if monolithic allocation was not requested.\n"
-      " - group name: " + m_info->m_group_name + "\n"
-      " - grid name : " + m_grid_name + "\n"
-      " - field name: " + f.name() + "\n");
-
-  m_monolithic_field = std::make_shared<Field>(f);
+  *m_monolithic_field = f;
 }
 
 } // namespace scream

--- a/components/eamxx/src/share/field/field_group.hpp
+++ b/components/eamxx/src/share/field/field_group.hpp
@@ -42,11 +42,13 @@ namespace scream {
 // and all downstream code uses FieldGroup instead of FieldGroup<T>, we can remove this
 // macro, and sed s/FieldGroup/FieldGroup/g all over the repo.
 
-struct FieldGroup {
+class FieldGroup {
+public:
   using ci_string = FieldGroupInfo::ci_string;
 
-  FieldGroup (const std::string& name);
-  FieldGroup (const FieldGroupInfo& info);
+  FieldGroup (const std::string& name, const std::string& grid_name);
+  FieldGroup (const std::shared_ptr<FieldGroupInfo>& info,
+              const std::string& grid_name);
 
   FieldGroup (const FieldGroup&) = default;
 
@@ -54,30 +56,42 @@ struct FieldGroup {
 
   FieldGroup& operator= (const FieldGroup& src) = default;
 
-  const std::string& grid_name () const;
+  const std::shared_ptr<FieldGroupInfo>& info () const { return m_info; }
 
-  // The fields in this group
-  std::map<ci_string,std::shared_ptr<Field>> m_individual_fields;
+  const std::string& grid_name () const { return m_grid_name; }
 
-  // If m_info->m_monolithic_alloc is true, this is the field
-  // that all fields in m_individual_fields are a subview of.
-  std::shared_ptr<Field> m_monolithic_field;
+  const std::map<ci_string,Field>& individual_fields () const { return *m_individual_fields; }
+        std::map<ci_string,Field>& individual_fields ()       { return *m_individual_fields; }
+
+  bool has_monolithic_field () const { return m_monolithic_field!=nullptr; }
+  const Field& monolithic_field () const { return *m_monolithic_field; }
+        Field& monolithic_field ()       { return *m_monolithic_field; }
+
+  void set_field (const Field& f);
+  void set_monolithic_field (const Field& f);
+
+private:
 
   // The info of this group.
   std::shared_ptr<FieldGroupInfo>  m_info;
 
-private:
+  // The name of the grid where the group lives
+  std::string m_grid_name;
 
   // Only used inside this class;
   FieldGroup () = default;
 
-  void copy_fields (const FieldGroup& src);
+  std::shared_ptr<std::map<ci_string,Field>> m_individual_fields;
+
+  // If m_info->m_monolithic_alloc is true, this is the field
+  // that all fields in m_individual_fields are a subview of.
+  std::shared_ptr<Field> m_monolithic_field;
 };
 
 // We use this to find a FieldGroup in a std container.
 // We do NOT allow two entries with same group name and grid name in such containers.
 inline bool operator== (const FieldGroup& lhs, const FieldGroup& rhs) {
-  return lhs.m_info->m_group_name == rhs.m_info->m_group_name &&
+  return lhs.info()->m_group_name == rhs.info()->m_group_name &&
          lhs.grid_name() == rhs.grid_name();
 }
 

--- a/components/eamxx/src/share/field/field_group.hpp
+++ b/components/eamxx/src/share/field/field_group.hpp
@@ -1,7 +1,6 @@
 #ifndef SCREAM_FIELD_GROUP_HPP
 #define SCREAM_FIELD_GROUP_HPP
 
-#include "share/field/field_group_info.hpp"
 #include "share/field/field.hpp"
 
 namespace scream {
@@ -16,12 +15,9 @@ namespace scream {
  *
  * A FieldGroup contains:
  *
- *   - a FieldGroupInfo struct
- *   - a list of fields pointers
- *   - a grid name (the grid where the fields are)
- *
- * The same FieldGroupInfo can be recycled for several FieldGroup's, each living
- * on a different grid.
+ *   - a name and a grid name (where the group lives)
+ *   - a map name->field_pointer
+ *   - possibly, a monolithic version of the field
  *
  * Notice that, if the group has a monolithic allocation, the monolithic field is allocated
  * with layout given by grid->get_Xd_vector_layout(), where grid is the
@@ -44,36 +40,33 @@ namespace scream {
 
 class FieldGroup {
 public:
-  using ci_string = FieldGroupInfo::ci_string;
 
   FieldGroup (const std::string& name, const std::string& grid_name);
-  FieldGroup (const std::shared_ptr<FieldGroupInfo>& info,
-              const std::string& grid_name);
-
   FieldGroup (const FieldGroup&) = default;
-
-  FieldGroup get_const () const;
 
   FieldGroup& operator= (const FieldGroup& src) = default;
 
-  const std::shared_ptr<FieldGroupInfo>& info () const { return m_info; }
+  FieldGroup get_const () const;
 
+  const std::string& name () const { return m_name; }
   const std::string& grid_name () const { return m_grid_name; }
 
-  const std::map<ci_string,Field>& individual_fields () const { return *m_individual_fields; }
-        std::map<ci_string,Field>& individual_fields ()       { return *m_individual_fields; }
+  const std::map<std::string,Field>& individual_fields () const { return *m_individual_fields; }
+        std::map<std::string,Field>& individual_fields ()       { return *m_individual_fields; }
 
-  bool has_monolithic_field () const { return m_monolithic_field!=nullptr; }
+  bool has_monolithic_field () const { return m_monolithic_field->is_allocated(); }
   const Field& monolithic_field () const { return *m_monolithic_field; }
         Field& monolithic_field ()       { return *m_monolithic_field; }
 
   void set_field (const Field& f);
   void set_monolithic_field (const Field& f);
 
+  std::size_t size () const { return m_individual_fields->size(); }
+
 private:
 
-  // The info of this group.
-  std::shared_ptr<FieldGroupInfo>  m_info;
+  // The name of this group
+  std::string m_name;
 
   // The name of the grid where the group lives
   std::string m_grid_name;
@@ -81,7 +74,7 @@ private:
   // Only used inside this class;
   FieldGroup () = default;
 
-  std::shared_ptr<std::map<ci_string,Field>> m_individual_fields;
+  std::shared_ptr<std::map<std::string,Field>> m_individual_fields;
 
   // If m_info->m_monolithic_alloc is true, this is the field
   // that all fields in m_individual_fields are a subview of.
@@ -91,7 +84,7 @@ private:
 // We use this to find a FieldGroup in a std container.
 // We do NOT allow two entries with same group name and grid name in such containers.
 inline bool operator== (const FieldGroup& lhs, const FieldGroup& rhs) {
-  return lhs.info()->m_group_name == rhs.info()->m_group_name &&
+  return lhs.name() == rhs.name() &&
          lhs.grid_name() == rhs.grid_name();
 }
 

--- a/components/eamxx/src/share/field/field_group_info.hpp
+++ b/components/eamxx/src/share/field/field_group_info.hpp
@@ -4,6 +4,7 @@
 #include <ekat_string_utils.hpp>
 
 #include <list>
+#include <set>
 #include <map>
 
 namespace scream {
@@ -52,14 +53,14 @@ struct FieldGroupInfo
   std::list<ci_string>   m_fields_names;
 
   // Store the grid which registered each field
-  std::map<ci_string, std::list<ci_string>> m_grid_registered;
+  std::map<ci_string, std::set<ci_string>> m_grid_registered;
 
   // Store any grid that is requested for a group.
   // This is useful in the case where we allocate
   // a monolithic field, we can add a grid that may
   // not have any registered fields, but that we want
   // the group to exist.
-  std::list<ci_string> m_requested_grids;
+  std::set<ci_string> m_requested_grids;
 
   // Whether the group allocated a monolithic field
   bool m_monolithic_allocation = false;

--- a/components/eamxx/src/share/field/field_tracking.hpp
+++ b/components/eamxx/src/share/field/field_tracking.hpp
@@ -49,6 +49,7 @@ public:
 
   // Add group name to the list of groups we belong to
   void add_group (const std::string& group) { m_groups.insert(group); }
+  bool has_group (const std::string& group) const { return m_groups.count(group)>0; }
 
   // Set the time stamp for this field. This can only be called once, due to TimeStamp implementation.
   // NOTE: if the field has 'children' (see FamilyTracking), their ts will be updated too.

--- a/components/eamxx/src/share/field/field_tracking.hpp
+++ b/components/eamxx/src/share/field/field_tracking.hpp
@@ -1,7 +1,6 @@
 #ifndef SCREAM_FIELD_TRACKING_HPP
 #define SCREAM_FIELD_TRACKING_HPP
 
-#include "share/field/field_group_info.hpp"
 #include "share/core/eamxx_types.hpp"
 #include "share/util/eamxx_time_stamp.hpp"
 #include "share/util/eamxx_family_tracking.hpp"

--- a/components/eamxx/src/share/field/tests/field_group_tests.cpp
+++ b/components/eamxx/src/share/field/tests/field_group_tests.cpp
@@ -22,33 +22,33 @@ TEST_CASE("field_group") {
   Field f (fid);
   f.allocate_view();
 
-  FieldGroupInfo info("G");
-  info.m_monolithic_allocation = true;
+  auto info = std::make_shared<FieldGroupInfo>("G");
+  info->m_monolithic_allocation = true;
   std::vector<Field> f_i;
   for (int i=0; i<ndims; ++i) {
     f_i.push_back(f.get_component(i));
-    info.m_fields_names.push_back(f_i[i].name());
-    info.m_subview_dim = 1;
-    info.m_subview_idx[f_i[i].name()] = i;
+    info->m_fields_names.push_back(f_i[i].name());
+    info->m_subview_dim = 1;
+    info->m_subview_idx[f_i[i].name()] = i;
   }
 
   // Create group and set subfields
-  FieldGroup g(info);
-  g.m_monolithic_field = std::make_shared<Field>(f);
+  FieldGroup g(info,"my_grid");
+  g.set_monolithic_field(f);
   for (int i=0; i<ndims; ++i) {
-    g.m_individual_fields["G_"+std::to_string(i)] = std::make_shared<Field>(f_i[i]);
+    g.set_field(f_i[i]);
   }
 
   // Check const cloning
   auto cg= g.get_const();
-  REQUIRE (cg.m_monolithic_field->is_read_only());
-  REQUIRE (cg.m_individual_fields.size()==g.m_individual_fields.size());
-  REQUIRE (*cg.m_info==*g.m_info);
-  REQUIRE (cg.m_monolithic_field->get_internal_view_data<const Real>()==
-            g.m_monolithic_field->get_internal_view_data<const Real>());
+  REQUIRE (cg.monolithic_field().is_read_only());
+  REQUIRE (cg.individual_fields().size()==g.individual_fields().size());
+  REQUIRE (*cg.info()==*g.info());
+  REQUIRE (cg.monolithic_field().get_internal_view_data<const Real>()==
+            g.monolithic_field().get_internal_view_data<const Real>());
   for (int i=0; i<ndims; ++i) {
-    const auto&  f =  *g.m_individual_fields.at("G_"+std::to_string(i));
-    const auto& cf = *cg.m_individual_fields.at("G_"+std::to_string(i));
+    const auto&  f =  g.individual_fields().at("V_"+std::to_string(i));
+    const auto& cf = cg.individual_fields().at("V_"+std::to_string(i));
     REQUIRE ( f.get_internal_view_data<const Real>()==
              cf.get_internal_view_data<const Real>());
   }

--- a/components/eamxx/src/share/field/tests/field_group_tests.cpp
+++ b/components/eamxx/src/share/field/tests/field_group_tests.cpp
@@ -22,28 +22,23 @@ TEST_CASE("field_group") {
   Field f (fid);
   f.allocate_view();
 
-  auto info = std::make_shared<FieldGroupInfo>("G");
-  info->m_monolithic_allocation = true;
-  std::vector<Field> f_i;
-  for (int i=0; i<ndims; ++i) {
-    f_i.push_back(f.get_component(i));
-    info->m_fields_names.push_back(f_i[i].name());
-    info->m_subview_dim = 1;
-    info->m_subview_idx[f_i[i].name()] = i;
-  }
-
   // Create group and set subfields
-  FieldGroup g(info,"my_grid");
+  FieldGroup g("my_group","my_grid");
+
+  std::vector<std::string> names = {"V_0","V_1","V_2","V_3"};
   g.set_monolithic_field(f);
-  for (int i=0; i<ndims; ++i) {
-    g.set_field(f_i[i]);
-  }
+  REQUIRE_THROWS(g.set_monolithic_field(f)); // Cannot reset monolithic field
+
+  REQUIRE_THROWS (g.set_field(f)); // Not a subfield of the monolithic field
+  for (int i=0; i<ndims; ++i)
+    g.set_field(f.get_component(i));
+
+  REQUIRE_THROWS(g.set_field(f.get_component(0))); // Cannot reset field
 
   // Check const cloning
   auto cg= g.get_const();
   REQUIRE (cg.monolithic_field().is_read_only());
   REQUIRE (cg.individual_fields().size()==g.individual_fields().size());
-  REQUIRE (*cg.info()==*g.info());
   REQUIRE (cg.monolithic_field().get_internal_view_data<const Real>()==
             g.monolithic_field().get_internal_view_data<const Real>());
   for (int i=0; i<ndims; ++i) {

--- a/components/eamxx/src/share/io/eamxx_output_manager.cpp
+++ b/components/eamxx/src/share/io/eamxx_output_manager.cpp
@@ -676,11 +676,11 @@ setup_internals (const std::shared_ptr<fm_type>& field_mgr,
       vos_t fnames;
       // There may be no RESTART group on this grid
       if (field_mgr->has_group("RESTART", gname)) {
-        auto restart_group = field_mgr->get_group_info("RESTART", gname);
+        auto restart_group = field_mgr->get_field_group("RESTART", gname);
         EKAT_REQUIRE_MSG (not fields_pl.isParameter(gname),
           "Error! For restart output, don't specify the fields names. We will create this info internally.\n");
-        for (const auto& n : restart_group.m_fields_names) {
-          fnames.push_back(n);
+        for (const auto& it : restart_group.individual_fields()) {
+          fnames.push_back(it.first);
         }
       }
       fields_pl.sublist(gname).set("field_names",fnames);

--- a/components/eamxx/src/share/io/tests/output_restart.cpp
+++ b/components/eamxx/src/share/io/tests/output_restart.cpp
@@ -36,7 +36,7 @@ get_test_gm(const ekat::Comm& comm, const Int num_gcols, const Int num_levs);
 void randomize_fields (const FieldManager& fm, int seed);
 
 void time_advance (const FieldManager& fm,
-                   const std::list<ekat::CaseInsensitiveString>& fnames,
+                   const std::vector<std::string>& fnames,
                    const int dt);
 
 TEST_CASE("output_restart","io")
@@ -59,7 +59,10 @@ TEST_CASE("output_restart","io")
   auto fm0 = get_test_fm(grid);
   randomize_fields(*fm0,seed);
 
-  const auto& out_fields = fm0->get_group_info("output").m_fields_names;
+  auto out_group = fm0->get_field_group("output");
+  std::vector<std::string> out_fields;
+  for (auto it : out_group.individual_fields())
+    out_fields.push_back(it.first);
 
   // Initialize the pio_subsystem for this test:
   scorpio::init_subsystem(comm);
@@ -229,7 +232,7 @@ get_test_gm(const ekat::Comm& comm, const Int num_gcols, const Int num_levs)
 }
 /*===================================================================================================*/
 void time_advance (const FieldManager& fm,
-                   const std::list<ekat::CaseInsensitiveString>& fnames,
+                   const std::vector<std::string>& fnames,
                    const int dt) {
   for (const auto& fname : fnames) {
     auto f  = fm.get_field(fname);

--- a/components/eamxx/tests/eamxx_ad_test.cpp
+++ b/components/eamxx/tests/eamxx_ad_test.cpp
@@ -40,7 +40,8 @@ TEST_CASE("scream_ad_test") {
   // Load ad parameter list
   ekat::ParameterList ad_params("Atmosphere Driver");
   parse_yaml_file(fname,ad_params);
-  ad_params.print();
+  if (ad_params.sublist("debug").get("print_params",false))
+    ad_params.print();
 
   // Time stepping parameters
         auto& ts     = ad_params.sublist("time_stepping");


### PR DESCRIPTION
Minor rework of the FieldGroup class and how FieldManager handles them.

[BFB]

---

The need for this minor cleanup arose while trying to fix the CI fails of #8606 , which were utltimately generated by some field groups going out of sync. The key mod is that a FG now stores everything via shared_ptr (including the map), and that the FM _always_ stores the groups and _always_ recomputes them when users extend a group (e.g., when the driver adds a field to the restart group). I also decided to do a minor cleanup of the class itself.

I verified that, when rebased on this branch, the p3 fail in the linked PR goes away.

Edit: this PR turned into a bigger overhaul of the FIeldGroup (FG) class and how groups are handled by the FieldManager (FM). A small summary:
- FG` no longer stores a `FieldGroupInfo` (FGI) member. The latter was meant to hold info of a group "across grids", and associating it with a group that lives on one specific grid (where LESS fields may be present for that group) was misleading at best.
- As a consequence of the above, FGI has been moved to `data_managers`, as it is exclusively used by FM.
- FM keeps the FGI map forever, but it is completely pointless after registration_ends (I may rm that map at the end of registration_ends for safety).
- FM now crates the monolithic field also for sub-groups of a monolithic field. E.g., there is a monolithic field for turb advected traers.
- FM allows to call `add_to_group` with a new group. It will simply create a group on the fly.
- At the end of registration ends, FM updates the FG for all currently registered groups. That means that groups are created not when `get_field_group` is called, but when `registration_ends` is called (or during `add_to_group` if called after registration).
