### PR TITLE
EAMxx:  data_timeline_type  for MAM4xx

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -427,6 +427,7 @@ be lost if SCREAM_HACK_XML is not enabled.
       <aero_microphys_remap_file hgrid="ne256np4.pg2">${DIN_LOC_ROOT}/atm/scream/maps/map_ne30pg2_to_ne256pg2_20231201.nc</aero_microphys_remap_file>
       <aero_microphys_remap_file hgrid="ne512np4.pg2">${DIN_LOC_ROOT}/atm/scream/maps/map_ne30pg2_to_ne512pg2_20231201.nc</aero_microphys_remap_file>
       <aero_microphys_remap_file hgrid="ne1024np4.pg2">${DIN_LOC_ROOT}/atm/scream/maps/map_ne30pg2_to_ne1024pg2_20231201.nc</aero_microphys_remap_file>
+      <time_interpolation_method type="string" doc="Method for interpolating MAM4 microphysics data in time">yearly_periodic</time_interpolation_method>
     </mam4_aero_microphys>
 
     <!-- MAM4xx-Optics -->
@@ -492,6 +493,7 @@ be lost if SCREAM_HACK_XML is not enabled.
       <srf_remap_file hgrid="ne256np4.pg2">${DIN_LOC_ROOT}/atm/scream/maps/map_ne30pg2_to_ne256pg2_20231201.nc</srf_remap_file>
       <srf_remap_file hgrid="ne512np4.pg2">${DIN_LOC_ROOT}/atm/scream/maps/map_ne30pg2_to_ne512pg2_20231201.nc</srf_remap_file>
       <srf_remap_file hgrid="ne1024np4.pg2">${DIN_LOC_ROOT}/atm/scream/maps/map_ne30pg2_to_ne1024pg2_20231201.nc</srf_remap_file>
+      <time_interpolation_method type="string" doc="Method for interpolating MAM4 surface emissions data in time">yearly_periodic</time_interpolation_method>
     </mam4_srf_online_emiss>
 
     <!-- MAM4xx-constituent fluxes -->

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -463,6 +463,8 @@ void MAMMicrophysics::set_oxid_reader()
   const auto oxid_file_name = m_params.get<std::string>("mam4_oxid_file_name");
   const std::string oxid_map_file =
         m_params.get<std::string>("aero_microphys_remap_file", "");
+  const auto oxid_time_interpolation_method = 
+      m_params.get<std::string>("time_interpolation_method", "yearly_periodic");
   // get fields from FM.
   std::vector<Field> oxid_fields;
   for(const auto &field_name : var_names_oxi_) {
@@ -470,7 +472,7 @@ void MAMMicrophysics::set_oxid_reader()
   }
 
   data_interp_oxid_ = std::make_shared<DataInterpolation>(grid_,oxid_fields);
-  data_interp_oxid_->setup_periodic_time_database ({oxid_file_name});
+  data_interp_oxid_->setup_time_database({oxid_file_name}, oxid_time_interpolation_method);
   data_interp_oxid_->create_horiz_remappers (oxid_map_file=="none" ? "" : oxid_map_file, m_iop_data_manager);
   data_interp_oxid_->set_logger(m_atm_logger);
   DataInterpolation::VertRemapData remap_data_oxid;
@@ -498,13 +500,15 @@ void MAMMicrophysics::set_linoz_reader(){
   const auto m_linoz_file_name = m_params.get<std::string>("mam4_linoz_file_name");
   const std::string linoz_map_file =
         m_params.get<std::string>("aero_microphys_remap_file", "");
+  const auto linoz_time_interpolation_method = 
+      m_params.get<std::string>("time_interpolation_method", "yearly_periodic");
   std::vector<Field> linoz_fields;
   for(const auto &field_name : var_names_linoz_) {
       linoz_fields.push_back(get_field_out(field_name));
   }
 
   data_interp_linoz_ = std::make_shared<DataInterpolation>(grid_,linoz_fields);
-  data_interp_linoz_->setup_periodic_time_database ({m_linoz_file_name});
+  data_interp_linoz_->setup_time_database({m_linoz_file_name}, linoz_time_interpolation_method);
   data_interp_linoz_->create_horiz_remappers (linoz_map_file=="none" ? "" : linoz_map_file, m_iop_data_manager);
   data_interp_linoz_->set_logger(m_atm_logger);
 
@@ -537,6 +541,8 @@ void MAMMicrophysics::set_exo_coldens_reader()
   const std::string exo_coldens_file_name = m_params.get<std::string>("mam4_exo_coldens_file_name");
   const std::string exo_coldens_map_file =
         m_params.get<std::string>("aero_microphys_remap_file", "");
+  const auto exo_coldens_time_interpolation_method = 
+      m_params.get<std::string>("time_interpolation_method", "yearly_periodic");
   // get fields from FM.
   auto grid_exo_coldens = grid_->clone("exo_grid",true);
   grid_exo_coldens->reset_vertical_configuration(1, AbstractGrid::VKind::Model);
@@ -552,7 +558,7 @@ void MAMMicrophysics::set_exo_coldens_reader()
   exo_coldens_fields_.push_back(field_exo);
 
   data_interp_exo_coldens_ = std::make_shared<DataInterpolation>(grid_exo_coldens,exo_coldens_fields_);
-  data_interp_exo_coldens_->setup_periodic_time_database ({exo_coldens_file_name});
+  data_interp_exo_coldens_->setup_time_database({exo_coldens_file_name}, exo_coldens_time_interpolation_method);
   data_interp_exo_coldens_->create_horiz_remappers (exo_coldens_map_file=="none" ? "" : exo_coldens_map_file, m_iop_data_manager);
   data_interp_exo_coldens_->set_logger(m_atm_logger);
   DataInterpolation::VertRemapData remap_exo_coldens;
@@ -576,6 +582,8 @@ void MAMMicrophysics::set_elevated_emissions_reader()
   const auto z_iface = get_field_out("z_mam4_int");
   const std::string extfrc_map_file =
         m_params.get<std::string>("aero_microphys_remap_file", "");
+  const auto elevated_emis_time_interpolation_method = 
+      m_params.get<std::string>("time_interpolation_method", "yearly_periodic");
   for(const auto &pair : elevated_emis_var_names_) {
     const auto& var_name=pair.first;
     std::string item_name = "mam4_" + var_name + "_elevated_emiss_file_name";
@@ -587,7 +595,7 @@ void MAMMicrophysics::set_elevated_emissions_reader()
     std::shared_ptr<DataInterpolation> di_vertical = std::make_shared<DataInterpolation>(grid_,vertical_fields);
     di_vertical->set_input_files_dimname(e2str(LEV),"altitude");
     di_vertical->set_input_files_dimname(e2str(ILEV),"altitude_int");
-    di_vertical->setup_periodic_time_database ({file_name});
+    di_vertical->setup_time_database({file_name}, elevated_emis_time_interpolation_method);
     di_vertical->create_horiz_remappers (extfrc_map_file=="none" ? "" : extfrc_map_file, m_iop_data_manager);
     di_vertical->set_logger(m_atm_logger);
     DataInterpolation::VertRemapData remap_data_vertical;

--- a/components/eamxx/src/physics/mam/eamxx_mam_srf_and_online_emissions_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_srf_and_online_emissions_process_interface.cpp
@@ -283,9 +283,11 @@ void MAMSrfOnlineEmiss::initialize_impl(const RunType run_type) {
   // Constituent fluxes of species in [kg/m2/s]
   constituent_fluxes_ = get_field_out("constituent_fluxes");
 
-    const std::string marine_organics_data_file =
+  const std::string marine_organics_data_file =
       m_params.get<std::string>("marine_organics_file");
   const auto marine_map_file = m_params.get<std::string>("srf_remap_file", "");
+  const auto marine_time_interpolation_method = 
+      m_params.get<std::string>("time_interpolation_method", "yearly_periodic");
 
    const std::vector<std::string> marine_org_fld_name = {
       "TRUEPOLYC", "TRUEPROTC", "TRUELIPC"};           
@@ -298,7 +300,7 @@ void MAMSrfOnlineEmiss::initialize_impl(const RunType run_type) {
 
   morg_data_interp_ = std::make_shared<DataInterpolation>(grid_, morg_fields_);
   morg_data_interp_->set_logger(m_atm_logger);
-  morg_data_interp_->setup_periodic_time_database({marine_organics_data_file});
+  morg_data_interp_->setup_time_database({marine_organics_data_file}, marine_time_interpolation_method);
   morg_data_interp_->create_horiz_remappers(
       marine_map_file == "none" ? "" : marine_map_file, m_iop_data_manager);
   DataInterpolation::VertRemapData remap_data;
@@ -312,7 +314,8 @@ void MAMSrfOnlineEmiss::initialize_impl(const RunType run_type) {
     using namespace ShortFieldTagsNames;
     const FieldLayout scalar2d = grid_->get_2d_scalar_layout();
     const auto srf_map_file    = m_params.get<std::string>("srf_remap_file", "");
-    const auto srf_time_interp = DataInterpolation::Linear;
+    const auto srf_time_interpolation_method = 
+        m_params.get<std::string>("time_interpolation_method", "yearly_periodic");
     for(srf_emiss_ &ispec_srf : srf_emiss_species_) {
       std::vector<Field> srf_fields;
       srf_fields.reserve(ispec_srf.sectors.size());
@@ -325,8 +328,8 @@ void MAMSrfOnlineEmiss::initialize_impl(const RunType run_type) {
 
       ispec_srf.data_interp_ = std::make_shared<DataInterpolation>(grid_, srf_fields);
       ispec_srf.data_interp_->set_logger(m_atm_logger);
-      ispec_srf.data_interp_->setup_periodic_time_database(
-          {ispec_srf.data_file});
+      ispec_srf.data_interp_->setup_time_database(
+          {ispec_srf.data_file}, srf_time_interpolation_method);
       ispec_srf.data_interp_->create_horiz_remappers(
           srf_map_file == "none" ? "" : srf_map_file, m_iop_data_manager);
 
@@ -334,7 +337,8 @@ void MAMSrfOnlineEmiss::initialize_impl(const RunType run_type) {
       remap_data.vr_type = DataInterpolation::None;
       ispec_srf.data_interp_->create_vert_remapper(remap_data);
 
-      ispec_srf.data_interp_->init_time_interpolation(start_of_step_ts(), srf_time_interp);
+      ispec_srf.data_interp_->init_time_interpolation(start_of_step_ts(), 
+                                                       DataInterpolation::Linear);
     }
   }
 

--- a/components/eamxx/src/physics/spa/eamxx_spa_process_interface.cpp
+++ b/components/eamxx/src/physics/spa/eamxx_spa_process_interface.cpp
@@ -87,16 +87,7 @@ void SPA::initialize_impl (const RunType /* run_type */)
   pint.allocate_view();
 
   m_data_interpolation = std::make_shared<DataInterpolation>(m_model_grid,spa_fields);
-  if (time_interpolation_method=="yearly_periodic") {
-    m_data_interpolation->setup_periodic_time_database ({spa_data_file});
-  } else if (time_interpolation_method=="linear") {
-    m_data_interpolation->setup_linear_time_database ({spa_data_file});
-  } else {
-    EKAT_ERROR_MSG("Error! Invalid time_interpolation_method: " +
-                   time_interpolation_method +
-                   ". Valid options are: yearly_periodic, linear.\n");
-  }
-
+  m_data_interpolation->setup_time_database({spa_data_file}, time_interpolation_method);
   m_data_interpolation->create_horiz_remappers(spa_map_file, m_iop_data_manager);
   DataInterpolation::VertRemapData vremap_data;
   vremap_data.vr_type = DataInterpolation::Dynamic3DRef;

--- a/components/eamxx/src/physics/spc/eamxx_spc_process_interface.cpp
+++ b/components/eamxx/src/physics/spc/eamxx_spc_process_interface.cpp
@@ -66,16 +66,7 @@ void SPC::initialize_impl (const RunType /* run_type */)
   auto pmid = get_field_in("p_mid");
   
   m_data_interpolation = std::make_shared<DataInterpolation>(m_model_grid,spc_fields);
-  if (time_interpolation_method=="yearly_periodic") {
-    m_data_interpolation->setup_periodic_time_database ({spc_data_file});
-  } else if (time_interpolation_method=="linear") {
-    m_data_interpolation->setup_linear_time_database ({spc_data_file});
-  } else {
-    EKAT_ERROR_MSG("Error! Invalid time_interpolation_method: " + 
-                   time_interpolation_method + 
-                   ". Valid options are: yearly_periodic, linear.\n");
-  }
-
+  m_data_interpolation->setup_time_database({spc_data_file}, time_interpolation_method);
   m_data_interpolation->create_horiz_remappers(spc_map_file, m_iop_data_manager);
   DataInterpolation::VertRemapData vremap_data;
   vremap_data.vr_type = DataInterpolation::Dynamic3DRef;

--- a/components/eamxx/src/share/algorithm/eamxx_data_interpolation.cpp
+++ b/components/eamxx/src/share/algorithm/eamxx_data_interpolation.cpp
@@ -259,6 +259,22 @@ init_time_interpolation (const util::TimeStamp& t0,
 }
 
 void DataInterpolation::
+setup_time_database (const strvec_t& input_files,
+                    const std::string& time_interpolation_method,
+                    const util::TimeStamp& ts)
+{
+  if (time_interpolation_method == "yearly_periodic") {
+    setup_periodic_time_database(input_files, ts);
+  } else if (time_interpolation_method == "linear") {
+    setup_linear_time_database(input_files, ts);
+  } else {
+    EKAT_ERROR_MSG("Error! Invalid time_interpolation_method: " +
+                   time_interpolation_method +
+                   ". Valid options are: yearly_periodic, linear.\n");
+  }
+}
+
+void DataInterpolation::
 setup_linear_time_database (const strvec_t& input_files,
                             const util::TimeStamp& ref_ts)
 {

--- a/components/eamxx/src/share/algorithm/eamxx_data_interpolation.hpp
+++ b/components/eamxx/src/share/algorithm/eamxx_data_interpolation.hpp
@@ -56,6 +56,12 @@ public:
 
   void set_logger (const std::shared_ptr<ekat::logger::LoggerBase>& logger);
 
+  // Setup time database based on time_interpolation_method string
+  // Valid options: "yearly_periodic", "linear"
+  void setup_time_database (const strvec_t& input_files,
+                           const std::string& time_interpolation_method,
+                           const util::TimeStamp& ts = util::TimeStamp());
+
   // Setup time database for LinearHistory time-dependent data interpolation
   void setup_linear_time_database (const strvec_t& input_files,
                                    const util::TimeStamp& ref_ts = util::TimeStamp());


### PR DESCRIPTION
Adding the namelist `data_timeline_type ` to the MAM4xx readers. In addition,
moving a block of code to the DataInterpolation class to avoid code duplication.

[BFB]