### PR TITLE
GWD stealth updates for EAM/QBO-SciDAC

### DIFF
--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -834,6 +834,8 @@ add_default($nl,'gw_convect_hdepth_min') if (get_default_value('gw_convect_hdept
 add_default($nl,'gw_convect_storm_speed_min') if (get_default_value('gw_convect_storm_speed_min'));
 add_default($nl,'gw_convect_plev_src_wind') if (get_default_value('gw_convect_plev_src_wind'));
 add_default($nl,'use_gw_convect_old', 'val'=>'.true.');
+add_default($nl,'use_gwut_min_limiter', 'val'=>'.false.');
+add_default($nl,'use_gw_front_RR_scaling', 'val'=>'.false.');
 add_default($nl,'linoz_psc_T');
 if ($cfg->get('microphys') =~ /^mg2/) {
     add_default($nl,'micro_mg_dcs_tdep');

--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -835,7 +835,7 @@ add_default($nl,'gw_convect_storm_speed_min') if (get_default_value('gw_convect_
 add_default($nl,'gw_convect_plev_src_wind') if (get_default_value('gw_convect_plev_src_wind'));
 add_default($nl,'use_gw_convect_old', 'val'=>'.true.');
 add_default($nl,'use_tau_limiter', 'val'=>'.false.');
-add_default($nl,'use_gw_front_RR_scaling', 'val'=>'.false.');
+add_default($nl,'use_gw_front_rr_scaling', 'val'=>'.false.');
 add_default($nl,'linoz_psc_T');
 if ($cfg->get('microphys') =~ /^mg2/) {
     add_default($nl,'micro_mg_dcs_tdep');

--- a/components/eam/bld/build-namelist
+++ b/components/eam/bld/build-namelist
@@ -834,7 +834,7 @@ add_default($nl,'gw_convect_hdepth_min') if (get_default_value('gw_convect_hdept
 add_default($nl,'gw_convect_storm_speed_min') if (get_default_value('gw_convect_storm_speed_min'));
 add_default($nl,'gw_convect_plev_src_wind') if (get_default_value('gw_convect_plev_src_wind'));
 add_default($nl,'use_gw_convect_old', 'val'=>'.true.');
-add_default($nl,'use_gwut_min_limiter', 'val'=>'.false.');
+add_default($nl,'use_tau_limiter', 'val'=>'.false.');
 add_default($nl,'use_gw_front_RR_scaling', 'val'=>'.false.');
 add_default($nl,'linoz_psc_T');
 if ($cfg->get('microphys') =~ /^mg2/) {

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -1231,6 +1231,16 @@ Background source strength (used for waves from frontogenesis).
 Default: set by build-namelist.
 </entry>
 
+<entry id="use_gwut_min_limiter" type="logical" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+switch to enable minimum limit on "gwut" values in GW calculations.
+</entry>
+
+<entry id="use_gw_front_RR_scaling" type="logical" category="gw_drag"
+       group="gw_drag_nl" valid_values="" >
+switch to enable Rossby radius scaling for the frontal GW scheme.
+</entry>
+
 <!-- Greenhouse Gases: CO2, CH4, N2O, CFC11, CFC12 (original CAM versions) -->
 
 <entry id="bndtvghg" type="char*256" input_pathname="abs" category="ghg_cam"

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -1236,7 +1236,7 @@ Default: set by build-namelist.
 switch to enable minimum limit on tau values in GW calculations.
 </entry>
 
-<entry id="use_gw_front_RR_scaling" type="logical" category="gw_drag"
+<entry id="use_gw_front_rr_scaling" type="logical" category="gw_drag"
        group="gw_drag_nl" valid_values="" >
 switch to enable Rossby radius scaling for the frontal GW scheme.
 </entry>

--- a/components/eam/bld/namelist_files/namelist_definition.xml
+++ b/components/eam/bld/namelist_files/namelist_definition.xml
@@ -1231,9 +1231,9 @@ Background source strength (used for waves from frontogenesis).
 Default: set by build-namelist.
 </entry>
 
-<entry id="use_gwut_min_limiter" type="logical" category="gw_drag"
+<entry id="use_tau_limiter" type="logical" category="gw_drag"
        group="gw_drag_nl" valid_values="" >
-switch to enable minimum limit on "gwut" values in GW calculations.
+switch to enable minimum limit on tau values in GW calculations.
 </entry>
 
 <entry id="use_gw_front_RR_scaling" type="logical" category="gw_drag"

--- a/components/eam/src/physics/cam/gw/gw_common.F90
+++ b/components/eam/src/physics/cam/gw/gw_common.F90
@@ -614,8 +614,8 @@ subroutine gwd_compute_tendencies_from_stress_divergence(ncol, ngwv, do_taper, &
   real(r8), parameter :: gwut_magnitude_min = 1.e-15_r8
   !-----------------------------------------------------------------------
 
-  !  override effgw effciency value from namelist if effgw_in is present
-  if (present(effgw_in)) then
+  ! Override scalar effgw with a column-varying value, if provided
+  if (present(effgw_loc_in)) then
     effgw_col(1:ncol) = effgw_loc_in(1:ncol)
   else
     effgw_col(1:ncol) = effgw

--- a/components/eam/src/physics/cam/gw/gw_common.F90
+++ b/components/eam/src/physics/cam/gw/gw_common.F90
@@ -608,7 +608,7 @@ subroutine gwd_compute_tendencies_from_stress_divergence(ncol, ngwv, do_taper, &
   ! Polar taper.
   real(r8) :: ptaper(ncol)
 
-  ! Efficiency parameter for each column 
+  ! Efficiency parameter for each column
   real(r8) :: effgw_col(ncol)
 
   real(r8), parameter :: gwut_magnitude_min = 1.e-15_r8
@@ -845,6 +845,8 @@ subroutine gw_drag_prof(ncol, ngwv, src_level, tend_level, do_taper, &
   ! and adjustments to tau below that level.
   ! Whether or not to apply the polar taper.
   logical(btype), intent(in) :: do_taper
+  ! flag to use minimum limit on gwut
+  logical(btype), intent(in) :: use_gwut_min_limiter
   ! Time step.
   real(r8), intent(in) :: dt
 

--- a/components/eam/src/physics/cam/gw/gw_common.F90
+++ b/components/eam/src/physics/cam/gw/gw_common.F90
@@ -660,6 +660,13 @@ subroutine gwd_compute_tendencies_from_stress_divergence(ncol, ngwv, do_taper, &
         ubtl = min(ubtl, umcfac * abs(c(:,l)-ubm(:,k)) / dt)
         ubtl = min(ubtl, tndmax)
 
+        ! Protection on small ubtl to prevent floating point issues
+        if (use_tau_limiter) then
+          where( abs(ubtl) < ubtl_magnitude_min )
+            ubtl = 0._r8
+          end where
+        end if
+
         where (k <= tend_level)
 
            ! Save tendency for each wave (for later computation of kzz),
@@ -676,13 +683,6 @@ subroutine gwd_compute_tendencies_from_stress_divergence(ncol, ngwv, do_taper, &
            where (k <= tend_level)
               ubt(:,k) = ubt(:,k) + sign(ubtl, c(:,l)-ubm(:,k))
            end where
-        end if
-
-        ! Protection on small gwut to prevent floating point issues
-        if (use_tau_limiter) then
-          where( abs(ubtl) < ubtl_magnitude_min )
-            ubtl = 0._r8
-          end where
         end if
 
         where (k <= tend_level)

--- a/components/eam/src/physics/cam/gw/gw_common.F90
+++ b/components/eam/src/physics/cam/gw/gw_common.F90
@@ -554,7 +554,7 @@ end subroutine gwd_project_tau
 !==========================================================================
 
 subroutine gwd_compute_tendencies_from_stress_divergence(ncol, ngwv, do_taper, &
-     use_gwut_min_limiter, dt, effgw, tend_level, lat, dpm, rdpm, c, ubm, t, nm, &
+     use_tau_limiter, dt, effgw, tend_level, lat, dpm, rdpm, c, ubm, t, nm, &
      xv, yv, tau, gwut, utgw, vtgw, effgw_loc_in)
 
   !------------------------------Arguments--------------------------------
@@ -564,7 +564,7 @@ subroutine gwd_compute_tendencies_from_stress_divergence(ncol, ngwv, do_taper, &
   ! Whether or not to apply the polar taper.
   logical(btype), intent(in) :: do_taper
   ! flag to use minimum limit on gwut
-  logical(btype), intent(in) :: use_gwut_min_limiter
+  logical(btype), intent(in) :: use_tau_limiter
   ! Time step.
   real(r8), intent(in) :: dt
   ! Tendency efficiency.
@@ -611,7 +611,7 @@ subroutine gwd_compute_tendencies_from_stress_divergence(ncol, ngwv, do_taper, &
   ! Efficiency parameter for each column
   real(r8) :: effgw_col(ncol)
 
-  real(r8), parameter :: gwut_magnitude_min = 1.e-15_r8
+  real(r8), parameter :: ubtl_magnitude_min = 1.e-15_r8
   !-----------------------------------------------------------------------
 
   ! Override scalar effgw with a column-varying value, if provided
@@ -679,9 +679,9 @@ subroutine gwd_compute_tendencies_from_stress_divergence(ncol, ngwv, do_taper, &
         end if
 
         ! Protection on small gwut to prevent floating point issues
-        if (use_gwut_min_limiter) then
-          where( abs(gwut(:,k,l)) < gwut_magnitude_min )
-            gwut(:,k,l) = 0._r8
+        if (use_tau_limiter) then
+          where( abs(ubtl) < ubtl_magnitude_min )
+            ubtl = 0._r8
           end where
         end if
 
@@ -814,7 +814,7 @@ end subroutine gwd_precalc_rhoi
 !==========================================================================
 
 subroutine gw_drag_prof(ncol, ngwv, src_level, tend_level, do_taper, &
-                        use_gwut_min_limiter, dt, &
+                        use_tau_limiter, dt, &
                         lat,           t,    ti,  pmid, pint, dpm,   rdpm, &
                         piln, rhoi,    nm,   ni,  ubm,  ubi,  xv,    yv,   &
                         effgw,      c, kvtt, q,   dse,  tau,  utgw,  vtgw, &
@@ -846,7 +846,7 @@ subroutine gw_drag_prof(ncol, ngwv, src_level, tend_level, do_taper, &
   ! Whether or not to apply the polar taper.
   logical(btype), intent(in) :: do_taper
   ! flag to use minimum limit on gwut
-  logical(btype), intent(in) :: use_gwut_min_limiter
+  logical(btype), intent(in) :: use_tau_limiter
   ! Time step.
   real(r8), intent(in) :: dt
 
@@ -930,7 +930,7 @@ subroutine gw_drag_prof(ncol, ngwv, src_level, tend_level, do_taper, &
   ! Compute the tendencies from the stress divergence.
   !------------------------------------------------------------------------
   call gwd_compute_tendencies_from_stress_divergence(ncol, ngwv, do_taper, &
-       use_gwut_min_limiter, dt, effgw, tend_level, lat, dpm, rdpm, c, ubm, &
+       use_tau_limiter, dt, effgw, tend_level, lat, dpm, rdpm, c, ubm, &
        t, nm, xv, yv, tau, gwut, utgw, vtgw, effgw_loc_in)
 
   if (ngwv > 0) then

--- a/components/eam/src/physics/cam/gw/gw_common.F90
+++ b/components/eam/src/physics/cam/gw/gw_common.F90
@@ -554,8 +554,8 @@ end subroutine gwd_project_tau
 !==========================================================================
 
 subroutine gwd_compute_tendencies_from_stress_divergence(ncol, ngwv, do_taper, &
-     use_tau_limiter, dt, effgw, tend_level, lat, dpm, rdpm, c, ubm, t, nm, &
-     xv, yv, tau, gwut, utgw, vtgw, effgw_loc_in)
+     dt, effgw, tend_level, lat, dpm, rdpm, c, ubm, t, nm, &
+     xv, yv, tau, gwut, utgw, vtgw, effgw_loc_in, use_tau_limiter)
 
   !------------------------------Arguments--------------------------------
   ! Column and gravity wave spectrum dimensions.
@@ -563,8 +563,6 @@ subroutine gwd_compute_tendencies_from_stress_divergence(ncol, ngwv, do_taper, &
 
   ! Whether or not to apply the polar taper.
   logical(btype), intent(in) :: do_taper
-  ! flag to use minimum limit on gwut
-  logical(btype), intent(in) :: use_tau_limiter
   ! Time step.
   real(r8), intent(in) :: dt
   ! Tendency efficiency.
@@ -591,6 +589,12 @@ subroutine gwd_compute_tendencies_from_stress_divergence(ncol, ngwv, do_taper, &
   ! Alternative effgw that varies with location - overrides scalar effgw
   real(r8), intent(in), optional :: effgw_loc_in(ncol)
 
+  ! flag to use minimum limit on gwut. Optional (and placed at the end of
+  ! the argument list) so that existing positional callers, such as the
+  ! EAMxx standalone GW unit-test bridge, continue to compile unmodified;
+  ! omitting it preserves the pre-existing (limiter disabled) behavior.
+  logical(btype), intent(in), optional :: use_tau_limiter
+
   ! Wave Reynolds stress.
   real(r8), intent(inout) :: tau(ncol,-pgwv:pgwv,0:pver)
 
@@ -611,6 +615,9 @@ subroutine gwd_compute_tendencies_from_stress_divergence(ncol, ngwv, do_taper, &
   ! Efficiency parameter for each column
   real(r8) :: effgw_col(ncol)
 
+  ! Local resolution of the optional use_tau_limiter flag.
+  logical(btype) :: use_tau_limiter_loc
+
   real(r8), parameter :: ubtl_magnitude_min = 1.e-15_r8
   !-----------------------------------------------------------------------
 
@@ -619,6 +626,12 @@ subroutine gwd_compute_tendencies_from_stress_divergence(ncol, ngwv, do_taper, &
     effgw_col(1:ncol) = effgw_loc_in(1:ncol)
   else
     effgw_col(1:ncol) = effgw
+  endif
+
+  if (present(use_tau_limiter)) then
+    use_tau_limiter_loc = use_tau_limiter
+  else
+    use_tau_limiter_loc = .false.
   endif
 
   if (do_taper) then    ! taper CM only
@@ -661,7 +674,7 @@ subroutine gwd_compute_tendencies_from_stress_divergence(ncol, ngwv, do_taper, &
         ubtl = min(ubtl, tndmax)
 
         ! Protection on small ubtl to prevent floating point issues
-        if (use_tau_limiter) then
+        if (use_tau_limiter_loc) then
           where( abs(ubtl) < ubtl_magnitude_min )
             ubtl = 0._r8
           end where
@@ -813,13 +826,12 @@ end subroutine gwd_precalc_rhoi
 
 !==========================================================================
 
-subroutine gw_drag_prof(ncol, ngwv, src_level, tend_level, do_taper, &
-                        use_tau_limiter, dt, &
+subroutine gw_drag_prof(ncol, ngwv, src_level, tend_level, do_taper, dt, &
                         lat,           t,    ti,  pmid, pint, dpm,   rdpm, &
                         piln, rhoi,    nm,   ni,  ubm,  ubi,  xv,    yv,   &
                         effgw,      c, kvtt, q,   dse,  tau,  utgw,  vtgw, &
                         ttgw, qtgw, taucd,   egwdffi,   gwut, dttdf, dttke, &
-                        effgw_loc_in)
+                        effgw_loc_in, use_tau_limiter)
 
   !-----------------------------------------------------------------------
   ! Solve for the drag profile from the multiple gravity wave drag
@@ -845,8 +857,6 @@ subroutine gw_drag_prof(ncol, ngwv, src_level, tend_level, do_taper, &
   ! and adjustments to tau below that level.
   ! Whether or not to apply the polar taper.
   logical(btype), intent(in) :: do_taper
-  ! flag to use minimum limit on gwut
-  logical(btype), intent(in) :: use_tau_limiter
   ! Time step.
   real(r8), intent(in) :: dt
 
@@ -904,6 +914,12 @@ subroutine gw_drag_prof(ncol, ngwv, src_level, tend_level, do_taper, &
   ! Alternative effgw that varies with location - overrides scalar effgw
   real(r8), intent(in), optional :: effgw_loc_in(ncol)
 
+  ! flag to use minimum limit on gwut. Optional (and placed at the end of
+  ! the argument list) so that existing positional callers, such as the
+  ! EAMxx standalone GW unit-test bridge, continue to compile unmodified;
+  ! omitting it preserves the pre-existing (limiter disabled) behavior.
+  logical(btype), intent(in), optional :: use_tau_limiter
+
   !------------------------------------------------------------------------
 
   ! Initialize gravity wave drag tendencies to zero.
@@ -930,8 +946,8 @@ subroutine gw_drag_prof(ncol, ngwv, src_level, tend_level, do_taper, &
   ! Compute the tendencies from the stress divergence.
   !------------------------------------------------------------------------
   call gwd_compute_tendencies_from_stress_divergence(ncol, ngwv, do_taper, &
-       use_tau_limiter, dt, effgw, tend_level, lat, dpm, rdpm, c, ubm, &
-       t, nm, xv, yv, tau, gwut, utgw, vtgw, effgw_loc_in)
+       dt, effgw, tend_level, lat, dpm, rdpm, c, ubm, &
+       t, nm, xv, yv, tau, gwut, utgw, vtgw, effgw_loc_in, use_tau_limiter)
 
   if (ngwv > 0) then
 

--- a/components/eam/src/physics/cam/gw/gw_common.F90
+++ b/components/eam/src/physics/cam/gw/gw_common.F90
@@ -553,8 +553,9 @@ end subroutine gwd_project_tau
 
 !==========================================================================
 
-subroutine gwd_compute_tendencies_from_stress_divergence(ncol, ngwv, do_taper, dt, effgw, tend_level, &
-     lat, dpm, rdpm, c, ubm, t, nm, xv, yv, tau, gwut, utgw, vtgw)
+subroutine gwd_compute_tendencies_from_stress_divergence(ncol, ngwv, do_taper, &
+     use_gwut_min_limiter, dt, effgw, tend_level, lat, dpm, rdpm, c, ubm, t, nm, &
+     xv, yv, tau, gwut, utgw, vtgw, effgw_loc_in)
 
   !------------------------------Arguments--------------------------------
   ! Column and gravity wave spectrum dimensions.
@@ -562,6 +563,8 @@ subroutine gwd_compute_tendencies_from_stress_divergence(ncol, ngwv, do_taper, d
 
   ! Whether or not to apply the polar taper.
   logical(btype), intent(in) :: do_taper
+  ! flag to use minimum limit on gwut
+  logical(btype), intent(in) :: use_gwut_min_limiter
   ! Time step.
   real(r8), intent(in) :: dt
   ! Tendency efficiency.
@@ -585,6 +588,9 @@ subroutine gwd_compute_tendencies_from_stress_divergence(ncol, ngwv, do_taper, d
   ! Unit vectors of source wind (zonal and meridional components).
   real(r8), intent(in) :: xv(ncol), yv(ncol)
 
+  ! Alternative effgw that varies with location - overrides scalar effgw
+  real(r8), intent(in), optional :: effgw_loc_in(ncol)
+
   ! Wave Reynolds stress.
   real(r8), intent(inout) :: tau(ncol,-pgwv:pgwv,0:pver)
 
@@ -601,6 +607,19 @@ subroutine gwd_compute_tendencies_from_stress_divergence(ncol, ngwv, do_taper, d
 
   ! Polar taper.
   real(r8) :: ptaper(ncol)
+
+  ! Efficiency parameter for each column 
+  real(r8) :: effgw_col(ncol)
+
+  real(r8), parameter :: gwut_magnitude_min = 1.e-15_r8
+  !-----------------------------------------------------------------------
+
+  !  override effgw effciency value from namelist if effgw_in is present
+  if (present(effgw_in)) then
+    effgw_col(1:ncol) = effgw_loc_in(1:ncol)
+  else
+    effgw_col(1:ncol) = effgw
+  endif
 
   if (do_taper) then    ! taper CM only
      do l=1, ncol
@@ -645,7 +664,7 @@ subroutine gwd_compute_tendencies_from_stress_divergence(ncol, ngwv, do_taper, d
 
            ! Save tendency for each wave (for later computation of kzz),
            ! applying efficiency and taper:
-           gwut(:,k,l) = sign(ubtl, c(:,l)-ubm(:,k)) * effgw * ptaper
+           gwut(:,k,l) = sign(ubtl, c(:,l)-ubm(:,k)) * effgw_col * ptaper
 
         end where
 
@@ -657,6 +676,13 @@ subroutine gwd_compute_tendencies_from_stress_divergence(ncol, ngwv, do_taper, d
            where (k <= tend_level)
               ubt(:,k) = ubt(:,k) + sign(ubtl, c(:,l)-ubm(:,k))
            end where
+        end if
+
+        ! Protection on small gwut to prevent floating point issues
+        if (use_gwut_min_limiter) then
+          where( abs(gwut(:,k,l)) < gwut_magnitude_min )
+            gwut(:,k,l) = 0._r8
+          end where
         end if
 
         where (k <= tend_level)
@@ -787,11 +813,13 @@ end subroutine gwd_precalc_rhoi
 
 !==========================================================================
 
-subroutine gw_drag_prof(ncol, ngwv, src_level, tend_level, do_taper, dt, &
-     lat,           t,    ti,  pmid, pint, dpm,   rdpm, &
-     piln, rhoi,    nm,   ni,  ubm,  ubi,  xv,    yv,   &
-     effgw,      c, kvtt, q,   dse,  tau,  utgw,  vtgw, &
-     ttgw, qtgw, taucd,   egwdffi,   gwut, dttdf, dttke)
+subroutine gw_drag_prof(ncol, ngwv, src_level, tend_level, do_taper, &
+                        use_gwut_min_limiter, dt, &
+                        lat,           t,    ti,  pmid, pint, dpm,   rdpm, &
+                        piln, rhoi,    nm,   ni,  ubm,  ubi,  xv,    yv,   &
+                        effgw,      c, kvtt, q,   dse,  tau,  utgw,  vtgw, &
+                        ttgw, qtgw, taucd,   egwdffi,   gwut, dttdf, dttke, &
+                        effgw_loc_in)
 
   !-----------------------------------------------------------------------
   ! Solve for the drag profile from the multiple gravity wave drag
@@ -871,6 +899,9 @@ subroutine gw_drag_prof(ncol, ngwv, src_level, tend_level, do_taper, dt, &
   real(r8), intent(out) :: dttdf(ncol,pver)
   real(r8), intent(out) :: dttke(ncol,pver)
 
+  ! Alternative effgw that varies with location - overrides scalar effgw
+  real(r8), intent(in), optional :: effgw_loc_in(ncol)
+
   !------------------------------------------------------------------------
 
   ! Initialize gravity wave drag tendencies to zero.
@@ -896,8 +927,9 @@ subroutine gw_drag_prof(ncol, ngwv, src_level, tend_level, do_taper, dt, &
   !------------------------------------------------------------------------
   ! Compute the tendencies from the stress divergence.
   !------------------------------------------------------------------------
-  call gwd_compute_tendencies_from_stress_divergence(ncol, ngwv, do_taper, dt, effgw, tend_level, &
-       lat, dpm, rdpm, c, ubm, t, nm, xv, yv, tau, gwut, utgw, vtgw)
+  call gwd_compute_tendencies_from_stress_divergence(ncol, ngwv, do_taper, &
+       use_gwut_min_limiter, dt, effgw, tend_level, lat, dpm, rdpm, c, ubm, &
+       t, nm, xv, yv, tau, gwut, utgw, vtgw, effgw_loc_in)
 
   if (ngwv > 0) then
 

--- a/components/eam/src/physics/cam/gw/gw_drag.F90
+++ b/components/eam/src/physics/cam/gw/gw_drag.F90
@@ -127,6 +127,9 @@ module gw_drag
   real(r8) :: gw_convect_hdepth_min       ! minimum hdepth for for convective GWD spectrum lookup table [km]
   real(r8) :: gw_convect_storm_speed_min  ! minimum convective storm speed for convective GWD           [m/s]
 
+  logical  :: use_gwut_min_limiter        ! switch to enable minimum limit on "gwut" values in GW calculations
+  logical  :: use_gw_front_RR_scaling     ! switch to enable Rossby radius scaling for the frontal GW scheme
+
 !==========================================================================
 contains
 !==========================================================================
@@ -152,7 +155,7 @@ subroutine gw_drag_readnl(nlfile)
       effgw_oro, fcrit2, frontgfc, gw_drag_file, taubgnd, gw_convect_hcf, &
       hdepth_scaling_factor, gw_convect_hdepth_min, &
       gw_convect_storm_speed_min, gw_convect_plev_src_wind, &
-      use_gw_convect_old
+      use_gw_convect_old, use_gwut_min_limiter, use_gw_front_RR_scaling
   !----------------------------------------------------------------------
 
   if (masterproc) then
@@ -187,6 +190,8 @@ subroutine gw_drag_readnl(nlfile)
   call mpibcast(gw_convect_storm_speed_min, 1, mpir8,  0, mpicom)
   call mpibcast(gw_convect_plev_src_wind,   1, mpir8,  0, mpicom)
   call mpibcast(use_gw_convect_old,         1, mpilog, 0, mpicom)
+  call mpibcast(use_gwut_min_limiter,       1, mpilog, 0, mpicom)
+  call mpibcast(use_gw_front_RR_scaling,    1, mpilog, 0, mpicom)
 #endif
 
   dc = gw_dc
@@ -644,10 +649,9 @@ subroutine gw_tend(state, sgh, pbuf, dt, ptend, cam_in)
   ! Location-dependent cpair
   use physconst,  only: cpairv
   use od_common,  only: oro_drag_interface
-  use gw_common,  only: gw_prof, momentum_energy_conservation, &
-       gw_drag_prof
+  use gw_common,  only: gw_prof, momentum_energy_conservation, gw_drag_prof
   use gw_oro,     only: gw_oro_src
-  use gw_front,   only: gw_cm_src
+  use gw_front,   only: gw_cm_src, gw_rossby_radius_ratio
   use gw_convect, only: gw_beres_src
   use dycore,     only: dycore_is
   use phys_grid,  only: get_rlat_all_p
@@ -731,6 +735,8 @@ subroutine gw_tend(state, sgh, pbuf, dt, ptend, cam_in)
   ! Frontogenesis
   real(r8), pointer :: frontgf(:,:)
   real(r8), pointer :: frontga(:,:)
+  real(r8) :: rossby_radius_ratio(state%ncol) ! Rossby radius ratio => Lr/(dx*nx)
+  real(r8) :: effgw_cm_var(state%ncol) ! locally modified version of effgw_cm
 
   ! Temperature change due to deep convection.
   real(r8), pointer, dimension(:,:) :: ttend_dp
@@ -855,7 +861,8 @@ subroutine gw_tend(state, sgh, pbuf, dt, ptend, cam_in)
         do_latitude_taper = .false.
 
         ! Solve for the drag profile with Beres source spectrum.
-        call gw_drag_prof(ncol, pgwv, src_level, tend_level, do_latitude_taper, dt, &
+        call gw_drag_prof(ncol, pgwv, src_level, tend_level, &
+             do_latitude_taper, use_gwut_min_limiter,dt, &
              state1%lat(:ncol), t,    ti, pmid, pint, dpm,   rdpm, &
              piln, rhoi,       nm,   ni, ubm,  ubi,  xv,    yv,   &
              effgw_beres, c,   kvtt, q,  dse,  tau,  utgw,  vtgw, &
@@ -917,12 +924,25 @@ subroutine gw_tend(state, sgh, pbuf, dt, ptend, cam_in)
           do_latitude_taper = .true.
         end if
 
+        if (use_gw_front_RR_scaling) then
+          ! Calculate the effgw_cm as a function of the ratio between the
+          ! Rossby radius and effective grid length of each column
+          call gw_rossby_radius_ratio(ncol, state1%lat(1:ncol),state1%lchnk,rossby_radius_ratio)
+          effgw_cm_var = effgw_cm
+          where (rossby_radius_ratio>1)
+            effgw_cm_var = effgw_cm/rossby_radius_index
+          end where
+        else
+          effgw_cm_var(1:ncol) = effgw_cm
+        end if
+
         ! Solve for the drag profile with C&M source spectrum.
-        call gw_drag_prof(ncol, pgwv, src_level, tend_level, do_latitude_taper, dt, &
+        call gw_drag_prof(ncol, pgwv, src_level, tend_level, &
+             do_latitude_taper, use_gwut_min_limiter, dt, &
              state1%lat(:ncol), t,    ti, pmid, pint, dpm,   rdpm, &
              piln, rhoi,       nm,   ni, ubm,  ubi,  xv,    yv,   &
              effgw_cm,    c,   kvtt, q,  dse,  tau,  utgw,  vtgw, &
-             ttgw, qtgw,  taucd,     egwdffi,  gwut, dttdf, dttke)
+             ttgw, qtgw,  taucd,     egwdffi,  gwut, dttdf, dttke, effgw_cm_var)
 
         !  add the diffusion coefficients
         do k = 0, pver
@@ -972,7 +992,8 @@ subroutine gw_tend(state, sgh, pbuf, dt, ptend, cam_in)
      do_latitude_taper = .false.
 
      ! Solve for the drag profile with orographic sources.
-     call gw_drag_prof(ncol, 0, src_level, tend_level, do_latitude_taper, dt, &
+     call gw_drag_prof(ncol, 0, src_level, tend_level, &
+          do_latitude_taper, use_gwut_min_limiter, dt, &
           state1%lat(:ncol), t,    ti, pmid, pint, dpm,   rdpm, &
           piln, rhoi,       nm,   ni, ubm,  ubi,  xv,    yv,   &
           effgw_oro,   c,   kvtt, q,  dse,  tau,  utgw,  vtgw, &

--- a/components/eam/src/physics/cam/gw/gw_drag.F90
+++ b/components/eam/src/physics/cam/gw/gw_drag.F90
@@ -128,7 +128,7 @@ module gw_drag
   real(r8) :: gw_convect_storm_speed_min  ! minimum convective storm speed for convective GWD           [m/s]
 
   logical  :: use_tau_limiter             ! switch to enable minimum limit on "gwut" values in GW calculations
-  logical  :: use_gw_front_RR_scaling     ! switch to enable Rossby radius scaling for the frontal GW scheme
+  logical  :: use_gw_front_rr_scaling     ! switch to enable Rossby radius scaling for the frontal GW scheme
 
 !==========================================================================
 contains
@@ -155,7 +155,7 @@ subroutine gw_drag_readnl(nlfile)
       effgw_oro, fcrit2, frontgfc, gw_drag_file, taubgnd, gw_convect_hcf, &
       hdepth_scaling_factor, gw_convect_hdepth_min, &
       gw_convect_storm_speed_min, gw_convect_plev_src_wind, &
-      use_gw_convect_old, use_tau_limiter, use_gw_front_RR_scaling
+      use_gw_convect_old, use_tau_limiter, use_gw_front_rr_scaling
   !----------------------------------------------------------------------
 
   if (masterproc) then
@@ -191,7 +191,7 @@ subroutine gw_drag_readnl(nlfile)
   call mpibcast(gw_convect_plev_src_wind,   1, mpir8,  0, mpicom)
   call mpibcast(use_gw_convect_old,         1, mpilog, 0, mpicom)
   call mpibcast(use_tau_limiter,            1, mpilog, 0, mpicom)
-  call mpibcast(use_gw_front_RR_scaling,    1, mpilog, 0, mpicom)
+  call mpibcast(use_gw_front_rr_scaling,    1, mpilog, 0, mpicom)
 #endif
 
   dc = gw_dc
@@ -925,14 +925,14 @@ subroutine gw_tend(state, sgh, pbuf, dt, ptend, cam_in)
           do_latitude_taper = .true.
         end if
 
-        if (use_gw_front_RR_scaling) then
+        if (use_gw_front_rr_scaling) then
           ! Calculate the effgw_cm as a function of the ratio between the
           ! Rossby radius and effective grid length of each column
           do i = 1, ncol
             grid_area(i) = get_area_p(lchnk, i)
           end do
           call gw_rossby_radius_ratio(ncol, state1%lat(1:ncol), grid_area(1:ncol), &
-               rearth, omega, pi, rossby_radius_ratio)
+                                      rearth, omega, pi, rossby_radius_ratio)
           effgw_cm_var = effgw_cm
           where (rossby_radius_ratio > 1._r8)
             effgw_cm_var = effgw_cm/rossby_radius_ratio
@@ -948,6 +948,22 @@ subroutine gw_tend(state, sgh, pbuf, dt, ptend, cam_in)
              effgw_cm,    c,   kvtt, q,  dse,  tau,  utgw,  vtgw, &
              ttgw, qtgw,  taucd,     egwdffi,  gwut, dttdf, dttke, effgw_cm_var, &
              use_tau_limiter=use_tau_limiter)
+
+        if (use_gw_front_rr_scaling) then
+          ! taucd is projected from the raw (unscaled) source stress inside
+          ! gw_drag_prof, before effgw_cm_var is applied to the tendencies
+          ! (gwd_compute_tendencies_from_stress_divergence only scales gwut/
+          ! utgw/vtgw). momentum_energy_conservation below uses taucd at
+          ! tend_level to set the below-source recoil tendency, so without
+          ! this correction that recoil stays at full strength even as
+          ! effgw_cm_var -> 0, defeating the intent of RR scaling to fully
+          ! disable the frontal scheme at high Rossby ratio. Scale taucd by
+          ! the same per-column ratio applied to the tendencies; this is a
+          ! no-op wherever rossby_radius_ratio <= 1 (effgw_cm_var == effgw_cm).
+          do i = 1, ncol
+            taucd(i,:,:) = taucd(i,:,:) * (effgw_cm_var(i)/effgw_cm)
+          end do
+        end if
 
         !  add the diffusion coefficients
         do k = 0, pver

--- a/components/eam/src/physics/cam/gw/gw_drag.F90
+++ b/components/eam/src/physics/cam/gw/gw_drag.F90
@@ -127,7 +127,7 @@ module gw_drag
   real(r8) :: gw_convect_hdepth_min       ! minimum hdepth for for convective GWD spectrum lookup table [km]
   real(r8) :: gw_convect_storm_speed_min  ! minimum convective storm speed for convective GWD           [m/s]
 
-  logical  :: use_gwut_min_limiter        ! switch to enable minimum limit on "gwut" values in GW calculations
+  logical  :: use_tau_limiter        ! switch to enable minimum limit on "gwut" values in GW calculations
   logical  :: use_gw_front_RR_scaling     ! switch to enable Rossby radius scaling for the frontal GW scheme
 
 !==========================================================================
@@ -155,7 +155,7 @@ subroutine gw_drag_readnl(nlfile)
       effgw_oro, fcrit2, frontgfc, gw_drag_file, taubgnd, gw_convect_hcf, &
       hdepth_scaling_factor, gw_convect_hdepth_min, &
       gw_convect_storm_speed_min, gw_convect_plev_src_wind, &
-      use_gw_convect_old, use_gwut_min_limiter, use_gw_front_RR_scaling
+      use_gw_convect_old, use_tau_limiter, use_gw_front_RR_scaling
   !----------------------------------------------------------------------
 
   if (masterproc) then
@@ -190,7 +190,7 @@ subroutine gw_drag_readnl(nlfile)
   call mpibcast(gw_convect_storm_speed_min, 1, mpir8,  0, mpicom)
   call mpibcast(gw_convect_plev_src_wind,   1, mpir8,  0, mpicom)
   call mpibcast(use_gw_convect_old,         1, mpilog, 0, mpicom)
-  call mpibcast(use_gwut_min_limiter,       1, mpilog, 0, mpicom)
+  call mpibcast(use_tau_limiter,            1, mpilog, 0, mpicom)
   call mpibcast(use_gw_front_RR_scaling,    1, mpilog, 0, mpicom)
 #endif
 
@@ -862,7 +862,7 @@ subroutine gw_tend(state, sgh, pbuf, dt, ptend, cam_in)
 
         ! Solve for the drag profile with Beres source spectrum.
         call gw_drag_prof(ncol, pgwv, src_level, tend_level, &
-             do_latitude_taper, use_gwut_min_limiter,dt, &
+             do_latitude_taper, use_tau_limiter,dt, &
              state1%lat(:ncol), t,    ti, pmid, pint, dpm,   rdpm, &
              piln, rhoi,       nm,   ni, ubm,  ubi,  xv,    yv,   &
              effgw_beres, c,   kvtt, q,  dse,  tau,  utgw,  vtgw, &
@@ -938,7 +938,7 @@ subroutine gw_tend(state, sgh, pbuf, dt, ptend, cam_in)
 
         ! Solve for the drag profile with C&M source spectrum.
         call gw_drag_prof(ncol, pgwv, src_level, tend_level, &
-             do_latitude_taper, use_gwut_min_limiter, dt, &
+             do_latitude_taper, use_tau_limiter, dt, &
              state1%lat(:ncol), t,    ti, pmid, pint, dpm,   rdpm, &
              piln, rhoi,       nm,   ni, ubm,  ubi,  xv,    yv,   &
              effgw_cm,    c,   kvtt, q,  dse,  tau,  utgw,  vtgw, &
@@ -993,7 +993,7 @@ subroutine gw_tend(state, sgh, pbuf, dt, ptend, cam_in)
 
      ! Solve for the drag profile with orographic sources.
      call gw_drag_prof(ncol, 0, src_level, tend_level, &
-          do_latitude_taper, use_gwut_min_limiter, dt, &
+          do_latitude_taper, use_tau_limiter, dt, &
           state1%lat(:ncol), t,    ti, pmid, pint, dpm,   rdpm, &
           piln, rhoi,       nm,   ni, ubm,  ubi,  xv,    yv,   &
           effgw_oro,   c,   kvtt, q,  dse,  tau,  utgw,  vtgw, &

--- a/components/eam/src/physics/cam/gw/gw_drag.F90
+++ b/components/eam/src/physics/cam/gw/gw_drag.F90
@@ -929,8 +929,8 @@ subroutine gw_tend(state, sgh, pbuf, dt, ptend, cam_in)
           ! Rossby radius and effective grid length of each column
           call gw_rossby_radius_ratio(ncol, state1%lat(1:ncol),state1%lchnk,rossby_radius_ratio)
           effgw_cm_var = effgw_cm
-          where (rossby_radius_ratio>1)
-            effgw_cm_var = effgw_cm/rossby_radius_index
+          where (rossby_radius_ratio > 1._r8)
+            effgw_cm_var = effgw_cm/rossby_radius_ratio
           end where
         else
           effgw_cm_var(1:ncol) = effgw_cm

--- a/components/eam/src/physics/cam/gw/gw_drag.F90
+++ b/components/eam/src/physics/cam/gw/gw_drag.F90
@@ -651,7 +651,7 @@ subroutine gw_tend(state, sgh, pbuf, dt, ptend, cam_in)
   use od_common,  only: oro_drag_interface
   use gw_common,  only: gw_prof, momentum_energy_conservation, gw_drag_prof
   use gw_oro,     only: gw_oro_src
-  use gw_front,   only: gw_cm_src, gw_rossby_radius_ratio
+  use gw_front,   only: gw_cm_src, gw_rossby_radius
   use gw_convect, only: gw_beres_src
   use dycore,     only: dycore_is
   use phys_grid,  only: get_rlat_all_p, get_area_p
@@ -735,9 +735,16 @@ subroutine gw_tend(state, sgh, pbuf, dt, ptend, cam_in)
   ! Frontogenesis
   real(r8), pointer :: frontgf(:,:)
   real(r8), pointer :: frontga(:,:)
-  real(r8) :: rossby_radius_ratio(state%ncol) ! Rossby radius ratio => Lr/(dx*nx)
+  real(r8) :: rossby_radius(state%ncol) ! Rossby radius [m], for RR scaling of the frontal GW scheme
+  real(r8) :: grid_length(state%ncol) ! effective local grid length (i.e. dx) [m], for RR scaling
+  real(r8) :: rossby_radius_ratio(state%ncol) ! number of grid lengths spanning the Rossby radius => Lr/dx
   real(r8) :: effgw_cm_var(state%ncol) ! locally modified version of effgw_cm
-  real(r8) :: grid_area(state%ncol) ! grid cell area [steradians], for gw_rossby_radius_ratio
+  real(r8) :: grid_area(state%ncol) ! grid cell area [steradians], for gw_rossby_radius / RR scaling
+  ! Below eff_res_grid_num_min grid lengths across the Rossby radius the
+  ! frontal GW scheme runs at full efficiency; above eff_res_grid_num_max
+  ! it is fully disabled; in between effgw_cm is tapered linearly to zero.
+  real(r8), parameter :: eff_res_grid_num_min = 6._r8
+  real(r8), parameter :: eff_res_grid_num_max = 20._r8
 
   ! Temperature change due to deep convection.
   real(r8), pointer, dimension(:,:) :: ttend_dp
@@ -926,16 +933,25 @@ subroutine gw_tend(state, sgh, pbuf, dt, ptend, cam_in)
         end if
 
         if (use_gw_front_rr_scaling) then
-          ! Calculate the effgw_cm as a function of the ratio between the
-          ! Rossby radius and effective grid length of each column
+          ! Calculate effgw_cm as a function of how many local grid lengths
+          ! span the Rossby radius: the frontal GW scheme runs at full
+          ! efficiency where the Rossby radius is poorly resolved (fewer than
+          ! eff_res_grid_num_min grid lengths across it), is fully disabled
+          ! where it is well resolved (more than eff_res_grid_num_max grid
+          ! lengths across it), and tapers linearly to zero in between.
           do i = 1, ncol
             grid_area(i) = get_area_p(lchnk, i)
           end do
-          call gw_rossby_radius_ratio(ncol, state1%lat(1:ncol), grid_area(1:ncol), &
-                                      rearth, omega, pi, rossby_radius_ratio)
-          effgw_cm_var = effgw_cm
-          where (rossby_radius_ratio > 1._r8)
-            effgw_cm_var = effgw_cm/rossby_radius_ratio
+          grid_length(1:ncol) = sqrt( grid_area(1:ncol) * rearth**2 ) ! sqrt( steradians x m2 ) => m
+          call gw_rossby_radius(ncol, state1%lat(1:ncol), omega, pi, rossby_radius(1:ncol))
+          rossby_radius_ratio(1:ncol) = rossby_radius(1:ncol) / grid_length(1:ncol)
+          where (rossby_radius_ratio <= eff_res_grid_num_min)
+            effgw_cm_var = effgw_cm
+          else where (rossby_radius_ratio >= eff_res_grid_num_max)
+            effgw_cm_var = 0._r8
+          else where
+            effgw_cm_var = effgw_cm * (eff_res_grid_num_max - rossby_radius_ratio) &
+                                     / (eff_res_grid_num_max - eff_res_grid_num_min)
           end where
         else
           effgw_cm_var(1:ncol) = effgw_cm
@@ -953,13 +969,11 @@ subroutine gw_tend(state, sgh, pbuf, dt, ptend, cam_in)
           ! taucd is projected from the raw (unscaled) source stress inside
           ! gw_drag_prof, before effgw_cm_var is applied to the tendencies
           ! (gwd_compute_tendencies_from_stress_divergence only scales gwut/
-          ! utgw/vtgw). momentum_energy_conservation below uses taucd at
-          ! tend_level to set the below-source recoil tendency, so without
-          ! this correction that recoil stays at full strength even as
-          ! effgw_cm_var -> 0, defeating the intent of RR scaling to fully
-          ! disable the frontal scheme at high Rossby ratio. Scale taucd by
-          ! the same per-column ratio applied to the tendencies; this is a
-          ! no-op wherever rossby_radius_ratio <= 1 (effgw_cm_var == effgw_cm).
+          ! utgw/vtgw). momentum_energy_conservation below uses taucd
+          ! to set the below-source correction for energy conservation.
+          ! without this correction that correction stays at full strength even
+          ! as effgw_cm_var->0, defeating the intent of RR scaling. Therefore,
+          ! we scale taucd here by the same per-column value as tendencies.
           do i = 1, ncol
             taucd(i,:,:) = taucd(i,:,:) * (effgw_cm_var(i)/effgw_cm)
           end do

--- a/components/eam/src/physics/cam/gw/gw_drag.F90
+++ b/components/eam/src/physics/cam/gw/gw_drag.F90
@@ -127,7 +127,7 @@ module gw_drag
   real(r8) :: gw_convect_hdepth_min       ! minimum hdepth for for convective GWD spectrum lookup table [km]
   real(r8) :: gw_convect_storm_speed_min  ! minimum convective storm speed for convective GWD           [m/s]
 
-  logical  :: use_tau_limiter        ! switch to enable minimum limit on "gwut" values in GW calculations
+  logical  :: use_tau_limiter             ! switch to enable minimum limit on "gwut" values in GW calculations
   logical  :: use_gw_front_RR_scaling     ! switch to enable Rossby radius scaling for the frontal GW scheme
 
 !==========================================================================
@@ -654,8 +654,8 @@ subroutine gw_tend(state, sgh, pbuf, dt, ptend, cam_in)
   use gw_front,   only: gw_cm_src, gw_rossby_radius_ratio
   use gw_convect, only: gw_beres_src
   use dycore,     only: dycore_is
-  use phys_grid,  only: get_rlat_all_p
-  use physconst,  only: gravit,rair
+  use phys_grid,  only: get_rlat_all_p, get_area_p
+  use physconst,  only: gravit,rair,omega
   !------------------------------Arguments--------------------------------
   type(physics_state), intent(in) :: state      ! physics state structure
   ! Standard deviation of orography.
@@ -737,6 +737,7 @@ subroutine gw_tend(state, sgh, pbuf, dt, ptend, cam_in)
   real(r8), pointer :: frontga(:,:)
   real(r8) :: rossby_radius_ratio(state%ncol) ! Rossby radius ratio => Lr/(dx*nx)
   real(r8) :: effgw_cm_var(state%ncol) ! locally modified version of effgw_cm
+  real(r8) :: grid_area(state%ncol) ! grid cell area [steradians], for gw_rossby_radius_ratio
 
   ! Temperature change due to deep convection.
   real(r8), pointer, dimension(:,:) :: ttend_dp
@@ -861,12 +862,12 @@ subroutine gw_tend(state, sgh, pbuf, dt, ptend, cam_in)
         do_latitude_taper = .false.
 
         ! Solve for the drag profile with Beres source spectrum.
-        call gw_drag_prof(ncol, pgwv, src_level, tend_level, &
-             do_latitude_taper, use_tau_limiter,dt, &
+        call gw_drag_prof(ncol, pgwv, src_level, tend_level, do_latitude_taper, dt, &
              state1%lat(:ncol), t,    ti, pmid, pint, dpm,   rdpm, &
              piln, rhoi,       nm,   ni, ubm,  ubi,  xv,    yv,   &
              effgw_beres, c,   kvtt, q,  dse,  tau,  utgw,  vtgw, &
-             ttgw, qtgw,  taucd,     egwdffi,  gwut, dttdf, dttke)
+             ttgw, qtgw,  taucd,     egwdffi,  gwut, dttdf, dttke, &
+             use_tau_limiter=use_tau_limiter)
 
         !  add the diffusion coefficients
         do k = 0, pver
@@ -927,7 +928,11 @@ subroutine gw_tend(state, sgh, pbuf, dt, ptend, cam_in)
         if (use_gw_front_RR_scaling) then
           ! Calculate the effgw_cm as a function of the ratio between the
           ! Rossby radius and effective grid length of each column
-          call gw_rossby_radius_ratio(ncol, state1%lat(1:ncol),state1%lchnk,rossby_radius_ratio)
+          do i = 1, ncol
+            grid_area(i) = get_area_p(lchnk, i)
+          end do
+          call gw_rossby_radius_ratio(ncol, state1%lat(1:ncol), grid_area(1:ncol), &
+               rearth, omega, pi, rossby_radius_ratio)
           effgw_cm_var = effgw_cm
           where (rossby_radius_ratio > 1._r8)
             effgw_cm_var = effgw_cm/rossby_radius_ratio
@@ -937,12 +942,12 @@ subroutine gw_tend(state, sgh, pbuf, dt, ptend, cam_in)
         end if
 
         ! Solve for the drag profile with C&M source spectrum.
-        call gw_drag_prof(ncol, pgwv, src_level, tend_level, &
-             do_latitude_taper, use_tau_limiter, dt, &
+        call gw_drag_prof(ncol, pgwv, src_level, tend_level, do_latitude_taper, dt, &
              state1%lat(:ncol), t,    ti, pmid, pint, dpm,   rdpm, &
              piln, rhoi,       nm,   ni, ubm,  ubi,  xv,    yv,   &
              effgw_cm,    c,   kvtt, q,  dse,  tau,  utgw,  vtgw, &
-             ttgw, qtgw,  taucd,     egwdffi,  gwut, dttdf, dttke, effgw_cm_var)
+             ttgw, qtgw,  taucd,     egwdffi,  gwut, dttdf, dttke, effgw_cm_var, &
+             use_tau_limiter=use_tau_limiter)
 
         !  add the diffusion coefficients
         do k = 0, pver
@@ -992,12 +997,12 @@ subroutine gw_tend(state, sgh, pbuf, dt, ptend, cam_in)
      do_latitude_taper = .false.
 
      ! Solve for the drag profile with orographic sources.
-     call gw_drag_prof(ncol, 0, src_level, tend_level, &
-          do_latitude_taper, use_tau_limiter, dt, &
+     call gw_drag_prof(ncol, 0, src_level, tend_level, do_latitude_taper, dt, &
           state1%lat(:ncol), t,    ti, pmid, pint, dpm,   rdpm, &
           piln, rhoi,       nm,   ni, ubm,  ubi,  xv,    yv,   &
           effgw_oro,   c,   kvtt, q,  dse,  tau,  utgw,  vtgw, &
-          ttgw, qtgw,  taucd,     egwdffi,  gwut(:,:,0:0), dttdf, dttke)
+          ttgw, qtgw,  taucd,     egwdffi,  gwut(:,:,0:0), dttdf, dttke, &
+          use_tau_limiter=use_tau_limiter)
   endif
   !
   if ( use_od_ls .or. use_od_bl .or. use_od_ss) then

--- a/components/eam/src/physics/cam/gw/gw_drag.F90
+++ b/components/eam/src/physics/cam/gw/gw_drag.F90
@@ -966,23 +966,19 @@ subroutine gw_tend(state, sgh, pbuf, dt, ptend, cam_in)
              use_tau_limiter=use_tau_limiter)
 
         if (use_gw_front_rr_scaling) then
-          ! taucd is projected from the raw (unscaled) source stress inside
-          ! gw_drag_prof, before effgw_cm_var is applied to the tendencies
-          ! (gwd_compute_tendencies_from_stress_divergence only scales gwut/
-          ! utgw/vtgw). momentum_energy_conservation below uses taucd
-          ! to set the below-source correction for energy conservation.
-          ! without this correction that correction stays at full strength even
-          ! as effgw_cm_var->0, defeating the intent of RR scaling. Therefore,
-          ! we scale taucd here by the same per-column value as tendencies.
-          if (effgw_cm == 0._r8) then
-            tau = 0._r8
-            taucd = 0._r8
-          else
-            do i = 1, ncol
-              tau(i,:,:) = tau(i,:,:) * (effgw_cm_var(i)/effgw_cm)
-              taucd(i,:,:) = taucd(i,:,:) * (effgw_cm_var(i)/effgw_cm)
-            end do
-          end if
+          ! tau/taucd are projected/reconstructed from the raw (unscaled)
+          ! source stress inside gw_drag_prof, before effgw_cm_var is applied
+          ! to the tendencies (gwd_compute_tendencies_from_stress_divergence
+          ! only scales gwut/utgw/vtgw). momentum_energy_conservation below
+          ! uses taucd to set the below-source correction for energy
+          ! conservation; without this correction that correction stays at
+          ! full strength even as effgw_cm_var->0, defeating the intent of RR
+          ! scaling. Therefore, we scale tau/taucd here by the same
+          ! per-column value applied to the tendencies.
+          do i = 1, ncol
+            tau(i,:,:) = tau(i,:,:) * effgw_cm_var(i)
+            taucd(i,:,:) = taucd(i,:,:) * effgw_cm_var(i)
+          end do
         end if
 
         !  add the diffusion coefficients

--- a/components/eam/src/physics/cam/gw/gw_drag.F90
+++ b/components/eam/src/physics/cam/gw/gw_drag.F90
@@ -974,9 +974,13 @@ subroutine gw_tend(state, sgh, pbuf, dt, ptend, cam_in)
           ! without this correction that correction stays at full strength even
           ! as effgw_cm_var->0, defeating the intent of RR scaling. Therefore,
           ! we scale taucd here by the same per-column value as tendencies.
-          do i = 1, ncol
-            taucd(i,:,:) = taucd(i,:,:) * (effgw_cm_var(i)/effgw_cm)
-          end do
+          if (effgw_cm == 0._r8) then
+            taucd = 0._r8
+          else
+            do i = 1, ncol
+              taucd(i,:,:) = taucd(i,:,:) * (effgw_cm_var(i)/effgw_cm)
+            end do
+          end if
         end if
 
         !  add the diffusion coefficients

--- a/components/eam/src/physics/cam/gw/gw_drag.F90
+++ b/components/eam/src/physics/cam/gw/gw_drag.F90
@@ -975,9 +975,11 @@ subroutine gw_tend(state, sgh, pbuf, dt, ptend, cam_in)
           ! as effgw_cm_var->0, defeating the intent of RR scaling. Therefore,
           ! we scale taucd here by the same per-column value as tendencies.
           if (effgw_cm == 0._r8) then
+            tau = 0._r8
             taucd = 0._r8
           else
             do i = 1, ncol
+              tau(i,:,:) = tau(i,:,:) * (effgw_cm_var(i)/effgw_cm)
               taucd(i,:,:) = taucd(i,:,:) * (effgw_cm_var(i)/effgw_cm)
             end do
           end if

--- a/components/eam/src/physics/cam/gw/gw_front.F90
+++ b/components/eam/src/physics/cam/gw/gw_front.F90
@@ -200,17 +200,23 @@ subroutine gw_rossby_radius_ratio(ncol, lat, lchnk, rossby_radius_ratio)
   !------------------------------------------------------------------------
   ! Local Variables
   integer :: i
+  real(r8), parameter :: max_rossby_radius = 1000e3_r8 ! limit RR to 1000km in the Tropics
   real(r8), parameter :: rossby_depth = 2.0e3_r8 ! effective depth / scale height
   real(r8), parameter :: eff_res_grid_num = 6 ! number of grid points for effective resolution
-  real(r8), :: coriolis_f    ! coriolis parameter
-  real(r8), :: grid_length   ! effective local grid length (i.e. dx) [m]
-  real(r8), :: rossby_radius ! Rossby radius [m]
+  real(r8) :: coriolis_f    ! coriolis parameter
+  real(r8) :: grid_length   ! effective local grid length (i.e. dx) [m]
+  real(r8) :: rossby_radius ! Rossby radius [m]
   !------------------------------------------------------------------------
   do i = 1,ncol
     ! Calculate coriolis parameter
-    coriolis_f = 2 * omega * sin(lat) ! latitude must be in radians
+    coriolis_f = 2 * omega * sin(lat(i)) ! latitude must be in radians
     ! Calculate Rossby Radius
-    rossby_radius = sqrt(gravit*rossby_depth)/abs(coriolis_f)
+    if (coriolis_f>0.0_r8) then
+      rossby_radius = sqrt(gravit*rossby_depth)/abs(coriolis_f)
+      rossby_radius = min(rossby_radius,max_rossby_radius)
+    else
+      rossby_radius = max_rossby_radius
+    end if
     ! Calculate grid length
     grid_length = sqrt( get_area_p(lchnk,i) * rearth**2 ) ! sqrt( steradians x m2 ) => m
     ! Calculate ratio of Rossby Radius to effective grid length

--- a/components/eam/src/physics/cam/gw/gw_front.F90
+++ b/components/eam/src/physics/cam/gw/gw_front.F90
@@ -18,7 +18,7 @@ public :: gw_cm_src
 ! Only public for testing
 public :: gw_front_project_winds
 public :: gw_front_gw_sources
-public :: gw_rossby_radius_ratio
+public :: gw_rossby_radius
 
 ! Tuneable settings.
 
@@ -179,42 +179,33 @@ subroutine gw_front_gw_sources(ncol, ngwv, kbot, frontgf, tau)
 end subroutine gw_front_gw_sources
 
 !==========================================================================
-subroutine gw_rossby_radius_ratio(ncol, lat, grid_area, rearth, omega, pi, &
-                                  rossby_radius_ratio)
+subroutine gw_rossby_radius(ncol, lat, omega, pi, rossby_radius)
   use gw_common, only: gravit
   !------------------------------------------------------------------------
-  ! The purpose of the "Rossby radius ratio" (RRR) is to act as a crude
-  ! estimate of whether frontogenesis process are resolved at each local
-  ! point of the grid. We do this by checking whether the Rossby radius is
-  ! well resolved locally, assuming that we need "eff_res_grid_num" number
-  ! of grid points to resolve a feature. Thus, when the Rossby radius is
-  ! larger than "grid_length*eff_res_grid_num" we can assume that frontogenesis
-  ! is resolved, and the frontal GW scheme can be disabled, or scaled down.
-  ! This is meant as a way to make the frontal GW scheme "scale aware".
+  ! Calculate the (baroclinic) Rossby radius at each column, which is used
+  ! as a crude estimate of the length scale of frontogenesis processes.
+  ! Comparing this against the local effective grid length lets the caller
+  ! judge whether frontogenesis is resolved at each point of the grid, and
+  ! scale down (or disable) the frontal GW scheme accordingly, making it
+  ! "scale aware".
   !
-  ! Note: the grid cell area and the rearth/omega/pi constants are passed
-  ! in (rather than obtained via "use phys_grid" / "use physconst") so that
-  ! this module stays independent of the EAM-specific grid decomposition
-  ! and physconst modules, which are unavailable to the standalone EAMxx
-  ! GW unit-test build.
+  ! Note: the omega/pi constants are passed in (rather than obtained via
+  ! "use physconst") so that this module stays independent of the
+  ! EAM-specific physconst module, which is unavailable to the standalone
+  ! EAMxx GW unit-test build.
   !------------------------------------------------------------------------
   ! Arguments
   integer,  intent(in) :: ncol
   real(r8), dimension(ncol), intent(in ) :: lat ! latitude [radians]
-  real(r8), dimension(ncol), intent(in ) :: grid_area ! grid cell area [steradians]
-  real(r8), intent(in) :: rearth ! radius of the Earth [m]
   real(r8), intent(in) :: omega  ! Earth's angular rotation rate [1/s]
   real(r8), intent(in) :: pi
-  real(r8), dimension(ncol), intent(out) :: rossby_radius_ratio ! rossby radius ratio
+  real(r8), dimension(ncol), intent(out) :: rossby_radius ! Rossby radius [m]
   !------------------------------------------------------------------------
   ! Local Variables
   integer :: i
   real(r8), parameter :: min_lat_deg = 5 ! min latitude for limiter (RR~10e6m@5deg) [deg]
   real(r8), parameter :: rossby_depth = 2.0e3_r8 ! effective depth / scale height
-  real(r8), parameter :: eff_res_grid_num = 6 ! number of grid points for effective resolution
   real(r8) :: coriolis_f    ! coriolis parameter [1/s]
-  real(r8) :: grid_length   ! effective local grid length (i.e. dx) [m]
-  real(r8) :: rossby_radius ! Rossby radius [m]
   real(r8) :: min_lat_rad   ! min_lat_deg converted to radians
   !------------------------------------------------------------------------
   min_lat_rad = min_lat_deg*pi/180.0_r8
@@ -226,14 +217,10 @@ subroutine gw_rossby_radius_ratio(ncol, lat, grid_area, rearth, omega, pi, &
       coriolis_f = 2 * omega * sin(sign(min_lat_rad,lat(i))) ! latitude must be in radians
     end if
     ! Calculate Rossby Radius
-    rossby_radius = sqrt(gravit*rossby_depth)/abs(coriolis_f)
-    ! Calculate grid length
-    grid_length = sqrt( grid_area(i) * rearth**2 ) ! sqrt( steradians x m2 ) => m
-    ! Calculate ratio of Rossby Radius to effective grid length
-    rossby_radius_ratio(i) = rossby_radius / (grid_length*eff_res_grid_num)
+    rossby_radius(i) = sqrt(gravit*rossby_depth)/abs(coriolis_f)
   end do
   !------------------------------------------------------------------------
-end subroutine gw_rossby_radius_ratio
+end subroutine gw_rossby_radius
 
 !==========================================================================
 subroutine gw_cm_src(ncol, ngwv, kbot, u, v, frontgf, &

--- a/components/eam/src/physics/cam/gw/gw_front.F90
+++ b/components/eam/src/physics/cam/gw/gw_front.F90
@@ -180,7 +180,7 @@ end subroutine gw_front_gw_sources
 
 !==========================================================================
 subroutine gw_rossby_radius_ratio(ncol, lat, lchnk, rossby_radius_ratio)
-  use physconst, only: rearth, gravit, omega
+  use physconst, only: rearth, gravit, omega, pi
   use phys_grid, only: get_area_p
   !------------------------------------------------------------------------
   ! The purpose of the "Rossby radius ratio" (RRR) is to act as a crude
@@ -200,23 +200,24 @@ subroutine gw_rossby_radius_ratio(ncol, lat, lchnk, rossby_radius_ratio)
   !------------------------------------------------------------------------
   ! Local Variables
   integer :: i
-  real(r8), parameter :: max_rossby_radius = 1000e3_r8 ! limit RR to 1000km in the Tropics
+  real(r8), parameter :: min_lat_deg = 5 ! min latitude for limiter (RR~10e6m@5deg) [deg]
   real(r8), parameter :: rossby_depth = 2.0e3_r8 ! effective depth / scale height
   real(r8), parameter :: eff_res_grid_num = 6 ! number of grid points for effective resolution
-  real(r8) :: coriolis_f    ! coriolis parameter
+  real(r8) :: coriolis_f    ! coriolis parameter [1/s]
   real(r8) :: grid_length   ! effective local grid length (i.e. dx) [m]
   real(r8) :: rossby_radius ! Rossby radius [m]
+  real(r8) :: min_lat_rad   ! min_lat_deg converted to radians
   !------------------------------------------------------------------------
+  min_lat_rad = min_lat_deg*pi/180.0_r8
   do i = 1,ncol
     ! Calculate coriolis parameter
-    coriolis_f = 2 * omega * sin(lat(i)) ! latitude must be in radians
-    ! Calculate Rossby Radius
-    if (coriolis_f>0.0_r8) then
-      rossby_radius = sqrt(gravit*rossby_depth)/abs(coriolis_f)
-      rossby_radius = min(rossby_radius,max_rossby_radius)
+    if (abs(lat(i)) > min_lat_rad) then
+      coriolis_f = 2 * omega * sin(lat(i)) ! latitude must be in radians
     else
-      rossby_radius = max_rossby_radius
+      coriolis_f = 2 * omega * sin(sign(min_lat_rad,lat(i))) ! latitude must be in radians
     end if
+    ! Calculate Rossby Radius
+    rossby_radius = sqrt(gravit*rossby_depth)/abs(coriolis_f)
     ! Calculate grid length
     grid_length = sqrt( get_area_p(lchnk,i) * rearth**2 ) ! sqrt( steradians x m2 ) => m
     ! Calculate ratio of Rossby Radius to effective grid length

--- a/components/eam/src/physics/cam/gw/gw_front.F90
+++ b/components/eam/src/physics/cam/gw/gw_front.F90
@@ -179,9 +179,9 @@ subroutine gw_front_gw_sources(ncol, ngwv, kbot, frontgf, tau)
 end subroutine gw_front_gw_sources
 
 !==========================================================================
-subroutine gw_rossby_radius_ratio(ncol, lat, lchnk, rossby_radius_ratio)
-  use physconst, only: rearth, gravit, omega, pi
-  use phys_grid, only: get_area_p
+subroutine gw_rossby_radius_ratio(ncol, lat, grid_area, rearth, omega, pi, &
+                                  rossby_radius_ratio)
+  use gw_common, only: gravit
   !------------------------------------------------------------------------
   ! The purpose of the "Rossby radius ratio" (RRR) is to act as a crude
   ! estimate of whether frontogenesis process are resolved at each local
@@ -191,11 +191,20 @@ subroutine gw_rossby_radius_ratio(ncol, lat, lchnk, rossby_radius_ratio)
   ! larger than "grid_length*eff_res_grid_num" we can assume that frontogenesis
   ! is resolved, and the frontal GW scheme can be disabled, or scaled down.
   ! This is meant as a way to make the frontal GW scheme "scale aware".
+  !
+  ! Note: the grid cell area and the rearth/omega/pi constants are passed
+  ! in (rather than obtained via "use phys_grid" / "use physconst") so that
+  ! this module stays independent of the EAM-specific grid decomposition
+  ! and physconst modules, which are unavailable to the standalone EAMxx
+  ! GW unit-test build.
   !------------------------------------------------------------------------
   ! Arguments
   integer,  intent(in) :: ncol
-  integer,  intent(in) :: lchnk
   real(r8), dimension(ncol), intent(in ) :: lat ! latitude [radians]
+  real(r8), dimension(ncol), intent(in ) :: grid_area ! grid cell area [steradians]
+  real(r8), intent(in) :: rearth ! radius of the Earth [m]
+  real(r8), intent(in) :: omega  ! Earth's angular rotation rate [1/s]
+  real(r8), intent(in) :: pi
   real(r8), dimension(ncol), intent(out) :: rossby_radius_ratio ! rossby radius ratio
   !------------------------------------------------------------------------
   ! Local Variables
@@ -219,7 +228,7 @@ subroutine gw_rossby_radius_ratio(ncol, lat, lchnk, rossby_radius_ratio)
     ! Calculate Rossby Radius
     rossby_radius = sqrt(gravit*rossby_depth)/abs(coriolis_f)
     ! Calculate grid length
-    grid_length = sqrt( get_area_p(lchnk,i) * rearth**2 ) ! sqrt( steradians x m2 ) => m
+    grid_length = sqrt( grid_area(i) * rearth**2 ) ! sqrt( steradians x m2 ) => m
     ! Calculate ratio of Rossby Radius to effective grid length
     rossby_radius_ratio(i) = rossby_radius / (grid_length*eff_res_grid_num)
   end do

--- a/components/eam/src/physics/cam/gw/gw_front.F90
+++ b/components/eam/src/physics/cam/gw/gw_front.F90
@@ -18,6 +18,7 @@ public :: gw_cm_src
 ! Only public for testing
 public :: gw_front_project_winds
 public :: gw_front_gw_sources
+public :: gw_rossby_radius_ratio
 
 ! Tuneable settings.
 
@@ -176,6 +177,47 @@ subroutine gw_front_gw_sources(ncol, ngwv, kbot, frontgf, tau)
   end do
 
 end subroutine gw_front_gw_sources
+
+!==========================================================================
+subroutine gw_rossby_radius_ratio(ncol, lat, lchnk, rossby_radius_ratio)
+  use physconst, only: rearth, gravit, omega
+  use phys_grid, only: get_area_p
+  !------------------------------------------------------------------------
+  ! The purpose of the "Rossby radius ratio" (RRR) is to act as a crude
+  ! estimate of whether frontogenesis process are resolved at each local
+  ! point of the grid. We do this by checking whether the Rossby radius is
+  ! well resolved locally, assuming that we need "eff_res_grid_num" number
+  ! of grid points to resolve a feature. Thus, when the Rossby radius is
+  ! larger than "grid_length*eff_res_grid_num" we can assume that frontogenesis
+  ! is resolved, and the frontal GW scheme can be disabled, or scaled down.
+  ! This is meant as a way to make the frontal GW scheme "scale aware".
+  !------------------------------------------------------------------------
+  ! Arguments
+  integer,  intent(in) :: ncol
+  integer,  intent(in) :: lchnk
+  real(r8), dimension(ncol), intent(in ) :: lat ! latitude [radians]
+  real(r8), dimension(ncol), intent(out) :: rossby_radius_ratio ! rossby radius ratio
+  !------------------------------------------------------------------------
+  ! Local Variables
+  integer :: i
+  real(r8), parameter :: rossby_depth = 2.0e3_r8 ! effective depth / scale height
+  real(r8), parameter :: eff_res_grid_num = 6 ! number of grid points for effective resolution
+  real(r8), :: coriolis_f    ! coriolis parameter
+  real(r8), :: grid_length   ! effective local grid length (i.e. dx) [m]
+  real(r8), :: rossby_radius ! Rossby radius [m]
+  !------------------------------------------------------------------------
+  do i = 1,ncol
+    ! Calculate coriolis parameter
+    coriolis_f = 2 * omega * sin(lat) ! latitude must be in radians
+    ! Calculate Rossby Radius
+    rossby_radius = sqrt(gravit*rossby_depth)/abs(coriolis_f)
+    ! Calculate grid length
+    grid_length = sqrt( get_area_p(lchnk,i) * rearth**2 ) ! sqrt( steradians x m2 ) => m
+    ! Calculate ratio of Rossby Radius to effective grid length
+    rossby_radius_ratio(i) = rossby_radius / (grid_length*eff_res_grid_num)
+  end do
+  !------------------------------------------------------------------------
+end subroutine gw_rossby_radius_ratio
 
 !==========================================================================
 subroutine gw_cm_src(ncol, ngwv, kbot, u, v, frontgf, &


### PR DESCRIPTION
This add two new capabilities to the GWD calculations as stealth features to facilitate QBO experiments.

- `use_tau_limiter` => GWD tendency limiter from NCAR colleagues
- `use_gw_front_RR_scaling` => scale-aware modification for frontal GWD scheme based on Rossby-Radius 

[BFB]