### PR TITLE
EAMxx: Fix out-of-bounds access in ZM views

### DIFF
--- a/components/eamxx/src/physics/zm/eamxx_zm_process_interface.cpp
+++ b/components/eamxx/src/physics/zm/eamxx_zm_process_interface.cpp
@@ -713,8 +713,6 @@ void ZMDeepConvection::init_buffers(const ATMBufferManager &buffer_manager)
                                                                   &zm_output.snow_prod,
                                                                   &zm_output.ntprprd,
                                                                   &zm_output.ntsnprd,
-                                                                  &zm_output.flxprec,
-                                                                  &zm_output.flxsnow,
                                                                   &zm_output.zdu,
                                                                   &zm_output.mflx_up,
                                                                   &zm_output.entr_up,
@@ -741,6 +739,8 @@ void ZMDeepConvection::init_buffers(const ATMBufferManager &buffer_manager)
                                                                   &zm_output.prec_flux,
                                                                   &zm_output.snow_flux,
                                                                   &zm_output.mass_flux,
+                                                                  &zm_output.flxprec,
+                                                                  &zm_output.flxsnow,
                                                                 };
   for (auto& v : ptrs_2d_intfc) {
     *v = ZMF::uview_2d<Real>(r_mem, m_ncol, nlev_int);

--- a/components/eamxx/src/physics/zm/zm_functions.hpp
+++ b/components/eamxx/src/physics/zm/zm_functions.hpp
@@ -414,8 +414,8 @@ struct Functions {
     // variable counters for device-side only
     static constexpr int num_1d_intgr =  5; // number of 1D integer views
     static constexpr int num_1d_scalr =  6; // number of 1D scalar views
-    static constexpr int num_2d_midlv = 24; // number of 2D mid-point views
-    static constexpr int num_2d_intfc =  3; // number of 2D interface views
+    static constexpr int num_2d_midlv = 22; // number of 2D mid-point views
+    static constexpr int num_2d_intfc =  5; // number of 2D interface views
     static constexpr int num_3d_midlv =  1; // number of 3D mid-point views (ncol,nwind,nlev)
     static constexpr int num_f_midlv  = 13; // number of fortran-bridge (LayoutLeft) 2D mid-point views
     static constexpr int num_f_intfc  =  3; // number of fortran-bridge (LayoutLeft) 2D interface views


### PR DESCRIPTION
Fix out-of-bounds memory access in the ZM scheme. The convective precipitation and snow flux views (flxprec and flxsnow) were incorrectly allocated with size pver (72) instead of pverp (73), causing out-of-bounds access when the code accessed index pver (72) for surface flux output. Note that my unit test, zm+wetscav, is using pver=72 levels. 

  ## Problem

  Kokkos bounds checking detected an out-of-bounds error in zm_conv_evap:

  Kokkos::View ERROR: out of bounds access
  label=("**UNMANAGED**") with indices [72] but extents [72]
  at components/eamxx/src/physics/zm/impl/zm_conv_evap_impl.hpp:59

  ## Root Cause
  In zm_conv_evap_impl.hpp, the code accesses:

  - flxprec(0), flxsnow(0) - top of atmosphere initialization
  - flxprec(k+1), flxsnow(k+1) for k=0..pver-1 -  [see here](https://github.com/E3SM-Project/E3SM/blob/69e927ab7c023ce39ace6f3d4d8c54d24bdf828a/components/eamxx/src/physics/zm/impl/zm_conv_evap_impl.hpp#L189)
  - flxprec(pver), flxsnow(pver)  [see here](https://github.com/E3SM-Project/E3SM/blob/69e927ab7c023ce39ace6f3d4d8c54d24bdf828a/components/eamxx/src/physics/zm/impl/zm_conv_evap_impl.hpp#L217)

  This requires indices [0..72], meaning 73 elements total, but only 72 were allocated. 