### PR TITLE
EAMxx: SPA bug fix to read in aerosol extinction and convert it to layer optical depth

### DIFF
--- a/components/eamxx/src/physics/spa/eamxx_spa_process_interface.cpp
+++ b/components/eamxx/src/physics/spa/eamxx_spa_process_interface.cpp
@@ -4,6 +4,7 @@
 #include "share/scorpio_interface/eamxx_scorpio_interface.hpp"
 #include "share/property_checks/field_within_interval_check.hpp"
 
+#include <ekat_team_policy_utils.hpp>
 #include <ekat_assert.hpp>
 #include <ekat_units.hpp>
 
@@ -28,24 +29,30 @@ void SPA::create_requests()
   m_model_grid = m_grids_manager->get_grid("physics");
   const auto& grid_name = m_model_grid->name();
 
+  ncol_ = m_model_grid->get_num_local_dofs();
+  nlev_ = m_model_grid->get_num_vertical_levels();
+
   // Get bands info from file, and log it
   const auto spa_data_file = m_params.get<std::string>("spa_data_file");
-  const int nswbands = scorpio::get_dimlen(spa_data_file,"swband");
-  const int nlwbands = scorpio::get_dimlen(spa_data_file,"lwband");
+  nswbands_ = scorpio::get_dimlen(spa_data_file,"swband");
+  nlwbands_ = scorpio::get_dimlen(spa_data_file,"lwband");
   this->log(LogLevel::info,
       "SPA data file bands dimensions:\n"
-      "  - num sw bands: " + std::to_string(nswbands) + "\n"
-      "  - num lw bands: " + std::to_string(nlwbands) + "\n");
+      "  - num sw bands: " + std::to_string(nswbands_) + "\n"
+      "  - num lw bands: " + std::to_string(nlwbands_) + "\n");
 
   // Define the different field layouts that will be used for this process
   auto scalar3d_mid    = m_model_grid->get_3d_scalar_layout(LEV);
   auto scalar2d        = m_model_grid->get_2d_scalar_layout();
   auto scalar1d_mid    = m_model_grid->get_vertical_layout(LEV);
-  auto scalar3d_swband = m_model_grid->get_3d_vector_layout(LEV,nswbands,"swband");
-  auto scalar3d_lwband = m_model_grid->get_3d_vector_layout(LEV,nlwbands,"lwband");
+  auto scalar3d_swband = m_model_grid->get_3d_vector_layout(LEV,nswbands_,"swband");
+  auto scalar3d_lwband = m_model_grid->get_3d_vector_layout(LEV,nlwbands_,"lwband");
 
   // Set of fields used strictly as input
-  add_field<Required>("p_mid"      , scalar3d_mid, Pa,     grid_name, ps);
+  add_field<Required>("p_mid",          scalar3d_mid, Pa,    grid_name, ps);
+  add_field<Required>("pseudo_density", scalar3d_mid, Pa,    grid_name, ps);
+  add_field<Required>("T_mid",          scalar3d_mid, K,     grid_name, ps);
+  add_field<Required>("qv",             scalar3d_mid, kg/kg, grid_name, ps);
 
   // Set of fields used strictly as output
   add_field<Computed>("nccn",        scalar3d_mid,    1/kg, grid_name, ps);
@@ -67,24 +74,14 @@ void SPA::initialize_impl (const RunType /* run_type */)
       get_field_out("nccn").alias("CCN3"),
       get_field_out("aero_g_sw").alias("AER_G_SW"),
       get_field_out("aero_ssa_sw").alias("AER_SSA_SW"),
-      get_field_out("aero_tau_sw").alias("AER_TAU_SW"),
-      get_field_out("aero_tau_lw").alias("AER_TAU_LW")
+      get_field_out("aero_tau_sw").alias("AER_EXT_SW"),
+      get_field_out("aero_tau_lw").alias("AER_EXT_LW")
   };
   auto spa_data_file = m_params.get<std::string>("spa_data_file");
   auto spa_map_file  = m_params.get<std::string>("spa_remap_file","");
   auto time_interpolation_method = m_params.get<std::string>("time_interpolation_method","yearly_periodic");
 
-  // SPA doesn't really *need* pint, but DataInterpolation does. It's important to stress that
-  // NO FIELD VALUES from p_int are accessed in the DataInterpolation we build, since we
-  // don't remap any field on interfaces. But when the VerticalRemapper in the DataInterpolation
-  // is setup, pint must store the correct layout of a field defined at interfaces; it does not
-  // have to have COL dimension. It just need to have the ILEV tag in the layout AND have alloc
-  // properties compatible with SCREAM_PACK_SIZE.
-  // NOTE: we could just add p_int as a required field, but that would be misleading in the DAG
   auto pmid = get_field_in("p_mid");
-  Field pint(FieldIdentifier("p_int",m_model_grid->get_vertical_layout(ILEV),Pa,m_model_grid->name()));
-  pint.get_header().get_alloc_properties().request_allocation(SCREAM_PACK_SIZE);
-  pint.allocate_view();
 
   m_data_interpolation = std::make_shared<DataInterpolation>(m_model_grid,spa_fields);
   if (time_interpolation_method=="yearly_periodic") {
@@ -102,9 +99,10 @@ void SPA::initialize_impl (const RunType /* run_type */)
   vremap_data.vr_type = DataInterpolation::Dynamic3DRef;
   vremap_data.pname = "PS";
   vremap_data.pmid = pmid;
-  vremap_data.pint = pint;
   m_data_interpolation->create_vert_remapper (vremap_data);
   m_data_interpolation->init_time_interpolation (start_of_step_ts(),DataInterpolation::Linear);
+
+  dz_ = view_2d("dz_", ncol_, nlev_);
 
   // Set property checks for fields in this process
   using FWI = FieldWithinIntervalCheck;
@@ -115,14 +113,61 @@ void SPA::initialize_impl (const RunType /* run_type */)
   // TODO: add an epslon to max possible upper bound of aero_ssa_sw?
   add_postcondition_check<FWI>(get_field_out("aero_g_sw"),m_model_grid,0.0,1.0,true);
   add_postcondition_check<FWI>(get_field_out("aero_ssa_sw"),m_model_grid,0.0,1.0,true);
-  add_postcondition_check<FWI>(get_field_out("aero_tau_sw"),m_model_grid,0.0,1.0,true);
-  add_postcondition_check<FWI>(get_field_out("aero_tau_lw"),m_model_grid,0.0,1.0,true);
+  add_postcondition_check<FWI>(get_field_out("aero_tau_sw"),m_model_grid,0.0,10.0,true);
+  add_postcondition_check<FWI>(get_field_out("aero_tau_lw"),m_model_grid,0.0,10.0,true);
 }
 
 // =========================================================================================
 void SPA::run_impl (const double /* dt */)
 {
+  using PF  = scream::PhysicsFunctions<DefaultDevice>;
+  using ExeSpace = KT::ExeSpace;
+  using MemberType = KT::MemberType;
+  using TPF = ekat::TeamPolicyFactory<ExeSpace>;
+
   m_data_interpolation->run(end_of_step_ts());
+
+  // Convert aerosol extinction (m^-1) to layer optical depth (unitless) by multiplying layer depth (m)
+  const int ncol = ncol_;
+  const int nlev = nlev_;
+  const int nswbands = nswbands_;
+  const int nlwbands = nlwbands_;
+
+  const auto p_mid          = get_field_in ("p_mid").get_view<const Real**>();
+  const auto pseudo_density = get_field_in ("pseudo_density").get_view<const Real**>();
+  const auto T_mid          = get_field_in ("T_mid").get_view<const Real**>();
+  const auto qv             = get_field_in ("qv").get_view<const Real**>();
+  auto aero_tau_sw    = get_field_out("aero_tau_sw").get_view<Real***>();
+  auto aero_tau_lw    = get_field_out("aero_tau_lw").get_view<Real***>();
+  auto dz = dz_;
+
+  const auto policy = TPF::get_default_team_policy(ncol, nlev);
+  Kokkos::parallel_for(policy, KOKKOS_LAMBDA (const MemberType& team) {
+    const int icol = team.league_rank();
+
+    const auto pseudo_density_icol = ekat::subview(pseudo_density, icol);
+    const auto p_mid_icol = ekat::subview(p_mid, icol);
+    const auto T_mid_icol = ekat::subview(T_mid, icol);
+    const auto qv_icol = ekat::subview(qv, icol);
+    auto dz_icol = ekat::subview(dz, icol);
+
+    PF::calculate_dz(team, pseudo_density_icol, p_mid_icol,
+                      T_mid_icol, qv_icol, dz_icol);
+    team.team_barrier();
+
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nswbands*nlev), [&] (const int&idx) {
+      auto isw = idx / nlev;
+      auto k = idx % nlev;
+      const auto dz_ik = dz_icol(k);
+      aero_tau_sw(icol,isw,k) *= dz_ik;
+    });
+    Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlwbands*nlev), [&] (const int&idx) {
+      auto ilw = idx / nlev;
+      auto k = idx % nlev;
+      const auto dz_ik = dz_icol(k);
+      aero_tau_lw(icol,ilw,k) *= dz_ik;
+    });
+  }); // icol parallel_for loop
 }
 
 } // namespace scream

--- a/components/eamxx/src/physics/spa/eamxx_spa_process_interface.hpp
+++ b/components/eamxx/src/physics/spa/eamxx_spa_process_interface.hpp
@@ -2,6 +2,7 @@
 #define SCREAM_PRESCRIBED_AEROSOL_HPP
 
 #include "share/atm_process/atmosphere_process.hpp"
+#include "share/physics/eamxx_common_physics_functions.hpp"
 
 namespace scream
 {
@@ -17,6 +18,8 @@ class DataInterpolation;
 
 class SPA : public AtmosphereProcess
 {
+  using KT           = ekat::KokkosTypes<DefaultDevice>;
+  using view_2d      = typename KT::template view_2d<Real>;
 public:
   // Constructors
   SPA (const ekat::Comm& comm, const ekat::ParameterList& params);
@@ -30,16 +33,26 @@ public:
   // Set the grid
   void create_requests ();
 
-protected:
-
   // The three main overrides for the subcomponent
   void initialize_impl (const RunType run_type);
   void run_impl        (const double dt);
   void finalize_impl   () { /* Nothing to do */ }
 
+  protected:
+
   std::shared_ptr<const AbstractGrid>   m_model_grid;
 
   std::shared_ptr<DataInterpolation>    m_data_interpolation;
+
+  // number of horizontal columns and vertical levels
+  int ncol_, nlev_;
+
+  // number of shortwave and longwave bands
+  int nswbands_, nlwbands_;
+
+  // layer thickness
+  view_2d dz_;
+
 }; // class SPA
 
 } // namespace scream


### PR DESCRIPTION
Current SPA interpolates layer optical depth between different vertical coordinate, which depends on layer depth, and causes AOD increase in EAMxx (from L80 in v3.LR to L128 EAMxx).

This PR fixes #8682 

Need to update new SPA file for the PR