### PR TITLE
Update pragmas in mpas_ocn_vel_hmix_leith

### DIFF
--- a/components/mpas-ocean/src/shared/mpas_ocn_vel_hmix_leith.F
+++ b/components/mpas-ocean/src/shared/mpas_ocn_vel_hmix_leith.F
@@ -402,13 +402,15 @@ contains
       !$acc    present(cellsOnEdge, verticesOnEdge, minLevelEdgeBot, maxLevelEdgeTop, &
       !$acc            dcEdge, dvEdge, meshScalingDel4, edgeMask, &
       !$acc            del2div, del2relVort, tend) &
-      !$acc private(k, cell1, cell2, vertex1, vertex2, del2relVortEdge, del2divEdge, &
-      !$acc         dcEdgeInv, dvEdgeInv, visc4, visc4tmp, visc4MaxTmp, uDiff, kmin, kmax)
+      !$acc private(k, cell1, cell2, vertex1, vertex2, &
+      !$acc         dcEdgeInv, dvEdgeInv, visc4, visc4tmp, visc4MaxTmp, uDiff, kmin, kmax, &
+      !$acc         leithDel2relVortEdge, leithDel2divEdge)
 #else
       !$omp parallel
       !$omp do schedule(runtime) &
       !$omp private(k, cell1, cell2, vertex1, vertex2, &
-      !$omp         dcEdgeInv, dvEdgeInv, visc4, visc4tmp, visc4MaxTmp, uDiff, kmin, kmax)
+      !$omp         dcEdgeInv, dvEdgeInv, visc4, visc4tmp, visc4MaxTmp, uDiff, kmin, kmax, &
+      !$omp         leithDel2relVortEdge, leithDel2divEdge)
 #endif
       do iEdge = 1, nEdgesOwned
          kmin = minLevelEdgeBot(iEdge)


### PR DESCRIPTION
Fixes pragmas in mpas_ocn_vel_hmix_leith.F code updated by PR #8417 that caused errors using the nvidia compiler with openacc on polaris.

[BFB] part of a stealth feature