### PR TITLE
Expose CAPE/DCAPE thresholds for ZM

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -276,17 +276,17 @@ be lost if SCREAM_HACK_XML is not enabled.
       <trig_ull           type="logical" doc="ZM flag to enable ULL mode"                   >true</trig_ull>
       <clos_dyn_adj       type="logical" doc="ZM flag to enable dynamic closure adjustment" >false</clos_dyn_adj>
       <!-- ZM tuning parameters -->
-      <upper_limit_pref type="real"    doc="ZM upper pressure limit for convection"    >40e2</upper_limit_pref>
-      <tau              type="real"    doc="ZM convective adjustment time scale"       >3600</tau>
-      <alfa             type="real"    doc="ZM max downdraft mass flux fraction"       >0.14</alfa>
-      <ke               type="real"    doc="ZM evaporation efficiency"                 >2.5E-6</ke>
-      <dmpdz            type="real"    doc="ZM fractional mass entrainment rate [1/m]" >-0.7e-3</dmpdz>
-      <tpert_fix        type="logical" doc="ZM flag to enable tpert"                   >true</tpert_fix>
-      <tpert_fac        type="real"    doc="ZM tunable temperature perturbation factor">2.0</tpert_fac>
-      <tiedke_add       type="real"    doc="ZM tunable temperature perturbation"       >0.8</tiedke_add>
-      <c0_lnd           type="real"    doc="ZM autoconversion coefficient over land"   >0.002</c0_lnd>
-      <c0_ocn           type="real"    doc="ZM autoconversion coefficient over ocean"  >0.002</c0_ocn>
-      <num_cin          type="integer" doc="ZM num of neg buoyancy regions allowed"    >1</num_cin>
+      <upper_limit_pref   type="real"    doc="ZM upper pressure limit for convection"    >40e2</upper_limit_pref>
+      <tau                type="real"    doc="ZM convective adjustment time scale"       >3600</tau>
+      <alfa               type="real"    doc="ZM max downdraft mass flux fraction"       >0.14</alfa>
+      <ke                 type="real"    doc="ZM evaporation efficiency"                 >2.5E-6</ke>
+      <dmpdz              type="real"    doc="ZM fractional mass entrainment rate [1/m]" >-0.7e-3</dmpdz>
+      <tpert_fix          type="logical" doc="ZM flag to enable tpert"                   >true</tpert_fix>
+      <tpert_fac          type="real"    doc="ZM tunable temperature perturbation factor">2.0</tpert_fac>
+      <tiedke_add         type="real"    doc="ZM tunable temperature perturbation"       >0.8</tiedke_add>
+      <c0_lnd             type="real"    doc="ZM autoconversion coefficient over land"   >0.002</c0_lnd>
+      <c0_ocn             type="real"    doc="ZM autoconversion coefficient over ocean"  >0.002</c0_ocn>
+      <num_cin            type="integer" doc="ZM num of neg buoyancy regions allowed"    >1</num_cin>
       <cape_threshold     type="real"    doc="ZM CAPE threshold [J/kg]"                  >0.</cape_threshold>
       <dcape_threshold    type="real"    doc="ZM DCAPE threshold [J/kg/s]"               >0.</dcape_threshold>
       <!-- MCSP -->

--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -287,6 +287,8 @@ be lost if SCREAM_HACK_XML is not enabled.
       <c0_lnd           type="real"    doc="ZM autoconversion coefficient over land"   >0.002</c0_lnd>
       <c0_ocn           type="real"    doc="ZM autoconversion coefficient over ocean"  >0.002</c0_ocn>
       <num_cin          type="integer" doc="ZM num of neg buoyancy regions allowed"    >1</num_cin>
+      <cape_threshold     type="real"    doc="ZM CAPE threshold [J/kg]"                  >0.</cape_threshold>
+      <dcape_threshold    type="real"    doc="ZM DCAPE threshold [J/kg/s]"               >0.</dcape_threshold>
       <!-- MCSP -->
       <mcsp_enabled type="logical" doc="ZM flag to enable MCSP in ZM" >true</mcsp_enabled>
       <mcsp_t_coeff type="real" doc="MCSP temperature coefficient"    >0.3</mcsp_t_coeff>

--- a/components/eamxx/cime_config/namelist_defaults_eamxx.xml
+++ b/components/eamxx/cime_config/namelist_defaults_eamxx.xml
@@ -287,7 +287,8 @@ be lost if SCREAM_HACK_XML is not enabled.
       <c0_lnd             type="real"    doc="ZM autoconversion coefficient over land"   >0.002</c0_lnd>
       <c0_ocn             type="real"    doc="ZM autoconversion coefficient over ocean"  >0.002</c0_ocn>
       <num_cin            type="integer" doc="ZM num of neg buoyancy regions allowed"    >1</num_cin>
-      <cape_threshold     type="real"    doc="ZM CAPE threshold [J/kg]"                  >0.</cape_threshold>
+      <cape_threshold     type="real"    doc="ZM CAPE threshold [J/kg](traditionally zero
+                                              w/ trig_dcape, or 70 otherwise)"           >0.</cape_threshold>
       <dcape_threshold    type="real"    doc="ZM DCAPE threshold [J/kg/s]"               >0.</dcape_threshold>
       <!-- MCSP -->
       <mcsp_enabled type="logical" doc="ZM flag to enable MCSP in ZM" >true</mcsp_enabled>

--- a/components/eamxx/src/physics/zm/impl/zm_conv_main_impl.hpp
+++ b/components/eamxx/src/physics/zm/impl/zm_conv_main_impl.hpp
@@ -281,7 +281,6 @@ void Functions<S,D>::zm_conv_main(
 
   //============================================================================
   // Host: Determine active columns
-  // cape_threshold_loc depends only on runtime_opt / is_first_step (same for all cols)
   //============================================================================
   const Real cape_threshold_loc = runtime_opt.cape_threshold;
   const bool use_dcape_trigger = runtime_opt.trig_dcape && !is_first_step;

--- a/components/eamxx/src/physics/zm/impl/zm_conv_main_impl.hpp
+++ b/components/eamxx/src/physics/zm/impl/zm_conv_main_impl.hpp
@@ -283,9 +283,7 @@ void Functions<S,D>::zm_conv_main(
   // Host: Determine active columns
   // cape_threshold_loc depends only on runtime_opt / is_first_step (same for all cols)
   //============================================================================
-  const Real cape_threshold_loc = (runtime_opt.trig_dcape && !is_first_step)
-                                    ? runtime_opt.cape_threshold
-                                    : ZMC::cape_threshold_old;
+  const Real cape_threshold_loc = runtime_opt.cape_threshold;
   const bool use_dcape_trigger = runtime_opt.trig_dcape && !is_first_step;
   int inactive_cnt = 0;
   Kokkos::parallel_reduce("zm_conv_main_active", RangePolicy(0, ncol),

--- a/components/eamxx/src/physics/zm/impl/zm_conv_main_impl.hpp
+++ b/components/eamxx/src/physics/zm/impl/zm_conv_main_impl.hpp
@@ -284,14 +284,14 @@ void Functions<S,D>::zm_conv_main(
   // cape_threshold_loc depends only on runtime_opt / is_first_step (same for all cols)
   //============================================================================
   const Real cape_threshold_loc = (runtime_opt.trig_dcape && !is_first_step)
-                                    ? ZMC::cape_threshold_new
+                                    ? runtime_opt.cape_threshold
                                     : ZMC::cape_threshold_old;
   const bool use_dcape_trigger = runtime_opt.trig_dcape && !is_first_step;
   int inactive_cnt = 0;
   Kokkos::parallel_reduce("zm_conv_main_active", RangePolicy(0, ncol),
                           KOKKOS_LAMBDA(const Int i, Int& local_inactive) {
       const bool is_active = use_dcape_trigger
-        ? (cape(i) > cape_threshold_loc && dcape(i) > ZMC::dcape_threshold)
+        ? (cape(i) > cape_threshold_loc && dcape(i) > runtime_opt.dcape_threshold)
         : (cape(i) > cape_threshold_loc);
       active(i) = is_active ? 1 : 0;
       if (!is_active) {

--- a/components/eamxx/src/physics/zm/impl/zm_inline_functions.hpp
+++ b/components/eamxx/src/physics/zm/impl/zm_inline_functions.hpp
@@ -153,12 +153,7 @@ static bool is_conv_active(
   Real& cape_threshold_loc)        // cape threshold
 {
   // set local threshold to be used for zm_closure()
-  if ( runtime_opt.trig_dcape && !is_first_step ) {
-    cape_threshold_loc = runtime_opt.cape_threshold;
-  }
-  else {
-    cape_threshold_loc = ZMC::cape_threshold_old;
-  }
+  cape_threshold_loc = runtime_opt.cape_threshold;
 
   //--------------------------------------------------------------------------
   // determine if column is active

--- a/components/eamxx/src/physics/zm/impl/zm_inline_functions.hpp
+++ b/components/eamxx/src/physics/zm/impl/zm_inline_functions.hpp
@@ -154,7 +154,7 @@ static bool is_conv_active(
 {
   // set local threshold to be used for zm_closure()
   if ( runtime_opt.trig_dcape && !is_first_step ) {
-    cape_threshold_loc = ZMC::cape_threshold_new;
+    cape_threshold_loc = runtime_opt.cape_threshold;
   }
   else {
     cape_threshold_loc = ZMC::cape_threshold_old;
@@ -163,7 +163,7 @@ static bool is_conv_active(
   //--------------------------------------------------------------------------
   // determine if column is active
   if ( runtime_opt.trig_dcape && ! is_first_step ) {
-    if ( cape > cape_threshold_loc && dcape > ZMC::dcape_threshold ) {
+    if ( cape > cape_threshold_loc && dcape > runtime_opt.dcape_threshold ) {
       return true;
     }
   }

--- a/components/eamxx/src/physics/zm/impl/zm_opts_impl.hpp
+++ b/components/eamxx/src/physics/zm/impl/zm_opts_impl.hpp
@@ -33,7 +33,7 @@ void Functions<S,D>::zm_opts_init()
   s_zm_opts.trig_ull            = true;
   s_zm_opts.clos_dyn_adj        = true;
   s_zm_opts.no_deep_pbl         = false;
-  s_zm_opts.cape_threshold      = ZMC::cape_threshold_new;
+  s_zm_opts.cape_threshold      = ZMC::cape_threshold;
   s_zm_opts.dcape_threshold     = ZMC::dcape_threshold;
   // ZM micro parameters
   s_zm_opts.zm_microp           = false;

--- a/components/eamxx/src/physics/zm/impl/zm_opts_impl.hpp
+++ b/components/eamxx/src/physics/zm/impl/zm_opts_impl.hpp
@@ -33,6 +33,8 @@ void Functions<S,D>::zm_opts_init()
   s_zm_opts.trig_ull            = true;
   s_zm_opts.clos_dyn_adj        = true;
   s_zm_opts.no_deep_pbl         = false;
+  s_zm_opts.cape_threshold      = ZMC::cape_threshold_new;
+  s_zm_opts.dcape_threshold     = ZMC::dcape_threshold;
   // ZM micro parameters
   s_zm_opts.zm_microp           = false;
   s_zm_opts.old_snow            = true;

--- a/components/eamxx/src/physics/zm/zm_functions.hpp
+++ b/components/eamxx/src/physics/zm/zm_functions.hpp
@@ -167,6 +167,8 @@ struct Functions {
       trig_ull            = params.get<bool>("trig_ull",            true);
       clos_dyn_adj        = params.get<bool>("clos_dyn_adj",        false);
       no_deep_pbl         = params.get<bool>("no_deep_pbl",         false);
+      cape_threshold      = params.get<Real>("cape_threshold",      ZMC::cape_threshold_new);
+      dcape_threshold     = params.get<Real>("dcape_threshold",     ZMC::dcape_threshold);
       // ZM micro parameters
       zm_microp           = params.get<bool>("zm_microp",           false);
       old_snow            = params.get<bool>("old_snow",            true);
@@ -243,6 +245,8 @@ struct Functions {
       os << indent << "trig_ull        : " << trig_ull       << "\n";
       os << indent << "clos_dyn_adj    : " << clos_dyn_adj   << "\n";
       os << indent << "no_deep_pbl     : " << no_deep_pbl    << "\n";
+      os << indent << "cape_threshold  : " << cape_threshold << "\n";
+      os << indent << "dcape_threshold : " << dcape_threshold<< "\n";
       // ZM micro parameters
       os << indent << "zm_microp       : " << zm_microp      << "\n";
       os << indent << "old_snow        : " << old_snow       << "\n";
@@ -273,6 +277,8 @@ struct Functions {
     bool trig_ull;          // true if to using the "unrestricted launch level" (ULL) mode
     bool clos_dyn_adj;      // flag for mass flux adjustment to CAPE closure
     bool no_deep_pbl;       // flag to eliminate deep convection within PBL
+    Real cape_threshold;    // CAPE threshold for trigger condition
+    Real dcape_threshold;   // DCAPE threshold for trigger condition
     bool apply_detr_tend;
     // ZM micro parameters
     bool zm_microp;         // switch for convective microphysics

--- a/components/eamxx/src/physics/zm/zm_functions.hpp
+++ b/components/eamxx/src/physics/zm/zm_functions.hpp
@@ -100,7 +100,6 @@ struct Functions {
     static inline constexpr Real lcl_pressure_threshold    = 600.0;    // if LCL pressure is lower => no convection and cape is zero
     static inline constexpr Real lwmax                     = 1.e-3;    // maximum condensate that can be held in cloud before rainout
     static inline constexpr Real ull_upper_launch_pressure = 600.0;    // upper search limit for unrestricted launch level (ULL)
-    static inline constexpr Real cape_threshold_old        = 70.;      // threshold value of cape for deep convection (old value before DCAPE)
     static inline constexpr Real cape_threshold_new        = 0.;       // threshold value of cape for deep convection
     static inline constexpr Real dcape_threshold           = 0.;       // threshold value of dcape for deep convection
     static inline constexpr Real beta                      = 0;        // proportion of liquid water from layer below used in closure

--- a/components/eamxx/src/physics/zm/zm_functions.hpp
+++ b/components/eamxx/src/physics/zm/zm_functions.hpp
@@ -100,7 +100,7 @@ struct Functions {
     static inline constexpr Real lcl_pressure_threshold    = 600.0;    // if LCL pressure is lower => no convection and cape is zero
     static inline constexpr Real lwmax                     = 1.e-3;    // maximum condensate that can be held in cloud before rainout
     static inline constexpr Real ull_upper_launch_pressure = 600.0;    // upper search limit for unrestricted launch level (ULL)
-    static inline constexpr Real cape_threshold_new        = 0.;       // threshold value of cape for deep convection
+    static inline constexpr Real cape_threshold            = 0.;       // threshold value of cape for deep convection
     static inline constexpr Real dcape_threshold           = 0.;       // threshold value of dcape for deep convection
     static inline constexpr Real beta                      = 0;        // proportion of liquid water from layer below used in closure
     static inline constexpr Real mu_min                    = 0.02;     // minimum updraft mass flux threshold [mb/s]
@@ -166,7 +166,7 @@ struct Functions {
       trig_ull            = params.get<bool>("trig_ull",            true);
       clos_dyn_adj        = params.get<bool>("clos_dyn_adj",        false);
       no_deep_pbl         = params.get<bool>("no_deep_pbl",         false);
-      cape_threshold      = params.get<Real>("cape_threshold",      ZMC::cape_threshold_new);
+      cape_threshold      = params.get<Real>("cape_threshold",      ZMC::cape_threshold);
       dcape_threshold     = params.get<Real>("dcape_threshold",     ZMC::dcape_threshold);
       // ZM micro parameters
       zm_microp           = params.get<bool>("zm_microp",           false);


### PR DESCRIPTION
This exposes the ZM thresholds for CAPE and DCAPE that determine whether a column is active. These have long been hard coded, but recent tests have shown that they are beneficial tuning parameters for our v4 target resolution of ne256.

Additionally, the `cape_threshold_old` parameter has been removed because it only affected the first time step and unnecessarily polluted the code for no real gain. Unfortunately, this makes the changes non-BFB, but it's a worthwhile simplification to make ahead of v4.

[non-BFB] except for ZM compsets and `zm_conv_main_bfb` unit test