### PR TITLE
Adds heat budget in ELM log files

### DIFF
--- a/components/elm/src/biogeophys/HeatBudgetMod.F90
+++ b/components/elm/src/biogeophys/HeatBudgetMod.F90
@@ -42,25 +42,37 @@ module HeatBudgetMod
   public :: HeatBudget_SetEndingStates
 
   !--- F for flux ---
-  ! Named/ordered to match the coupler's own NET HEAT BUDGET rows
-  ! (hnetsw/hlwdn/hlwup/hlatvap/hsen) for direct cross-validation against
-  ! cpl.log's 'lnd' column.
+  ! Named and ordered exactly like the coupler's NET HEAT BUDGET rows for
+  ! direct cross-validation against cpl.log's land column. The land model has
+  ! no hfreeze, hmelt, hpolar, or hh2otemp flux, so those rows remain zero.
 
-  integer, parameter :: f_netsw = 1
-  integer, parameter :: f_lwdn  = 2
-  integer, parameter :: f_lwup  = 3
-  integer, parameter :: f_lh    = 4
-  integer, parameter :: f_sh    = 5
+  integer, parameter :: f_hfreeze  = 1
+  integer, parameter :: f_hmelt    = 2
+  integer, parameter :: f_netsw    = 3
+  integer, parameter :: f_lwdn     = 4
+  integer, parameter :: f_lwup     = 5
+  integer, parameter :: f_hlatvap  = 6
+  integer, parameter :: f_hlatfus  = 7
+  integer, parameter :: f_hiroff   = 8
+  integer, parameter :: f_hsen     = 9
+  integer, parameter :: f_hpolar   = 10
+  integer, parameter :: f_hh2otemp = 11
 
-  integer, parameter, public :: f_size = f_sh
+  integer, parameter, public :: f_size = f_hh2otemp
 
   character(len=12),parameter :: fname(f_size) = &
        (/&
-       '      netsw ', &
-       '       lwdn ', &
-       '       lwup ', &
-       '        lh  ', &
-       '        sh  '  &
+       '     hfreeze', &
+       '       hmelt', &
+       '      hnetsw', &
+       '       hlwdn', &
+       '       hlwup', &
+       '     hlatvap', &
+       '     hlatfus', &
+       '      hiroff', &
+       '        hsen', &
+       '      hpolar', &
+       '    hh2otemp'  &
        /)
 
   !--- P for period ---
@@ -483,7 +495,7 @@ contains
     ! printed here for that reason, not as a stand-in for the former.
     !
     use domainMod, only : ldomain
-    use elm_varcon, only : re
+    use elm_varcon, only : re, hfus
     !
     implicit none
 
@@ -496,10 +508,12 @@ contains
 
     associate(                                                              &
          forc_lwdn   => atm2lnd_vars%forc_lwrad_not_downscaled_grc        , &
+         forc_snow   => atm2lnd_vars%forc_snow_not_downscaled_grc         , &
          netsw       => lnd2atm_vars%fsa_grc                              , &
          lwup        => lnd2atm_vars%eflx_lwrad_out_grc                   , &
          eflx_sh_tot => lnd2atm_vars%eflx_sh_tot_grc                      , &
          eflx_lh_tot => lnd2atm_vars%eflx_lh_tot_grc                      , &
+         qflx_rofice => lnd2atm_vars%qflx_rofice_grc                      , &
          beg_hc_grc  => grc_es%beg_hc                                     , &
          end_hc_grc  => grc_es%end_hc                                     , &
          beg_hcsoi_grc => grc_es%beg_hc_soi                               , &
@@ -524,8 +538,10 @@ contains
          nf = f_netsw; budg_fluxL(nf,ip) = budg_fluxL(nf,ip) + netsw(g)*af
          nf = f_lwdn ; budg_fluxL(nf,ip) = budg_fluxL(nf,ip) + forc_lwdn(g)*af
          nf = f_lwup ; budg_fluxL(nf,ip) = budg_fluxL(nf,ip) - lwup(g)*af
-         nf = f_lh   ; budg_fluxL(nf,ip) = budg_fluxL(nf,ip) - eflx_lh_tot(g)*af
-         nf = f_sh   ; budg_fluxL(nf,ip) = budg_fluxL(nf,ip) - eflx_sh_tot(g)*af
+         nf = f_hlatvap; budg_fluxL(nf,ip) = budg_fluxL(nf,ip) - eflx_lh_tot(g)*af
+         nf = f_hlatfus; budg_fluxL(nf,ip) = budg_fluxL(nf,ip) - forc_snow(g)*hfus*af
+         nf = f_hiroff ; budg_fluxL(nf,ip) = budg_fluxL(nf,ip) + qflx_rofice(g)*hfus*af
+         nf = f_hsen   ; budg_fluxL(nf,ip) = budg_fluxL(nf,ip) - eflx_sh_tot(g)*af
 
          if (beg_hc_grc(g) /= spval .and. end_hc_grc(g) /= spval) then
             nf = s_h_beg ; budg_stateL(nf,ip) = budg_stateL(nf,ip) + beg_hc_grc(g)*af
@@ -607,7 +623,8 @@ contains
     integer :: year, mon, day, sec
     integer :: cdate
     logical :: sumdone
-    real(r8) :: unit_conversion
+    real(r8) :: area_normalization
+    real(r8) :: state_conversion
     real(r8) :: budg_fluxGpr (f_size,p_size) ! values to print, scaled and such
     real(r8) :: budg_gfluxGpr (g_size,p_size) ! values to print, scaled and such
 
@@ -640,15 +657,16 @@ contains
        endif
 
        if (plev > 0) then
-          unit_conversion = 1.d0/(4.0_r8*shr_const_pi)*1.0e6_r8
+          area_normalization = 1._r8/(4._r8*shr_const_pi)
+          state_conversion = area_normalization*1.e6_r8
           if (.not.sumdone) then
              sumdone = .true.
              call HeatBudget_Sum0()
              budg_fluxGpr = budg_fluxG
-             budg_fluxGpr = budg_fluxGpr*unit_conversion
+             budg_fluxGpr = budg_fluxGpr*area_normalization
              budg_fluxGpr = budg_fluxGpr/budg_fluxN
              budg_gfluxGpr = budg_gfluxG
-             budg_gfluxGpr = budg_gfluxGpr*unit_conversion
+             budg_gfluxGpr = budg_gfluxGpr*area_normalization
              budg_gfluxGpr = budg_gfluxGpr/budg_gfluxN
           end if
 
@@ -662,28 +680,30 @@ contains
              write(iulog,*)'NET HEAT FLUXES : period ',trim(pname(ip)),': date = ',cdate,sec
              write(iulog,FA0)'  Time  ','  Time    '
              write(iulog,FA0)'averaged','integrated'
-             write(iulog,FA0)'W/m2*1e6','MJ/m2*1e6'
+             write(iulog,FA0)'   W/m2   ','MJ/m2*1e6'
              write(iulog,'(32("-"),"|",20("-"))')
              do f = 1, f_size
-                write(iulog,FF)fname(f),budg_fluxGpr(f,ip),budg_fluxG(f,ip)*unit_conversion*get_step_size()/1.e6_r8
+                write(iulog,FF)fname(f),budg_fluxGpr(f,ip), &
+                     budg_fluxG(f,ip)*area_normalization*get_step_size()
              end do
              write(iulog,'(32("-"),"|",20("-"))')
              write(iulog,FF)'   *SUM*', &
-                  sum(budg_fluxGpr(:,ip)), sum(budg_fluxG(:,ip))*unit_conversion*get_step_size()/1.e6_r8
+                  sum(budg_fluxGpr(:,ip)), sum(budg_fluxG(:,ip))*area_normalization*get_step_size()
              write(iulog,'(32("-"),"|",20("-"))')
 
              write(iulog,*)''
              write(iulog,*)'NET HEAT FLUXES (into ground) : period ',trim(pname(ip)),': date = ',cdate,sec
              write(iulog,FA0)'  Time  ','  Time    '
              write(iulog,FA0)'averaged','integrated'
-             write(iulog,FA0)'W/m2*1e6','MJ/m2*1e6'
+             write(iulog,FA0)'   W/m2   ','MJ/m2*1e6'
              write(iulog,'(32("-"),"|",20("-"))')
              do f = 1, g_size
-                write(iulog,FF)gname(f),budg_gfluxGpr(f,ip),budg_gfluxG(f,ip)*unit_conversion*get_step_size()/1.e6_r8
+                write(iulog,FF)gname(f),budg_gfluxGpr(f,ip), &
+                     budg_gfluxG(f,ip)*area_normalization*get_step_size()
              end do
              write(iulog,'(32("-"),"|",20("-"))')
              write(iulog,FF)'   *SUM*', &
-                  sum(budg_gfluxGpr(:,ip)), sum(budg_gfluxG(:,ip))*unit_conversion*get_step_size()/1.e6_r8
+                  sum(budg_gfluxGpr(:,ip)), sum(budg_gfluxG(:,ip))*area_normalization*get_step_size()
              write(iulog,'(32("-"),"|",20("-"))')
              write(iulog,*)'  (integrated column is directly comparable to the *NET CHANGE* row of HEAT STATES below)'
 
@@ -696,24 +716,24 @@ contains
                   '       TOTAL      '
              write(iulog,'(71("-"),"|",20("-"))')
              write(iulog,HS) '         beg', &
-                  budg_stateG(s_hsoi_beg,ip)*unit_conversion, &
-                  (budg_stateG(s_h_beg,ip)-budg_stateG(s_hsoi_beg,ip))*unit_conversion, &
-                  budg_stateG(s_h_beg,ip)*unit_conversion
+                  budg_stateG(s_hsoi_beg,ip)*state_conversion, &
+                  (budg_stateG(s_h_beg,ip)-budg_stateG(s_hsoi_beg,ip))*state_conversion, &
+                  budg_stateG(s_h_beg,ip)*state_conversion
              write(iulog,HS) '         end', &
-                  budg_stateG(s_hsoi_end,ip)*unit_conversion, &
-                  (budg_stateG(s_h_end,ip)-budg_stateG(s_hsoi_end,ip))*unit_conversion, &
-                  budg_stateG(s_h_end,ip)*unit_conversion
+                  budg_stateG(s_hsoi_end,ip)*state_conversion, &
+                  (budg_stateG(s_h_end,ip)-budg_stateG(s_hsoi_end,ip))*state_conversion, &
+                  budg_stateG(s_h_end,ip)*state_conversion
              write(iulog,HS3)'*NET CHANGE*', &
-                  (budg_stateG(s_hsoi_end,ip)-budg_stateG(s_hsoi_beg,ip))*unit_conversion, &
+                  (budg_stateG(s_hsoi_end,ip)-budg_stateG(s_hsoi_beg,ip))*state_conversion, &
                   ((budg_stateG(s_h_end,ip)-budg_stateG(s_hsoi_end,ip)) &
-                  -(budg_stateG(s_h_beg,ip)-budg_stateG(s_hsoi_beg,ip)))*unit_conversion, &
-                  budg_stateG(s_h_errsoi,ip)*unit_conversion/budg_fluxN(1,ip), &
-                  (budg_stateG(s_h_end,ip)-budg_stateG(s_h_beg,ip))*unit_conversion
+                  -(budg_stateG(s_h_beg,ip)-budg_stateG(s_hsoi_beg,ip)))*state_conversion, &
+                  budg_stateG(s_h_errsoi,ip)*state_conversion/budg_fluxN(1,ip), &
+                  (budg_stateG(s_h_end,ip)-budg_stateG(s_h_beg,ip))*state_conversion
              write(iulog,'(71("-"),"|",20("-"))')
              write(iulog,HS2)'   *SUM*    ', &
-                  (budg_stateG(s_h_end,ip)-budg_stateG(s_h_beg,ip))*unit_conversion &
-                  - budg_stateG(s_h_errsoi,ip)*unit_conversion/budg_fluxN(1,ip), &
-                  (budg_stateG(s_h_end,ip)-budg_stateG(s_h_beg,ip))*unit_conversion
+                  (budg_stateG(s_h_end,ip)-budg_stateG(s_h_beg,ip))*state_conversion &
+                  - budg_stateG(s_h_errsoi,ip)*state_conversion/budg_fluxN(1,ip), &
+                  (budg_stateG(s_h_end,ip)-budg_stateG(s_h_beg,ip))*state_conversion
              write(iulog,'(71("-"),"|",20("-"))')
           end if
        end if

--- a/components/elm/src/biogeophys/HeatBudgetMod.F90
+++ b/components/elm/src/biogeophys/HeatBudgetMod.F90
@@ -25,6 +25,9 @@ module HeatBudgetMod
   use spmdMod           , only : masterproc
   use elm_varcon        , only : spval
   use ColumnDataType    , only : col_es, col_ef, col_ws
+  use ColumnType        , only : col_pp
+  use LandunitType      , only : lun_pp
+  use VegetationType    , only : veg_pp
   use VegetationDataType, only : veg_ef
   use GridcellDataType  , only : grc_es, grc_ef
   use timeinfoMod
@@ -93,44 +96,30 @@ module HeatBudgetMod
   real(r8) :: budg_fluxN(f_size, p_size) ! counter, valid only on root pe
 
   !--- G for the into-ground flux table ---
-  ! Rows that (up to errsoi_col's own tiny residual) sum to exactly the
-  ! rate of change of col_es%hc_soisno -- i.e. this table's *SUM*, unlike
-  ! NET HEAT FLUXES' *SUM*, is directly comparable to HEAT STATES'
-  ! *NET CHANGE*. Derived from the exact identity
-  !   d(cv*T)/dt = cv*(dT/dt) + T*(dcv/dt)
-  ! applied to SoilFluxesMod.F90's own errsoi_patch formula (whose
-  ! ΔT/fact terms are exactly the cv*(dT/dt) part, evaluated with cv held
-  ! at whatever mass was current for that call):
-  !   d(hc_soisno)/dt = eflx_soil_grnd - xmf - xmf_h2osfc
-  !        - frac_h2osfc*(t_h2osfc-t_h2osfc_bef)*(c_h2osfc/dtime)
-  !        + eflx_h2osfc_to_snow + eflx_building_heat
-  !        + tssbef*(cv-cv_bef)/dtime - errsoi_col
-  ! grnd and phase use only already-persistent veg_ef/col_ef/col_es/col_ws
-  ! fields. masschg (the T*(dcv/dt) term above) needed a small, purely
-  ! additive change to SoilTemperatureMod.F90/LakeTemperatureMod.F90: a new
-  ! col_es%cv_bef snapshot of layer heat capacity from the previous call,
-  ! and col_ef%eflx_hc_masschg computed from it and the existing tssbef.
-  ! It captures how hc_soisno changes purely from water mass changing
-  ! (infiltration, drainage, ET) while referenced to absolute Kelvin
-  ! temperature -- not itself a boundary flux, but the dominant missing
-  ! piece once phase is accounted for. LakeTemperatureMod folds its own
-  ! analogous correction into eflx_sh_tot instead of keeping it separate,
-  ! and masschg does not cover the lake-water layers themselves (cv_lake),
-  ! so g_phase and g_masschg both under-represent lake columns specifically
-  ! -- any residual for a lake-containing gridcell shows up against
-  ! errsoi_col, not as a bug in this table.
+  ! grnd and phase are the terms in SoilFluxesMod's native errsoi equation.
+  ! ELM does not have a native whole-land heat budget, and hc_soisno is a
+  ! diagnostic cv*T state rather than the enthalpy used by every solver.
+  ! stateadj is therefore diagnosed at gridcell level as
+  !
+  !   d(hc_soisno)/dt - grnd - phase
+  !
+  ! so that it explicitly exposes, and the table consistently accounts for,
+  ! heat-capacity changes, snow-layer creation/removal, the lake solver's
+  ! different reference state, and heat carried by hydrologic mass changes.
+  ! It is a state-coordinate adjustment, not an external boundary flux.
+  ! The independent numerical check remains col_ef%errsoi in HEAT STATES.
 
-  integer, parameter :: g_grnd    = 1
-  integer, parameter :: g_phase   = 2
-  integer, parameter :: g_masschg = 3
+  integer, parameter :: g_grnd     = 1
+  integer, parameter :: g_phase    = 2
+  integer, parameter :: g_stateadj = 3
 
-  integer, parameter, public :: g_size = g_masschg
+  integer, parameter, public :: g_size = g_stateadj
 
   character(len=12),parameter :: gname(g_size) = &
        (/&
        '        grnd', &
        '       phase', &
-       '     masschg'  &
+       '    stateadj'  &
        /)
 
   real(r8) :: budg_gfluxL(g_size, p_size) ! local sum, valid on all pes
@@ -139,13 +128,10 @@ module HeatBudgetMod
 
   !--- S for state ---
   ! Column heat content (col_es%hc_soisno = snow+soil+lake heat content,
-  ! MJ/m2) aggregated to the gridcell, split into two reservoirs the same
-  ! way col_es%hc_soi already splits it internally: "Soil" (hc_soi, j>=1
-  ! layers only) and "Snow+Lake" (hc_soisno-hc_soi, derived at print time --
-  ! snow layers for non-lake columns, snow-on-lake plus the lake water
-  ! itself for lake columns; the model has no field that separates those
-  ! two for lake columns specifically). Plus the soil/lake solver's own
-  ! column-level numerical-closure residual (col_ef%errsoi, W/m2),
+  ! MJ/m2) aggregated to the gridcell and split into Soil, Snow and Lake.
+  ! LakeTemperature records lake-water heat separately in hc_lake; snow is
+  ! then the exact remainder hc_soisno-hc_soi-hc_lake. Plus the soil/lake
+  ! solver's own column-level numerical-closure residual (col_ef%errsoi, W/m2),
   ! aggregated the same way. Canopy heat storage is not tracked anywhere
   ! in the model, so there is deliberately no canopy reservoir here
   ! (unlike a fabricated always-zero one).
@@ -154,7 +140,9 @@ module HeatBudgetMod
   integer, parameter :: s_h_end     = 2
   integer, parameter :: s_hsoi_beg  = 3
   integer, parameter :: s_hsoi_end  = 4
-  integer, parameter :: s_h_errsoi  = 5
+  integer, parameter :: s_hlake_beg = 5
+  integer, parameter :: s_hlake_end = 6
+  integer, parameter :: s_h_errsoi  = 7
 
   integer, parameter, public :: s_size = s_h_errsoi
 
@@ -164,6 +152,8 @@ module HeatBudgetMod
        'total_hc_end', &
        ' soil_hc_beg', &
        ' soil_hc_end', &
+       ' lake_hc_beg', &
+       ' lake_hc_end', &
        '  errsoi_col'  &
        /)
 
@@ -173,10 +163,10 @@ module HeatBudgetMod
   !----- formats -----
   character(*),parameter :: FA0= "('    ',12x,(3x,a10,2x),' | ',(3x,a10,2x))"
   character(*),parameter :: FF = "('    ',a12,f15.8,' | ',f18.2)"
-  character(*),parameter :: HS0= "('    ',12x,3(a18),' | ',(a18))"
-  character(*),parameter :: HS = "('    ',a12,2(f18.2),18x,' | ',(f18.2))"
-  character(*),parameter :: HS2= "('    ',a12,18x,f18.2,18x,' | ',f18.2)"
-  character(*),parameter :: HS3= "('    ',a12,3(f18.2),' | ',(f18.2))"
+  character(*),parameter :: HS0= "('    ',12x,4(a18),' | ',a18)"
+  character(*),parameter :: HS = "('    ',a12,3(f18.2),18x,' | ',f18.2)"
+  character(*),parameter :: HS2= "('    ',a12,72x,' | ',f18.2)"
+  character(*),parameter :: HS3= "('    ',a12,4(f18.2),' | ',f18.2)"
 
 contains
 
@@ -343,11 +333,13 @@ contains
        if (update_state_beg) then
           nf = s_h_beg    ; budg_stateL(nf,ip) = budg_stateL(nf, p_inst)
           nf = s_hsoi_beg ; budg_stateL(nf,ip) = budg_stateL(nf, p_inst)
+          nf = s_hlake_beg; budg_stateL(nf,ip) = budg_stateL(nf, p_inst)
        endif
 
        if (update_state_end) then
           nf = s_h_end    ; budg_stateL(nf,ip) = budg_stateL(nf, p_inst)
           nf = s_hsoi_end ; budg_stateL(nf,ip) = budg_stateL(nf, p_inst)
+          nf = s_hlake_end; budg_stateL(nf,ip) = budg_stateL(nf, p_inst)
        endif
        nf = s_h_errsoi ; budg_stateL(nf,ip) = budg_stateL(nf,ip) + budg_stateL(nf, p_inst)
     end do
@@ -390,6 +382,10 @@ contains
          grc_es%beg_hc_soi(bounds%begg:bounds%endg), &
          c2l_scale_type='unity', l2g_scale_type='unity')
 
+    call c2g(bounds, col_es%hc_lake(bounds%begc:bounds%endc), &
+         grc_es%beg_hc_lake(bounds%begg:bounds%endg), &
+         c2l_scale_type='unity', l2g_scale_type='unity')
+
   end subroutine HeatBudget_SetBeginningStates
 
   !-----------------------------------------------------------------------
@@ -407,12 +403,13 @@ contains
     ! fluxes are gathered) only reads the results, mirroring
     ! WaterBudget_Run's own read-only use of grc_ws%endwb.
     !
-    ! Also aggregate the two terms behind the "into ground" flux table:
+    ! Also form the three terms behind the "into ground" table:
     ! grc_ef%heat_into_grnd (p2g of veg_ef%eflx_soil_grnd) and
     ! grc_ef%heat_phase_corr (c2g of a per-column combination of the
     ! phase-change and h2osfc/building-heat terms from
     ! SoilFluxesMod.F90's own errsoi_patch formula -- see HeatBudget_Run's
-    ! header for the exact expression and its provenance).
+    ! header for the exact expression and its provenance), followed by the
+    ! gridcell-level state adjustment defined in the module header.
     !
     use subgridAveMod, only : c2g, p2g
     !
@@ -420,8 +417,9 @@ contains
     !
     type(bounds_type), intent(in) :: bounds
     !
-    integer  :: c
+    integer  :: c, l, p
     real(r8) :: phase_col(bounds%begc:bounds%endc)
+    real(r8) :: grnd_patch(bounds%begp:bounds%endp)
 
     call c2g(bounds, col_es%hc_soisno(bounds%begc:bounds%endc), &
          grc_es%end_hc(bounds%begg:bounds%endg), &
@@ -431,11 +429,25 @@ contains
          grc_es%end_hc_soi(bounds%begg:bounds%endg), &
          c2l_scale_type='unity', l2g_scale_type='unity')
 
+    call c2g(bounds, col_es%hc_lake(bounds%begc:bounds%endc), &
+         grc_es%end_hc_lake(bounds%begg:bounds%endg), &
+         c2l_scale_type='unity', l2g_scale_type='unity')
+
     call c2g(bounds, col_ef%errsoi(bounds%begc:bounds%endc), &
          grc_es%errsoi(bounds%begg:bounds%endg), &
          c2l_scale_type='unity', l2g_scale_type='unity')
 
-    call p2g(bounds, veg_ef%eflx_soil_grnd(bounds%begp:bounds%endp), &
+    do p = bounds%begp, bounds%endp
+       c = veg_pp%column(p)
+       l = col_pp%landunit(c)
+       if (lun_pp%urbpoi(l)) then
+          grnd_patch(p) = spval
+       else
+          grnd_patch(p) = veg_ef%eflx_soil_grnd(p)
+       end if
+    end do
+
+    call p2g(bounds, grnd_patch(bounds%begp:bounds%endp), &
          grc_ef%heat_into_grnd(bounds%begg:bounds%endg), &
          p2c_scale_type='unity', c2l_scale_type='unity', l2g_scale_type='unity')
 
@@ -451,7 +463,16 @@ contains
          )
 
       do c = bounds%begc, bounds%endc
-         if (xmf(c) == spval .or. xmf_h2osfc(c) == spval .or. h2osfc2snow(c) == spval &
+         l = col_pp%landunit(c)
+         if (lun_pp%urbpoi(l)) then
+            ! The printed state excludes urban walls, roofs and roads, so its
+            ! matching flux table must exclude those reservoirs as well.
+            phase_col(c) = spval
+         else if (col_pp%is_lake(c)) then
+            ! LakeTemperature's state is its native enthalpy (ncvts), whose
+            ! change is balanced directly by eflx_soil_grnd.
+            phase_col(c) = 0._r8
+         else if (xmf(c) == spval .or. xmf_h2osfc(c) == spval .or. h2osfc2snow(c) == spval &
               .or. bldg_heat(c) == spval .or. frac_h2osfc(c) == spval &
               .or. t_h2osfc(c) == spval .or. t_h2osfc_bef(c) == spval .or. c_h2osfc(c) == spval) then
             phase_col(c) = spval
@@ -468,9 +489,18 @@ contains
          grc_ef%heat_phase_corr(bounds%begg:bounds%endg), &
          c2l_scale_type='unity', l2g_scale_type='unity')
 
-    call c2g(bounds, col_ef%eflx_hc_masschg(bounds%begc:bounds%endc), &
-         grc_ef%heat_masschg(bounds%begg:bounds%endg), &
-         c2l_scale_type='unity', l2g_scale_type='unity')
+    ! Diagnose all non-temperature state changes after subgrid aggregation.
+    ! Doing this at gridcell level gives every term identical spatial
+    ! support and also handles snow layers that appear or disappear.
+    do c = bounds%begg, bounds%endg
+       if (grc_es%beg_hc(c) /= spval .and. grc_es%end_hc(c) /= spval &
+            .and. grc_ef%heat_into_grnd(c) /= spval .and. grc_ef%heat_phase_corr(c) /= spval) then
+          grc_ef%heat_state_adj(c) = (grc_es%end_hc(c)-grc_es%beg_hc(c))*1.e6_r8/dtime_mod &
+               - grc_ef%heat_into_grnd(c) - grc_ef%heat_phase_corr(c)
+       else
+          grc_ef%heat_state_adj(c) = spval
+       end if
+    end do
 
   end subroutine HeatBudget_SetEndingStates
 
@@ -485,12 +515,10 @@ contains
     ! Also accumulate the grid-level heat-content state (col_es%hc_soisno,
     ! now holding this step's ending value since SoilTemperature/
     ! SoilFluxes/LakeTemperature have already run) and the soil/lake
-    ! solver's own numerical-closure residual (col_ef%errsoi). Note that
-    ! (end_hc - beg_hc) - (net flux table * dt) is NOT a clean numerical
-    ! truncation term the way water's errh2o is: it also contains real,
-    ! currently-unmodeled advected heat carried by precipitation,
-    ! snowmelt, and runoff (see HEAT_BUDGET_PLAN.md, Phase 2 issue #3).
-    ! errsoi_col itself, by contrast, IS a validated, tightly-bounded
+    ! solver's own numerical-closure residual (col_ef%errsoi). stateadj in
+    ! the into-ground table contains state-coordinate and unmodeled
+    ! advective-heat effects; it must not be interpreted as a numerical
+    ! truncation error. errsoi_col, by contrast, IS a validated, tightly-bounded
     ! (<1e-5 W/m2, or the model aborts) internal closure term -- it is
     ! printed here for that reason, not as a stand-in for the former.
     !
@@ -518,10 +546,12 @@ contains
          end_hc_grc  => grc_es%end_hc                                     , &
          beg_hcsoi_grc => grc_es%beg_hc_soi                               , &
          end_hcsoi_grc => grc_es%end_hc_soi                               , &
+         beg_hclake_grc => grc_es%beg_hc_lake                             , &
+         end_hclake_grc => grc_es%end_hc_lake                             , &
          errsoi_grc  => grc_es%errsoi                                     , &
          grnd_grc    => grc_ef%heat_into_grnd                             , &
          phase_grc   => grc_ef%heat_phase_corr                            , &
-         masschg_grc => grc_ef%heat_masschg                                 &
+         stateadj_grc => grc_ef%heat_state_adj                               &
          )
 
       ip = p_inst
@@ -551,6 +581,10 @@ contains
             nf = s_hsoi_beg ; budg_stateL(nf,ip) = budg_stateL(nf,ip) + beg_hcsoi_grc(g)*af
             nf = s_hsoi_end ; budg_stateL(nf,ip) = budg_stateL(nf,ip) + end_hcsoi_grc(g)*af
          end if
+         if (beg_hclake_grc(g) /= spval .and. end_hclake_grc(g) /= spval) then
+            nf = s_hlake_beg ; budg_stateL(nf,ip) = budg_stateL(nf,ip) + beg_hclake_grc(g)*af
+            nf = s_hlake_end ; budg_stateL(nf,ip) = budg_stateL(nf,ip) + end_hclake_grc(g)*af
+         end if
          if (errsoi_grc(g) /= spval) then
             nf = s_h_errsoi ; budg_stateL(nf,ip) = budg_stateL(nf,ip) + errsoi_grc(g)*af
          end if
@@ -561,8 +595,8 @@ contains
          if (phase_grc(g) /= spval) then
             nf = g_phase ; budg_gfluxL(nf,ip) = budg_gfluxL(nf,ip) + phase_grc(g)*af
          end if
-         if (masschg_grc(g) /= spval) then
-            nf = g_masschg ; budg_gfluxL(nf,ip) = budg_gfluxL(nf,ip) + masschg_grc(g)*af
+         if (stateadj_grc(g) /= spval) then
+            nf = g_stateadj ; budg_gfluxL(nf,ip) = budg_gfluxL(nf,ip) + stateadj_grc(g)*af
          end if
       end do
 
@@ -706,35 +740,41 @@ contains
                   sum(budg_gfluxGpr(:,ip)), sum(budg_gfluxG(:,ip))*area_normalization*get_step_size()
              write(iulog,'(32("-"),"|",20("-"))')
              write(iulog,*)'  (integrated column is directly comparable to the *NET CHANGE* row of HEAT STATES below)'
+             write(iulog,*)'  (stateadj is a diagnosed heat-state adjustment, not an external boundary flux)'
+             write(iulog,*)'  (ground terms and heat states exclude urban roof, wall, and road reservoirs)'
 
              write(iulog,*)''
              write(iulog,*)'HEAT STATES (MJ/m2*1e6): period ',trim(pname(ip)),': date = ',cdate,sec
              write(iulog,HS0) &
                   '       Soil       ', &
-                  '     Snow+Lake    ', &
+                  '       Snow       ', &
+                  '       Lake       ', &
                   '   Grid-level Err ', &
                   '       TOTAL      '
-             write(iulog,'(71("-"),"|",20("-"))')
+             write(iulog,'(88("-"),"|",20("-"))')
              write(iulog,HS) '         beg', &
                   budg_stateG(s_hsoi_beg,ip)*state_conversion, &
-                  (budg_stateG(s_h_beg,ip)-budg_stateG(s_hsoi_beg,ip))*state_conversion, &
+                  (budg_stateG(s_h_beg,ip)-budg_stateG(s_hsoi_beg,ip) &
+                  -budg_stateG(s_hlake_beg,ip))*state_conversion, &
+                  budg_stateG(s_hlake_beg,ip)*state_conversion, &
                   budg_stateG(s_h_beg,ip)*state_conversion
              write(iulog,HS) '         end', &
                   budg_stateG(s_hsoi_end,ip)*state_conversion, &
-                  (budg_stateG(s_h_end,ip)-budg_stateG(s_hsoi_end,ip))*state_conversion, &
+                  (budg_stateG(s_h_end,ip)-budg_stateG(s_hsoi_end,ip) &
+                  -budg_stateG(s_hlake_end,ip))*state_conversion, &
+                  budg_stateG(s_hlake_end,ip)*state_conversion, &
                   budg_stateG(s_h_end,ip)*state_conversion
              write(iulog,HS3)'*NET CHANGE*', &
                   (budg_stateG(s_hsoi_end,ip)-budg_stateG(s_hsoi_beg,ip))*state_conversion, &
-                  ((budg_stateG(s_h_end,ip)-budg_stateG(s_hsoi_end,ip)) &
-                  -(budg_stateG(s_h_beg,ip)-budg_stateG(s_hsoi_beg,ip)))*state_conversion, &
+                  ((budg_stateG(s_h_end,ip)-budg_stateG(s_hsoi_end,ip)-budg_stateG(s_hlake_end,ip)) &
+                  -(budg_stateG(s_h_beg,ip)-budg_stateG(s_hsoi_beg,ip)-budg_stateG(s_hlake_beg,ip)))*state_conversion, &
+                  (budg_stateG(s_hlake_end,ip)-budg_stateG(s_hlake_beg,ip))*state_conversion, &
                   budg_stateG(s_h_errsoi,ip)*state_conversion/budg_fluxN(1,ip), &
                   (budg_stateG(s_h_end,ip)-budg_stateG(s_h_beg,ip))*state_conversion
-             write(iulog,'(71("-"),"|",20("-"))')
+             write(iulog,'(88("-"),"|",20("-"))')
              write(iulog,HS2)'   *SUM*    ', &
-                  (budg_stateG(s_h_end,ip)-budg_stateG(s_h_beg,ip))*state_conversion &
-                  - budg_stateG(s_h_errsoi,ip)*state_conversion/budg_fluxN(1,ip), &
                   (budg_stateG(s_h_end,ip)-budg_stateG(s_h_beg,ip))*state_conversion
-             write(iulog,'(71("-"),"|",20("-"))')
+             write(iulog,'(88("-"),"|",20("-"))')
           end if
        end if
     end do
@@ -787,15 +827,15 @@ contains
          dim1name='heat_budg_flux', &
          long_name='heat_budg_fluxN', units='-', ncid=ncid)
 
-    call ncd_defvar(varname='heat_budg_stateG', xtype=ncd_double, &
+    call ncd_defvar(varname='heat_budg_stateG_v2', xtype=ncd_double, &
          dim1name='heat_budg_state', &
          long_name='heat_budg_stateG', units='MJ/m2 or W/m2', ncid=ncid)
 
-    call ncd_defvar(varname='heat_budg_gfluxG', xtype=ncd_double, &
+    call ncd_defvar(varname='heat_budg_gfluxG_v2', xtype=ncd_double, &
          dim1name='heat_budg_gflux', &
          long_name='heat_budg_gfluxG', units='W/m2', ncid=ncid)
 
-    call ncd_defvar(varname='heat_budg_gfluxN', xtype=ncd_double, &
+    call ncd_defvar(varname='heat_budg_gfluxN_v2', xtype=ncd_double, &
          dim1name='heat_budg_gflux', &
          long_name='heat_budg_gfluxN', units='-', ncid=ncid)
 
@@ -866,9 +906,9 @@ contains
 
     call ncd_io(flag=flag, varname='heat_budg_fluxG', data=budg_fluxG_1D, ncid=ncid)
     call ncd_io(flag=flag, varname='heat_budg_fluxN', data=budg_fluxN_1D, ncid=ncid)
-    call ncd_io(flag=flag, varname='heat_budg_stateG', data=budg_stateG_1D, ncid=ncid)
-    call ncd_io(flag=flag, varname='heat_budg_gfluxG', data=budg_gfluxG_1D, ncid=ncid)
-    call ncd_io(flag=flag, varname='heat_budg_gfluxN', data=budg_gfluxN_1D, ncid=ncid)
+    call ncd_io(flag=flag, varname='heat_budg_stateG_v2', data=budg_stateG_1D, ncid=ncid)
+    call ncd_io(flag=flag, varname='heat_budg_gfluxG_v2', data=budg_gfluxG_1D, ncid=ncid)
+    call ncd_io(flag=flag, varname='heat_budg_gfluxN_v2', data=budg_gfluxN_1D, ncid=ncid)
 
   end subroutine HeatBudget_Restart_Write
 
@@ -893,10 +933,12 @@ contains
     integer  :: f, s, p, count
     logical  :: readvar_fluxG, readvar_fluxN, readvar_stateG, readvar_gfluxG, readvar_gfluxN
 
-    ! Every restart file that predates this change will lack these
-    ! variables; guard with readvar and zero-initialize the accumulators
-    ! rather than aborting or reading garbage, so restarting from an older
-    ! case works.
+    ! Every restart file that predates this diagnostic will lack these
+    ! variables. The v2 state and into-ground names also prevent a
+    ! prototype restart, whose state vector had a different shape and whose
+    ! third ground term had different semantics, from being misinterpreted.
+    ! Guard with readvar and zero-initialize missing accumulators so an old
+    ! restart remains usable.
     budg_fluxG_1D = 0._r8
     budg_fluxN_1D = 0._r8
     budg_stateG_1D = 0._r8
@@ -905,9 +947,9 @@ contains
 
     call ncd_io(flag=flag, varname='heat_budg_fluxG', data=budg_fluxG_1D, ncid=ncid, readvar=readvar_fluxG)
     call ncd_io(flag=flag, varname='heat_budg_fluxN', data=budg_fluxN_1D, ncid=ncid, readvar=readvar_fluxN)
-    call ncd_io(flag=flag, varname='heat_budg_stateG', data=budg_stateG_1D, ncid=ncid, readvar=readvar_stateG)
-    call ncd_io(flag=flag, varname='heat_budg_gfluxG', data=budg_gfluxG_1D, ncid=ncid, readvar=readvar_gfluxG)
-    call ncd_io(flag=flag, varname='heat_budg_gfluxN', data=budg_gfluxN_1D, ncid=ncid, readvar=readvar_gfluxN)
+    call ncd_io(flag=flag, varname='heat_budg_stateG_v2', data=budg_stateG_1D, ncid=ncid, readvar=readvar_stateG)
+    call ncd_io(flag=flag, varname='heat_budg_gfluxG_v2', data=budg_gfluxG_1D, ncid=ncid, readvar=readvar_gfluxG)
+    call ncd_io(flag=flag, varname='heat_budg_gfluxN_v2', data=budg_gfluxN_1D, ncid=ncid, readvar=readvar_gfluxN)
 
     if (.not. readvar_fluxG) budg_fluxG_1D = 0._r8
     if (.not. readvar_fluxN) budg_fluxN_1D = 0._r8

--- a/components/elm/src/biogeophys/HeatBudgetMod.F90
+++ b/components/elm/src/biogeophys/HeatBudgetMod.F90
@@ -1,17 +1,13 @@
 module HeatBudgetMod
   ! !DESCRIPTION:
   ! Heat (energy) budget diagnostic for ELM's lnd.log, mirroring
-  ! WaterBudgetMod. Two tables are printed:
+  ! WaterBudgetMod. One table is printed:
   !
   ! - NET HEAT FLUXES: a cross-boundary flux-conservation check
   !   (comparable to the coupler's own NET HEAT BUDGET table in cpl.log).
-  ! - HEAT STATES: a beginning/end-of-timestep snapshot of column heat
-  !   content (col_es%hc_soisno, snow+soil+lake) plus the soil/lake
-  !   solver's own numerical-closure residual (col_ef%errsoi), both
-  !   already validated every timestep by SoilFluxesMod/LakeTemperatureMod/
-  !   BalanceCheckMod -- see HeatBudget_Run's header for what this
-  !   table can and cannot be used to conclude, and HEAT_BUDGET_PLAN.md's
-  !   Phase 2 section for the full reasoning.
+  ! Ground-flux and heat-state diagnostics are accumulated internally but
+  ! are not printed because their state-adjustment term is diagnosed as a
+  ! residual rather than computed directly from physical processes.
   !
   ! !USES:
   use shr_kind_mod      , only : r8 => shr_kind_r8
@@ -95,7 +91,7 @@ module HeatBudgetMod
   real(r8) :: budg_fluxG(f_size, p_size) ! global sum, valid only on root pe
   real(r8) :: budg_fluxN(f_size, p_size) ! counter, valid only on root pe
 
-  !--- G for the into-ground flux table ---
+  !--- G for the internal into-ground diagnostic ---
   ! grnd and phase are the terms in SoilFluxesMod's native errsoi equation.
   ! ELM does not have a native whole-land heat budget, and hc_soisno is a
   ! diagnostic cv*T state rather than the enthalpy used by every solver.
@@ -103,11 +99,11 @@ module HeatBudgetMod
   !
   !   d(hc_soisno)/dt - grnd - phase
   !
-  ! so that it explicitly exposes, and the table consistently accounts for,
+  ! so that it explicitly exposes, and the diagnostic consistently accounts for,
   ! heat-capacity changes, snow-layer creation/removal, the lake solver's
   ! different reference state, and heat carried by hydrologic mass changes.
   ! It is a state-coordinate adjustment, not an external boundary flux.
-  ! The independent numerical check remains col_ef%errsoi in HEAT STATES.
+  ! The independent numerical check remains col_ef%errsoi.
 
   integer, parameter :: g_grnd     = 1
   integer, parameter :: g_phase    = 2
@@ -163,10 +159,6 @@ module HeatBudgetMod
   !----- formats -----
   character(*),parameter :: FA0= "('    ',12x,(3x,a10,2x),' | ',(3x,a10,2x))"
   character(*),parameter :: FF = "('    ',a12,f15.8,' | ',f18.2)"
-  character(*),parameter :: HS0= "('    ',12x,4(a18),' | ',a18)"
-  character(*),parameter :: HS = "('    ',a12,3(f18.2),18x,' | ',f18.2)"
-  character(*),parameter :: HS2= "('    ',a12,72x,' | ',f18.2)"
-  character(*),parameter :: HS3= "('    ',a12,4(f18.2),' | ',f18.2)"
 
 contains
 
@@ -403,7 +395,7 @@ contains
     ! fluxes are gathered) only reads the results, mirroring
     ! WaterBudget_Run's own read-only use of grc_ws%endwb.
     !
-    ! Also form the three terms behind the "into ground" table:
+    ! Also form the three terms behind the internal into-ground diagnostic:
     ! grc_ef%heat_into_grnd (p2g of veg_ef%eflx_soil_grnd) and
     ! grc_ef%heat_phase_corr (c2g of a per-column combination of the
     ! phase-change and h2osfc/building-heat terms from
@@ -465,7 +457,7 @@ contains
       do c = bounds%begc, bounds%endc
          l = col_pp%landunit(c)
          if (lun_pp%urbpoi(l)) then
-            ! The printed state excludes urban walls, roofs and roads, so its
+            ! The heat state excludes urban walls, roofs and roads, so its
             ! matching flux table must exclude those reservoirs as well.
             phase_col(c) = spval
          else if (col_pp%is_lake(c)) then
@@ -516,11 +508,11 @@ contains
     ! now holding this step's ending value since SoilTemperature/
     ! SoilFluxes/LakeTemperature have already run) and the soil/lake
     ! solver's own numerical-closure residual (col_ef%errsoi). stateadj in
-    ! the into-ground table contains state-coordinate and unmodeled
+    ! the internal into-ground diagnostic contains state-coordinate and unmodeled
     ! advective-heat effects; it must not be interpreted as a numerical
     ! truncation error. errsoi_col, by contrast, IS a validated, tightly-bounded
-    ! (<1e-5 W/m2, or the model aborts) internal closure term -- it is
-    ! printed here for that reason, not as a stand-in for the former.
+    ! (<1e-5 W/m2, or the model aborts) internal closure term. Both are
+    ! retained for future work but are not printed.
     !
     use domainMod, only : ldomain
     use elm_varcon, only : re, hfus
@@ -658,9 +650,7 @@ contains
     integer :: cdate
     logical :: sumdone
     real(r8) :: area_normalization
-    real(r8) :: state_conversion
     real(r8) :: budg_fluxGpr (f_size,p_size) ! values to print, scaled and such
-    real(r8) :: budg_gfluxGpr (g_size,p_size) ! values to print, scaled and such
 
     sumdone = .false.
 
@@ -692,16 +682,12 @@ contains
 
        if (plev > 0) then
           area_normalization = 1._r8/(4._r8*shr_const_pi)
-          state_conversion = area_normalization*1.e6_r8
           if (.not.sumdone) then
              sumdone = .true.
              call HeatBudget_Sum0()
              budg_fluxGpr = budg_fluxG
              budg_fluxGpr = budg_fluxGpr*area_normalization
              budg_fluxGpr = budg_fluxGpr/budg_fluxN
-             budg_gfluxGpr = budg_gfluxG
-             budg_gfluxGpr = budg_gfluxGpr*area_normalization
-             budg_gfluxGpr = budg_gfluxGpr/budg_gfluxN
           end if
 
           if (ip == p_day .and. get_nstep() == 1) cycle
@@ -724,57 +710,6 @@ contains
              write(iulog,FF)'   *SUM*', &
                   sum(budg_fluxGpr(:,ip)), sum(budg_fluxG(:,ip))*area_normalization*get_step_size()
              write(iulog,'(32("-"),"|",20("-"))')
-
-             write(iulog,*)''
-             write(iulog,*)'NET HEAT FLUXES (into ground) : period ',trim(pname(ip)),': date = ',cdate,sec
-             write(iulog,FA0)'  Time  ','  Time    '
-             write(iulog,FA0)'averaged','integrated'
-             write(iulog,FA0)'   W/m2   ','MJ/m2*1e6'
-             write(iulog,'(32("-"),"|",20("-"))')
-             do f = 1, g_size
-                write(iulog,FF)gname(f),budg_gfluxGpr(f,ip), &
-                     budg_gfluxG(f,ip)*area_normalization*get_step_size()
-             end do
-             write(iulog,'(32("-"),"|",20("-"))')
-             write(iulog,FF)'   *SUM*', &
-                  sum(budg_gfluxGpr(:,ip)), sum(budg_gfluxG(:,ip))*area_normalization*get_step_size()
-             write(iulog,'(32("-"),"|",20("-"))')
-             write(iulog,*)'  (integrated column is directly comparable to the *NET CHANGE* row of HEAT STATES below)'
-             write(iulog,*)'  (stateadj is a diagnosed heat-state adjustment, not an external boundary flux)'
-             write(iulog,*)'  (ground terms and heat states exclude urban roof, wall, and road reservoirs)'
-
-             write(iulog,*)''
-             write(iulog,*)'HEAT STATES (MJ/m2*1e6): period ',trim(pname(ip)),': date = ',cdate,sec
-             write(iulog,HS0) &
-                  '       Soil       ', &
-                  '       Snow       ', &
-                  '       Lake       ', &
-                  '   Grid-level Err ', &
-                  '       TOTAL      '
-             write(iulog,'(88("-"),"|",20("-"))')
-             write(iulog,HS) '         beg', &
-                  budg_stateG(s_hsoi_beg,ip)*state_conversion, &
-                  (budg_stateG(s_h_beg,ip)-budg_stateG(s_hsoi_beg,ip) &
-                  -budg_stateG(s_hlake_beg,ip))*state_conversion, &
-                  budg_stateG(s_hlake_beg,ip)*state_conversion, &
-                  budg_stateG(s_h_beg,ip)*state_conversion
-             write(iulog,HS) '         end', &
-                  budg_stateG(s_hsoi_end,ip)*state_conversion, &
-                  (budg_stateG(s_h_end,ip)-budg_stateG(s_hsoi_end,ip) &
-                  -budg_stateG(s_hlake_end,ip))*state_conversion, &
-                  budg_stateG(s_hlake_end,ip)*state_conversion, &
-                  budg_stateG(s_h_end,ip)*state_conversion
-             write(iulog,HS3)'*NET CHANGE*', &
-                  (budg_stateG(s_hsoi_end,ip)-budg_stateG(s_hsoi_beg,ip))*state_conversion, &
-                  ((budg_stateG(s_h_end,ip)-budg_stateG(s_hsoi_end,ip)-budg_stateG(s_hlake_end,ip)) &
-                  -(budg_stateG(s_h_beg,ip)-budg_stateG(s_hsoi_beg,ip)-budg_stateG(s_hlake_beg,ip)))*state_conversion, &
-                  (budg_stateG(s_hlake_end,ip)-budg_stateG(s_hlake_beg,ip))*state_conversion, &
-                  budg_stateG(s_h_errsoi,ip)*state_conversion/budg_fluxN(1,ip), &
-                  (budg_stateG(s_h_end,ip)-budg_stateG(s_h_beg,ip))*state_conversion
-             write(iulog,'(88("-"),"|",20("-"))')
-             write(iulog,HS2)'   *SUM*    ', &
-                  (budg_stateG(s_h_end,ip)-budg_stateG(s_h_beg,ip))*state_conversion
-             write(iulog,'(88("-"),"|",20("-"))')
           end if
        end if
     end do

--- a/components/elm/src/biogeophys/HeatBudgetMod.F90
+++ b/components/elm/src/biogeophys/HeatBudgetMod.F90
@@ -126,15 +126,23 @@ module HeatBudgetMod
   real(r8) :: budg_gfluxN(g_size, p_size) ! counter, valid only on root pe
 
   !--- S for state ---
-  ! Column heat content (col_es%hc_soisno = snow+soil+lake heat content, MJ/m2)
-  ! aggregated to the gridcell, plus the soil/lake solver's own column-level
-  ! numerical-closure residual (col_ef%errsoi, W/m2) aggregated the same way.
-  ! Canopy heat storage is not tracked anywhere in the model, so there is
-  ! deliberately no canopy row here (unlike a fabricated always-zero one).
+  ! Column heat content (col_es%hc_soisno = snow+soil+lake heat content,
+  ! MJ/m2) aggregated to the gridcell, split into two reservoirs the same
+  ! way col_es%hc_soi already splits it internally: "Soil" (hc_soi, j>=1
+  ! layers only) and "Snow+Lake" (hc_soisno-hc_soi, derived at print time --
+  ! snow layers for non-lake columns, snow-on-lake plus the lake water
+  ! itself for lake columns; the model has no field that separates those
+  ! two for lake columns specifically). Plus the soil/lake solver's own
+  ! column-level numerical-closure residual (col_ef%errsoi, W/m2),
+  ! aggregated the same way. Canopy heat storage is not tracked anywhere
+  ! in the model, so there is deliberately no canopy reservoir here
+  ! (unlike a fabricated always-zero one).
 
-  integer, parameter :: s_h_beg    = 1
-  integer, parameter :: s_h_end    = 2
-  integer, parameter :: s_h_errsoi = 3
+  integer, parameter :: s_h_beg     = 1
+  integer, parameter :: s_h_end     = 2
+  integer, parameter :: s_hsoi_beg  = 3
+  integer, parameter :: s_hsoi_end  = 4
+  integer, parameter :: s_h_errsoi  = 5
 
   integer, parameter, public :: s_size = s_h_errsoi
 
@@ -142,6 +150,8 @@ module HeatBudgetMod
        (/&
        'total_hc_beg', &
        'total_hc_end', &
+       ' soil_hc_beg', &
+       ' soil_hc_end', &
        '  errsoi_col'  &
        /)
 
@@ -151,9 +161,10 @@ module HeatBudgetMod
   !----- formats -----
   character(*),parameter :: FA0= "('    ',12x,(3x,a10,2x),' | ',(3x,a10,2x))"
   character(*),parameter :: FF = "('    ',a12,f15.8,' | ',f18.2)"
-  character(*),parameter :: HS0= "('    ',12x,2(a18),' | ',(a18))"
-  character(*),parameter :: HS = "('    ',a12,f18.2,18x,' | ',(f18.2))"
-  character(*),parameter :: HS3= "('    ',a12,2(f18.2),' | ',(f18.2))"
+  character(*),parameter :: HS0= "('    ',12x,3(a18),' | ',(a18))"
+  character(*),parameter :: HS = "('    ',a12,2(f18.2),18x,' | ',(f18.2))"
+  character(*),parameter :: HS2= "('    ',a12,18x,f18.2,18x,' | ',f18.2)"
+  character(*),parameter :: HS3= "('    ',a12,3(f18.2),' | ',(f18.2))"
 
 contains
 
@@ -318,11 +329,13 @@ contains
        if (get_nstep() == 1) update_state_beg = .true.
 
        if (update_state_beg) then
-          nf = s_h_beg ; budg_stateL(nf,ip) = budg_stateL(nf, p_inst)
+          nf = s_h_beg    ; budg_stateL(nf,ip) = budg_stateL(nf, p_inst)
+          nf = s_hsoi_beg ; budg_stateL(nf,ip) = budg_stateL(nf, p_inst)
        endif
 
        if (update_state_end) then
-          nf = s_h_end ; budg_stateL(nf,ip) = budg_stateL(nf, p_inst)
+          nf = s_h_end    ; budg_stateL(nf,ip) = budg_stateL(nf, p_inst)
+          nf = s_hsoi_end ; budg_stateL(nf,ip) = budg_stateL(nf, p_inst)
        endif
        nf = s_h_errsoi ; budg_stateL(nf,ip) = budg_stateL(nf,ip) + budg_stateL(nf, p_inst)
     end do
@@ -361,6 +374,10 @@ contains
          grc_es%beg_hc(bounds%begg:bounds%endg), &
          c2l_scale_type='unity', l2g_scale_type='unity')
 
+    call c2g(bounds, col_es%hc_soi(bounds%begc:bounds%endc), &
+         grc_es%beg_hc_soi(bounds%begg:bounds%endg), &
+         c2l_scale_type='unity', l2g_scale_type='unity')
+
   end subroutine HeatBudget_SetBeginningStates
 
   !-----------------------------------------------------------------------
@@ -396,6 +413,10 @@ contains
 
     call c2g(bounds, col_es%hc_soisno(bounds%begc:bounds%endc), &
          grc_es%end_hc(bounds%begg:bounds%endg), &
+         c2l_scale_type='unity', l2g_scale_type='unity')
+
+    call c2g(bounds, col_es%hc_soi(bounds%begc:bounds%endc), &
+         grc_es%end_hc_soi(bounds%begg:bounds%endg), &
          c2l_scale_type='unity', l2g_scale_type='unity')
 
     call c2g(bounds, col_ef%errsoi(bounds%begc:bounds%endc), &
@@ -481,6 +502,8 @@ contains
          eflx_lh_tot => lnd2atm_vars%eflx_lh_tot_grc                      , &
          beg_hc_grc  => grc_es%beg_hc                                     , &
          end_hc_grc  => grc_es%end_hc                                     , &
+         beg_hcsoi_grc => grc_es%beg_hc_soi                               , &
+         end_hcsoi_grc => grc_es%end_hc_soi                               , &
          errsoi_grc  => grc_es%errsoi                                     , &
          grnd_grc    => grc_ef%heat_into_grnd                             , &
          phase_grc   => grc_ef%heat_phase_corr                            , &
@@ -507,6 +530,10 @@ contains
          if (beg_hc_grc(g) /= spval .and. end_hc_grc(g) /= spval) then
             nf = s_h_beg ; budg_stateL(nf,ip) = budg_stateL(nf,ip) + beg_hc_grc(g)*af
             nf = s_h_end ; budg_stateL(nf,ip) = budg_stateL(nf,ip) + end_hc_grc(g)*af
+         end if
+         if (beg_hcsoi_grc(g) /= spval .and. end_hcsoi_grc(g) /= spval) then
+            nf = s_hsoi_beg ; budg_stateL(nf,ip) = budg_stateL(nf,ip) + beg_hcsoi_grc(g)*af
+            nf = s_hsoi_end ; budg_stateL(nf,ip) = budg_stateL(nf,ip) + end_hcsoi_grc(g)*af
          end if
          if (errsoi_grc(g) /= spval) then
             nf = s_h_errsoi ; budg_stateL(nf,ip) = budg_stateL(nf,ip) + errsoi_grc(g)*af
@@ -635,46 +662,59 @@ contains
              write(iulog,*)'NET HEAT FLUXES : period ',trim(pname(ip)),': date = ',cdate,sec
              write(iulog,FA0)'  Time  ','  Time    '
              write(iulog,FA0)'averaged','integrated'
-             write(iulog,FA0)'  W/m2  ','  J/m2   '
+             write(iulog,FA0)'W/m2*1e6','MJ/m2*1e6'
              write(iulog,'(32("-"),"|",20("-"))')
              do f = 1, f_size
-                write(iulog,FF)fname(f),budg_fluxGpr(f,ip),budg_fluxG(f,ip)*unit_conversion*get_step_size()
+                write(iulog,FF)fname(f),budg_fluxGpr(f,ip),budg_fluxG(f,ip)*unit_conversion*get_step_size()/1.e6_r8
              end do
              write(iulog,'(32("-"),"|",20("-"))')
              write(iulog,FF)'   *SUM*', &
-                  sum(budg_fluxGpr(:,ip)), sum(budg_fluxG(:,ip))*unit_conversion*get_step_size()
+                  sum(budg_fluxGpr(:,ip)), sum(budg_fluxG(:,ip))*unit_conversion*get_step_size()/1.e6_r8
              write(iulog,'(32("-"),"|",20("-"))')
 
              write(iulog,*)''
              write(iulog,*)'NET HEAT FLUXES (into ground) : period ',trim(pname(ip)),': date = ',cdate,sec
              write(iulog,FA0)'  Time  ','  Time    '
              write(iulog,FA0)'averaged','integrated'
-             write(iulog,FA0)'  W/m2  ','  J/m2   '
+             write(iulog,FA0)'W/m2*1e6','MJ/m2*1e6'
              write(iulog,'(32("-"),"|",20("-"))')
              do f = 1, g_size
-                write(iulog,FF)gname(f),budg_gfluxGpr(f,ip),budg_gfluxG(f,ip)*unit_conversion*get_step_size()
+                write(iulog,FF)gname(f),budg_gfluxGpr(f,ip),budg_gfluxG(f,ip)*unit_conversion*get_step_size()/1.e6_r8
              end do
              write(iulog,'(32("-"),"|",20("-"))')
              write(iulog,FF)'   *SUM*', &
-                  sum(budg_gfluxGpr(:,ip)), sum(budg_gfluxG(:,ip))*unit_conversion*get_step_size()
+                  sum(budg_gfluxGpr(:,ip)), sum(budg_gfluxG(:,ip))*unit_conversion*get_step_size()/1.e6_r8
              write(iulog,'(32("-"),"|",20("-"))')
+             write(iulog,*)'  (integrated column is directly comparable to the *NET CHANGE* row of HEAT STATES below)'
 
              write(iulog,*)''
              write(iulog,*)'HEAT STATES (MJ/m2*1e6): period ',trim(pname(ip)),': date = ',cdate,sec
              write(iulog,HS0) &
-                  '   Heat Content   ', &
+                  '       Soil       ', &
+                  '     Snow+Lake    ', &
                   '   Grid-level Err ', &
                   '       TOTAL      '
-             write(iulog,'(53("-"),"|",20("-"))')
-             write(iulog,HS) '         beg', budg_stateG(s_h_beg,ip)*unit_conversion, &
+             write(iulog,'(71("-"),"|",20("-"))')
+             write(iulog,HS) '         beg', &
+                  budg_stateG(s_hsoi_beg,ip)*unit_conversion, &
+                  (budg_stateG(s_h_beg,ip)-budg_stateG(s_hsoi_beg,ip))*unit_conversion, &
                   budg_stateG(s_h_beg,ip)*unit_conversion
-             write(iulog,HS) '         end', budg_stateG(s_h_end,ip)*unit_conversion, &
+             write(iulog,HS) '         end', &
+                  budg_stateG(s_hsoi_end,ip)*unit_conversion, &
+                  (budg_stateG(s_h_end,ip)-budg_stateG(s_hsoi_end,ip))*unit_conversion, &
                   budg_stateG(s_h_end,ip)*unit_conversion
              write(iulog,HS3)'*NET CHANGE*', &
-                  (budg_stateG(s_h_end,ip)-budg_stateG(s_h_beg,ip))*unit_conversion, &
+                  (budg_stateG(s_hsoi_end,ip)-budg_stateG(s_hsoi_beg,ip))*unit_conversion, &
+                  ((budg_stateG(s_h_end,ip)-budg_stateG(s_hsoi_end,ip)) &
+                  -(budg_stateG(s_h_beg,ip)-budg_stateG(s_hsoi_beg,ip)))*unit_conversion, &
                   budg_stateG(s_h_errsoi,ip)*unit_conversion/budg_fluxN(1,ip), &
                   (budg_stateG(s_h_end,ip)-budg_stateG(s_h_beg,ip))*unit_conversion
-             write(iulog,'(53("-"),"|",20("-"))')
+             write(iulog,'(71("-"),"|",20("-"))')
+             write(iulog,HS2)'   *SUM*    ', &
+                  (budg_stateG(s_h_end,ip)-budg_stateG(s_h_beg,ip))*unit_conversion &
+                  - budg_stateG(s_h_errsoi,ip)*unit_conversion/budg_fluxN(1,ip), &
+                  (budg_stateG(s_h_end,ip)-budg_stateG(s_h_beg,ip))*unit_conversion
+             write(iulog,'(71("-"),"|",20("-"))')
           end if
        end if
     end do

--- a/components/elm/src/biogeophys/HeatBudgetMod.F90
+++ b/components/elm/src/biogeophys/HeatBudgetMod.F90
@@ -1,0 +1,895 @@
+module HeatBudgetMod
+  ! !DESCRIPTION:
+  ! Heat (energy) budget diagnostic for ELM's lnd.log, mirroring
+  ! WaterBudgetMod. Two tables are printed:
+  !
+  ! - NET HEAT FLUXES: a cross-boundary flux-conservation check
+  !   (comparable to the coupler's own NET HEAT BUDGET table in cpl.log).
+  ! - HEAT STATES: a beginning/end-of-timestep snapshot of column heat
+  !   content (col_es%hc_soisno, snow+soil+lake) plus the soil/lake
+  !   solver's own numerical-closure residual (col_ef%errsoi), both
+  !   already validated every timestep by SoilFluxesMod/LakeTemperatureMod/
+  !   BalanceCheckMod -- see HeatBudget_Run's header for what this
+  !   table can and cannot be used to conclude, and HEAT_BUDGET_PLAN.md's
+  !   Phase 2 section for the full reasoning.
+  !
+  ! !USES:
+  use shr_kind_mod      , only : r8 => shr_kind_r8
+  use shr_log_mod       , only : errMsg => shr_log_errMsg
+  use shr_sys_mod       , only : shr_sys_abort
+  use decompMod         , only : bounds_type
+  use abortutils        , only : endrun
+  use elm_varctl        , only : iulog
+  use atm2lndType       , only : atm2lnd_type
+  use lnd2atmType       , only : lnd2atm_type
+  use spmdMod           , only : masterproc
+  use elm_varcon        , only : spval
+  use ColumnDataType    , only : col_es, col_ef, col_ws
+  use VegetationDataType, only : veg_ef
+  use GridcellDataType  , only : grc_es, grc_ef
+  use timeinfoMod
+
+  implicit none
+  save
+  private
+
+  public :: HeatBudget_Reset
+  public :: HeatBudget_Run
+  public :: HeatBudget_Accum
+  public :: HeatBudget_Print
+  public :: HeatBudget_Restart
+  public :: HeatBudget_SetBeginningStates
+  public :: HeatBudget_SetEndingStates
+
+  !--- F for flux ---
+  ! Named/ordered to match the coupler's own NET HEAT BUDGET rows
+  ! (hnetsw/hlwdn/hlwup/hlatvap/hsen) for direct cross-validation against
+  ! cpl.log's 'lnd' column.
+
+  integer, parameter :: f_netsw = 1
+  integer, parameter :: f_lwdn  = 2
+  integer, parameter :: f_lwup  = 3
+  integer, parameter :: f_lh    = 4
+  integer, parameter :: f_sh    = 5
+
+  integer, parameter, public :: f_size = f_sh
+
+  character(len=12),parameter :: fname(f_size) = &
+       (/&
+       '      netsw ', &
+       '       lwdn ', &
+       '       lwup ', &
+       '        lh  ', &
+       '        sh  '  &
+       /)
+
+  !--- P for period ---
+
+  integer, parameter :: p_inst = 1
+  integer, parameter :: p_day  = 2
+  integer, parameter :: p_mon  = 3
+  integer, parameter :: p_ann  = 4
+  integer, parameter :: p_inf  = 5
+
+  integer, parameter, public :: p_size = p_inf
+
+  character(len=8),parameter :: pname(p_size) = &
+       (/'    inst','   daily',' monthly','  annual','all_time' /)
+
+  real(r8) :: budg_fluxL(f_size, p_size) ! local sum, valid on all pes
+  real(r8) :: budg_fluxG(f_size, p_size) ! global sum, valid only on root pe
+  real(r8) :: budg_fluxN(f_size, p_size) ! counter, valid only on root pe
+
+  !--- G for the into-ground flux table ---
+  ! Rows that (up to errsoi_col's own tiny residual) sum to exactly the
+  ! rate of change of col_es%hc_soisno -- i.e. this table's *SUM*, unlike
+  ! NET HEAT FLUXES' *SUM*, is directly comparable to HEAT STATES'
+  ! *NET CHANGE*. Derived from the exact identity
+  !   d(cv*T)/dt = cv*(dT/dt) + T*(dcv/dt)
+  ! applied to SoilFluxesMod.F90's own errsoi_patch formula (whose
+  ! ΔT/fact terms are exactly the cv*(dT/dt) part, evaluated with cv held
+  ! at whatever mass was current for that call):
+  !   d(hc_soisno)/dt = eflx_soil_grnd - xmf - xmf_h2osfc
+  !        - frac_h2osfc*(t_h2osfc-t_h2osfc_bef)*(c_h2osfc/dtime)
+  !        + eflx_h2osfc_to_snow + eflx_building_heat
+  !        + tssbef*(cv-cv_bef)/dtime - errsoi_col
+  ! grnd and phase use only already-persistent veg_ef/col_ef/col_es/col_ws
+  ! fields. masschg (the T*(dcv/dt) term above) needed a small, purely
+  ! additive change to SoilTemperatureMod.F90/LakeTemperatureMod.F90: a new
+  ! col_es%cv_bef snapshot of layer heat capacity from the previous call,
+  ! and col_ef%eflx_hc_masschg computed from it and the existing tssbef.
+  ! It captures how hc_soisno changes purely from water mass changing
+  ! (infiltration, drainage, ET) while referenced to absolute Kelvin
+  ! temperature -- not itself a boundary flux, but the dominant missing
+  ! piece once phase is accounted for. LakeTemperatureMod folds its own
+  ! analogous correction into eflx_sh_tot instead of keeping it separate,
+  ! and masschg does not cover the lake-water layers themselves (cv_lake),
+  ! so g_phase and g_masschg both under-represent lake columns specifically
+  ! -- any residual for a lake-containing gridcell shows up against
+  ! errsoi_col, not as a bug in this table.
+
+  integer, parameter :: g_grnd    = 1
+  integer, parameter :: g_phase   = 2
+  integer, parameter :: g_masschg = 3
+
+  integer, parameter, public :: g_size = g_masschg
+
+  character(len=12),parameter :: gname(g_size) = &
+       (/&
+       '        grnd', &
+       '       phase', &
+       '     masschg'  &
+       /)
+
+  real(r8) :: budg_gfluxL(g_size, p_size) ! local sum, valid on all pes
+  real(r8) :: budg_gfluxG(g_size, p_size) ! global sum, valid only on root pe
+  real(r8) :: budg_gfluxN(g_size, p_size) ! counter, valid only on root pe
+
+  !--- S for state ---
+  ! Column heat content (col_es%hc_soisno = snow+soil+lake heat content, MJ/m2)
+  ! aggregated to the gridcell, plus the soil/lake solver's own column-level
+  ! numerical-closure residual (col_ef%errsoi, W/m2) aggregated the same way.
+  ! Canopy heat storage is not tracked anywhere in the model, so there is
+  ! deliberately no canopy row here (unlike a fabricated always-zero one).
+
+  integer, parameter :: s_h_beg    = 1
+  integer, parameter :: s_h_end    = 2
+  integer, parameter :: s_h_errsoi = 3
+
+  integer, parameter, public :: s_size = s_h_errsoi
+
+  character(len=12),parameter :: sname(s_size) = &
+       (/&
+       'total_hc_beg', &
+       'total_hc_end', &
+       '  errsoi_col'  &
+       /)
+
+  real(r8) :: budg_stateL(s_size, p_size) ! local sum, valid on all pes
+  real(r8), public :: budg_stateG(s_size, p_size) ! global sum, valid only on root pe
+
+  !----- formats -----
+  character(*),parameter :: FA0= "('    ',12x,(3x,a10,2x),' | ',(3x,a10,2x))"
+  character(*),parameter :: FF = "('    ',a12,f15.8,' | ',f18.2)"
+  character(*),parameter :: HS0= "('    ',12x,2(a18),' | ',(a18))"
+  character(*),parameter :: HS = "('    ',a12,f18.2,18x,' | ',(f18.2))"
+  character(*),parameter :: HS3= "('    ',a12,2(f18.2),' | ',(f18.2))"
+
+contains
+
+  !-----------------------------------------------------------------------
+  subroutine HeatBudget_Reset(mode)
+    !
+    use elm_time_manager, only : get_curr_date, get_prev_date
+    !
+    implicit none
+    !
+    character(len=*), intent(in),optional :: mode
+    !
+    integer :: year, mon, day, sec
+    integer :: ip
+    character(*),parameter :: subName = '(HeatBudget_Reset) '
+
+    if (.not.present(mode)) then
+       call get_curr_date(year, mon, day, sec)
+       call get_prev_date(year, mon, day, sec)
+
+       do ip = 1,p_size
+          if (ip == p_inst) then
+             budg_fluxL(:,ip)  = 0.0_r8
+             budg_fluxG(:,ip)  = 0.0_r8
+             budg_fluxN(:,ip)  = 0.0_r8
+             budg_stateL(:,ip) = 0.0_r8
+             budg_stateG(:,ip) = 0.0_r8
+             budg_gfluxL(:,ip) = 0.0_r8
+             budg_gfluxG(:,ip) = 0.0_r8
+             budg_gfluxN(:,ip) = 0.0_r8
+          endif
+          if (ip==p_day .and. sec==0) then
+             budg_fluxL(:,ip)  = 0.0_r8
+             budg_fluxG(:,ip)  = 0.0_r8
+             budg_fluxN(:,ip)  = 0.0_r8
+             budg_stateL(:,ip) = 0.0_r8
+             budg_stateG(:,ip) = 0.0_r8
+             budg_gfluxL(:,ip) = 0.0_r8
+             budg_gfluxG(:,ip) = 0.0_r8
+             budg_gfluxN(:,ip) = 0.0_r8
+          endif
+          if (ip==p_mon .and. day==1 .and. sec==0) then
+             budg_fluxL(:,ip)  = 0.0_r8
+             budg_fluxG(:,ip)  = 0.0_r8
+             budg_fluxN(:,ip)  = 0.0_r8
+             budg_stateL(:,ip) = 0.0_r8
+             budg_stateG(:,ip) = 0.0_r8
+             budg_gfluxL(:,ip) = 0.0_r8
+             budg_gfluxG(:,ip) = 0.0_r8
+             budg_gfluxN(:,ip) = 0.0_r8
+          endif
+          if (ip==p_ann .and. mon==1 .and. day==1 .and. sec==0) then
+             budg_fluxL(:,ip)  = 0.0_r8
+             budg_fluxG(:,ip)  = 0.0_r8
+             budg_fluxN(:,ip)  = 0.0_r8
+             budg_stateL(:,ip) = 0.0_r8
+             budg_stateG(:,ip) = 0.0_r8
+             budg_gfluxL(:,ip) = 0.0_r8
+             budg_gfluxG(:,ip) = 0.0_r8
+             budg_gfluxN(:,ip) = 0.0_r8
+          endif
+       enddo
+
+    else
+
+       if (trim(mode) == 'inst') then
+          budg_fluxL  (:,p_inst)   = 0.0_r8
+          budg_fluxG  (:,p_inst)   = 0.0_r8
+          budg_fluxN  (:,p_inst)   = 0.0_r8
+          budg_stateL (:,p_inst)   = 0.0_r8
+          budg_stateG (:,p_inst)   = 0.0_r8
+          budg_gfluxL (:,p_inst)   = 0.0_r8
+          budg_gfluxG (:,p_inst)   = 0.0_r8
+          budg_gfluxN (:,p_inst)   = 0.0_r8
+       elseif (trim(mode) == 'day') then
+          budg_fluxL  (:,p_day)    = 0.0_r8
+          budg_fluxG  (:,p_day)    = 0.0_r8
+          budg_fluxN  (:,p_day)    = 0.0_r8
+          budg_stateL (:,p_day)    = 0.0_r8
+          budg_stateG (:,p_day)    = 0.0_r8
+          budg_gfluxL (:,p_day)    = 0.0_r8
+          budg_gfluxG (:,p_day)    = 0.0_r8
+          budg_gfluxN (:,p_day)    = 0.0_r8
+       elseif (trim(mode) == 'mon') then
+          budg_fluxL  (:,p_mon)    = 0.0_r8
+          budg_fluxG  (:,p_mon)    = 0.0_r8
+          budg_fluxN  (:,p_mon)    = 0.0_r8
+          budg_stateL (:,p_mon)    = 0.0_r8
+          budg_stateG (:,p_mon)    = 0.0_r8
+          budg_gfluxL (:,p_mon)    = 0.0_r8
+          budg_gfluxG (:,p_mon)    = 0.0_r8
+          budg_gfluxN (:,p_mon)    = 0.0_r8
+       elseif (trim(mode) == 'ann') then
+          budg_fluxL  (:,p_ann)    = 0.0_r8
+          budg_fluxG  (:,p_ann)    = 0.0_r8
+          budg_fluxN  (:,p_ann)    = 0.0_r8
+          budg_stateL (:,p_ann)    = 0.0_r8
+          budg_stateG (:,p_ann)    = 0.0_r8
+          budg_gfluxL (:,p_ann)    = 0.0_r8
+          budg_gfluxG (:,p_ann)    = 0.0_r8
+          budg_gfluxN (:,p_ann)    = 0.0_r8
+       elseif (trim(mode) == 'inf') then
+          budg_fluxL  (:,p_inf)    = 0.0_r8
+          budg_fluxG  (:,p_inf)    = 0.0_r8
+          budg_fluxN  (:,p_inf)    = 0.0_r8
+          budg_stateL (:,p_inf)    = 0.0_r8
+          budg_stateG (:,p_inf)    = 0.0_r8
+          budg_gfluxL (:,p_inf)    = 0.0_r8
+          budg_gfluxG (:,p_inf)    = 0.0_r8
+          budg_gfluxN (:,p_inf)    = 0.0_r8
+       elseif (trim(mode) == 'all') then
+          budg_fluxL  (:,:)        = 0.0_r8
+          budg_fluxG  (:,:)        = 0.0_r8
+          budg_fluxN  (:,:)        = 0.0_r8
+          budg_stateL (:,:)        = 0.0_r8
+          budg_stateG (:,:)        = 0.0_r8
+          budg_gfluxL (:,:)        = 0.0_r8
+          budg_gfluxG (:,:)        = 0.0_r8
+          budg_gfluxN (:,:)        = 0.0_r8
+       else
+          call shr_sys_abort(subname//' ERROR in mode '//trim(mode))
+       endif
+    endif
+
+  end subroutine HeatBudget_Reset
+
+  !-----------------------------------------------------------------------
+  subroutine HeatBudget_Accum()
+    !
+    use elm_time_manager, only : get_curr_date, get_prev_date, get_nstep
+    !
+    implicit none
+    !
+    integer                :: ip, nf
+    integer                :: year_prev, month_prev, day_prev, sec_prev
+    integer                :: year_curr, month_curr, day_curr, sec_curr
+    character(*),parameter :: subName = '(HeatBudget_Accum)'
+    logical                :: update_state_beg, update_state_end
+
+    call get_prev_date(year_prev, month_prev, day_prev, sec_prev)
+    call get_curr_date(year_curr, month_curr, day_curr, sec_curr)
+
+    do ip = p_inst+1, p_size
+       budg_fluxL(:,ip)  = budg_fluxL(:,ip)  + budg_fluxL(:,p_inst)
+       budg_gfluxL(:,ip) = budg_gfluxL(:,ip) + budg_gfluxL(:,p_inst)
+       update_state_beg = .false.
+       update_state_end = .false.
+
+       select case (ip)
+       case (p_day)
+          if (sec_prev == 0) update_state_beg = .true.
+          if (sec_curr == 0) update_state_end = .true.
+       case (p_mon)
+          if (sec_prev == 0 .and. day_prev == 1) update_state_beg = .true.
+          if (sec_curr == 0 .and. day_curr == 1) update_state_end = .true.
+       case (p_ann)
+          if (sec_prev == 0 .and. day_prev == 1 .and. month_prev == 1) update_state_beg = .true.
+          if (sec_curr == 0 .and. day_curr == 1 .and. month_curr == 1) update_state_end = .true.
+       case (p_inf)
+          update_state_end = .true.
+       end select
+       if (get_nstep() == 1) update_state_beg = .true.
+
+       if (update_state_beg) then
+          nf = s_h_beg ; budg_stateL(nf,ip) = budg_stateL(nf, p_inst)
+       endif
+
+       if (update_state_end) then
+          nf = s_h_end ; budg_stateL(nf,ip) = budg_stateL(nf, p_inst)
+       endif
+       nf = s_h_errsoi ; budg_stateL(nf,ip) = budg_stateL(nf,ip) + budg_stateL(nf, p_inst)
+    end do
+    budg_fluxN(:,:)  = budg_fluxN(:,:)  + 1._r8
+    budg_gfluxN(:,:) = budg_gfluxN(:,:) + 1._r8
+
+  end subroutine HeatBudget_Accum
+
+  !-----------------------------------------------------------------------
+  subroutine HeatBudget_SetBeginningStates(bounds)
+    !
+    ! !DESCRIPTION:
+    ! Snapshot the grid-level column heat content (snow+soil+lake,
+    ! col_es%hc_soisno) at the beginning of the time step, before
+    ! dynSubgrid_driver reweights columns for this step. This mirrors
+    ! BalanceCheckMod's BeginGridWaterBalance, which captures grc_ws%begwb
+    ! at the same point in elm_driver.F90 for exactly the same reason:
+    ! taking the snapshot any later would double-count (or miss) the
+    ! land-cover reweighting jump that eflx_dynbal already corrects for
+    ! in the flux table.
+    !
+    ! col_es%hc_soisno is a diagnostic (not a prognostic state): it holds
+    ! spval until the first call to SoilTemperature/LakeTemperature this
+    ! run, so grc_es%beg_hc will legitimately be spval on the very first
+    ! timestep (and over any all-urban gridcell, since urban columns are
+    ! never included in hc_soisno). HeatBudget_Run skips accumulating the
+    ! state terms wherever that happens.
+    !
+    use subgridAveMod, only : c2g
+    !
+    implicit none
+    !
+    type(bounds_type), intent(in) :: bounds
+
+    call c2g(bounds, col_es%hc_soisno(bounds%begc:bounds%endc), &
+         grc_es%beg_hc(bounds%begg:bounds%endg), &
+         c2l_scale_type='unity', l2g_scale_type='unity')
+
+  end subroutine HeatBudget_SetBeginningStates
+
+  !-----------------------------------------------------------------------
+  subroutine HeatBudget_SetEndingStates(bounds)
+    !
+    ! !DESCRIPTION:
+    ! Snapshot the grid-level column heat content (col_es%hc_soisno) and
+    ! the soil/lake solver's own numerical-closure residual
+    ! (col_ef%errsoi) at the end of the time step, once
+    ! SoilTemperature/SoilFluxes/LakeTemperature have all run for this
+    ! step. Called per-clump alongside GridBalanceCheck/
+    ! WaterBudget_SetEndingMonthlyStates, matching where those grid-level
+    ! c2g aggregations already happen in elm_driver.F90 -- HeatBudget_Run
+    ! itself (called once, on bounds_proc, right before lnd2atm_vars-based
+    ! fluxes are gathered) only reads the results, mirroring
+    ! WaterBudget_Run's own read-only use of grc_ws%endwb.
+    !
+    ! Also aggregate the two terms behind the "into ground" flux table:
+    ! grc_ef%heat_into_grnd (p2g of veg_ef%eflx_soil_grnd) and
+    ! grc_ef%heat_phase_corr (c2g of a per-column combination of the
+    ! phase-change and h2osfc/building-heat terms from
+    ! SoilFluxesMod.F90's own errsoi_patch formula -- see HeatBudget_Run's
+    ! header for the exact expression and its provenance).
+    !
+    use subgridAveMod, only : c2g, p2g
+    !
+    implicit none
+    !
+    type(bounds_type), intent(in) :: bounds
+    !
+    integer  :: c
+    real(r8) :: phase_col(bounds%begc:bounds%endc)
+
+    call c2g(bounds, col_es%hc_soisno(bounds%begc:bounds%endc), &
+         grc_es%end_hc(bounds%begg:bounds%endg), &
+         c2l_scale_type='unity', l2g_scale_type='unity')
+
+    call c2g(bounds, col_ef%errsoi(bounds%begc:bounds%endc), &
+         grc_es%errsoi(bounds%begg:bounds%endg), &
+         c2l_scale_type='unity', l2g_scale_type='unity')
+
+    call p2g(bounds, veg_ef%eflx_soil_grnd(bounds%begp:bounds%endp), &
+         grc_ef%heat_into_grnd(bounds%begg:bounds%endg), &
+         p2c_scale_type='unity', c2l_scale_type='unity', l2g_scale_type='unity')
+
+    associate(                                       &
+         xmf          => col_ef%xmf                , &
+         xmf_h2osfc   => col_ef%xmf_h2osfc         , &
+         h2osfc2snow  => col_ef%eflx_h2osfc_to_snow, &
+         bldg_heat    => col_ef%eflx_building_heat , &
+         frac_h2osfc  => col_ws%frac_h2osfc        , &
+         t_h2osfc     => col_es%t_h2osfc           , &
+         t_h2osfc_bef => col_es%t_h2osfc_bef       , &
+         c_h2osfc     => col_es%c_h2osfc             &
+         )
+
+      do c = bounds%begc, bounds%endc
+         if (xmf(c) == spval .or. xmf_h2osfc(c) == spval .or. h2osfc2snow(c) == spval &
+              .or. bldg_heat(c) == spval .or. frac_h2osfc(c) == spval &
+              .or. t_h2osfc(c) == spval .or. t_h2osfc_bef(c) == spval .or. c_h2osfc(c) == spval) then
+            phase_col(c) = spval
+         else
+            phase_col(c) = -xmf(c) - xmf_h2osfc(c) &
+                 - frac_h2osfc(c)*(t_h2osfc(c)-t_h2osfc_bef(c))*(c_h2osfc(c)/dtime_mod) &
+                 + h2osfc2snow(c) + bldg_heat(c)
+         end if
+      end do
+
+    end associate
+
+    call c2g(bounds, phase_col(bounds%begc:bounds%endc), &
+         grc_ef%heat_phase_corr(bounds%begg:bounds%endg), &
+         c2l_scale_type='unity', l2g_scale_type='unity')
+
+    call c2g(bounds, col_ef%eflx_hc_masschg(bounds%begc:bounds%endc), &
+         grc_ef%heat_masschg(bounds%begg:bounds%endg), &
+         c2l_scale_type='unity', l2g_scale_type='unity')
+
+  end subroutine HeatBudget_SetEndingStates
+
+  !-----------------------------------------------------------------------
+  subroutine HeatBudget_Run(bounds, atm2lnd_vars, lnd2atm_vars)
+    !
+    ! !DESCRIPTION:
+    ! Accumulate the instantaneous, area-weighted net heat fluxes
+    ! exchanged between ELM and the atmosphere. Mirrors WaterBudget_Run's
+    ! gridcell loop and area weighting exactly.
+    !
+    ! Also accumulate the grid-level heat-content state (col_es%hc_soisno,
+    ! now holding this step's ending value since SoilTemperature/
+    ! SoilFluxes/LakeTemperature have already run) and the soil/lake
+    ! solver's own numerical-closure residual (col_ef%errsoi). Note that
+    ! (end_hc - beg_hc) - (net flux table * dt) is NOT a clean numerical
+    ! truncation term the way water's errh2o is: it also contains real,
+    ! currently-unmodeled advected heat carried by precipitation,
+    ! snowmelt, and runoff (see HEAT_BUDGET_PLAN.md, Phase 2 issue #3).
+    ! errsoi_col itself, by contrast, IS a validated, tightly-bounded
+    ! (<1e-5 W/m2, or the model aborts) internal closure term -- it is
+    ! printed here for that reason, not as a stand-in for the former.
+    !
+    use domainMod, only : ldomain
+    use elm_varcon, only : re
+    !
+    implicit none
+
+    type(bounds_type)        , intent(in) :: bounds
+    type(atm2lnd_type)       , intent(in) :: atm2lnd_vars
+    type(lnd2atm_type)       , intent(in) :: lnd2atm_vars
+
+    integer  :: g, nf, ip
+    real(r8) :: af, one_over_re2
+
+    associate(                                                              &
+         forc_lwdn   => atm2lnd_vars%forc_lwrad_not_downscaled_grc        , &
+         netsw       => lnd2atm_vars%fsa_grc                              , &
+         lwup        => lnd2atm_vars%eflx_lwrad_out_grc                   , &
+         eflx_sh_tot => lnd2atm_vars%eflx_sh_tot_grc                      , &
+         eflx_lh_tot => lnd2atm_vars%eflx_lh_tot_grc                      , &
+         beg_hc_grc  => grc_es%beg_hc                                     , &
+         end_hc_grc  => grc_es%end_hc                                     , &
+         errsoi_grc  => grc_es%errsoi                                     , &
+         grnd_grc    => grc_ef%heat_into_grnd                             , &
+         phase_grc   => grc_ef%heat_phase_corr                            , &
+         masschg_grc => grc_ef%heat_masschg                                 &
+         )
+
+      ip = p_inst
+
+      budg_stateL(:,ip) = 0._r8
+      budg_gfluxL(:,ip) = 0._r8
+      one_over_re2 = 1._r8/(re**2._r8)
+
+      do g = bounds%begg, bounds%endg
+
+         af   = (ldomain%area(g) * one_over_re2) * & ! area (converting km**2 to radians**2)
+                ldomain%frac(g)                      ! land fraction
+
+         nf = f_netsw; budg_fluxL(nf,ip) = budg_fluxL(nf,ip) + netsw(g)*af
+         nf = f_lwdn ; budg_fluxL(nf,ip) = budg_fluxL(nf,ip) + forc_lwdn(g)*af
+         nf = f_lwup ; budg_fluxL(nf,ip) = budg_fluxL(nf,ip) - lwup(g)*af
+         nf = f_lh   ; budg_fluxL(nf,ip) = budg_fluxL(nf,ip) - eflx_lh_tot(g)*af
+         nf = f_sh   ; budg_fluxL(nf,ip) = budg_fluxL(nf,ip) - eflx_sh_tot(g)*af
+
+         if (beg_hc_grc(g) /= spval .and. end_hc_grc(g) /= spval) then
+            nf = s_h_beg ; budg_stateL(nf,ip) = budg_stateL(nf,ip) + beg_hc_grc(g)*af
+            nf = s_h_end ; budg_stateL(nf,ip) = budg_stateL(nf,ip) + end_hc_grc(g)*af
+         end if
+         if (errsoi_grc(g) /= spval) then
+            nf = s_h_errsoi ; budg_stateL(nf,ip) = budg_stateL(nf,ip) + errsoi_grc(g)*af
+         end if
+
+         if (grnd_grc(g) /= spval) then
+            nf = g_grnd ; budg_gfluxL(nf,ip) = budg_gfluxL(nf,ip) + grnd_grc(g)*af
+         end if
+         if (phase_grc(g) /= spval) then
+            nf = g_phase ; budg_gfluxL(nf,ip) = budg_gfluxL(nf,ip) + phase_grc(g)*af
+         end if
+         if (masschg_grc(g) /= spval) then
+            nf = g_masschg ; budg_gfluxL(nf,ip) = budg_gfluxL(nf,ip) + masschg_grc(g)*af
+         end if
+      end do
+
+    end associate
+
+  end subroutine HeatBudget_Run
+
+  !-----------------------------------------------------------------------
+  subroutine HeatBudget_Sum0()
+    !
+    use spmdMod    , only : mpicom
+    use shr_mpi_mod, only : shr_mpi_sum
+    !
+    implicit none
+    !
+    real(r8)               :: budg_fluxGtmp(f_size,p_size) ! temporary sum
+    real(r8)               :: budg_stateGtmp(s_size,p_size) ! temporary sum
+    real(r8)               :: budg_gfluxGtmp(g_size,p_size) ! temporary sum
+    character(*),parameter :: subName = '(HeatBudget_Sum0)'
+
+    budg_fluxGtmp = 0._r8
+    budg_stateGtmp = 0._r8
+    budg_gfluxGtmp = 0._r8
+
+    call shr_mpi_sum(budg_fluxL, budg_fluxGtmp, mpicom, subName, all=.true. )
+    call shr_mpi_sum(budg_stateL, budg_stateGtmp, mpicom, subName, all=.true. )
+    call shr_mpi_sum(budg_gfluxL, budg_gfluxGtmp, mpicom, subName, all=.true. )
+
+    budg_fluxG  = budg_fluxG + budg_fluxGtmp
+    budg_stateG = budg_stateGtmp
+    budg_gfluxG = budg_gfluxG + budg_gfluxGtmp
+
+    budg_fluxL            = 0._r8 ! reset all fluxes
+    budg_stateL(:,p_inst) = 0._r8 ! only reset instantaneous states
+    budg_gfluxL            = 0._r8 ! reset all fluxes
+
+  end subroutine HeatBudget_Sum0
+
+  !-----------------------------------------------------------------------
+  subroutine HeatBudget_Print(budg_print_inst,  budg_print_daily,  budg_print_month,  &
+       budg_print_ann,  budg_print_ltann,  budg_print_ltend)
+    !
+    use elm_time_manager, only : get_curr_date, get_prev_date, get_nstep, get_step_size
+    use shr_const_mod   , only : shr_const_pi
+    !
+    implicit none
+    !
+    integer , intent(in) :: budg_print_inst
+    integer , intent(in) :: budg_print_daily
+    integer , intent(in) :: budg_print_month
+    integer , intent(in) :: budg_print_ann
+    integer , intent(in) :: budg_print_ltann
+    integer , intent(in) :: budg_print_ltend
+    !
+    ! !LOCAL VARIABLES:
+    integer :: f,ip ! data array indicies
+    integer :: plev        ! print level
+    integer :: year, mon, day, sec
+    integer :: cdate
+    logical :: sumdone
+    real(r8) :: unit_conversion
+    real(r8) :: budg_fluxGpr (f_size,p_size) ! values to print, scaled and such
+    real(r8) :: budg_gfluxGpr (g_size,p_size) ! values to print, scaled and such
+
+    sumdone = .false.
+
+    if (get_nstep() <= 1) then
+       call get_prev_date(year, mon, day, sec);
+    else
+       call get_curr_date(year, mon, day, sec);
+    end if
+
+    cdate = year*10000 + mon*100 + day
+
+    do ip = 1,p_size
+       plev = 0
+       if (ip == p_inst) then
+          plev = max(plev,budg_print_inst)
+       endif
+       if (ip==p_day .and. sec==0) then
+          plev = max(plev,budg_print_daily)
+       endif
+       if (ip==p_mon .and. day==1 .and. sec==0) then
+          plev = max(plev,budg_print_month)
+       endif
+       if (ip==p_ann .and. mon==1 .and. day==1 .and. sec==0) then
+          plev = max(plev,budg_print_ann)
+       endif
+       if (ip==p_inf .and. mon==1 .and. day==1 .and. sec==0) then
+          plev = max(plev,budg_print_ltann)
+       endif
+
+       if (plev > 0) then
+          unit_conversion = 1.d0/(4.0_r8*shr_const_pi)*1.0e6_r8
+          if (.not.sumdone) then
+             sumdone = .true.
+             call HeatBudget_Sum0()
+             budg_fluxGpr = budg_fluxG
+             budg_fluxGpr = budg_fluxGpr*unit_conversion
+             budg_fluxGpr = budg_fluxGpr/budg_fluxN
+             budg_gfluxGpr = budg_gfluxG
+             budg_gfluxGpr = budg_gfluxGpr*unit_conversion
+             budg_gfluxGpr = budg_gfluxGpr/budg_gfluxN
+          end if
+
+          if (ip == p_day .and. get_nstep() == 1) cycle
+          if (ip == p_mon .and. get_nstep() == 1) cycle
+          if (ip == p_ann .and. get_nstep() == 1) cycle
+          if (ip == p_inf .and. get_nstep() == 1) cycle
+
+          if (masterproc) then
+             write(iulog,*)''
+             write(iulog,*)'NET HEAT FLUXES : period ',trim(pname(ip)),': date = ',cdate,sec
+             write(iulog,FA0)'  Time  ','  Time    '
+             write(iulog,FA0)'averaged','integrated'
+             write(iulog,FA0)'  W/m2  ','  J/m2   '
+             write(iulog,'(32("-"),"|",20("-"))')
+             do f = 1, f_size
+                write(iulog,FF)fname(f),budg_fluxGpr(f,ip),budg_fluxG(f,ip)*unit_conversion*get_step_size()
+             end do
+             write(iulog,'(32("-"),"|",20("-"))')
+             write(iulog,FF)'   *SUM*', &
+                  sum(budg_fluxGpr(:,ip)), sum(budg_fluxG(:,ip))*unit_conversion*get_step_size()
+             write(iulog,'(32("-"),"|",20("-"))')
+
+             write(iulog,*)''
+             write(iulog,*)'NET HEAT FLUXES (into ground) : period ',trim(pname(ip)),': date = ',cdate,sec
+             write(iulog,FA0)'  Time  ','  Time    '
+             write(iulog,FA0)'averaged','integrated'
+             write(iulog,FA0)'  W/m2  ','  J/m2   '
+             write(iulog,'(32("-"),"|",20("-"))')
+             do f = 1, g_size
+                write(iulog,FF)gname(f),budg_gfluxGpr(f,ip),budg_gfluxG(f,ip)*unit_conversion*get_step_size()
+             end do
+             write(iulog,'(32("-"),"|",20("-"))')
+             write(iulog,FF)'   *SUM*', &
+                  sum(budg_gfluxGpr(:,ip)), sum(budg_gfluxG(:,ip))*unit_conversion*get_step_size()
+             write(iulog,'(32("-"),"|",20("-"))')
+
+             write(iulog,*)''
+             write(iulog,*)'HEAT STATES (MJ/m2*1e6): period ',trim(pname(ip)),': date = ',cdate,sec
+             write(iulog,HS0) &
+                  '   Heat Content   ', &
+                  '   Grid-level Err ', &
+                  '       TOTAL      '
+             write(iulog,'(53("-"),"|",20("-"))')
+             write(iulog,HS) '         beg', budg_stateG(s_h_beg,ip)*unit_conversion, &
+                  budg_stateG(s_h_beg,ip)*unit_conversion
+             write(iulog,HS) '         end', budg_stateG(s_h_end,ip)*unit_conversion, &
+                  budg_stateG(s_h_end,ip)*unit_conversion
+             write(iulog,HS3)'*NET CHANGE*', &
+                  (budg_stateG(s_h_end,ip)-budg_stateG(s_h_beg,ip))*unit_conversion, &
+                  budg_stateG(s_h_errsoi,ip)*unit_conversion/budg_fluxN(1,ip), &
+                  (budg_stateG(s_h_end,ip)-budg_stateG(s_h_beg,ip))*unit_conversion
+             write(iulog,'(53("-"),"|",20("-"))')
+          end if
+       end if
+    end do
+
+  end subroutine HeatBudget_Print
+
+  !-----------------------------------------------------------------------
+  subroutine HeatBudget_Restart(bounds, ncid, flag)
+    !
+    use ncdio_pio, only : file_desc_t, ncd_io, ncd_double, ncd_int
+    use ncdio_pio, only : ncd_defvar
+    !
+    implicit none
+    !
+    type(bounds_type), intent(in)    :: bounds
+    type(file_desc_t), intent(inout) :: ncid   ! netcdf id
+    character(len=*) , intent(in)    :: flag   ! 'read' or 'write'
+    !
+    character(len=*),parameter :: subname = 'HeatBudget_Restart'
+
+    select case (trim(flag))
+    case ('define')
+       call HeatBudget_Restart_Define(bounds, ncid)
+    case ('write')
+       call HeatBudget_Restart_Write(bounds, ncid, flag)
+    case ('read')
+       call HeatBudget_Restart_Read(bounds, ncid, flag)
+    case default
+       write(iulog,*) trim(subname),' ERROR: unknown flag = ',flag
+       call endrun(msg=errMsg(__FILE__, __LINE__))
+    end select
+
+  end subroutine HeatBudget_Restart
+
+  !-----------------------------------------------------------------------
+  subroutine HeatBudget_Restart_Define(bounds, ncid)
+    !
+    use ncdio_pio, only : file_desc_t, ncd_io, ncd_double, ncd_defvar
+    !
+    implicit none
+    !
+    type(bounds_type), intent(in)    :: bounds
+    type(file_desc_t), intent(inout) :: ncid   ! netcdf id
+
+    call ncd_defvar(varname='heat_budg_fluxG', xtype=ncd_double, &
+         dim1name='heat_budg_flux', &
+         long_name='heat_budg_fluxG', units='W/m2', ncid=ncid)
+
+    call ncd_defvar(varname='heat_budg_fluxN', xtype=ncd_double, &
+         dim1name='heat_budg_flux', &
+         long_name='heat_budg_fluxN', units='-', ncid=ncid)
+
+    call ncd_defvar(varname='heat_budg_stateG', xtype=ncd_double, &
+         dim1name='heat_budg_state', &
+         long_name='heat_budg_stateG', units='MJ/m2 or W/m2', ncid=ncid)
+
+    call ncd_defvar(varname='heat_budg_gfluxG', xtype=ncd_double, &
+         dim1name='heat_budg_gflux', &
+         long_name='heat_budg_gfluxG', units='W/m2', ncid=ncid)
+
+    call ncd_defvar(varname='heat_budg_gfluxN', xtype=ncd_double, &
+         dim1name='heat_budg_gflux', &
+         long_name='heat_budg_gfluxN', units='-', ncid=ncid)
+
+  end subroutine HeatBudget_Restart_Define
+
+  !-----------------------------------------------------------------------
+  subroutine HeatBudget_Restart_Write(bounds, ncid, flag)
+    !
+    use ncdio_pio   , only : file_desc_t, ncd_io, ncd_double, ncd_int
+    use ncdio_pio   , only : ncd_defvar
+    use spmdMod     , only : mpicom
+    use shr_mpi_mod , only : shr_mpi_sum
+    !
+    implicit none
+    !
+    type(bounds_type), intent(in)    :: bounds
+    type(file_desc_t), intent(inout) :: ncid   ! netcdf id
+    character(len=*) , intent(in)    :: flag   ! 'read' or 'write'
+    !
+    ! !LOCAL VARIABLES:
+    real(r8) :: budg_fluxGtmp(f_size,p_size) ! temporary sum
+    real(r8) :: budg_stateGtmp(s_size,p_size) ! temporary sum
+    real(r8) :: budg_gfluxGtmp(g_size,p_size) ! temporary sum
+    real(r8) :: budg_fluxG_1D (f_size*p_size)
+    real(r8) :: budg_fluxN_1D (f_size*p_size)
+    real(r8) :: budg_stateG_1D(s_size*p_size)
+    real(r8) :: budg_gfluxG_1D(g_size*p_size)
+    real(r8) :: budg_gfluxN_1D(g_size*p_size)
+    integer  :: f, s, p, count
+    character(*),parameter :: subName = '(HeatBudget_Restart_Write) '
+
+    budg_fluxGtmp = 0._r8
+    budg_stateGtmp = 0._r8
+    budg_gfluxGtmp = 0._r8
+
+    call shr_mpi_sum(budg_fluxL, budg_fluxGtmp, mpicom, subName, all=.true.)
+    call shr_mpi_sum(budg_stateL, budg_stateGtmp, mpicom, subName, all=.true.)
+    call shr_mpi_sum(budg_gfluxL, budg_gfluxGtmp, mpicom, subName, all=.true.)
+
+    ! Copy data from 2D into 1D array
+    count = 0
+    do f = 1, f_size
+       do p = 1, p_size
+          count = count + 1
+          budg_fluxG_1D(count) = budg_fluxG(f,p) + budg_fluxGtmp(f,p)
+          budg_fluxN_1D(count) = budg_fluxN(f,p)
+       end do
+    end do
+
+    ! Copy data from 2D into 1D array
+    count = 0
+    do s = 1, s_size
+       do p = 1, p_size
+          count = count + 1
+          budg_stateG_1D(count) = budg_stateGtmp(s,p)
+       end do
+    end do
+
+    ! Copy data from 2D into 1D array
+    count = 0
+    do f = 1, g_size
+       do p = 1, p_size
+          count = count + 1
+          budg_gfluxG_1D(count) = budg_gfluxG(f,p) + budg_gfluxGtmp(f,p)
+          budg_gfluxN_1D(count) = budg_gfluxN(f,p)
+       end do
+    end do
+
+    call ncd_io(flag=flag, varname='heat_budg_fluxG', data=budg_fluxG_1D, ncid=ncid)
+    call ncd_io(flag=flag, varname='heat_budg_fluxN', data=budg_fluxN_1D, ncid=ncid)
+    call ncd_io(flag=flag, varname='heat_budg_stateG', data=budg_stateG_1D, ncid=ncid)
+    call ncd_io(flag=flag, varname='heat_budg_gfluxG', data=budg_gfluxG_1D, ncid=ncid)
+    call ncd_io(flag=flag, varname='heat_budg_gfluxN', data=budg_gfluxN_1D, ncid=ncid)
+
+  end subroutine HeatBudget_Restart_Write
+
+  !-----------------------------------------------------------------------
+  subroutine HeatBudget_Restart_Read(bounds, ncid, flag)
+    !
+    use ncdio_pio, only : file_desc_t, ncd_io, ncd_double, ncd_int
+    use ncdio_pio, only : ncd_defvar
+    !
+    implicit none
+    !
+    type(bounds_type), intent(in)    :: bounds
+    type(file_desc_t), intent(inout) :: ncid   ! netcdf id
+    character(len=*) , intent(in)    :: flag   ! 'read' or 'write'
+    !
+    ! !LOCAL VARIABLES:
+    real(r8) :: budg_fluxG_1D (f_size*p_size)
+    real(r8) :: budg_fluxN_1D (f_size*p_size)
+    real(r8) :: budg_stateG_1D(s_size*p_size)
+    real(r8) :: budg_gfluxG_1D(g_size*p_size)
+    real(r8) :: budg_gfluxN_1D(g_size*p_size)
+    integer  :: f, s, p, count
+    logical  :: readvar_fluxG, readvar_fluxN, readvar_stateG, readvar_gfluxG, readvar_gfluxN
+
+    ! Every restart file that predates this change will lack these
+    ! variables; guard with readvar and zero-initialize the accumulators
+    ! rather than aborting or reading garbage, so restarting from an older
+    ! case works.
+    budg_fluxG_1D = 0._r8
+    budg_fluxN_1D = 0._r8
+    budg_stateG_1D = 0._r8
+    budg_gfluxG_1D = 0._r8
+    budg_gfluxN_1D = 0._r8
+
+    call ncd_io(flag=flag, varname='heat_budg_fluxG', data=budg_fluxG_1D, ncid=ncid, readvar=readvar_fluxG)
+    call ncd_io(flag=flag, varname='heat_budg_fluxN', data=budg_fluxN_1D, ncid=ncid, readvar=readvar_fluxN)
+    call ncd_io(flag=flag, varname='heat_budg_stateG', data=budg_stateG_1D, ncid=ncid, readvar=readvar_stateG)
+    call ncd_io(flag=flag, varname='heat_budg_gfluxG', data=budg_gfluxG_1D, ncid=ncid, readvar=readvar_gfluxG)
+    call ncd_io(flag=flag, varname='heat_budg_gfluxN', data=budg_gfluxN_1D, ncid=ncid, readvar=readvar_gfluxN)
+
+    if (.not. readvar_fluxG) budg_fluxG_1D = 0._r8
+    if (.not. readvar_fluxN) budg_fluxN_1D = 0._r8
+    if (.not. readvar_stateG) budg_stateG_1D = 0._r8
+    if (.not. readvar_gfluxG) budg_gfluxG_1D = 0._r8
+    if (.not. readvar_gfluxN) budg_gfluxN_1D = 0._r8
+
+    ! Copy data from 1D into 2D array
+    count = 0
+    do f = 1, f_size
+       do p = 1, p_size
+          count = count + 1
+          budg_fluxG(f,p) = budg_fluxG_1D(count)
+          budg_fluxN(f,p) = budg_fluxN_1D(count)
+       end do
+    end do
+
+    ! Copy data from 1D into 2D array
+    count = 0
+    do f = 1, g_size
+       do p = 1, p_size
+          count = count + 1
+          budg_gfluxG(f,p) = budg_gfluxG_1D(count)
+          budg_gfluxN(f,p) = budg_gfluxN_1D(count)
+       end do
+    end do
+
+    ! Copy data from 1D into 2D array. Only masterproc's budg_stateL is
+    ! seeded with the restored sum: HeatBudget_Sum0 recomputes budg_stateG
+    ! as an MPI sum of budg_stateL across all procs (an overwrite, not an
+    ! accumulation, unlike the flux side), so seeding every proc identically
+    ! here would multiply the restored value by the number of MPI ranks.
+    if (masterproc) then
+       count = 0
+       do s = 1, s_size
+          do p = 1, p_size
+             count = count + 1
+             budg_stateL(s,p) = budg_stateG_1D(count)
+          end do
+       end do
+    end if
+
+  end subroutine HeatBudget_Restart_Read
+
+end module HeatBudgetMod

--- a/components/elm/src/biogeophys/LakeTemperatureMod.F90
+++ b/components/elm/src/biogeophys/LakeTemperatureMod.F90
@@ -245,8 +245,7 @@ contains
          t_lake          =>   col_es%t_lake          , & ! Output: [real(r8) (:,:) ]  col lake temperature (Kelvin)
          hc_soi          =>   col_es%hc_soi          , & ! Output: [real(r8) (:)   ]  soil heat content (MJ/m2)
          hc_soisno       =>   col_es%hc_soisno       , & ! Output: [real(r8) (:)   ]  soil plus snow plus lake heat content (MJ/m2)
-         cv_bef          =>   col_es%cv_bef          , & ! Output: [real(r8) (:,:) ]  layer heat capacity as of the previous call [J/(m2 K)]
-         eflx_hc_masschg =>   col_ef%eflx_hc_masschg , & ! Output: [real(r8) (:)   ]  heat-capacity-change term, snow/soil-under-lake layers only (W/m2)
+         hc_lake         =>   col_es%hc_lake         , & ! Output: [real(r8) (:)   ]  lake-water heat content (MJ/m2)
 
          beta            =>   lakestate_vars%betaprime_col         , & ! Output: [real(r8) (:)   ]  col effective beta: sabg_lyr(p,jtop) for snow layers, beta otherwise
          lake_icefrac    =>   lakestate_vars%lake_icefrac_col      , & ! Output: [real(r8) (:,:) ]  col mass fraction of lake layer that is frozen
@@ -293,7 +292,7 @@ contains
        esum2(c) = 0._r8
        hc_soisno(c) = 0._r8
        hc_soi(c)    = 0._r8
-       eflx_hc_masschg(c) = 0._r8
+       hc_lake(c)   = 0._r8
        if (use_lch4) then
           jconvect(c) = 0
           jconvectbot(c) = nlevlak+1
@@ -997,6 +996,7 @@ contains
           fin(c) = fin(c) + phi(c,j)
           ! New for CLM 4
           hc_soisno(c) = hc_soisno(c) + cv_lake(c,j)*t_lake(c,j)/1.e6
+          hc_lake(c) = hc_lake(c) + cv_lake(c,j)*t_lake(c,j)/1.e6
        end do
     end do
 
@@ -1013,23 +1013,10 @@ contains
              end if
              hc_soisno(c) = hc_soisno(c) + cv(c,j)*t_soisno(c,j)/1.e6
              if (j >= 1) hc_soi(c) = hc_soi(c) + cv(c,j)*t_soisno(c,j)/1.e6
-             ! Heat-capacity-change term for the snow-on-lake/soil-under-lake
-             ! layers, mirroring SoilTemperatureMod.F90's identical addition;
-             ! t_soisno_bef (captured above, before this call's own solve)
-             ! plays the same role tssbef plays there. cv_bef is shared with
-             ! the non-lake path and starts at spval (see ColumnDataType.F90),
-             ! so this is skipped on the first call after cold start or a
-             ! pre-existing restart.
-             if (cv_bef(c,j) /= spval) then
-                eflx_hc_masschg(c) = eflx_hc_masschg(c) &
-                     + t_soisno_bef(c,j)*(cv(c,j)-cv_bef(c,j))/dtime
-             end if
-             cv_bef(c,j) = cv(c,j)
           end if
           if (j == 1) fin(c) = fin(c) + phi_soil(c)
        end do
     end do
-
 
     ! Check energy conservation.
     do fp = 1, num_lakep

--- a/components/elm/src/biogeophys/LakeTemperatureMod.F90
+++ b/components/elm/src/biogeophys/LakeTemperatureMod.F90
@@ -114,7 +114,7 @@ contains
     use TridiagonalMod     , only : Tridiagonal
     use elm_varpar         , only : nlevlak, nlevgrnd, nlevsno
     use elm_varcon         , only : hfus, cpliq, cpice, tkwat, tkice, denice
-    use elm_varcon         , only : vkc, grav, denh2o, tfrz, cnfac
+    use elm_varcon         , only : vkc, grav, denh2o, tfrz, cnfac, spval
     use elm_varctl         , only : iulog, use_lch4
     !
     ! !ARGUMENTS:
@@ -245,6 +245,8 @@ contains
          t_lake          =>   col_es%t_lake          , & ! Output: [real(r8) (:,:) ]  col lake temperature (Kelvin)
          hc_soi          =>   col_es%hc_soi          , & ! Output: [real(r8) (:)   ]  soil heat content (MJ/m2)
          hc_soisno       =>   col_es%hc_soisno       , & ! Output: [real(r8) (:)   ]  soil plus snow plus lake heat content (MJ/m2)
+         cv_bef          =>   col_es%cv_bef          , & ! Output: [real(r8) (:,:) ]  layer heat capacity as of the previous call [J/(m2 K)]
+         eflx_hc_masschg =>   col_ef%eflx_hc_masschg , & ! Output: [real(r8) (:)   ]  heat-capacity-change term, snow/soil-under-lake layers only (W/m2)
 
          beta            =>   lakestate_vars%betaprime_col         , & ! Output: [real(r8) (:)   ]  col effective beta: sabg_lyr(p,jtop) for snow layers, beta otherwise
          lake_icefrac    =>   lakestate_vars%lake_icefrac_col      , & ! Output: [real(r8) (:,:) ]  col mass fraction of lake layer that is frozen
@@ -291,6 +293,7 @@ contains
        esum2(c) = 0._r8
        hc_soisno(c) = 0._r8
        hc_soi(c)    = 0._r8
+       eflx_hc_masschg(c) = 0._r8
        if (use_lch4) then
           jconvect(c) = 0
           jconvectbot(c) = nlevlak+1
@@ -1010,6 +1013,18 @@ contains
              end if
              hc_soisno(c) = hc_soisno(c) + cv(c,j)*t_soisno(c,j)/1.e6
              if (j >= 1) hc_soi(c) = hc_soi(c) + cv(c,j)*t_soisno(c,j)/1.e6
+             ! Heat-capacity-change term for the snow-on-lake/soil-under-lake
+             ! layers, mirroring SoilTemperatureMod.F90's identical addition;
+             ! t_soisno_bef (captured above, before this call's own solve)
+             ! plays the same role tssbef plays there. cv_bef is shared with
+             ! the non-lake path and starts at spval (see ColumnDataType.F90),
+             ! so this is skipped on the first call after cold start or a
+             ! pre-existing restart.
+             if (cv_bef(c,j) /= spval) then
+                eflx_hc_masschg(c) = eflx_hc_masschg(c) &
+                     + t_soisno_bef(c,j)*(cv(c,j)-cv_bef(c,j))/dtime
+             end if
+             cv_bef(c,j) = cv(c,j)
           end if
           if (j == 1) fin(c) = fin(c) + phi_soil(c)
        end do

--- a/components/elm/src/biogeophys/SoilTemperatureMod.F90
+++ b/components/elm/src/biogeophys/SoilTemperatureMod.F90
@@ -282,6 +282,8 @@ contains
          emg                     => col_es%emg                              , & ! Input:  [real(r8) (:)   ]  ground emissivity
          hc_soi                  => col_es%hc_soi                           , & ! Input:  [real(r8) (:)   ]  soil heat content (MJ/m2)               ! TODO: make a module variable
          hc_soisno               => col_es%hc_soisno                        , & ! Input:  [real(r8) (:)   ]  soil plus snow plus lake heat content (MJ/m2) !TODO: make a module variable
+         cv_bef                  => col_es%cv_bef                           , & ! Output: [real(r8) (:,:) ]  layer heat capacity as of the previous call [J/(m2 K)]
+         eflx_hc_masschg         => col_ef%eflx_hc_masschg                  , & ! Output: [real(r8) (:)   ]  heat-capacity-change term, tssbef*(cv-cv_bef)/dtime (W/m2)
          tssbef                  => col_es%t_ssbef                          , & ! Input:  [real(r8) (:,:) ]  temperature at previous time step [K]
          t_h2osfc                => col_es%t_h2osfc                         , & ! Output: [real(r8) (:)   ]  surface water temperature
          t_soisno                => col_es%t_soisno                         , & ! Output: [real(r8) (:,:) ]  soil temperature (Kelvin)
@@ -665,6 +667,7 @@ contains
          if (.not. lun_pp%urbpoi(l)) then
             hc_soisno(c) = 0._r8
             hc_soi(c)    = 0._r8
+            eflx_hc_masschg(c) = 0._r8
          end if
          eflx_fgr12(c)= 0._r8
       end do
@@ -688,6 +691,17 @@ contains
             if (.not. lun_pp%urbpoi(l)) then
                if (j >= snl(c)+1) then
                   hc_soisno(c) = hc_soisno(c) + cv(c,j)*t_soisno(c,j) / 1.e6_r8
+                  ! Heat-capacity-change term: the part of d(cv*T)/dt that the
+                  ! ΔT/fact terms elsewhere in this module (and in
+                  ! SoilFluxesMod.F90's errsoi_patch) cannot capture, since
+                  ! those hold cv fixed within a single call. cv_bef starts
+                  ! at spval (see ColumnDataType.F90), so this is skipped on
+                  ! the first call after cold start or a pre-existing restart.
+                  if (cv_bef(c,j) /= spval) then
+                     eflx_hc_masschg(c) = eflx_hc_masschg(c) &
+                          + tssbef(c,j)*(cv(c,j)-cv_bef(c,j))/dtime
+                  end if
+                  cv_bef(c,j) = cv(c,j)
                endif
                if (j >= 1) then
                   hc_soi(c) = hc_soi(c) + cv(c,j)*t_soisno(c,j) / 1.e6_r8

--- a/components/elm/src/biogeophys/SoilTemperatureMod.F90
+++ b/components/elm/src/biogeophys/SoilTemperatureMod.F90
@@ -282,8 +282,7 @@ contains
          emg                     => col_es%emg                              , & ! Input:  [real(r8) (:)   ]  ground emissivity
          hc_soi                  => col_es%hc_soi                           , & ! Input:  [real(r8) (:)   ]  soil heat content (MJ/m2)               ! TODO: make a module variable
          hc_soisno               => col_es%hc_soisno                        , & ! Input:  [real(r8) (:)   ]  soil plus snow plus lake heat content (MJ/m2) !TODO: make a module variable
-         cv_bef                  => col_es%cv_bef                           , & ! Output: [real(r8) (:,:) ]  layer heat capacity as of the previous call [J/(m2 K)]
-         eflx_hc_masschg         => col_ef%eflx_hc_masschg                  , & ! Output: [real(r8) (:)   ]  heat-capacity-change term, tssbef*(cv-cv_bef)/dtime (W/m2)
+         hc_lake                 => col_es%hc_lake                          , & ! Output: [real(r8) (:)   ]  lake-water heat content (MJ/m2; zero for non-lake columns)
          tssbef                  => col_es%t_ssbef                          , & ! Input:  [real(r8) (:,:) ]  temperature at previous time step [K]
          t_h2osfc                => col_es%t_h2osfc                         , & ! Output: [real(r8) (:)   ]  surface water temperature
          t_soisno                => col_es%t_soisno                         , & ! Output: [real(r8) (:,:) ]  soil temperature (Kelvin)
@@ -667,7 +666,7 @@ contains
          if (.not. lun_pp%urbpoi(l)) then
             hc_soisno(c) = 0._r8
             hc_soi(c)    = 0._r8
-            eflx_hc_masschg(c) = 0._r8
+            hc_lake(c)   = 0._r8
          end if
          eflx_fgr12(c)= 0._r8
       end do
@@ -691,17 +690,6 @@ contains
             if (.not. lun_pp%urbpoi(l)) then
                if (j >= snl(c)+1) then
                   hc_soisno(c) = hc_soisno(c) + cv(c,j)*t_soisno(c,j) / 1.e6_r8
-                  ! Heat-capacity-change term: the part of d(cv*T)/dt that the
-                  ! ΔT/fact terms elsewhere in this module (and in
-                  ! SoilFluxesMod.F90's errsoi_patch) cannot capture, since
-                  ! those hold cv fixed within a single call. cv_bef starts
-                  ! at spval (see ColumnDataType.F90), so this is skipped on
-                  ! the first call after cold start or a pre-existing restart.
-                  if (cv_bef(c,j) /= spval) then
-                     eflx_hc_masschg(c) = eflx_hc_masschg(c) &
-                          + tssbef(c,j)*(cv(c,j)-cv_bef(c,j))/dtime
-                  end if
-                  cv_bef(c,j) = cv(c,j)
                endif
                if (j >= 1) then
                   hc_soi(c) = hc_soi(c) + cv(c,j)*t_soisno(c,j) / 1.e6_r8
@@ -709,7 +697,6 @@ contains
             end if
          end do
       end do
-
 
       ! Free up memory
       deallocate(filter_nolakec_and_nourbanc)

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -89,7 +89,7 @@ module ColumnDataType
     ! heat content variables (diagnostic)
     real(r8), pointer :: hc_soi        (:)   => null() ! soil heat content (MJ/m2)
     real(r8), pointer :: hc_soisno     (:)   => null() ! soil plus snow heat content (MJ/m2)
-    real(r8), pointer :: cv_bef        (:,:) => null() ! layer heat capacity as of the previous call to SoilTemperature (J/(m2 K)) (-nlevsno+1:nlevgrnd)
+    real(r8), pointer :: hc_lake       (:)   => null() ! lake-water heat content (MJ/m2; zero for non-lake columns)
     ! other quantities related to energy state
     real(r8), pointer :: emg           (:)   => null() ! ground emissivity (unitless)
     real(r8), pointer :: fact          (:,:) => null() ! factors used in computing tridiagonal matrix
@@ -440,7 +440,6 @@ module ColumnDataType
     real(r8), pointer :: htvp                    (:)   => null() ! latent heat of vapor of water (or sublimation) [j/kg]
     real(r8), pointer :: xmf                     (:)   => null() ! total latent heat of phase change of ground water
     real(r8), pointer :: xmf_h2osfc              (:)   => null() ! latent heat of phase change of surface water
-    real(r8), pointer :: eflx_hc_masschg         (:)   => null() ! heat-capacity-change term, tssbef*(cv-cv_bef)/dtime (W/m2)
     integer , pointer :: imelt                   (:,:) => null() ! flag for melting (=1), freezing (=2), Not=0 (-nlevsno+1:nlevgrnd)
     ! for couplig with pflotran
     real(r8), pointer :: eflx_soil_grnd          (:)   => null() ! integrated soil ground heat flux (W/m2)  [+ = into ground]
@@ -1141,7 +1140,7 @@ contains
     allocate(this%thv              (begc:endc))                     ; this%thv                (:)   = spval
     allocate(this%hc_soi           (begc:endc))                     ; this%hc_soi             (:)   = spval
     allocate(this%hc_soisno        (begc:endc))                     ; this%hc_soisno          (:)   = spval
-    allocate(this%cv_bef           (begc:endc,-nlevsno+1:nlevgrnd)) ; this%cv_bef             (:,:) = spval
+    allocate(this%hc_lake          (begc:endc))                     ; this%hc_lake            (:)   = spval
     allocate(this%emg              (begc:endc))                     ; this%emg                (:)   = spval
     allocate(this%fact             (begc:endc, -nlevsno+1:nlevgrnd)); this%fact               (:,:) = spval
     allocate(this%c_h2osfc         (begc:endc))                     ; this%c_h2osfc           (:)   = spval
@@ -5660,7 +5659,6 @@ contains
     allocate(this%htvp                 (begc:endc))              ; this%htvp                 (:)   = spval
     allocate(this%xmf                  (begc:endc))              ; this%xmf                  (:)   = spval
     allocate(this%xmf_h2osfc           (begc:endc))              ; this%xmf_h2osfc           (:)   = spval
-    allocate(this%eflx_hc_masschg      (begc:endc))              ; this%eflx_hc_masschg      (:)   = spval
     allocate(this%imelt                (begc:endc,-nlevsno+1:nlevgrnd))  ; this%imelt        (:,:) = huge(1)
     allocate(this%eflx_soil_grnd       (begc:endc))              ; this%eflx_soil_grnd       (:)   = spval
     allocate(this%eflx_rnet_soil       (begc:endc))              ; this%eflx_rnet_soil       (:)   = spval

--- a/components/elm/src/data_types/ColumnDataType.F90
+++ b/components/elm/src/data_types/ColumnDataType.F90
@@ -89,6 +89,7 @@ module ColumnDataType
     ! heat content variables (diagnostic)
     real(r8), pointer :: hc_soi        (:)   => null() ! soil heat content (MJ/m2)
     real(r8), pointer :: hc_soisno     (:)   => null() ! soil plus snow heat content (MJ/m2)
+    real(r8), pointer :: cv_bef        (:,:) => null() ! layer heat capacity as of the previous call to SoilTemperature (J/(m2 K)) (-nlevsno+1:nlevgrnd)
     ! other quantities related to energy state
     real(r8), pointer :: emg           (:)   => null() ! ground emissivity (unitless)
     real(r8), pointer :: fact          (:,:) => null() ! factors used in computing tridiagonal matrix
@@ -439,6 +440,7 @@ module ColumnDataType
     real(r8), pointer :: htvp                    (:)   => null() ! latent heat of vapor of water (or sublimation) [j/kg]
     real(r8), pointer :: xmf                     (:)   => null() ! total latent heat of phase change of ground water
     real(r8), pointer :: xmf_h2osfc              (:)   => null() ! latent heat of phase change of surface water
+    real(r8), pointer :: eflx_hc_masschg         (:)   => null() ! heat-capacity-change term, tssbef*(cv-cv_bef)/dtime (W/m2)
     integer , pointer :: imelt                   (:,:) => null() ! flag for melting (=1), freezing (=2), Not=0 (-nlevsno+1:nlevgrnd)
     ! for couplig with pflotran
     real(r8), pointer :: eflx_soil_grnd          (:)   => null() ! integrated soil ground heat flux (W/m2)  [+ = into ground]
@@ -1139,6 +1141,7 @@ contains
     allocate(this%thv              (begc:endc))                     ; this%thv                (:)   = spval
     allocate(this%hc_soi           (begc:endc))                     ; this%hc_soi             (:)   = spval
     allocate(this%hc_soisno        (begc:endc))                     ; this%hc_soisno          (:)   = spval
+    allocate(this%cv_bef           (begc:endc,-nlevsno+1:nlevgrnd)) ; this%cv_bef             (:,:) = spval
     allocate(this%emg              (begc:endc))                     ; this%emg                (:)   = spval
     allocate(this%fact             (begc:endc, -nlevsno+1:nlevgrnd)); this%fact               (:,:) = spval
     allocate(this%c_h2osfc         (begc:endc))                     ; this%c_h2osfc           (:)   = spval
@@ -5657,6 +5660,7 @@ contains
     allocate(this%htvp                 (begc:endc))              ; this%htvp                 (:)   = spval
     allocate(this%xmf                  (begc:endc))              ; this%xmf                  (:)   = spval
     allocate(this%xmf_h2osfc           (begc:endc))              ; this%xmf_h2osfc           (:)   = spval
+    allocate(this%eflx_hc_masschg      (begc:endc))              ; this%eflx_hc_masschg      (:)   = spval
     allocate(this%imelt                (begc:endc,-nlevsno+1:nlevgrnd))  ; this%imelt        (:,:) = huge(1)
     allocate(this%eflx_soil_grnd       (begc:endc))              ; this%eflx_soil_grnd       (:)   = spval
     allocate(this%eflx_rnet_soil       (begc:endc))              ; this%eflx_rnet_soil       (:)   = spval

--- a/components/elm/src/data_types/GridcellDataType.F90
+++ b/components/elm/src/data_types/GridcellDataType.F90
@@ -32,6 +32,9 @@ module GridcellDataType
     real(r8), pointer :: heat2                (:)   ! post land cover change total heat content
     real(r8), pointer :: liquid_water_temp1   (:)   ! initial weighted average liquid water temperature (K)
     real(r8), pointer :: liquid_water_temp2   (:)   ! post land cover change weighted average liquid water temperature (K)
+    real(r8), pointer :: beg_hc               (:)   ! grid-level column heat content (snow+soil+lake) at beginning of time step (MJ/m2)
+    real(r8), pointer :: end_hc               (:)   ! grid-level column heat content (snow+soil+lake) at end of time step (MJ/m2)
+    real(r8), pointer :: errsoi               (:)   ! grid-level column-level soil/lake energy conservation error (W/m2)
 
   contains
     procedure, public :: Init    => grc_es_init
@@ -43,6 +46,9 @@ module GridcellDataType
   !-----------------------------------------------------------------------
   type, public :: gridcell_energy_flux
     real(r8), pointer :: eflx_dynbal           (:)   ! dynamic land cover change conversion energy flux (W/m**2)
+    real(r8), pointer :: heat_into_grnd        (:)   ! grid-level ground heat flux, p2g of eflx_soil_grnd (W/m**2) [+ = into ground]
+    real(r8), pointer :: heat_phase_corr       (:)   ! grid-level phase-change/h2osfc/building-heat correction (W/m**2)
+    real(r8), pointer :: heat_masschg          (:)   ! grid-level heat-capacity-change term, c2g of col_ef%eflx_hc_masschg (W/m**2)
 
   contains
     procedure, public :: Init    => grc_ef_init
@@ -265,6 +271,9 @@ contains
     allocate(this%heat2                (begg:endg))                      ; this%heat2                (:)   = spval
     allocate(this%liquid_water_temp1   (begg:endg))                      ; this%liquid_water_temp1   (:)   = spval
     allocate(this%liquid_water_temp2   (begg:endg))                      ; this%liquid_water_temp2   (:)   = spval
+    allocate(this%beg_hc               (begg:endg))                      ; this%beg_hc               (:)   = spval
+    allocate(this%end_hc               (begg:endg))                      ; this%end_hc               (:)   = spval
+    allocate(this%errsoi               (begg:endg))                      ; this%errsoi               (:)   = spval
 
     !-----------------------------------------------------------------------
     ! initialize history fields for select members of grc_es
@@ -296,6 +305,9 @@ contains
     deallocate(this%heat2)
     deallocate(this%liquid_water_temp1)
     deallocate(this%liquid_water_temp2)
+    deallocate(this%beg_hc)
+    deallocate(this%end_hc)
+    deallocate(this%errsoi)
   end subroutine grc_es_clean
   
   !------------------------------------------------------------------------
@@ -312,6 +324,9 @@ contains
     ! allocate for each member of grc_ef
     !-----------------------------------------------------------------------
     allocate(this%eflx_dynbal              (begg:endg))                  ; this%eflx_dynbal             (:)   = spval
+    allocate(this%heat_into_grnd           (begg:endg))                  ; this%heat_into_grnd          (:)   = spval
+    allocate(this%heat_phase_corr          (begg:endg))                  ; this%heat_phase_corr         (:)   = spval
+    allocate(this%heat_masschg             (begg:endg))                  ; this%heat_masschg            (:)   = spval
 
     !-----------------------------------------------------------------------
     ! initialize history fields for select members of grc_ef
@@ -349,6 +364,9 @@ contains
     class(gridcell_energy_flux) :: this
     !------------------------------------------------------------------------
     deallocate(this%eflx_dynbal)
+    deallocate(this%heat_into_grnd)
+    deallocate(this%heat_phase_corr)
+    deallocate(this%heat_masschg)
   end subroutine grc_ef_clean
   
   !------------------------------------------------------------------------

--- a/components/elm/src/data_types/GridcellDataType.F90
+++ b/components/elm/src/data_types/GridcellDataType.F90
@@ -36,6 +36,8 @@ module GridcellDataType
     real(r8), pointer :: end_hc               (:)   ! grid-level column heat content (snow+soil+lake) at end of time step (MJ/m2)
     real(r8), pointer :: beg_hc_soi           (:)   ! grid-level column soil-only heat content at beginning of time step (MJ/m2)
     real(r8), pointer :: end_hc_soi           (:)   ! grid-level column soil-only heat content at end of time step (MJ/m2)
+    real(r8), pointer :: beg_hc_lake          (:)   ! grid-level lake-water heat content at beginning of time step (MJ/m2)
+    real(r8), pointer :: end_hc_lake          (:)   ! grid-level lake-water heat content at end of time step (MJ/m2)
     real(r8), pointer :: errsoi               (:)   ! grid-level column-level soil/lake energy conservation error (W/m2)
 
   contains
@@ -50,7 +52,7 @@ module GridcellDataType
     real(r8), pointer :: eflx_dynbal           (:)   ! dynamic land cover change conversion energy flux (W/m**2)
     real(r8), pointer :: heat_into_grnd        (:)   ! grid-level ground heat flux, p2g of eflx_soil_grnd (W/m**2) [+ = into ground]
     real(r8), pointer :: heat_phase_corr       (:)   ! grid-level phase-change/h2osfc/building-heat correction (W/m**2)
-    real(r8), pointer :: heat_masschg          (:)   ! grid-level heat-capacity-change term, c2g of col_ef%eflx_hc_masschg (W/m**2)
+    real(r8), pointer :: heat_state_adj        (:)   ! grid-level adjustment from solver flux terms to diagnostic heat-state change (W/m**2)
 
   contains
     procedure, public :: Init    => grc_ef_init
@@ -277,6 +279,8 @@ contains
     allocate(this%end_hc               (begg:endg))                      ; this%end_hc               (:)   = spval
     allocate(this%beg_hc_soi           (begg:endg))                      ; this%beg_hc_soi           (:)   = spval
     allocate(this%end_hc_soi           (begg:endg))                      ; this%end_hc_soi           (:)   = spval
+    allocate(this%beg_hc_lake          (begg:endg))                      ; this%beg_hc_lake          (:)   = spval
+    allocate(this%end_hc_lake          (begg:endg))                      ; this%end_hc_lake          (:)   = spval
     allocate(this%errsoi               (begg:endg))                      ; this%errsoi               (:)   = spval
 
     !-----------------------------------------------------------------------
@@ -313,6 +317,8 @@ contains
     deallocate(this%end_hc)
     deallocate(this%beg_hc_soi)
     deallocate(this%end_hc_soi)
+    deallocate(this%beg_hc_lake)
+    deallocate(this%end_hc_lake)
     deallocate(this%errsoi)
   end subroutine grc_es_clean
   
@@ -332,7 +338,7 @@ contains
     allocate(this%eflx_dynbal              (begg:endg))                  ; this%eflx_dynbal             (:)   = spval
     allocate(this%heat_into_grnd           (begg:endg))                  ; this%heat_into_grnd          (:)   = spval
     allocate(this%heat_phase_corr          (begg:endg))                  ; this%heat_phase_corr         (:)   = spval
-    allocate(this%heat_masschg             (begg:endg))                  ; this%heat_masschg            (:)   = spval
+    allocate(this%heat_state_adj           (begg:endg))                  ; this%heat_state_adj          (:)   = spval
 
     !-----------------------------------------------------------------------
     ! initialize history fields for select members of grc_ef
@@ -372,7 +378,7 @@ contains
     deallocate(this%eflx_dynbal)
     deallocate(this%heat_into_grnd)
     deallocate(this%heat_phase_corr)
-    deallocate(this%heat_masschg)
+    deallocate(this%heat_state_adj)
   end subroutine grc_ef_clean
   
   !------------------------------------------------------------------------

--- a/components/elm/src/data_types/GridcellDataType.F90
+++ b/components/elm/src/data_types/GridcellDataType.F90
@@ -34,6 +34,8 @@ module GridcellDataType
     real(r8), pointer :: liquid_water_temp2   (:)   ! post land cover change weighted average liquid water temperature (K)
     real(r8), pointer :: beg_hc               (:)   ! grid-level column heat content (snow+soil+lake) at beginning of time step (MJ/m2)
     real(r8), pointer :: end_hc               (:)   ! grid-level column heat content (snow+soil+lake) at end of time step (MJ/m2)
+    real(r8), pointer :: beg_hc_soi           (:)   ! grid-level column soil-only heat content at beginning of time step (MJ/m2)
+    real(r8), pointer :: end_hc_soi           (:)   ! grid-level column soil-only heat content at end of time step (MJ/m2)
     real(r8), pointer :: errsoi               (:)   ! grid-level column-level soil/lake energy conservation error (W/m2)
 
   contains
@@ -273,6 +275,8 @@ contains
     allocate(this%liquid_water_temp2   (begg:endg))                      ; this%liquid_water_temp2   (:)   = spval
     allocate(this%beg_hc               (begg:endg))                      ; this%beg_hc               (:)   = spval
     allocate(this%end_hc               (begg:endg))                      ; this%end_hc               (:)   = spval
+    allocate(this%beg_hc_soi           (begg:endg))                      ; this%beg_hc_soi           (:)   = spval
+    allocate(this%end_hc_soi           (begg:endg))                      ; this%end_hc_soi           (:)   = spval
     allocate(this%errsoi               (begg:endg))                      ; this%errsoi               (:)   = spval
 
     !-----------------------------------------------------------------------
@@ -307,6 +311,8 @@ contains
     deallocate(this%liquid_water_temp2)
     deallocate(this%beg_hc)
     deallocate(this%end_hc)
+    deallocate(this%beg_hc_soi)
+    deallocate(this%end_hc_soi)
     deallocate(this%errsoi)
   end subroutine grc_es_clean
   

--- a/components/elm/src/main/elm_driver.F90
+++ b/components/elm/src/main/elm_driver.F90
@@ -181,6 +181,8 @@ module elm_driver
   use WaterBudgetMod              , only : WaterBudget_Reset, WaterBudget_Run, WaterBudget_Accum, WaterBudget_Print
   use WaterBudgetMod              , only : WaterBudget_SetBeginningMonthlyStates
   use WaterBudgetMod              , only : WaterBudget_SetEndingMonthlyStates
+  use HeatBudgetMod                , only : HeatBudget_Reset, HeatBudget_Run, HeatBudget_Accum, HeatBudget_Print
+  use HeatBudgetMod                , only : HeatBudget_SetBeginningStates, HeatBudget_SetEndingStates
   use CNPBudgetMod                , only : CNPBudget_Run, CNPBudget_Accum, CNPBudget_Print, CNPBudget_Reset
   use CNPBudgetMod                , only : CNPBudget_SetBeginningMonthlyStates, CNPBudget_SetEndingMonthlyStates
   use elm_varctl                  , only : do_budgets, budget_inst, budget_daily, budget_month
@@ -276,6 +278,7 @@ contains
 
     if (do_budgets) then
        call WaterBudget_Reset()
+       call HeatBudget_Reset()
 
        if (use_cn) then
           call CNPBudget_Reset()
@@ -373,6 +376,9 @@ contains
             filter(nc)%num_lakec, filter(nc)%lakec,           &
             filter(nc)%num_hydrologyc, filter(nc)%hydrologyc, &
             soilhydrology_vars )
+       if (do_budgets) then
+          call HeatBudget_SetBeginningStates(bounds_clump)
+       end if
        call t_stopf('beggridwbal')
 
        if (use_betr) then
@@ -1346,6 +1352,7 @@ contains
 
        if (do_budgets) then
           call WaterBudget_SetEndingMonthlyStates(bounds_clump)
+          call HeatBudget_SetEndingStates(bounds_clump)
           if (use_cn) then
              call CNPBudget_SetEndingMonthlyStates(bounds_clump, col_cs, grc_cs)
           endif
@@ -1537,6 +1544,11 @@ contains
             soilhydrology_vars)
        call WaterBudget_Accum()
        call WaterBudget_Print(budget_inst,  budget_daily,  budget_month,  &
+            budget_ann,  budget_ltann,  budget_ltend)
+
+       call HeatBudget_Run(bounds_proc, atm2lnd_vars, lnd2atm_vars)
+       call HeatBudget_Accum()
+       call HeatBudget_Print(budget_inst,  budget_daily,  budget_month,  &
             budget_ann,  budget_ltann,  budget_ltend)
 
        if (use_cn .and. do_budgets) then

--- a/components/elm/src/main/elm_driver.F90
+++ b/components/elm/src/main/elm_driver.F90
@@ -1537,18 +1537,18 @@ contains
     call t_stopf('hbuf')
 
     ! ============================================================================
-    ! Compute water budget
+    ! Compute heat and water budgets (heat first, matching the coupler log)
     ! ============================================================================
     if (get_nstep()>0 .and. do_budgets) then
+       call HeatBudget_Run(bounds_proc, atm2lnd_vars, lnd2atm_vars)
+       call HeatBudget_Accum()
+       call HeatBudget_Print(budget_inst,  budget_daily,  budget_month,  &
+            budget_ann,  budget_ltann,  budget_ltend)
+
        call WaterBudget_Run(bounds_proc, atm2lnd_vars, lnd2atm_vars, &
             soilhydrology_vars)
        call WaterBudget_Accum()
        call WaterBudget_Print(budget_inst,  budget_daily,  budget_month,  &
-            budget_ann,  budget_ltann,  budget_ltend)
-
-       call HeatBudget_Run(bounds_proc, atm2lnd_vars, lnd2atm_vars)
-       call HeatBudget_Accum()
-       call HeatBudget_Print(budget_inst,  budget_daily,  budget_month,  &
             budget_ann,  budget_ltann,  budget_ltend)
 
        if (use_cn .and. do_budgets) then

--- a/components/elm/src/main/elm_initializeMod.F90
+++ b/components/elm/src/main/elm_initializeMod.F90
@@ -39,6 +39,7 @@ module elm_initializeMod
 
   use elm_instMod
   use WaterBudgetMod         , only : WaterBudget_Reset
+  use HeatBudgetMod          , only : HeatBudget_Reset
   use CNPBudgetMod           , only : CNPBudget_Reset
   use elm_varctl             , only : do_budgets
   !
@@ -603,6 +604,7 @@ contains
 
     if (do_budgets) then
        call WaterBudget_Reset('all')
+       call HeatBudget_Reset('all')
        if (use_cn) then
           call CNPBudget_Reset('all')
        endif
@@ -868,6 +870,7 @@ contains
                sedflux_vars, ep_betr, alm_fates, glc2lnd_vars, crop_vars)
 
          call WaterBudget_Reset('all')
+         call HeatBudget_Reset('all')
          if (use_cn) then
             call CNPBudget_Reset('all')
          endif

--- a/components/elm/src/main/restFileMod.F90
+++ b/components/elm/src/main/restFileMod.F90
@@ -112,6 +112,7 @@ contains
     ! Define/write CLM restart file.
     !
     use WaterBudgetMod, only : WaterBudget_Restart
+    use HeatBudgetMod , only : HeatBudget_Restart
     use CNPBudgetMod  , only : CNPBudget_Restart
     use elm_varctl    , only : do_budgets, use_cn
     !
@@ -292,6 +293,7 @@ contains
 
     if (do_budgets) then
        call WaterBudget_Restart(bounds, ncid, flag='define')
+       call HeatBudget_Restart(bounds, ncid, flag='define')
        if (use_cn) then
           call CNPBudget_Restart(bounds, ncid, flag='define')
        endif
@@ -430,6 +432,7 @@ contains
 
     if (do_budgets) then
        call WaterBudget_Restart(bounds, ncid, flag='write')
+       call HeatBudget_Restart(bounds, ncid, flag='write')
        if (use_cn) then
           call CNPBudget_Restart(bounds, ncid, flag='write')
        endif
@@ -476,6 +479,7 @@ contains
     use decompMod        , only : bounds_type
     use reweightMod      , only : reweight_wrapup
     use WaterBudgetMod   , only : WaterBudget_Restart
+    use HeatBudgetMod    , only : HeatBudget_Restart
     use CNPBudgetMod     , only : CNPBudget_Restart
     use elm_varctl       , only : do_budgets, use_cn
     !
@@ -655,6 +659,7 @@ contains
 
     if (do_budgets) then
        call WaterBudget_Restart(bounds, ncid, flag='read')
+       call HeatBudget_Restart(bounds, ncid, flag='read')
        if (use_cn) then
           call CNPBudget_Restart(bounds, ncid, flag='read')
        endif
@@ -924,6 +929,7 @@ contains
     use decompMod            , only : get_proc_global
     use elm_varctl           , only : do_budgets
     use WaterBudgetMod       , only : f_size, s_size, p_size
+    use HeatBudgetMod        , only : h_f_size => f_size, h_s_size => s_size, h_g_size => g_size, h_p_size => p_size
     use CNPBudgetMod         , only : c_f_size, c_s_size, n_f_size, n_s_size, p_f_size, p_s_size
     !
     ! !ARGUMENTS:
@@ -979,6 +985,9 @@ contains
     if (do_budgets) then
        call ncd_defdim(ncid , 'budg_flux' , f_size*p_size,  dimid)
        call ncd_defdim(ncid , 'budg_state', s_size*p_size,  dimid)
+       call ncd_defdim(ncid , 'heat_budg_flux', h_f_size*h_p_size,  dimid)
+       call ncd_defdim(ncid , 'heat_budg_state', h_s_size*h_p_size,  dimid)
+       call ncd_defdim(ncid , 'heat_budg_gflux', h_g_size*h_p_size,  dimid)
        if (use_cn) then
           call ncd_defdim(ncid , 'C_budg_flux' , c_f_size*p_size,  dimid)
           call ncd_defdim(ncid , 'C_budg_state', c_s_size*p_size,  dimid)


### PR DESCRIPTION
Adds heat budget in the ELM log file to match the values reported 
in the coupler log file.

[BFB]

--------------------------------------------------

An example of heat and budget in `cpl.log.*` file:
```
(seq_diag_print_mct) NET HEAT BUDGET (W/m2): period =  monthly: date =     10201     0
                           atm            lnd            rof            ocn         ice nh         ice sh            glc        *SUM*
         hfreeze     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000
           hmelt     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000
          hnetsw     0.00000000    33.11954505     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000    33.11954505
           hlwdn  -333.98475689    82.30138855     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000  -251.68336834
           hlwup     0.00000000  -101.16708504     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000  -101.16708504
         hlatvap     0.00000000    -3.81156155     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000    -3.81156155
         hlatfus     0.63586553    -0.32418787     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000     0.31167765
          hiroff     0.00000000     0.07032525    -0.00000000     0.00000000     0.00000000     0.00000000     0.00000000     0.07032525
            hsen     0.00000000    -8.50131293     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000    -8.50131293
          hpolar     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000
        hh2otemp     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000
           hgsmb     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000
           *SUM*  -333.34889136     1.68711145    -0.00000000     0.00000000     0.00000000     0.00000000     0.00000000  -331.66177991

(seq_diag_print_mct) NET WATER BUDGET (kg/m2s*1e6): period =  monthly: date =     10201     0
                           atm            lnd            rof            ocn         ice nh         ice sh            glc        *SUM*
         wfreeze     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000
           wmelt     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000
           wrain   -29.14472179     5.16462136     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000   -23.98010043
           wsnow    -1.90550053     0.97149498     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000    -0.93400555
          wpolar     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000
           wgsmb     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000
           wevap     0.00000000    -1.53056231     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000    -1.53056231
         wrunoff     0.00000000    -0.35281180     0.20370109     0.00000000     0.00000000     0.00000000     0.00000000    -0.14911071
         wfrzrof     0.00000000    -0.21074392    -0.00000000     0.00000000     0.00000000     0.00000000     0.00000000    -0.21074392
          wirrig     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000     0.00000000
           *SUM*   -31.05022232     4.04199830     0.20370109     0.00000000     0.00000000     0.00000000     0.00000000   -26.80452293

```
that matches the heat and water budget in `lnd.log.*` file:
```
 NET HEAT FLUXES : period  monthly: date =        10201           0
                       Time     |      Time
                     averaged   |    integrated
                      W/m2      |     MJ/m2*1e6
--------------------------------|--------------------
         hfreeze     0.00000000 |               0.00
           hmelt     0.00000000 |               0.00
          hnetsw    33.11954505 |        88707389.46
           hlwdn    82.30138855 |       220436039.08
           hlwup  -101.16708504 |      -270965920.57
         hlatvap    -3.81156155 |       -10208886.46
         hlatfus    -0.32418787 |         -868304.80
          hiroff     0.07032525 |          188359.14
            hsen    -8.50131293 |       -22769916.55
          hpolar     0.00000000 |               0.00
        hh2otemp     0.00000000 |               0.00
--------------------------------|--------------------
           *SUM*     1.68711145 |         4518759.31
--------------------------------|--------------------

 NET WATER FLUXES : period  monthly: date =        10201           0
                       Time     |      Time
                     averaged   |    integrated
                   kg/m2s*1e6   |     kg/m2*1e6
--------------------------------|--------------------
            rain     5.16462136 |        13832921.85
            snow     0.97149498 |         2602052.15
            evap    -1.53056231 |        -4099458.10
          runoff    -0.35281180 |         -944971.12
          frzrof    -0.21074392 |         -564456.52
           irrig     0.00000000 |               0.00
--------------------------------|--------------------
           *SUM*     4.04199830 |        10826088.25
--------------------------------|--------------------
```

